### PR TITLE
fix(db): correct artifact_history backfill join (by Lumen)

### DIFF
--- a/supabase/migrations/20260213093000_workspace_container_backfill_and_artifact_comments.sql
+++ b/supabase/migrations/20260213093000_workspace_container_backfill_and_artifact_comments.sql
@@ -211,14 +211,13 @@ WHERE a.created_by_identity_id IS NULL
 
 UPDATE public.artifact_history ah
 SET changed_by_identity_id = ai.id
-FROM public.artifacts a
-JOIN public.agent_identities ai
-  ON ai.user_id = COALESCE(ah.changed_by_user_id, a.user_id)
- AND ai.agent_id = ah.changed_by_agent_id
- AND ai.workspace_id IS NOT DISTINCT FROM ah.workspace_id
+FROM public.artifacts a, public.agent_identities ai
 WHERE ah.changed_by_identity_id IS NULL
   AND ah.artifact_id = a.id
-  AND ah.changed_by_agent_id IS NOT NULL;
+  AND ah.changed_by_agent_id IS NOT NULL
+  AND ai.user_id = COALESCE(ah.changed_by_user_id, a.user_id)
+  AND ai.agent_id = ah.changed_by_agent_id
+  AND ai.workspace_id IS NOT DISTINCT FROM ah.workspace_id;
 
 -- ----------------------------------------------------------------------------
 -- 5) Constraints + indexes


### PR DESCRIPTION
## Summary
- fix the `artifact_history.changed_by_identity_id` backfill statement in `20260213093000_workspace_container_backfill_and_artifact_comments.sql`
- move `ah` references out of the `JOIN ... ON` clause into the `WHERE` clause so Postgres can resolve target-table columns during `UPDATE ... FROM`
- keep backfill semantics unchanged while making the migration runnable from a clean `initial_schema` state

## Test plan
- [x] apply migration via `mcp__supabase__apply_migration` after re-auth
- [x] verify migration appears in `mcp__supabase__list_migrations`
- [x] verify restored tables/columns exist via `mcp__supabase__execute_sql`

Generated with [Codex CLI](https://openai.com/)