### PR TITLE
feat: add artifact comments + identity UUID refs (by Lumen)

### DIFF
--- a/packages/api/src/data/supabase/types.ts
+++ b/packages/api/src/data/supabase/types.ts
@@ -410,6 +410,7 @@ export type Database = {
           change_summary: string | null
           change_type: string | null
           changed_by_agent_id: string | null
+          changed_by_identity_id: string | null
           changed_by_user_id: string | null
           content: string
           created_at: string | null
@@ -422,6 +423,7 @@ export type Database = {
           change_summary?: string | null
           change_type?: string | null
           changed_by_agent_id?: string | null
+          changed_by_identity_id?: string | null
           changed_by_user_id?: string | null
           content: string
           created_at?: string | null
@@ -434,6 +436,7 @@ export type Database = {
           change_summary?: string | null
           change_type?: string | null
           changed_by_agent_id?: string | null
+          changed_by_identity_id?: string | null
           changed_by_user_id?: string | null
           content?: string
           created_at?: string | null
@@ -456,6 +459,84 @@ export type Database = {
             referencedRelation: "users"
             referencedColumns: ["id"]
           },
+          {
+            foreignKeyName: "artifact_history_changed_by_identity_id_fkey"
+            columns: ["changed_by_identity_id"]
+            isOneToOne: false
+            referencedRelation: "agent_identities"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      artifact_comments: {
+        Row: {
+          artifact_id: string
+          content: string
+          created_at: string | null
+          created_by_agent_id: string | null
+          created_by_identity_id: string | null
+          deleted_at: string | null
+          id: string
+          metadata: Json | null
+          parent_comment_id: string | null
+          updated_at: string | null
+          user_id: string
+        }
+        Insert: {
+          artifact_id: string
+          content: string
+          created_at?: string | null
+          created_by_agent_id?: string | null
+          created_by_identity_id?: string | null
+          deleted_at?: string | null
+          id?: string
+          metadata?: Json | null
+          parent_comment_id?: string | null
+          updated_at?: string | null
+          user_id: string
+        }
+        Update: {
+          artifact_id?: string
+          content?: string
+          created_at?: string | null
+          created_by_agent_id?: string | null
+          created_by_identity_id?: string | null
+          deleted_at?: string | null
+          id?: string
+          metadata?: Json | null
+          parent_comment_id?: string | null
+          updated_at?: string | null
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "artifact_comments_artifact_id_fkey"
+            columns: ["artifact_id"]
+            isOneToOne: false
+            referencedRelation: "artifacts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "artifact_comments_created_by_identity_id_fkey"
+            columns: ["created_by_identity_id"]
+            isOneToOne: false
+            referencedRelation: "agent_identities"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "artifact_comments_parent_comment_id_fkey"
+            columns: ["parent_comment_id"]
+            isOneToOne: false
+            referencedRelation: "artifact_comments"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "artifact_comments_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
         ]
       }
       artifacts: {
@@ -466,6 +547,7 @@ export type Database = {
           content_type: string | null
           created_at: string | null
           created_by_agent_id: string | null
+          created_by_identity_id: string | null
           id: string
           metadata: Json | null
           tags: string[] | null
@@ -483,6 +565,7 @@ export type Database = {
           content_type?: string | null
           created_at?: string | null
           created_by_agent_id?: string | null
+          created_by_identity_id?: string | null
           id?: string
           metadata?: Json | null
           tags?: string[] | null
@@ -500,6 +583,7 @@ export type Database = {
           content_type?: string | null
           created_at?: string | null
           created_by_agent_id?: string | null
+          created_by_identity_id?: string | null
           id?: string
           metadata?: Json | null
           tags?: string[] | null
@@ -516,6 +600,13 @@ export type Database = {
             columns: ["user_id"]
             isOneToOne: false
             referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "artifacts_created_by_identity_id_fkey"
+            columns: ["created_by_identity_id"]
+            isOneToOne: false
+            referencedRelation: "agent_identities"
             referencedColumns: ["id"]
           },
         ]

--- a/packages/api/src/mcp/tools/artifact-handlers.test.ts
+++ b/packages/api/src/mcp/tools/artifact-handlers.test.ts
@@ -457,7 +457,7 @@ describe('artifact comment + identity UUID flows', () => {
     });
   });
 
-  it('handleCreateArtifact gracefully degrades when agent identity is missing', async () => {
+  it('handleCreateArtifact keeps slug behavior when identity row is missing', async () => {
     const supabase = createTableAwareSupabaseMock({
       agent_identities: [
         { maybeSingle: [{ data: null, error: null }] },
@@ -468,8 +468,8 @@ describe('artifact comment + identity UUID flows', () => {
           single: [{
             data: {
               id: 'artifact-2',
-              uri: 'pcp://specs/no-identity',
-              title: 'No Identity',
+              uri: 'pcp://specs/slug-only',
+              title: 'Slug only',
               artifact_type: 'spec',
               version: 1,
               created_at: '2026-02-11T00:00:00Z',
@@ -483,12 +483,12 @@ describe('artifact comment + identity UUID flows', () => {
 
     const result = await handleCreateArtifact(
       {
-        userId: '00000000-0000-0000-0000-000000000001',
-        uri: 'pcp://specs/no-identity',
-        title: 'No Identity',
-        content: '# Hello',
+        userId: '550e8400-e29b-41d4-a716-446655440000',
+        uri: 'pcp://specs/slug-only',
+        title: 'Slug only',
+        content: '# Hi',
         artifactType: 'spec',
-        agentId: 'unknown-agent',
+        agentId: 'unknown-agent-slug',
       },
       createMockDataComposer(supabase)
     );
@@ -497,9 +497,15 @@ describe('artifact comment + identity UUID flows', () => {
     expect(parsed.success).toBe(true);
 
     const artifactInsertBuilder = supabase.calls.find((c) => c.table === 'artifacts' && (c.builder.insert as ReturnType<typeof vi.fn>).mock.calls.length > 0)?.builder;
+    const historyInsertBuilder = supabase.calls.find((c) => c.table === 'artifact_history')?.builder;
+
     expect((artifactInsertBuilder?.insert as ReturnType<typeof vi.fn>).mock.calls[0][0]).toMatchObject({
-      created_by_agent_id: 'unknown-agent',
+      created_by_agent_id: 'unknown-agent-slug',
       created_by_identity_id: null,
+    });
+    expect((historyInsertBuilder?.insert as ReturnType<typeof vi.fn>).mock.calls[0][0]).toMatchObject({
+      changed_by_agent_id: 'unknown-agent-slug',
+      changed_by_identity_id: null,
     });
   });
 
@@ -509,7 +515,9 @@ describe('artifact comment + identity UUID flows', () => {
         { single: [{ data: { id: '11111111-1111-1111-1111-111111111111', uri: 'pcp://specs/test' }, error: null }] },
       ],
       agent_identities: [
-        { maybeSingle: [{ data: { id: 'identity-1', agent_id: 'lumen', name: 'Lumen', backend: 'codex' }, error: null }] },
+        {
+          maybeSingle: [{ data: { id: 'identity-1', agent_id: 'lumen', name: 'Lumen', backend: 'codex' }, error: null }],
+        },
       ],
       artifact_comments: [
         {

--- a/packages/api/src/mcp/tools/artifact-handlers.test.ts
+++ b/packages/api/src/mcp/tools/artifact-handlers.test.ts
@@ -1,15 +1,18 @@
 /**
  * Artifact Handler Tests
  *
- * Tests for three-way merge logic in update_artifact.
+ * Covers three-way merge/CAS behavior plus comment + identity UUID flows.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { handleUpdateArtifact } from './artifact-handlers';
-
-// =====================================================
-// MOCK SETUP
-// =====================================================
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { DataComposer } from '../../data/composer';
+import { createTableAwareSupabaseMock } from '../../test/table-aware-supabase-mock';
+import {
+  handleAddArtifactComment,
+  handleCreateArtifact,
+  handleListArtifactComments,
+  handleUpdateArtifact,
+} from './artifact-handlers';
 
 vi.mock('../../services/user-resolver', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../services/user-resolver')>();
@@ -30,10 +33,6 @@ vi.mock('../../utils/logger', () => ({
     debug: vi.fn(),
   },
 }));
-
-// =====================================================
-// HELPERS
-// =====================================================
 
 function createMockSupabase(overrides: {
   artifact?: Record<string, unknown> | null;
@@ -58,6 +57,20 @@ function createMockSupabase(overrides: {
   const insertedHistory: Record<string, unknown>[] = [];
 
   const mockFrom = vi.fn().mockImplementation((table: string) => {
+    if (table === 'agent_identities') {
+      return {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              maybeSingle: vi.fn().mockResolvedValue({
+                data: null,
+                error: null,
+              }),
+            }),
+          }),
+        }),
+      };
+    }
     if (table === 'artifacts') {
       return {
         select: vi.fn().mockReturnValue({
@@ -72,7 +85,6 @@ function createMockSupabase(overrides: {
         }),
         update: vi.fn().mockImplementation((updates: Record<string, unknown>) => {
           Object.assign(updatedArtifact, updates);
-          // CAS guard: .eq('id', ...).eq('version', ...).select().maybeSingle()
           return {
             eq: vi.fn().mockReturnValue({
               eq: vi.fn().mockReturnValue({
@@ -113,20 +125,14 @@ function createMockSupabase(overrides: {
     supabase: { from: mockFrom },
     updatedArtifact,
     insertedHistory,
-    mockFrom,
   };
 }
 
 function createMockDataComposer(supabase: { from: ReturnType<typeof vi.fn> }) {
   return {
     getClient: () => supabase,
-    repositories: {},
-  } as unknown as Parameters<typeof handleUpdateArtifact>[1];
+  } as unknown as DataComposer;
 }
-
-// =====================================================
-// TESTS
-// =====================================================
 
 describe('handleUpdateArtifact', () => {
   beforeEach(() => {
@@ -165,7 +171,7 @@ describe('handleUpdateArtifact', () => {
           userId: '00000000-0000-0000-0000-000000000001',
           uri: 'pcp://test/doc',
           content: 'Updated content',
-          baseVersion: 1, // matches current version
+          baseVersion: 1,
           agentId: 'wren',
         },
         dataComposer,
@@ -180,13 +186,8 @@ describe('handleUpdateArtifact', () => {
 
   describe('three-way merge', () => {
     it('should auto-merge when changes are in different sections', async () => {
-      // Base (version 1): three sections
       const baseContent = '# Section A\nOriginal A content\n\n# Section B\nOriginal B content\n\n# Section C\nOriginal C content\n';
-
-      // Current (version 2): someone edited section B
       const currentContent = '# Section A\nOriginal A content\n\n# Section B\nModified B content by Myra\n\n# Section C\nOriginal C content\n';
-
-      // Incoming: agent edited section C (based on version 1)
       const incomingContent = '# Section A\nOriginal A content\n\n# Section B\nOriginal B content\n\n# Section C\nModified C content by Wren\n';
 
       const { supabase, updatedArtifact, insertedHistory } = createMockSupabase({
@@ -211,7 +212,7 @@ describe('handleUpdateArtifact', () => {
           userId: '00000000-0000-0000-0000-000000000001',
           uri: 'pcp://test/doc',
           content: incomingContent,
-          baseVersion: 1, // doesn't match current version 2
+          baseVersion: 1,
           agentId: 'wren',
         },
         dataComposer,
@@ -221,13 +222,8 @@ describe('handleUpdateArtifact', () => {
       expect(parsed.success).toBe(true);
       expect(parsed.mergePerformed).toBe(true);
       expect(parsed.mergedFromBase).toBe(1);
-
-      // The merged content should have Myra's B changes AND Wren's C changes
-      const merged = updatedArtifact.content as string;
-      expect(merged).toContain('Modified B content by Myra');
-      expect(merged).toContain('Modified C content by Wren');
-
-      // History should record it as a merge
+      expect((updatedArtifact.content as string)).toContain('Modified B content by Myra');
+      expect((updatedArtifact.content as string)).toContain('Modified C content by Wren');
       expect(insertedHistory[0].change_type).toBe('merge');
     });
 
@@ -269,13 +265,11 @@ describe('handleUpdateArtifact', () => {
       expect(parsed.conflict).toBe(true);
       expect(parsed.currentVersion).toBe(2);
       expect(parsed.baseVersion).toBe(1);
-      expect(parsed.conflicts).toBeDefined();
       expect(parsed.conflicts.length).toBeGreaterThan(0);
     });
 
     it('should handle false conflicts (both made same change) gracefully', async () => {
       const baseContent = '# Title\nOriginal content\n\n# Footer\nFooter content\n';
-      // Both editors made the exact same change
       const currentContent = '# Title\nSame new content\n\n# Footer\nFooter content\n';
       const incomingContent = '# Title\nSame new content\n\n# Footer\nFooter content\n';
 
@@ -308,7 +302,6 @@ describe('handleUpdateArtifact', () => {
       );
 
       const parsed = JSON.parse(result.content[0].text);
-      // excludeFalseConflicts: true means identical changes merge cleanly
       expect(parsed.success).toBe(true);
     });
 
@@ -348,7 +341,7 @@ describe('handleUpdateArtifact', () => {
   describe('CAS (compare-and-swap) guard', () => {
     it('should return staleWrite conflict when another writer wins the race', async () => {
       const { supabase } = createMockSupabase({
-        casFailure: true, // simulate another writer incrementing version between read and write
+        casFailure: true,
       });
       const dataComposer = createMockDataComposer(supabase);
 
@@ -371,7 +364,7 @@ describe('handleUpdateArtifact', () => {
 
   describe('non-content updates', () => {
     it('should not trigger merge for metadata-only updates even with baseVersion', async () => {
-      const { supabase, updatedArtifact } = createMockSupabase({
+      const { supabase } = createMockSupabase({
         artifact: {
           id: 'artifact-1',
           uri: 'pcp://test/doc',
@@ -392,7 +385,7 @@ describe('handleUpdateArtifact', () => {
           userId: '00000000-0000-0000-0000-000000000001',
           uri: 'pcp://test/doc',
           tags: ['new-tag'],
-          baseVersion: 1, // mismatches but no content change
+          baseVersion: 1,
           agentId: 'wren',
         },
         dataComposer,
@@ -402,5 +395,255 @@ describe('handleUpdateArtifact', () => {
       expect(parsed.success).toBe(true);
       expect(parsed.mergePerformed).toBeFalsy();
     });
+  });
+});
+
+describe('artifact comment + identity UUID flows', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('handleCreateArtifact stores created_by_identity_id and history changed_by_identity_id', async () => {
+    const supabase = createTableAwareSupabaseMock({
+      agent_identities: [
+        {
+          maybeSingle: [{ data: { id: 'identity-1', agent_id: 'lumen', name: 'Lumen', backend: 'codex' }, error: null }],
+        },
+      ],
+      artifacts: [
+        { maybeSingle: [{ data: null, error: null }] },
+        {
+          single: [{
+            data: {
+              id: 'artifact-1',
+              uri: 'pcp://specs/test',
+              title: 'Test Spec',
+              artifact_type: 'spec',
+              version: 1,
+              created_at: '2026-02-11T00:00:00Z',
+            },
+            error: null,
+          }],
+        },
+      ],
+      artifact_history: [{ then: { data: null, error: null } }],
+    });
+
+    const result = await handleCreateArtifact(
+      {
+        userId: '00000000-0000-0000-0000-000000000001',
+        uri: 'pcp://specs/test',
+        title: 'Test Spec',
+        content: '# Hello',
+        artifactType: 'spec',
+        agentId: 'lumen',
+      },
+      createMockDataComposer(supabase)
+    );
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.success).toBe(true);
+
+    const artifactInsertBuilder = supabase.calls.find((c) => c.table === 'artifacts' && (c.builder.insert as ReturnType<typeof vi.fn>).mock.calls.length > 0)?.builder;
+    const historyInsertBuilder = supabase.calls.find((c) => c.table === 'artifact_history')?.builder;
+
+    expect((artifactInsertBuilder?.insert as ReturnType<typeof vi.fn>).mock.calls[0][0]).toMatchObject({
+      created_by_agent_id: 'lumen',
+      created_by_identity_id: 'identity-1',
+    });
+    expect((historyInsertBuilder?.insert as ReturnType<typeof vi.fn>).mock.calls[0][0]).toMatchObject({
+      changed_by_agent_id: 'lumen',
+      changed_by_identity_id: 'identity-1',
+    });
+  });
+
+  it('handleCreateArtifact gracefully degrades when agent identity is missing', async () => {
+    const supabase = createTableAwareSupabaseMock({
+      agent_identities: [
+        { maybeSingle: [{ data: null, error: null }] },
+      ],
+      artifacts: [
+        { maybeSingle: [{ data: null, error: null }] },
+        {
+          single: [{
+            data: {
+              id: 'artifact-2',
+              uri: 'pcp://specs/no-identity',
+              title: 'No Identity',
+              artifact_type: 'spec',
+              version: 1,
+              created_at: '2026-02-11T00:00:00Z',
+            },
+            error: null,
+          }],
+        },
+      ],
+      artifact_history: [{ then: { data: null, error: null } }],
+    });
+
+    const result = await handleCreateArtifact(
+      {
+        userId: '00000000-0000-0000-0000-000000000001',
+        uri: 'pcp://specs/no-identity',
+        title: 'No Identity',
+        content: '# Hello',
+        artifactType: 'spec',
+        agentId: 'unknown-agent',
+      },
+      createMockDataComposer(supabase)
+    );
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.success).toBe(true);
+
+    const artifactInsertBuilder = supabase.calls.find((c) => c.table === 'artifacts' && (c.builder.insert as ReturnType<typeof vi.fn>).mock.calls.length > 0)?.builder;
+    expect((artifactInsertBuilder?.insert as ReturnType<typeof vi.fn>).mock.calls[0][0]).toMatchObject({
+      created_by_agent_id: 'unknown-agent',
+      created_by_identity_id: null,
+    });
+  });
+
+  it('handleAddArtifactComment resolves identity UUID and returns identity metadata', async () => {
+    const supabase = createTableAwareSupabaseMock({
+      artifacts: [
+        { single: [{ data: { id: '11111111-1111-1111-1111-111111111111', uri: 'pcp://specs/test' }, error: null }] },
+      ],
+      agent_identities: [
+        { maybeSingle: [{ data: { id: 'identity-1', agent_id: 'lumen', name: 'Lumen', backend: 'codex' }, error: null }] },
+      ],
+      artifact_comments: [
+        {
+          single: [{
+            data: {
+              id: 'comment-1',
+              artifact_id: '11111111-1111-1111-1111-111111111111',
+              user_id: '00000000-0000-0000-0000-000000000001',
+              parent_comment_id: null,
+              content: 'Great point.',
+              metadata: {},
+              created_by_agent_id: 'lumen',
+              created_by_identity_id: 'identity-1',
+              created_at: '2026-02-11T00:00:00Z',
+              updated_at: '2026-02-11T00:00:00Z',
+            },
+            error: null,
+          }],
+        },
+      ],
+    });
+
+    const result = await handleAddArtifactComment(
+      {
+        userId: '00000000-0000-0000-0000-000000000001',
+        artifactId: '11111111-1111-1111-1111-111111111111',
+        content: 'Great point.',
+        agentId: 'lumen',
+      },
+      createMockDataComposer(supabase)
+    );
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.success).toBe(true);
+    expect(parsed.comment.createdByIdentityId).toBe('identity-1');
+    expect(parsed.comment.createdByIdentity.agentId).toBe('lumen');
+
+    const commentsBuilder = supabase.calls.find((c) => c.table === 'artifact_comments')?.builder;
+    expect((commentsBuilder?.insert as ReturnType<typeof vi.fn>).mock.calls[0][0]).toMatchObject({
+      created_by_agent_id: 'lumen',
+      created_by_identity_id: 'identity-1',
+      content: 'Great point.',
+    });
+  });
+
+  it('handleAddArtifactComment rejects invalid parent comment reference', async () => {
+    const supabase = createTableAwareSupabaseMock({
+      artifacts: [
+        { single: [{ data: { id: '11111111-1111-1111-1111-111111111111', uri: 'pcp://specs/test' }, error: null }] },
+      ],
+      artifact_comments: [
+        { maybeSingle: [{ data: null, error: null }] },
+      ],
+    });
+
+    await expect(
+      handleAddArtifactComment(
+        {
+          userId: '00000000-0000-0000-0000-000000000001',
+          artifactId: '11111111-1111-1111-1111-111111111111',
+          content: 'Replying to thread',
+          parentCommentId: '22222222-2222-2222-2222-222222222222',
+        },
+        createMockDataComposer(supabase)
+      )
+    ).rejects.toThrow('Parent comment not found');
+  });
+
+  it('handleListArtifactComments enriches comments with identity details', async () => {
+    const supabase = createTableAwareSupabaseMock({
+      artifacts: [
+        { single: [{ data: { id: '11111111-1111-1111-1111-111111111111', uri: 'pcp://specs/test' }, error: null }] },
+      ],
+      artifact_comments: [
+        {
+          then: {
+            data: [
+              {
+                id: 'comment-1',
+                artifact_id: '11111111-1111-1111-1111-111111111111',
+                parent_comment_id: null,
+                content: 'From Lumen',
+                metadata: {},
+                created_by_agent_id: 'lumen',
+                created_by_identity_id: 'identity-1',
+                created_at: '2026-02-11T00:00:00Z',
+                updated_at: '2026-02-11T00:00:00Z',
+                user_id: '00000000-0000-0000-0000-000000000001',
+                deleted_at: null,
+              },
+              {
+                id: 'comment-2',
+                artifact_id: '11111111-1111-1111-1111-111111111111',
+                parent_comment_id: null,
+                content: 'Anonymous note',
+                metadata: {},
+                created_by_agent_id: null,
+                created_by_identity_id: null,
+                created_at: '2026-02-11T00:05:00Z',
+                updated_at: '2026-02-11T00:05:00Z',
+                user_id: '00000000-0000-0000-0000-000000000001',
+                deleted_at: null,
+              },
+            ],
+            error: null,
+          },
+        },
+      ],
+      agent_identities: [
+        {
+          then: {
+            data: [{ id: 'identity-1', agent_id: 'lumen', name: 'Lumen', backend: 'codex' }],
+            error: null,
+          },
+        },
+      ],
+    });
+
+    const result = await handleListArtifactComments(
+      {
+        userId: '00000000-0000-0000-0000-000000000001',
+        artifactId: '11111111-1111-1111-1111-111111111111',
+      },
+      createMockDataComposer(supabase)
+    );
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.success).toBe(true);
+    expect(parsed.count).toBe(2);
+    expect(parsed.comments[0].createdByIdentity).toMatchObject({
+      id: 'identity-1',
+      agentId: 'lumen',
+      name: 'Lumen',
+    });
+    expect(parsed.comments[1].createdByIdentity).toBeNull();
   });
 });

--- a/packages/api/src/mcp/tools/artifact-handlers.ts
+++ b/packages/api/src/mcp/tools/artifact-handlers.ts
@@ -7,10 +7,11 @@
 
 import { z } from 'zod';
 import { merge as diff3Merge, diff3Merge as diff3MergeRegions } from 'node-diff3';
+import type { SupabaseClient } from '@supabase/supabase-js';
 import type { DataComposer } from '../../data/composer';
 import { resolveUserOrThrow, userIdentifierBaseSchema } from '../../services/user-resolver';
 import { logger } from '../../utils/logger';
-import type { Json } from '../../data/supabase/types';
+import type { Database, Json } from '../../data/supabase/types';
 
 // ============== Schemas ==============
 
@@ -65,6 +66,71 @@ const getArtifactHistorySchema = userIdentifierBaseSchema.extend({
   limit: z.number().min(1).max(50).optional().default(10).describe('Max history entries'),
 });
 
+const addArtifactCommentSchema = userIdentifierBaseSchema.extend({
+  uri: z.string().optional().describe('URI of the artifact'),
+  artifactId: z.string().uuid().optional().describe('ID of the artifact'),
+  content: z.string().min(1).describe('Comment text'),
+  agentId: z.string().optional().describe('Agent authoring the comment'),
+  parentCommentId: z.string().uuid().optional().describe('Optional parent comment ID for threading'),
+  metadata: z.record(z.unknown()).optional().describe('Additional metadata'),
+});
+
+const listArtifactCommentsSchema = userIdentifierBaseSchema.extend({
+  uri: z.string().optional().describe('URI of the artifact'),
+  artifactId: z.string().uuid().optional().describe('ID of the artifact'),
+  limit: z.number().min(1).max(200).optional().default(100).describe('Max comments to return'),
+});
+
+// ============== Helpers ==============
+
+async function resolveIdentityForAgent(
+  supabase: SupabaseClient<Database>,
+  userId: string,
+  agentId?: string
+) {
+  if (!agentId) return null;
+
+  const { data, error } = await supabase
+    .from('agent_identities')
+    .select('id, agent_id, name, backend')
+    .eq('user_id', userId)
+    .eq('agent_id', agentId)
+    .maybeSingle();
+
+  if (error || !data) {
+    logger.warn(`No agent identity record found for agentId "${agentId}", continuing without UUID reference`, {
+      userId,
+      agentId,
+      error: error?.message,
+    });
+    return null;
+  }
+
+  return data;
+}
+
+function resolveArtifactForUser(
+  supabase: SupabaseClient<Database>,
+  userId: string,
+  params: { uri?: string; artifactId?: string },
+  selectColumns = '*'
+) {
+  const { uri, artifactId } = params;
+  if (!uri && !artifactId) {
+    throw new Error('Must provide either uri or artifactId');
+  }
+
+  let query = supabase.from('artifacts').select(selectColumns).eq('user_id', userId);
+
+  if (uri) {
+    query = query.eq('uri', uri);
+  } else if (artifactId) {
+    query = query.eq('id', artifactId);
+  }
+
+  return query;
+}
+
 // ============== Handlers ==============
 
 export async function handleCreateArtifact(
@@ -86,6 +152,7 @@ export async function handleCreateArtifact(
     tags = [],
     metadata = {},
   } = parsed;
+  const authorIdentity = await resolveIdentityForAgent(supabase, resolved.user.id, agentId);
 
   // Check if URI already exists
   const { data: existing } = await supabase
@@ -104,6 +171,7 @@ export async function handleCreateArtifact(
       uri,
       user_id: resolved.user.id,
       created_by_agent_id: agentId || null,
+      created_by_identity_id: authorIdentity?.id || null,
       title,
       content,
       artifact_type: artifactType,
@@ -128,6 +196,7 @@ export async function handleCreateArtifact(
     title,
     content,
     changed_by_agent_id: agentId || null,
+    changed_by_identity_id: authorIdentity?.id || null,
     changed_by_user_id: agentId ? null : resolved.user.id,
     change_type: 'create',
     change_summary: 'Initial creation',
@@ -165,18 +234,7 @@ export async function handleGetArtifact(
   const resolved = await resolveUserOrThrow(parsed, dataComposer);
 
   const { uri, artifactId } = parsed;
-
-  if (!uri && !artifactId) {
-    throw new Error('Must provide either uri or artifactId');
-  }
-
-  let query = supabase.from('artifacts').select('*').eq('user_id', resolved.user.id);
-
-  if (uri) {
-    query = query.eq('uri', uri);
-  } else if (artifactId) {
-    query = query.eq('id', artifactId);
-  }
+  const query = resolveArtifactForUser(supabase, resolved.user.id, { uri, artifactId });
 
   const { data: artifact, error } = await query.maybeSingle();
 
@@ -213,6 +271,7 @@ export async function handleGetArtifact(
             contentType: artifact.content_type,
             artifactType: artifact.artifact_type,
             createdByAgentId: artifact.created_by_agent_id,
+            createdByIdentityId: artifact.created_by_identity_id,
             collaborators: artifact.collaborators,
             visibility: artifact.visibility,
             version: artifact.version,
@@ -236,19 +295,10 @@ export async function handleUpdateArtifact(
   const resolved = await resolveUserOrThrow(parsed, dataComposer);
 
   const { uri, artifactId, title, content, baseVersion, agentId, collaborators, tags, changeSummary } = parsed;
-
-  if (!uri && !artifactId) {
-    throw new Error('Must provide either uri or artifactId');
-  }
+  const editorIdentity = await resolveIdentityForAgent(supabase, resolved.user.id, agentId);
 
   // First, get the current artifact
-  let query = supabase.from('artifacts').select('*').eq('user_id', resolved.user.id);
-
-  if (uri) {
-    query = query.eq('uri', uri);
-  } else if (artifactId) {
-    query = query.eq('id', artifactId);
-  }
+  const query = resolveArtifactForUser(supabase, resolved.user.id, { uri, artifactId });
 
   const { data: current, error: fetchError } = await query.single();
 
@@ -423,6 +473,7 @@ export async function handleUpdateArtifact(
     title: updated.title,
     content: updated.content,
     changed_by_agent_id: agentId || null,
+    changed_by_identity_id: editorIdentity?.id || null,
     changed_by_user_id: agentId ? null : resolved.user.id,
     change_type: changeType,
     change_summary: mergeSummary,
@@ -523,18 +574,13 @@ export async function handleGetArtifactHistory(
 
   const { uri, artifactId, limit = 10 } = parsed;
 
-  if (!uri && !artifactId) {
-    throw new Error('Must provide either uri or artifactId');
-  }
-
   // First get the artifact to verify ownership
-  let artifactQuery = supabase.from('artifacts').select('id').eq('user_id', resolved.user.id);
-
-  if (uri) {
-    artifactQuery = artifactQuery.eq('uri', uri);
-  } else if (artifactId) {
-    artifactQuery = artifactQuery.eq('id', artifactId);
-  }
+  const artifactQuery = resolveArtifactForUser(
+    supabase,
+    resolved.user.id,
+    { uri, artifactId },
+    'id'
+  );
 
   const { data: artifact, error: artifactError } = await artifactQuery.single();
 
@@ -566,11 +612,201 @@ export async function handleGetArtifactHistory(
             version: h.version,
             title: h.title,
             changedByAgentId: h.changed_by_agent_id,
+            changedByIdentityId: h.changed_by_identity_id,
             changedByUserId: h.changed_by_user_id,
             changeType: h.change_type,
             changeSummary: h.change_summary,
             createdAt: h.created_at,
           })),
+        }),
+      },
+    ],
+  };
+}
+
+export async function handleAddArtifactComment(
+  args: unknown,
+  dataComposer: DataComposer
+) {
+  const supabase = dataComposer.getClient();
+  const parsed = addArtifactCommentSchema.parse(args);
+  const resolved = await resolveUserOrThrow(parsed, dataComposer);
+
+  const { uri, artifactId, content, agentId, parentCommentId, metadata = {} } = parsed;
+  const trimmed = content.trim();
+  if (!trimmed) {
+    throw new Error('Comment content cannot be empty');
+  }
+
+  const { data: artifact, error: artifactError } = await resolveArtifactForUser(
+    supabase,
+    resolved.user.id,
+    { uri, artifactId }
+  ).single();
+
+  if (artifactError) {
+    throw new Error(`Artifact not found: ${uri || artifactId}`);
+  }
+
+  if (parentCommentId) {
+    const { data: parent, error: parentError } = await supabase
+      .from('artifact_comments')
+      .select('id')
+      .eq('id', parentCommentId)
+      .eq('artifact_id', artifact.id)
+      .eq('user_id', resolved.user.id)
+      .maybeSingle();
+
+    if (parentError || !parent) {
+      throw new Error(`Parent comment not found: ${parentCommentId}`);
+    }
+  }
+
+  const authorIdentity = await resolveIdentityForAgent(supabase, resolved.user.id, agentId);
+
+  const { data: created, error: createError } = await supabase
+    .from('artifact_comments')
+    .insert({
+      artifact_id: artifact.id,
+      user_id: resolved.user.id,
+      created_by_agent_id: agentId || null,
+      created_by_identity_id: authorIdentity?.id || null,
+      parent_comment_id: parentCommentId || null,
+      content: trimmed,
+      metadata: metadata as Json,
+    })
+    .select('*')
+    .single();
+
+  if (createError) {
+    throw new Error(`Failed to add artifact comment: ${createError.message}`);
+  }
+
+  logger.info('Artifact comment added', {
+    artifactId: artifact.id,
+    commentId: created.id,
+    agentId: agentId || null,
+    identityId: authorIdentity?.id || null,
+  });
+
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: JSON.stringify({
+          success: true,
+          message: 'Artifact comment added',
+          comment: {
+            id: created.id,
+            artifactId: created.artifact_id,
+            parentCommentId: created.parent_comment_id,
+            content: created.content,
+            metadata: created.metadata,
+            createdByAgentId: created.created_by_agent_id,
+            createdByIdentityId: created.created_by_identity_id,
+            createdByIdentity: authorIdentity
+              ? {
+                  id: authorIdentity.id,
+                  agentId: authorIdentity.agent_id,
+                  name: authorIdentity.name,
+                  backend: authorIdentity.backend,
+                }
+              : null,
+            createdAt: created.created_at,
+            updatedAt: created.updated_at,
+          },
+        }),
+      },
+    ],
+  };
+}
+
+export async function handleListArtifactComments(
+  args: unknown,
+  dataComposer: DataComposer
+) {
+  const supabase = dataComposer.getClient();
+  const parsed = listArtifactCommentsSchema.parse(args);
+  const resolved = await resolveUserOrThrow(parsed, dataComposer);
+
+  const { uri, artifactId, limit = 100 } = parsed;
+
+  const { data: artifact, error: artifactError } = await resolveArtifactForUser(
+    supabase,
+    resolved.user.id,
+    { uri, artifactId }
+  ).single();
+
+  if (artifactError) {
+    throw new Error(`Artifact not found: ${uri || artifactId}`);
+  }
+
+  const { data: comments, error } = await supabase
+    .from('artifact_comments')
+    .select('*')
+    .eq('artifact_id', artifact.id)
+    .eq('user_id', resolved.user.id)
+    .is('deleted_at', null)
+    .order('created_at', { ascending: true })
+    .limit(limit);
+
+  if (error) {
+    throw new Error(`Failed to list artifact comments: ${error.message}`);
+  }
+
+  const identityIds = Array.from(
+    new Set((comments || []).map((c) => c.created_by_identity_id).filter(Boolean) as string[])
+  );
+
+  let identitiesById = new Map<string, { id: string; agent_id: string; name: string; backend: string | null }>();
+  if (identityIds.length > 0) {
+    const { data: identities, error: identitiesError } = await supabase
+      .from('agent_identities')
+      .select('id, agent_id, name, backend')
+      .in('id', identityIds);
+
+    if (identitiesError) {
+      throw new Error(`Failed to resolve comment identities: ${identitiesError.message}`);
+    }
+
+    identitiesById = new Map(
+      (identities || []).map((identity) => [identity.id, identity])
+    );
+  }
+
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: JSON.stringify({
+          success: true,
+          artifactId: artifact.id,
+          artifactUri: artifact.uri,
+          count: comments?.length || 0,
+          comments: (comments || []).map((comment) => {
+            const identity = comment.created_by_identity_id
+              ? identitiesById.get(comment.created_by_identity_id) ?? null
+              : null;
+            return {
+              id: comment.id,
+              artifactId: comment.artifact_id,
+              parentCommentId: comment.parent_comment_id,
+              content: comment.content,
+              metadata: comment.metadata,
+              createdByAgentId: comment.created_by_agent_id,
+              createdByIdentityId: comment.created_by_identity_id,
+              createdByIdentity: identity
+                ? {
+                    id: identity.id,
+                    agentId: identity.agent_id,
+                    name: identity.name,
+                    backend: identity.backend,
+                  }
+                : null,
+              createdAt: comment.created_at,
+              updatedAt: comment.updated_at,
+            };
+          }),
         }),
       },
     ],
@@ -611,5 +847,18 @@ export const artifactToolDefinitions = [
     description: 'Get version history for an artifact.',
     schema: getArtifactHistorySchema,
     handler: handleGetArtifactHistory,
+  },
+  {
+    name: 'add_artifact_comment',
+    description:
+      'Add a comment to an artifact without modifying artifact content. Uses identity_id UUID as canonical author reference.',
+    schema: addArtifactCommentSchema,
+    handler: handleAddArtifactComment,
+  },
+  {
+    name: 'list_artifact_comments',
+    description: 'List comments for an artifact, including canonical identity UUID author metadata.',
+    schema: listArtifactCommentsSchema,
+    handler: handleListArtifactComments,
   },
 ];

--- a/packages/api/src/mcp/tools/artifact-handlers.ts
+++ b/packages/api/src/mcp/tools/artifact-handlers.ts
@@ -97,11 +97,19 @@ async function resolveIdentityForAgent(
     .eq('agent_id', agentId)
     .maybeSingle();
 
-  if (error || !data) {
-    logger.warn(`No agent identity record found for agentId "${agentId}", continuing without UUID reference`, {
+  if (error) {
+    logger.warn('Failed to resolve identity UUID for agent slug; continuing with slug-only reference', {
       userId,
       agentId,
-      error: error?.message,
+      error: error.message,
+    });
+    return null;
+  }
+
+  if (!data) {
+    logger.warn('No identity row found for agent slug; continuing with slug-only reference', {
+      userId,
+      agentId,
     });
     return null;
   }

--- a/packages/api/src/mcp/tools/index.ts
+++ b/packages/api/src/mcp/tools/index.ts
@@ -152,6 +152,8 @@ import {
   handleUpdateArtifact,
   handleListArtifacts,
   handleGetArtifactHistory,
+  handleAddArtifactComment,
+  handleListArtifactComments,
   artifactToolDefinitions,
 } from './artifact-handlers';
 
@@ -251,7 +253,7 @@ export function registerAllTools(server: McpServer, dataComposer: DataComposer):
   // Calls exceeding SLOW_TOOL_THRESHOLD_MS are logged at warn level.
   // ---------------------------------------------------------------------------
   const SLOW_TOOL_THRESHOLD_MS = 500;
-  const _originalRegisterTool = server.registerTool.bind(server);
+  const originalRegisterTool = server.registerTool.bind(server);
   (server as any).registerTool = (name: string, ...rest: any[]) => {
     const handler = rest[rest.length - 1];
     if (typeof handler === 'function') {
@@ -273,7 +275,15 @@ export function registerAllTools(server: McpServer, dataComposer: DataComposer):
         }
       };
     }
-    return (_originalRegisterTool as any)(name, ...rest);
+    return (originalRegisterTool as any)(name, ...rest);
+  };
+
+  const getArtifactToolSchema = (toolName: string) => {
+    const tool = artifactToolDefinitions.find((definition) => definition.name === toolName);
+    if (!tool) {
+      throw new Error(`Artifact tool schema not found: ${toolName}`);
+    }
+    return tool.schema;
   };
 
   // Register save_link tool
@@ -2182,7 +2192,7 @@ Update a PCP session's status and Claude session ID. Use this to mark your sessi
 Use for specs, designs, decisions, and shared documents that multiple beings may work on.
 
 User can be identified by ONE of: userId, email, phone, or platform + platformId`,
-      inputSchema: artifactToolDefinitions[0].schema,
+      inputSchema: getArtifactToolSchema('create_artifact'),
     },
     async (args: Record<string, unknown>) => {
       try {
@@ -2203,7 +2213,7 @@ User can be identified by ONE of: userId, email, phone, or platform + platformId
       description: `Get an artifact by URI or ID. Returns the full content and metadata.
 
 User can be identified by ONE of: userId, email, phone, or platform + platformId`,
-      inputSchema: artifactToolDefinitions[1].schema,
+      inputSchema: getArtifactToolSchema('get_artifact'),
     },
     async (args: Record<string, unknown>) => {
       try {
@@ -2228,7 +2238,7 @@ Supports three-way merge: pass baseVersion (the version you read before editing)
 Omit baseVersion for legacy last-write-wins behavior (not recommended for collaborative editing).
 
 User can be identified by ONE of: userId, email, phone, or platform + platformId`,
-      inputSchema: artifactToolDefinitions[2].schema,
+      inputSchema: getArtifactToolSchema('update_artifact'),
     },
     async (args: Record<string, unknown>) => {
       try {
@@ -2249,7 +2259,7 @@ User can be identified by ONE of: userId, email, phone, or platform + platformId
       description: `List artifacts with optional filters for type, tags, visibility, and search.
 
 User can be identified by ONE of: userId, email, phone, or platform + platformId`,
-      inputSchema: artifactToolDefinitions[3].schema,
+      inputSchema: getArtifactToolSchema('list_artifacts'),
     },
     async (args: Record<string, unknown>) => {
       try {
@@ -2270,13 +2280,58 @@ User can be identified by ONE of: userId, email, phone, or platform + platformId
       description: `Get version history for an artifact. Shows all previous versions and who made changes.
 
 User can be identified by ONE of: userId, email, phone, or platform + platformId`,
-      inputSchema: artifactToolDefinitions[4].schema,
+      inputSchema: getArtifactToolSchema('get_artifact_history'),
     },
     async (args: Record<string, unknown>) => {
       try {
         return await handleGetArtifactHistory(args, dataComposer);
       } catch (error) {
         logger.error('Error in get_artifact_history:', error);
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ success: false, error: error instanceof Error ? error.message : 'Unknown error' }) }],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  server.registerTool(
+    'add_artifact_comment',
+    {
+      description: `Add a comment to an artifact without modifying the artifact body.
+
+Use this for collaborative review/discussion to avoid overwrite conflicts.
+Stores canonical author identity via agent_identities.id while preserving agentId slug for display.
+
+User can be identified by ONE of: userId, email, phone, or platform + platformId`,
+      inputSchema: getArtifactToolSchema('add_artifact_comment'),
+    },
+    async (args: Record<string, unknown>) => {
+      try {
+        return await handleAddArtifactComment(args, dataComposer);
+      } catch (error) {
+        logger.error('Error in add_artifact_comment:', error);
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ success: false, error: error instanceof Error ? error.message : 'Unknown error' }) }],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  server.registerTool(
+    'list_artifact_comments',
+    {
+      description: `List comments for an artifact, including canonical identity UUID author metadata.
+
+User can be identified by ONE of: userId, email, phone, or platform + platformId`,
+      inputSchema: getArtifactToolSchema('list_artifact_comments'),
+    },
+    async (args: Record<string, unknown>) => {
+      try {
+        return await handleListArtifactComments(args, dataComposer);
+      } catch (error) {
+        logger.error('Error in list_artifact_comments:', error);
         return {
           content: [{ type: 'text' as const, text: JSON.stringify({ success: false, error: error instanceof Error ? error.message : 'Unknown error' }) }],
           isError: true,

--- a/packages/api/src/mcp/tools/index.ts
+++ b/packages/api/src/mcp/tools/index.ts
@@ -247,6 +247,18 @@ const userIdentifierFields = {
   platformId: z.string().optional().describe('Platform-specific user ID or username'),
 };
 
+const artifactToolsByName = new Map(
+  artifactToolDefinitions.map((definition) => [definition.name, definition])
+);
+
+function getArtifactToolSchema(name: string) {
+  const definition = artifactToolsByName.get(name);
+  if (!definition) {
+    throw new Error(`Artifact tool definition not found: ${name}`);
+  }
+  return definition.schema;
+}
+
 export function registerAllTools(server: McpServer, dataComposer: DataComposer): void {
   // ---------------------------------------------------------------------------
   // Timing diagnostics — wraps every tool handler to log execution time.

--- a/packages/api/src/routes/admin.artifact-comments.test.ts
+++ b/packages/api/src/routes/admin.artifact-comments.test.ts
@@ -1,0 +1,189 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Request, Response } from 'express';
+import { createTableAwareSupabaseMock } from '../test/table-aware-supabase-mock';
+
+let currentSupabaseMock: ReturnType<typeof createTableAwareSupabaseMock>;
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(() => currentSupabaseMock),
+}));
+
+vi.mock('../services/authorization', () => ({
+  getAuthorizationService: vi.fn(() => ({
+    listTrustedUsers: vi.fn().mockResolvedValue([]),
+  })),
+}));
+
+vi.mock('../services/oauth', () => ({
+  getOAuthService: vi.fn(() => ({})),
+}));
+
+vi.mock('../config/env', () => ({
+  env: {
+    SUPABASE_URL: 'http://localhost:54321',
+    SUPABASE_SECRET_KEY: 'test-secret',
+    MCP_HTTP_PORT: 3001,
+  },
+}));
+
+vi.mock('../utils/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock('../utils/request-context', () => ({
+  runWithRequestContext: (_context: unknown, fn: () => void) => fn(),
+}));
+
+import router from './admin';
+
+function createMockReq(overrides: Partial<Request> = {}): Request {
+  return {
+    headers: {},
+    params: {},
+    body: {},
+    ...overrides,
+  } as unknown as Request;
+}
+
+function createMockRes(): Response & { _status: number; _json: unknown } {
+  const res = {
+    _status: 200,
+    _json: null,
+    status(code: number) {
+      res._status = code;
+      return res;
+    },
+    json(payload: unknown) {
+      res._json = payload;
+      return res;
+    },
+  };
+  return res as unknown as Response & { _status: number; _json: unknown };
+}
+
+function getRouteHandler(path: string, method: 'get' | 'post') {
+  const layer = (router as any).stack.find(
+    (entry: any) => entry.route?.path === path && entry.route?.methods?.[method]
+  );
+  if (!layer) {
+    throw new Error(`Route not found: ${method.toUpperCase()} ${path}`);
+  }
+  return layer.route.stack[0].handle as (req: Request, res: Response) => Promise<void>;
+}
+
+describe('admin artifact comments routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('GET /artifacts/:id/comments returns comments enriched with identity metadata', async () => {
+    currentSupabaseMock = createTableAwareSupabaseMock({
+      artifacts: [
+        { single: [{ data: { id: 'artifact-1' }, error: null }] },
+      ],
+      artifact_comments: [
+        {
+          then: {
+            data: [
+              {
+                id: 'comment-1',
+                artifact_id: 'artifact-1',
+                parent_comment_id: null,
+                content: 'Looks good',
+                metadata: {},
+                created_by_agent_id: 'lumen',
+                created_by_identity_id: 'identity-1',
+                created_at: '2026-02-11T00:00:00Z',
+                updated_at: '2026-02-11T00:00:00Z',
+                user_id: '550e8400-e29b-41d4-a716-446655440000',
+                deleted_at: null,
+              },
+            ],
+            error: null,
+          },
+        },
+      ],
+      agent_identities: [
+        {
+          then: {
+            data: [{ id: 'identity-1', agent_id: 'lumen', name: 'Lumen', backend: 'codex' }],
+            error: null,
+          },
+        },
+      ],
+    });
+
+    const handler = getRouteHandler('/artifacts/:id/comments', 'get');
+    const req = createMockReq({
+      params: { id: 'artifact-1' } as Record<string, string>,
+      pcpUserId: '550e8400-e29b-41d4-a716-446655440000',
+    } as unknown as Partial<Request>);
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    expect(res._status).toBe(200);
+    const payload = res._json as { comments: Array<{ createdByIdentity: { agentId: string } }> };
+    expect(payload.comments).toHaveLength(1);
+    expect(payload.comments[0].createdByIdentity.agentId).toBe('lumen');
+  });
+
+  it('POST /artifacts/:id/comments creates comment with canonical identity UUID', async () => {
+    currentSupabaseMock = createTableAwareSupabaseMock({
+      artifacts: [
+        { single: [{ data: { id: 'artifact-1' }, error: null }] },
+      ],
+      agent_identities: [
+        { single: [{ data: { id: 'identity-1', agent_id: 'lumen', name: 'Lumen', backend: 'codex' }, error: null }] },
+      ],
+      artifact_comments: [
+        {
+          single: [{
+            data: {
+              id: 'comment-1',
+              artifact_id: 'artifact-1',
+              parent_comment_id: null,
+              content: 'Adding a review comment',
+              metadata: {},
+              created_by_agent_id: 'lumen',
+              created_by_identity_id: 'identity-1',
+              created_at: '2026-02-11T00:00:00Z',
+              updated_at: '2026-02-11T00:00:00Z',
+            },
+            error: null,
+          }],
+        },
+      ],
+    });
+
+    const handler = getRouteHandler('/artifacts/:id/comments', 'post');
+    const req = createMockReq({
+      params: { id: 'artifact-1' } as Record<string, string>,
+      body: { content: 'Adding a review comment', agentId: 'lumen' },
+      pcpUserId: '550e8400-e29b-41d4-a716-446655440000',
+    } as unknown as Partial<Request>);
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    expect(res._status).toBe(200);
+    const payload = res._json as {
+      comment: { createdByIdentityId: string; createdByIdentity: { agentId: string } };
+    };
+    expect(payload.comment.createdByIdentityId).toBe('identity-1');
+    expect(payload.comment.createdByIdentity.agentId).toBe('lumen');
+
+    const commentsBuilder = currentSupabaseMock.calls.find((c) => c.table === 'artifact_comments')?.builder;
+    expect(commentsBuilder).toBeDefined();
+    expect((commentsBuilder?.insert as ReturnType<typeof vi.fn>).mock.calls[0][0]).toMatchObject({
+      created_by_agent_id: 'lumen',
+      created_by_identity_id: 'identity-1',
+      content: 'Adding a review comment',
+    });
+  });
+});

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -1373,6 +1373,7 @@ router.get('/artifacts/:id', async (req: Request, res: Response) => {
         contentType: artifact.content_type,
         artifactType: artifact.artifact_type,
         createdByAgentId: artifact.created_by_agent_id,
+        createdByIdentityId: artifact.created_by_identity_id,
         collaborators: artifact.collaborators,
         visibility: artifact.visibility,
         version: artifact.version,
@@ -1385,6 +1386,216 @@ router.get('/artifacts/:id', async (req: Request, res: Response) => {
   } catch (error) {
     logger.error('Failed to get artifact:', error);
     res.status(500).json({ error: 'Failed to get artifact' });
+  }
+});
+
+/**
+ * GET /api/admin/artifacts/:id/comments
+ * List comments for a specific artifact
+ */
+router.get('/artifacts/:id/comments', async (req: Request, res: Response) => {
+  try {
+    const { id } = req.params;
+    const supabase = createClient(env.SUPABASE_URL, env.SUPABASE_SECRET_KEY);
+    const authReq = req as Request & { pcpUserId: string };
+    const pcpUserId = authReq.pcpUserId;
+
+    const { data: artifact } = await supabase
+      .from('artifacts')
+      .select('id')
+      .eq('id', id)
+      .eq('user_id', pcpUserId)
+      .single();
+
+    if (!artifact) {
+      res.status(404).json({ error: 'Artifact not found' });
+      return;
+    }
+
+    const { data: comments, error } = await supabase
+      .from('artifact_comments')
+      .select('*')
+      .eq('artifact_id', id)
+      .eq('user_id', pcpUserId)
+      .is('deleted_at', null)
+      .order('created_at', { ascending: true });
+
+    if (error) {
+      logger.error('Failed to list artifact comments:', error);
+      res.status(500).json({ error: 'Failed to list comments' });
+      return;
+    }
+
+    const identityIds = Array.from(
+      new Set((comments || []).map((c) => c.created_by_identity_id).filter(Boolean) as string[])
+    );
+
+    const identitiesById = new Map<string, { id: string; agent_id: string; name: string; backend: string | null }>();
+
+    if (identityIds.length > 0) {
+      const { data: identities, error: identitiesError } = await supabase
+        .from('agent_identities')
+        .select('id, agent_id, name, backend')
+        .in('id', identityIds);
+
+      if (identitiesError) {
+        logger.error('Failed to resolve artifact comment identities:', identitiesError);
+        res.status(500).json({ error: 'Failed to resolve comment identities' });
+        return;
+      }
+
+      for (const identity of identities || []) {
+        identitiesById.set(identity.id, identity);
+      }
+    }
+
+    res.json({
+      artifactId: id,
+      comments: (comments || []).map((comment) => {
+        const identity = comment.created_by_identity_id
+          ? identitiesById.get(comment.created_by_identity_id) ?? null
+          : null;
+        return {
+          id: comment.id,
+          artifactId: comment.artifact_id,
+          parentCommentId: comment.parent_comment_id,
+          content: comment.content,
+          metadata: comment.metadata,
+          createdByAgentId: comment.created_by_agent_id,
+          createdByIdentityId: comment.created_by_identity_id,
+          createdByIdentity: identity
+            ? {
+                id: identity.id,
+                agentId: identity.agent_id,
+                name: identity.name,
+                backend: identity.backend,
+              }
+            : null,
+          createdAt: comment.created_at,
+          updatedAt: comment.updated_at,
+        };
+      }),
+    });
+  } catch (error) {
+    logger.error('Failed to list artifact comments:', error);
+    res.status(500).json({ error: 'Failed to list comments' });
+  }
+});
+
+/**
+ * POST /api/admin/artifacts/:id/comments
+ * Add a comment to a specific artifact
+ */
+router.post('/artifacts/:id/comments', async (req: Request, res: Response) => {
+  try {
+    const { id } = req.params;
+    const { content, agentId, parentCommentId, metadata } = req.body as {
+      content?: string;
+      agentId?: string;
+      parentCommentId?: string;
+      metadata?: Record<string, unknown>;
+    };
+    const trimmed = content?.trim() || '';
+
+    if (!trimmed) {
+      res.status(400).json({ error: 'content is required' });
+      return;
+    }
+
+    const supabase = createClient(env.SUPABASE_URL, env.SUPABASE_SECRET_KEY);
+    const authReq = req as Request & { pcpUserId: string };
+    const pcpUserId = authReq.pcpUserId;
+
+    const { data: artifact } = await supabase
+      .from('artifacts')
+      .select('id')
+      .eq('id', id)
+      .eq('user_id', pcpUserId)
+      .single();
+
+    if (!artifact) {
+      res.status(404).json({ error: 'Artifact not found' });
+      return;
+    }
+
+    if (parentCommentId) {
+      const { data: parent } = await supabase
+        .from('artifact_comments')
+        .select('id')
+        .eq('id', parentCommentId)
+        .eq('artifact_id', id)
+        .eq('user_id', pcpUserId)
+        .single();
+
+      if (!parent) {
+        res.status(400).json({ error: 'Invalid parentCommentId' });
+        return;
+      }
+    }
+
+    let identity: { id: string; agent_id: string; name: string; backend: string | null } | null = null;
+    if (agentId) {
+      const { data: identityRow, error: identityError } = await supabase
+        .from('agent_identities')
+        .select('id, agent_id, name, backend')
+        .eq('user_id', pcpUserId)
+        .eq('agent_id', agentId)
+        .single();
+
+      if (identityError || !identityRow) {
+        // Deliberately stricter than MCP tool behavior:
+        // dashboard/admin writes should reference a known identity explicitly,
+        // while MCP handlers allow slug-only fallback for backward compatibility.
+        res.status(400).json({ error: `Unknown agent identity: ${agentId}` });
+        return;
+      }
+      identity = identityRow;
+    }
+
+    const { data: comment, error } = await supabase
+      .from('artifact_comments')
+      .insert({
+        artifact_id: id,
+        user_id: pcpUserId,
+        created_by_agent_id: agentId || null,
+        created_by_identity_id: identity?.id || null,
+        parent_comment_id: parentCommentId || null,
+        content: trimmed,
+        metadata: metadata || {},
+      })
+      .select('*')
+      .single();
+
+    if (error || !comment) {
+      logger.error('Failed to create artifact comment:', error);
+      res.status(500).json({ error: 'Failed to create comment' });
+      return;
+    }
+
+    res.json({
+      comment: {
+        id: comment.id,
+        artifactId: comment.artifact_id,
+        parentCommentId: comment.parent_comment_id,
+        content: comment.content,
+        metadata: comment.metadata,
+        createdByAgentId: comment.created_by_agent_id,
+        createdByIdentityId: comment.created_by_identity_id,
+        createdByIdentity: identity
+          ? {
+              id: identity.id,
+              agentId: identity.agent_id,
+              name: identity.name,
+              backend: identity.backend,
+            }
+          : null,
+        createdAt: comment.created_at,
+        updatedAt: comment.updated_at,
+      },
+    });
+  } catch (error) {
+    logger.error('Failed to create artifact comment:', error);
+    res.status(500).json({ error: 'Failed to create comment' });
   }
 });
 
@@ -1444,6 +1655,7 @@ router.get('/artifacts/:id/history', async (req: Request, res: Response) => {
         title: h.title,
         content: h.content,
         changedByAgentId: h.changed_by_agent_id,
+        changedByIdentityId: h.changed_by_identity_id,
         changedByUserId: h.changed_by_user_id,
         changeType: h.change_type,
         changeSummary: h.change_summary,

--- a/packages/api/src/test/table-aware-supabase-mock.ts
+++ b/packages/api/src/test/table-aware-supabase-mock.ts
@@ -1,0 +1,56 @@
+import { vi } from 'vitest';
+
+export type QueryResult = { data: unknown; error: unknown };
+
+export interface BuilderSpec {
+  single?: QueryResult[];
+  maybeSingle?: QueryResult[];
+  then?: QueryResult;
+}
+
+export function createTableAwareSupabaseMock(specs: Record<string, BuilderSpec[]>) {
+  const calls: Array<{ table: string; builder: Record<string, unknown> }> = [];
+
+  const from = vi.fn((table: string) => {
+    const queue = specs[table];
+    if (!queue || queue.length === 0) {
+      throw new Error(`No query builder configured for table "${table}"`);
+    }
+
+    const spec = queue.shift() as BuilderSpec;
+    const singleQueue = [...(spec.single || [])];
+    const maybeSingleQueue = [...(spec.maybeSingle || [])];
+
+    const builder: Record<string, unknown> = {};
+    const methods = [
+      'select', 'insert', 'update', 'delete', 'upsert',
+      'eq', 'neq', 'in', 'is', 'or', 'and',
+      'gt', 'gte', 'lt', 'lte',
+      'ilike', 'like', 'overlaps', 'contains',
+      'order', 'limit', 'range',
+    ];
+
+    for (const method of methods) {
+      builder[method] = vi.fn().mockReturnValue(builder);
+    }
+
+    builder.single = vi.fn().mockImplementation(() =>
+      Promise.resolve(singleQueue.shift() || { data: null, error: null })
+    );
+
+    builder.maybeSingle = vi.fn().mockImplementation(() =>
+      Promise.resolve(maybeSingleQueue.shift() || { data: null, error: null })
+    );
+
+    builder.then = (resolve: (value: QueryResult) => void) => {
+      const result = spec.then || { data: null, error: null };
+      resolve(result);
+      return Promise.resolve(result);
+    };
+
+    calls.push({ table, builder });
+    return builder;
+  });
+
+  return { from, calls };
+}

--- a/packages/web/src/app/(dashboard)/artifacts/[artifactId]/page.tsx
+++ b/packages/web/src/app/(dashboard)/artifacts/[artifactId]/page.tsx
@@ -1,13 +1,13 @@
 'use client';
 
-import React from 'react';
+import React, { useState } from 'react';
 import { useParams } from 'next/navigation';
 import Link from 'next/link';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { ArrowLeft, BookOpen, Lightbulb, FileCheck, FileText, StickyNote, Eye, Users, Lock, History, Loader2 } from 'lucide-react';
-import { useApiQuery } from '@/lib/api';
+import { useApiPost, useApiQuery, useQueryClient } from '@/lib/api';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import clsx from 'clsx';
@@ -31,6 +31,31 @@ interface Artifact {
 
 interface ArtifactResponse {
   artifact: Artifact;
+}
+
+interface ArtifactCommentIdentity {
+  id: string;
+  agentId: string;
+  name: string;
+  backend: string | null;
+}
+
+interface ArtifactComment {
+  id: string;
+  artifactId: string;
+  parentCommentId: string | null;
+  content: string;
+  metadata?: Record<string, unknown>;
+  createdByAgentId: string | null;
+  createdByIdentityId: string | null;
+  createdByIdentity: ArtifactCommentIdentity | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface ArtifactCommentsResponse {
+  artifactId: string;
+  comments: ArtifactComment[];
 }
 
 const typeConfig = {
@@ -84,6 +109,9 @@ const visibilityConfig = {
 export default function ArtifactDetailPage() {
   const params = useParams();
   const artifactId = params.artifactId as string;
+  const queryClient = useQueryClient();
+  const [commentDraft, setCommentDraft] = useState('');
+  const [commentAgentId, setCommentAgentId] = useState('');
 
   const {
     data: artifactData,
@@ -93,8 +121,30 @@ export default function ArtifactDetailPage() {
     ['artifacts', artifactId],
     `/api/admin/artifacts/${artifactId}`
   );
+  const {
+    data: commentsData,
+    isLoading: commentsLoading,
+    error: commentsError,
+  } = useApiQuery<ArtifactCommentsResponse>(
+    ['artifact-comments', artifactId],
+    `/api/admin/artifacts/${artifactId}/comments`
+  );
+
+  const addCommentMutation = useApiPost<{ comment: ArtifactComment }, {
+    content: string;
+    agentId?: string;
+  }>(
+    `/api/admin/artifacts/${artifactId}/comments`,
+    {
+      onSuccess: () => {
+        setCommentDraft('');
+        queryClient.invalidateQueries({ queryKey: ['artifact-comments', artifactId] });
+      },
+    }
+  );
 
   const artifact = artifactData?.artifact ?? null;
+  const comments = commentsData?.comments ?? [];
 
   if (isLoading) {
     return (
@@ -131,6 +181,17 @@ export default function ArtifactDetailPage() {
   const visConfig = visibilityConfig[artifact.visibility] || visibilityConfig.private;
   const TypeIcon = config.icon;
   const VisIcon = visConfig.icon;
+  const commentsErrorMessage = commentsError?.message || addCommentMutation.error?.message;
+
+  const handleAddComment = (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!commentDraft.trim()) return;
+
+    addCommentMutation.mutate({
+      content: commentDraft.trim(),
+      ...(commentAgentId.trim() ? { agentId: commentAgentId.trim() } : {}),
+    });
+  };
 
   return (
     <div>
@@ -184,6 +245,79 @@ export default function ArtifactDetailPage() {
           <div className="prose prose-sm max-w-none prose-headings:font-semibold prose-headings:mt-4 prose-headings:mb-2 prose-p:my-2 prose-ul:my-2 prose-ol:my-2 prose-li:my-0">
             <ReactMarkdown remarkPlugins={[remarkGfm]}>{artifact.content}</ReactMarkdown>
           </div>
+        </CardContent>
+      </Card>
+
+      {/* Comments */}
+      <Card className="mt-6">
+        <CardContent className="p-6">
+          <div className="mb-4 flex items-center justify-between">
+            <h2 className="text-lg font-semibold text-gray-900">Comments</h2>
+            <span className="text-sm text-gray-500">{comments.length}</span>
+          </div>
+
+          <form onSubmit={handleAddComment} className="mb-6 space-y-3">
+            <textarea
+              value={commentDraft}
+              onChange={(event) => setCommentDraft(event.target.value)}
+              placeholder="Add a comment about this artifact…"
+              rows={3}
+              className="w-full rounded-md border border-gray-300 p-3 text-sm focus:border-gray-400 focus:outline-none"
+            />
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+              <input
+                value={commentAgentId}
+                onChange={(event) => setCommentAgentId(event.target.value)}
+                placeholder="Agent ID (optional, e.g. lumen)"
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm sm:max-w-xs focus:border-gray-400 focus:outline-none"
+              />
+              <Button
+                type="submit"
+                size="sm"
+                disabled={addCommentMutation.isPending || !commentDraft.trim()}
+              >
+                {addCommentMutation.isPending ? 'Posting…' : 'Post Comment'}
+              </Button>
+            </div>
+          </form>
+
+          {commentsErrorMessage && (
+            <div className="mb-4 rounded-md bg-red-50 p-3 text-sm text-red-700">
+              {commentsErrorMessage}
+            </div>
+          )}
+
+          {commentsLoading ? (
+            <p className="text-sm text-gray-500">Loading comments…</p>
+          ) : comments.length === 0 ? (
+            <p className="text-sm text-gray-500">No comments yet.</p>
+          ) : (
+            <div className="space-y-4">
+              {comments.map((comment) => {
+                const identityName =
+                  comment.createdByIdentity?.name ||
+                  comment.createdByIdentity?.agentId ||
+                  comment.createdByAgentId ||
+                  'Unknown';
+                return (
+                  <div key={comment.id} className="rounded-md border border-gray-200 p-4">
+                    <div className="mb-2 flex items-center justify-between text-xs text-gray-500">
+                      <div className="flex items-center gap-2">
+                        <span className="font-medium text-gray-700">{identityName}</span>
+                        {comment.createdByIdentity?.backend && (
+                          <Badge variant="outline" className="text-[10px]">
+                            {comment.createdByIdentity.backend}
+                          </Badge>
+                        )}
+                      </div>
+                      <span>{new Date(comment.createdAt).toLocaleString()}</span>
+                    </div>
+                    <p className="whitespace-pre-wrap text-sm text-gray-800">{comment.content}</p>
+                  </div>
+                );
+              })}
+            </div>
+          )}
         </CardContent>
       </Card>
 

--- a/supabase/migrations/015_add_artifact_comments_and_identity_refs.sql
+++ b/supabase/migrations/015_add_artifact_comments_and_identity_refs.sql
@@ -1,0 +1,112 @@
+-- Add artifact comments and move artifact authorship toward canonical identity UUIDs.
+-- This is phase 1 of migrating from text agent_id to agent_identities.id references.
+
+-- ============================================================================
+-- 1) Add identity UUID references to existing artifact tables (backward compatible)
+-- ============================================================================
+
+ALTER TABLE artifacts
+  ADD COLUMN IF NOT EXISTS created_by_identity_id UUID REFERENCES agent_identities(id) ON DELETE SET NULL;
+
+ALTER TABLE artifact_history
+  ADD COLUMN IF NOT EXISTS changed_by_identity_id UUID REFERENCES agent_identities(id) ON DELETE SET NULL;
+
+-- Backfill artifacts.created_by_identity_id from existing text agent IDs.
+UPDATE artifacts a
+SET created_by_identity_id = ai.id
+FROM agent_identities ai
+WHERE a.created_by_identity_id IS NULL
+  AND a.created_by_agent_id IS NOT NULL
+  AND ai.user_id = a.user_id
+  AND ai.agent_id = a.created_by_agent_id;
+
+-- Backfill artifact_history.changed_by_identity_id from existing text agent IDs.
+-- Prefer changed_by_user_id when available; otherwise fall back to artifact owner.
+UPDATE artifact_history h
+SET changed_by_identity_id = ai.id
+FROM artifacts a
+JOIN agent_identities ai
+  ON ai.agent_id = h.changed_by_agent_id
+  AND ai.user_id = COALESCE(h.changed_by_user_id, a.user_id)
+WHERE h.changed_by_identity_id IS NULL
+  AND h.changed_by_agent_id IS NOT NULL
+  AND a.id = h.artifact_id;
+
+CREATE INDEX IF NOT EXISTS idx_artifacts_created_by_identity_id
+  ON artifacts(created_by_identity_id);
+
+CREATE INDEX IF NOT EXISTS idx_artifact_history_changed_by_identity_id
+  ON artifact_history(changed_by_identity_id);
+
+-- ============================================================================
+-- 2) Add artifact_comments table
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS artifact_comments (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  artifact_id UUID NOT NULL REFERENCES artifacts(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+
+  -- Backward-compatible display slug (human-readable)
+  created_by_agent_id TEXT,
+
+  -- Canonical author reference (new source of truth)
+  created_by_identity_id UUID REFERENCES agent_identities(id) ON DELETE SET NULL,
+
+  -- Optional thread support (future-proofing)
+  parent_comment_id UUID REFERENCES artifact_comments(id) ON DELETE CASCADE,
+
+  content TEXT NOT NULL CHECK (char_length(trim(content)) > 0),
+  metadata JSONB DEFAULT '{}'::jsonb,
+
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  deleted_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_artifact_comments_artifact_id_created_at
+  ON artifact_comments(artifact_id, created_at ASC);
+
+CREATE INDEX IF NOT EXISTS idx_artifact_comments_user_id
+  ON artifact_comments(user_id);
+
+CREATE INDEX IF NOT EXISTS idx_artifact_comments_created_by_identity_id
+  ON artifact_comments(created_by_identity_id);
+
+CREATE INDEX IF NOT EXISTS idx_artifact_comments_parent_comment_id
+  ON artifact_comments(parent_comment_id)
+  WHERE parent_comment_id IS NOT NULL;
+
+DROP TRIGGER IF EXISTS update_artifact_comments_updated_at ON artifact_comments;
+CREATE TRIGGER update_artifact_comments_updated_at
+  BEFORE UPDATE ON artifact_comments
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+ALTER TABLE artifact_comments ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view own artifact comments"
+  ON artifact_comments FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert own artifact comments"
+  ON artifact_comments FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can update own artifact comments"
+  ON artifact_comments FOR UPDATE
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can delete own artifact comments"
+  ON artifact_comments FOR DELETE
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Service role full access to artifact_comments"
+  ON artifact_comments FOR ALL
+  USING (auth.jwt() ->> 'role' = 'service_role');
+
+COMMENT ON TABLE artifact_comments IS 'Threaded comments attached to shared artifacts. Uses created_by_identity_id (UUID FK) as canonical author reference.';
+COMMENT ON COLUMN artifact_comments.created_by_agent_id IS 'Backward-compatible display slug (e.g., wren, lumen). Not canonical for referential integrity.';
+COMMENT ON COLUMN artifact_comments.created_by_identity_id IS 'Canonical FK to agent_identities.id for comment authorship.';
+COMMENT ON COLUMN artifacts.created_by_identity_id IS 'Canonical FK to agent_identities.id for artifact creator. created_by_agent_id remains display/backward-compat.';
+COMMENT ON COLUMN artifact_history.changed_by_identity_id IS 'Canonical FK to agent_identities.id for artifact history actor. changed_by_agent_id remains display/backward-compat.';


### PR DESCRIPTION
## Summary
- add `artifact_comments` table with RLS, indexes, threading support, and metadata
- add canonical UUID identity references for artifact authorship/history (`created_by_identity_id`, `changed_by_identity_id`) with migration backfills
- add MCP tools for comments: `add_artifact_comment` and `list_artifact_comments`
- add admin REST endpoints for artifact comments (`GET/POST /api/admin/artifacts/:id/comments`)
- add dashboard artifact comment display + comment compose UI
- add backend tests for MCP comment handlers and admin artifact comment routes

## Test plan
- [x] `yarn workspace @personal-context/api vitest run src/mcp/tools/artifact-handlers.test.ts src/routes/admin.artifact-comments.test.ts`
- [x] `yarn workspace @personal-context/api exec eslint src/mcp/tools/artifact-handlers.ts src/mcp/tools/index.ts`
- [x] `yarn workspace @personal-context/web type-check`

🤖 Generated with [Codex](https://openai.com/codex)