### PR TITLE
docs: extract conventions into CONTRIBUTING.md (by Wren)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -214,9 +214,9 @@ recall(userId: "...", query: "...", agentId: "wren", includeShared: true)
 
 Personal Context Protocol (PCP) is a system that captures and manages personal context (links, notes, tasks, reminders) across AI interfaces. It uses MCP (Model Context Protocol) to expose tools that AI agents can use to store and retrieve user context.
 
-## Coding Style
+## Coding Style & Conventions
 
-Use extreme camelCase for variable and function names. Use PascalCase for class names and types. Use SCREAMING_SNAKE_CASE for constants. For extreme camelCase and PascalCase, acronyms and initialisms should be treated as words (e.g., `userId`, `HttpClient`, `apiResponse`).
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for the full reference on coding style, naming, formatting (prettier/husky), git conventions, PR process, and coding conventions. **Read it** — it applies to all contributors (OBs and SBs).
 
 ## Project Structure
 
@@ -358,46 +358,11 @@ All tools support multiple identification methods:
 
 ## Coding Conventions
 
-### TypeScript
+Defined in [CONTRIBUTING.md](./CONTRIBUTING.md). Key points repeated here for agent context:
 
-- Strict typing, avoid `any`
-- Use Zod for runtime validation
-- Prefer `async/await` over callbacks
-
-### File Organization
-
-- One class/module per file
-- Co-locate tests (`*.test.ts`)
-- Export types from `types.ts` files
-
-### Naming
-
-- PascalCase for classes and types
-- camelCase for functions and variables
-- SCREAMING_SNAKE for constants
-
-### Error Handling
-
-- Use typed errors where possible
-- Log errors with context
-- Return structured error responses
-
-### Upsert / Partial Update Safety
-
-- When building upsert or update objects, **never set optional fields to `null` just because they weren't provided**. Omitted fields should preserve their existing database values.
-- Use `undefined` checks (`field !== undefined`) to distinguish "not provided" from "explicitly cleared":
-
-  ```typescript
-  // WRONG: wipes existing value when field is omitted
-  soul: soul || null,
-
-  // RIGHT: preserves existing value when field is omitted
-  soul: soul !== undefined ? (soul || null) : (existing?.soul ?? null),
-  ```
-
-- Only set a field to `null` when the caller explicitly passes `null` (or an empty string that should clear the field).
-- For handlers that accept partial updates, fetch the existing record first and merge provided fields over it.
-- When adding new columns to a table, also update: (1) archive/history triggers, (2) history response mappings, (3) restore handlers.
+- Strict TypeScript, avoid `any`. Use Zod for runtime validation.
+- One class/module per file. Co-locate tests (`*.test.ts`).
+- **Upsert safety**: never set optional fields to `null` just because they weren't provided. Use `undefined` checks to distinguish "not provided" from "explicitly cleared". When adding new columns, also update archive/history triggers, history response mappings, and restore handlers.
 
 ## Environment Variables
 
@@ -453,49 +418,13 @@ npx @modelcontextprotocol/inspector packages/api/dist/index.js
 
 When we refer to "specs" in this project, we mean **PCP artifacts** — versioned documents stored in Supabase and managed via the `create_artifact` / `update_artifact` / `get_artifact` MCP tools. They are NOT local markdown files. To view or update a spec, use the artifact tools with the artifact's UUID or URI (e.g., `pcp://specs/agent-orchestrator`).
 
-## Pull Request Convention
+## Pull Requests & Git
 
-When an SB creates or significantly contributes to a PR, attribute it in the title:
+Defined in [CONTRIBUTING.md](./CONTRIBUTING.md). Key SB-specific reminders:
 
-```
-feat: add web chat interface (by Wren)
-fix: resolve kindle token expiry (by Lumen)
-```
-
-The `(by <name>)` suffix goes at the end of the title, after the conventional commit description. This makes it easy to see at a glance who worked on what in the PR list.
-
-In the PR body, use the standard format:
-
-```markdown
-## Summary
-
-- <bullet points>
-
-## Test plan
-
-- [ ] <checklist>
-
-Generated with [Claude Code](https://claude.com/claude-code)
-```
-
-Replace "Claude Code" with the appropriate tool if the SB used a different interface (e.g., Gemini CLI, Codex).
-
-### PR Reviews
-
-When leaving comments or reviews on a pull request, sign off with your agent name so other contributors know who said what. This is especially important in a multi-agent codebase where several SBs may review the same PR.
-
-```
-— Wren
-— Lumen
-```
-
-### Branching
-
-**Never set your upstream to `origin/main` from a non-main branch.** When pushing a feature branch, use `git push -u origin <your-branch-name>`. Pushing directly to `origin/main` from a feature branch bypasses the PR review process and can overwrite others' work.
-
-### Merging
-
-**Do not squash commits.** SBs commit at logical points throughout a PR, and since PRs often span multiple features, preserving individual commits tells a clearer story than a single squashed blob. Use **merge commit** (not squash or rebase) when merging PRs.
+- **Title format**: `feat: description (by <SB name>)` — the `(by <name>)` suffix attributes work.
+- **Sign reviews**: end PR comments with `— Wren`, `— Lumen`, etc.
+- **Never push directly to main** from a feature branch. Always use PRs.
 
 ## Architecture Notes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,170 @@
+# Contributing to PCP
+
+This guide covers conventions for everyone working in this codebase — both organic beings (OBs) and synthetically-born beings (SBs).
+
+## Git Conventions
+
+### Commits
+
+We use the [Angular commit convention](https://github.com/angular/angular/blob/main/CONTRIBUTING.md):
+
+```
+<type>(<scope>): <short summary>
+  │       │             │
+  │       │             └─⫸ Imperative present tense. Not capitalized. No period.
+  │       │
+  │       └─⫸ Optional. Succinct, relevant to the initiative.
+  │
+  └─⫸ feat|fix|refactor|chore|docs|test|perf|build|ci|style
+```
+
+Examples:
+
+```
+feat(cli): add global install via symlink
+fix(sessions): preserve existing fields on upsert
+refactor(mcp): extract identity resolution into service
+chore: bump typescript to 5.4
+```
+
+### Branching
+
+We follow [GitHub flow](https://www.geeksforgeeks.org/git-flow-vs-github-flow/): feature branches off `main`, which must always be stable and deployable.
+
+```
+<initials or moniker>/<type>/<scope>
+  │                      │       │
+  │                      │       └─⫸ Kebab-case. Succinct description.
+  │                      │
+  │                      └─⫸ Same types as commits.
+  │
+  └─⫸ Your initials or unique moniker (e.g., cm, wren, myra)
+```
+
+Examples:
+
+```bash
+git checkout -b cm/feat/agent-orchestrator
+git checkout -b wren/fix/session-resume
+git checkout -b myra/chore/heartbeat-cleanup
+```
+
+When syncing with main: rebase first; if conflicts get messy, merge main in and move on.
+
+**Never set your upstream to `origin/main` from a non-main branch.** When pushing a feature branch, use `git push -u origin <your-branch-name>`. Pushing directly to `origin/main` from a feature branch bypasses the PR review process and can overwrite others' work.
+
+### Merging
+
+**Do not squash commits.** SBs commit at logical points throughout a PR, and since PRs often span multiple features, preserving individual commits tells a clearer story than a single squashed blob. Use **merge commit** (not squash or rebase) when merging PRs.
+
+### Code Comments
+
+```
+<author>(<scope>): <short summary>
+  │         │             │
+  │         │             └─⫸ Be succinct. Present tense.
+  │         │
+  │         └─⫸ Optional. todo|bug|???|<commit-style scope>
+  │
+  └─⫸ Optional. Your initials or common name.
+```
+
+A plain comment needs no prefix — any comment is implicitly a note. Only add structure when it conveys something the comment alone wouldn't.
+
+Examples:
+
+```typescript
+// cm(todo): extract this into a shared utility
+// wren(bug): race condition when two agents write simultaneously
+// ???: unclear why this timeout is needed — removing it breaks auth
+// Simple explanation needs no prefix
+```
+
+## Pull Requests
+
+When an SB creates or significantly contributes to a PR, attribute it in the title:
+
+```
+feat: add web chat interface (by Wren)
+fix: resolve kindle token expiry (by Lumen)
+```
+
+The `(by <name>)` suffix goes at the end of the title, after the conventional commit description.
+
+In the PR body, use the standard format:
+
+```markdown
+## Summary
+
+- <bullet points>
+
+## Test plan
+
+- [ ] <checklist>
+
+Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+Replace "Claude Code" with the appropriate tool if the SB used a different interface (e.g., Gemini CLI, Codex).
+
+### PR Reviews
+
+When leaving comments or reviews on a pull request, sign off with your agent name so other contributors know who said what. This is especially important in a multi-agent codebase where several SBs may review the same PR.
+
+```
+— Wren
+— Lumen
+```
+
+## Coding Style
+
+- **camelCase** for variables and functions (acronyms treated as words: `userId`, `apiResponse`)
+- **PascalCase** for classes and types (`HttpClient`, `UserIdentity`)
+- **SCREAMING_SNAKE_CASE** for constants
+
+### Formatting
+
+Prettier runs automatically on every commit via Husky + lint-staged. You do **not** need to run prettier manually — just commit and it handles formatting for `*.{ts,tsx,js,jsx,json,css,md}` files.
+
+To format without committing:
+
+```bash
+npx prettier --write "path/to/file"
+```
+
+## Coding Conventions
+
+### TypeScript
+
+- Strict typing, avoid `any`
+- Use Zod for runtime validation
+- Prefer `async/await` over callbacks
+
+### File Organization
+
+- One class/module per file
+- Co-locate tests (`*.test.ts`)
+- Export types from `types.ts` files
+
+### Error Handling
+
+- Use typed errors where possible
+- Log errors with context
+- Return structured error responses
+
+### Upsert / Partial Update Safety
+
+- When building upsert or update objects, **never set optional fields to `null` just because they weren't provided**. Omitted fields should preserve their existing database values.
+- Use `undefined` checks (`field !== undefined`) to distinguish "not provided" from "explicitly cleared":
+
+  ```typescript
+  // WRONG: wipes existing value when field is omitted
+  soul: soul || null,
+
+  // RIGHT: preserves existing value when field is omitted
+  soul: soul !== undefined ? (soul || null) : (existing?.soul ?? null),
+  ```
+
+- Only set a field to `null` when the caller explicitly passes `null` (or an empty string that should clear the field).
+- For handlers that accept partial updates, fetch the existing record first and merge provided fields over it.
+- When adding new columns to a table, also update: (1) archive/history triggers, (2) history response mappings, (3) restore handlers.

--- a/README.md
+++ b/README.md
@@ -94,9 +94,10 @@ personal-context-protocol/
 │   └── cli/              # CLI-related stories
 ├── supabase/
 │   └── migrations/       # Database migrations
-├── AGENTS.md             # Agent onboarding (points to CLAUDE.md)
+├── AGENTS.md             # Agent onboarding and guidelines
 ├── ARCHITECTURE.md       # System architecture
-├── CLAUDE.md             # Detailed agent guidelines
+├── CLAUDE.md             # Claude Code entrypoint (points to AGENTS.md)
+├── CONTRIBUTING.md       # Git, coding style, and PR conventions
 └── README.md             # This file
 ```
 
@@ -129,7 +130,7 @@ See [ARCHITECTURE.md](./ARCHITECTURE.md) for system diagrams, data flow, and des
 
 ## For AI Agents
 
-See [AGENTS.md](./AGENTS.md) for onboarding instructions. Detailed guidelines are in [CLAUDE.md](./CLAUDE.md).
+See [AGENTS.md](./AGENTS.md) for onboarding instructions.
 
 ## Development
 
@@ -142,84 +143,9 @@ yarn pm2 list              # List running processes
 yarn pm2 restart pcp       # Restart PCP server
 ```
 
-## Git Conventions
+## Contributing
 
-### Commits
-
-We use the [Angular commit convention](https://github.com/angular/angular/blob/main/CONTRIBUTING.md):
-
-```
-<type>(<scope>): <short summary>
-  │       │             │
-  │       │             └─⫸ Imperative present tense. Not capitalized. No period.
-  │       │
-  │       └─⫸ Optional. Succinct, relevant to the initiative.
-  │
-  └─⫸ feat|fix|refactor|chore|docs|test|perf|build|ci|style
-```
-
-Examples:
-
-```
-feat(cli): add global install via symlink
-fix(sessions): preserve existing fields on upsert
-refactor(mcp): extract identity resolution into service
-chore: bump typescript to 5.4
-```
-
-### Branching
-
-We follow [GitHub flow](https://www.geeksforgeeks.org/git-flow-vs-github-flow/): feature branches off `main`, which must always be stable and deployable.
-
-```
-<initials or moniker>/<type>/<scope>
-  │                      │       │
-  │                      │       └─⫸ Kebab-case. Succinct description.
-  │                      │
-  │                      └─⫸ Same types as commits.
-  │
-  └─⫸ Your initials or unique moniker (e.g., cm, wren, myra)
-```
-
-Examples:
-
-```bash
-git checkout -b cm/feat/agent-orchestrator
-git checkout -b wren/fix/session-resume
-git checkout -b myra/chore/heartbeat-cleanup
-```
-
-When syncing with main: rebase first; if conflicts get messy, merge main in and move on.
-
-### Code Comments
-
-```
-<author>(<scope>): <short summary>
-  │         │             │
-  │         │             └─⫸ Be succinct. Present tense.
-  │         │
-  │         └─⫸ Optional. todo|bug|???|<commit-style scope>
-  │
-  └─⫸ Optional. Your initials or common name.
-```
-
-A plain comment needs no prefix — any comment is implicitly a note. Only add structure when it conveys something the comment alone wouldn't.
-
-Examples:
-
-```typescript
-// cm(todo): extract this into a shared utility
-// wren(bug): race condition when two agents write simultaneously
-// ???: unclear why this timeout is needed — removing it breaks auth
-// Simple explanation needs no prefix
-```
-
-## Coding Conventions
-
-- **camelCase** for variables and functions (acronyms treated as words: `userId`, `apiResponse`)
-- **PascalCase** for classes and types (`HttpClient`, `UserIdentity`)
-- **SCREAMING_SNAKE** for constants
-- Strict TypeScript, Zod for runtime validation, `async/await` over callbacks
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for git conventions, coding style, PR process, and coding conventions. This applies to both human and AI contributors.
 
 ## License
 


### PR DESCRIPTION
## Summary

- Create `CONTRIBUTING.md` as the single source of truth for git conventions, coding style, formatting (prettier/husky), PR process, and coding conventions
- Replace duplicated sections in `README.md` (git conventions, coding conventions) and `AGENTS.md` (coding style, coding conventions, PR convention) with pointers to CONTRIBUTING.md
- AGENTS.md keeps short SB-specific reminders (title attribution, review sign-off) inline
- Subsumes PR #23 (prettier/husky note) — that PR can be closed

## Test plan

- [x] `yarn workspace @personal-context/api test` — 658 tests pass
- [x] All three files cross-reference correctly

-- Wren

🤖 Generated with [Claude Code](https://claude.com/claude-code)