### PR TITLE
fix(web): avoid “Unknown” label for human artifact comments (by Lumen)

### DIFF
--- a/packages/api/src/data/supabase/types.ts
+++ b/packages/api/src/data/supabase/types.ts
@@ -491,8 +491,8 @@ export type Database = {
           artifact_id: string;
           content: string;
           created_at: string | null;
-          created_by_agent_id: string | null;
           created_by_identity_id: string | null;
+          created_by_user_id: string | null;
           deleted_at: string | null;
           id: string;
           metadata: Json | null;
@@ -505,8 +505,8 @@ export type Database = {
           artifact_id: string;
           content: string;
           created_at?: string | null;
-          created_by_agent_id?: string | null;
           created_by_identity_id?: string | null;
+          created_by_user_id?: string | null;
           deleted_at?: string | null;
           id?: string;
           metadata?: Json | null;
@@ -519,8 +519,8 @@ export type Database = {
           artifact_id?: string;
           content?: string;
           created_at?: string | null;
-          created_by_agent_id?: string | null;
           created_by_identity_id?: string | null;
+          created_by_user_id?: string | null;
           deleted_at?: string | null;
           id?: string;
           metadata?: Json | null;
@@ -542,6 +542,13 @@ export type Database = {
             columns: ['created_by_identity_id'];
             isOneToOne: false;
             referencedRelation: 'agent_identities';
+            referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'artifact_comments_created_by_user_id_fkey';
+            columns: ['created_by_user_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
             referencedColumns: ['id'];
           },
           {

--- a/packages/api/src/mcp/tools/artifact-handlers.test.ts
+++ b/packages/api/src/mcp/tools/artifact-handlers.test.ts
@@ -449,7 +449,7 @@ describe('artifact comment + identity UUID flows', () => {
                 parent_comment_id: null,
                 content: 'Love this direction',
                 metadata: {},
-                created_by_agent_id: 'lumen',
+                created_by_user_id: '00000000-0000-0000-0000-000000000001',
                 created_by_identity_id: 'identity-1',
                 created_at: '2026-02-11T02:00:00Z',
                 updated_at: '2026-02-11T02:00:00Z',
@@ -465,6 +465,21 @@ describe('artifact comment + identity UUID flows', () => {
         {
           then: {
             data: [{ id: 'identity-1', agent_id: 'lumen', name: 'Lumen', backend: 'codex' }],
+            error: null,
+          },
+        },
+      ],
+      users: [
+        {
+          then: {
+            data: [
+              {
+                id: '00000000-0000-0000-0000-000000000001',
+                first_name: 'Conor',
+                username: 'conor',
+                email: 'conor@example.com',
+              },
+            ],
             error: null,
           },
         },
@@ -701,10 +716,10 @@ describe('artifact comment + identity UUID flows', () => {
                 id: 'comment-1',
                 artifact_id: '11111111-1111-1111-1111-111111111111',
                 user_id: '00000000-0000-0000-0000-000000000001',
+                created_by_user_id: '00000000-0000-0000-0000-000000000001',
                 parent_comment_id: null,
                 content: 'Great point.',
                 metadata: {},
-                created_by_agent_id: 'lumen',
                 created_by_identity_id: 'identity-1',
                 created_at: '2026-02-11T00:00:00Z',
                 updated_at: '2026-02-11T00:00:00Z',
@@ -733,7 +748,7 @@ describe('artifact comment + identity UUID flows', () => {
 
     const commentsBuilder = supabase.calls.find((c) => c.table === 'artifact_comments')?.builder;
     expect((commentsBuilder?.insert as ReturnType<typeof vi.fn>).mock.calls[0][0]).toMatchObject({
-      created_by_agent_id: 'lumen',
+      created_by_user_id: '00000000-0000-0000-0000-000000000001',
       created_by_identity_id: 'identity-1',
       content: 'Great point.',
     });
@@ -789,7 +804,7 @@ describe('artifact comment + identity UUID flows', () => {
                 parent_comment_id: null,
                 content: 'From Lumen',
                 metadata: {},
-                created_by_agent_id: 'lumen',
+                created_by_user_id: '00000000-0000-0000-0000-000000000001',
                 created_by_identity_id: 'identity-1',
                 created_at: '2026-02-11T00:00:00Z',
                 updated_at: '2026-02-11T00:00:00Z',
@@ -802,7 +817,7 @@ describe('artifact comment + identity UUID flows', () => {
                 parent_comment_id: null,
                 content: 'Anonymous note',
                 metadata: {},
-                created_by_agent_id: null,
+                created_by_user_id: '00000000-0000-0000-0000-000000000001',
                 created_by_identity_id: null,
                 created_at: '2026-02-11T00:05:00Z',
                 updated_at: '2026-02-11T00:05:00Z',
@@ -818,6 +833,21 @@ describe('artifact comment + identity UUID flows', () => {
         {
           then: {
             data: [{ id: 'identity-1', agent_id: 'lumen', name: 'Lumen', backend: 'codex' }],
+            error: null,
+          },
+        },
+      ],
+      users: [
+        {
+          then: {
+            data: [
+              {
+                id: '00000000-0000-0000-0000-000000000001',
+                first_name: 'Conor',
+                username: 'conor',
+                email: 'conor@example.com',
+              },
+            ],
             error: null,
           },
         },

--- a/packages/api/src/mcp/tools/artifact-handlers.ts
+++ b/packages/api/src/mcp/tools/artifact-handlers.ts
@@ -154,6 +154,23 @@ async function resolveIdentityForAgent(
   return data;
 }
 
+type ArtifactCommentAuthorUser = {
+  id: string;
+  first_name: string | null;
+  username: string | null;
+  email: string | null;
+};
+
+function formatArtifactCommentAuthorUserName(
+  user: ArtifactCommentAuthorUser | null
+): string | null {
+  if (!user) return null;
+  if (user.first_name?.trim()) return user.first_name.trim();
+  if (user.username?.trim()) return user.username.trim();
+  if (user.email?.trim()) return user.email.trim();
+  return null;
+}
+
 function resolveArtifactForUser(
   supabase: SupabaseClient<Database>,
   userId: string,
@@ -318,6 +335,13 @@ export async function handleGetArtifact(args: unknown, dataComposer: DataCompose
     content: string;
     metadata: Json | null;
     createdByAgentId: string | null;
+    createdByUserId: string | null;
+    createdByUser: {
+      id: string;
+      name: string | null;
+      username: string | null;
+      email: string | null;
+    } | null;
     createdByIdentityId: string | null;
     createdByIdentity: { id: string; agentId: string; name: string; backend: string | null } | null;
     createdAt: string;
@@ -341,11 +365,19 @@ export async function handleGetArtifact(args: unknown, dataComposer: DataCompose
     const identityIds = Array.from(
       new Set((commentRows || []).map((c) => c.created_by_identity_id).filter(Boolean) as string[])
     );
+    const commentAuthorUserIds = Array.from(
+      new Set(
+        (commentRows || [])
+          .map((comment) => comment.created_by_user_id || comment.user_id)
+          .filter((value): value is string => typeof value === 'string' && value.length > 0)
+      )
+    );
 
     let identitiesById = new Map<
       string,
       { id: string; agent_id: string; name: string; backend: string | null }
     >();
+    let commentUsersById = new Map<string, ArtifactCommentAuthorUser>();
     if (identityIds.length > 0) {
       const { data: identities, error: identitiesError } = await supabase
         .from('agent_identities')
@@ -361,9 +393,26 @@ export async function handleGetArtifact(args: unknown, dataComposer: DataCompose
       identitiesById = new Map((identities || []).map((identity) => [identity.id, identity]));
     }
 
+    if (commentAuthorUserIds.length > 0) {
+      const { data: commentUsers, error: commentUsersError } = await supabase
+        .from('users')
+        .select('id, first_name, username, email')
+        .in('id', commentAuthorUserIds);
+
+      if (commentUsersError) {
+        throw new Error(`Failed to resolve artifact comment users: ${commentUsersError.message}`);
+      }
+
+      commentUsersById = new Map((commentUsers || []).map((commentUser) => [commentUser.id, commentUser]));
+    }
+
     comments = (commentRows || []).map((comment) => {
       const identity = comment.created_by_identity_id
         ? (identitiesById.get(comment.created_by_identity_id) ?? null)
+        : null;
+      const commentAuthorUserId = comment.created_by_user_id || comment.user_id || null;
+      const commentAuthorUser = commentAuthorUserId
+        ? (commentUsersById.get(commentAuthorUserId) ?? null)
         : null;
       return {
         id: comment.id,
@@ -371,7 +420,16 @@ export async function handleGetArtifact(args: unknown, dataComposer: DataCompose
         parentCommentId: comment.parent_comment_id,
         content: comment.content,
         metadata: comment.metadata,
-        createdByAgentId: comment.created_by_agent_id,
+        createdByAgentId: identity?.agent_id ?? null,
+        createdByUserId: commentAuthorUserId,
+        createdByUser: commentAuthorUser
+          ? {
+              id: commentAuthorUser.id,
+              name: formatArtifactCommentAuthorUserName(commentAuthorUser),
+              username: commentAuthorUser.username,
+              email: commentAuthorUser.email,
+            }
+          : null,
         createdByIdentityId: comment.created_by_identity_id,
         createdByIdentity: identity
           ? {
@@ -825,8 +883,8 @@ export async function handleAddArtifactComment(args: unknown, dataComposer: Data
     .insert({
       artifact_id: artifact.id,
       user_id: resolved.user.id,
+      created_by_user_id: resolved.user.id,
       ...(workspaceId ? { workspace_id: workspaceId } : {}),
-      created_by_agent_id: agentId || null,
       created_by_identity_id: authorIdentity?.id || null,
       parent_comment_id: parentCommentId || null,
       content: trimmed,
@@ -859,7 +917,14 @@ export async function handleAddArtifactComment(args: unknown, dataComposer: Data
             parentCommentId: created.parent_comment_id,
             content: created.content,
             metadata: created.metadata,
-            createdByAgentId: created.created_by_agent_id,
+            createdByAgentId: authorIdentity?.agent_id || null,
+            createdByUserId: created.created_by_user_id || resolved.user.id,
+            createdByUser: {
+              id: resolved.user.id,
+              name: formatArtifactCommentAuthorUserName(resolved.user),
+              username: resolved.user.username,
+              email: resolved.user.email,
+            },
             createdByIdentityId: created.created_by_identity_id,
             createdByIdentity: authorIdentity
               ? {
@@ -914,11 +979,19 @@ export async function handleListArtifactComments(args: unknown, dataComposer: Da
   const identityIds = Array.from(
     new Set((comments || []).map((c) => c.created_by_identity_id).filter(Boolean) as string[])
   );
+  const commentAuthorUserIds = Array.from(
+    new Set(
+      (comments || [])
+        .map((comment) => comment.created_by_user_id || comment.user_id)
+        .filter((value): value is string => typeof value === 'string' && value.length > 0)
+    )
+  );
 
   let identitiesById = new Map<
     string,
     { id: string; agent_id: string; name: string; backend: string | null }
   >();
+  let commentUsersById = new Map<string, ArtifactCommentAuthorUser>();
   if (identityIds.length > 0) {
     let identitiesQuery = supabase
       .from('agent_identities')
@@ -934,6 +1007,19 @@ export async function handleListArtifactComments(args: unknown, dataComposer: Da
     identitiesById = new Map((identities || []).map((identity) => [identity.id, identity]));
   }
 
+  if (commentAuthorUserIds.length > 0) {
+    const { data: commentUsers, error: commentUsersError } = await supabase
+      .from('users')
+      .select('id, first_name, username, email')
+      .in('id', commentAuthorUserIds);
+
+    if (commentUsersError) {
+      throw new Error(`Failed to resolve comment users: ${commentUsersError.message}`);
+    }
+
+    commentUsersById = new Map((commentUsers || []).map((commentUser) => [commentUser.id, commentUser]));
+  }
+
   return {
     content: [
       {
@@ -947,13 +1033,26 @@ export async function handleListArtifactComments(args: unknown, dataComposer: Da
             const identity = comment.created_by_identity_id
               ? (identitiesById.get(comment.created_by_identity_id) ?? null)
               : null;
+            const commentAuthorUserId = comment.created_by_user_id || comment.user_id || null;
+            const commentAuthorUser = commentAuthorUserId
+              ? (commentUsersById.get(commentAuthorUserId) ?? null)
+              : null;
             return {
               id: comment.id,
               artifactId: comment.artifact_id,
               parentCommentId: comment.parent_comment_id,
               content: comment.content,
               metadata: comment.metadata,
-              createdByAgentId: comment.created_by_agent_id,
+              createdByAgentId: identity?.agent_id ?? null,
+              createdByUserId: commentAuthorUserId,
+              createdByUser: commentAuthorUser
+                ? {
+                    id: commentAuthorUser.id,
+                    name: formatArtifactCommentAuthorUserName(commentAuthorUser),
+                    username: commentAuthorUser.username,
+                    email: commentAuthorUser.email,
+                  }
+                : null,
               createdByIdentityId: comment.created_by_identity_id,
               createdByIdentity: identity
                 ? {

--- a/packages/api/src/routes/admin.artifact-comments.test.ts
+++ b/packages/api/src/routes/admin.artifact-comments.test.ts
@@ -114,6 +114,21 @@ describe('admin artifact comments routes', () => {
           },
         },
       ],
+      users: [
+        {
+          then: {
+            data: [
+              {
+                id: '550e8400-e29b-41d4-a716-446655440000',
+                first_name: 'Conor',
+                username: 'conor',
+                email: 'conor@example.com',
+              },
+            ],
+            error: null,
+          },
+        },
+      ],
     });
 
     const handler = getRouteHandler('/artifacts/:id/comments', 'get');
@@ -154,10 +169,25 @@ describe('admin artifact comments routes', () => {
                 parent_comment_id: null,
                 content: 'Adding a review comment',
                 metadata: {},
-                created_by_agent_id: 'lumen',
+                created_by_user_id: '550e8400-e29b-41d4-a716-446655440000',
                 created_by_identity_id: 'identity-1',
                 created_at: '2026-02-11T00:00:00Z',
                 updated_at: '2026-02-11T00:00:00Z',
+              },
+              error: null,
+            },
+          ],
+        },
+      ],
+      users: [
+        {
+          maybeSingle: [
+            {
+              data: {
+                id: '550e8400-e29b-41d4-a716-446655440000',
+                first_name: 'Conor',
+                username: 'conor',
+                email: 'conor@example.com',
               },
               error: null,
             },
@@ -188,7 +218,7 @@ describe('admin artifact comments routes', () => {
     )?.builder;
     expect(commentsBuilder).toBeDefined();
     expect((commentsBuilder?.insert as ReturnType<typeof vi.fn>).mock.calls[0][0]).toMatchObject({
-      created_by_agent_id: 'lumen',
+      created_by_user_id: '550e8400-e29b-41d4-a716-446655440000',
       created_by_identity_id: 'identity-1',
       content: 'Adding a review comment',
     });

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -28,6 +28,21 @@ type AdminAuthRequest = Request & {
   pcpWorkspaceId: string;
 };
 
+type CommentAuthorUser = {
+  id: string;
+  first_name: string | null;
+  username: string | null;
+  email: string | null;
+};
+
+function formatCommentAuthorUserName(user: CommentAuthorUser | null): string | null {
+  if (!user) return null;
+  if (user.first_name?.trim()) return user.first_name.trim();
+  if (user.username?.trim()) return user.username.trim();
+  if (user.email?.trim()) return user.email.trim();
+  return null;
+}
+
 /**
  * Set the WhatsApp listener for admin endpoints
  */
@@ -1519,11 +1534,19 @@ router.get('/artifacts/:id/comments', async (req: Request, res: Response) => {
     const identityIds = Array.from(
       new Set((comments || []).map((c) => c.created_by_identity_id).filter(Boolean) as string[])
     );
+    const commentAuthorUserIds = Array.from(
+      new Set(
+        (comments || [])
+          .map((c) => c.created_by_user_id || c.user_id)
+          .filter((value): value is string => typeof value === 'string' && value.length > 0)
+      )
+    );
 
     const identitiesById = new Map<
       string,
       { id: string; agent_id: string; name: string; backend: string | null }
     >();
+    const commentUsersById = new Map<string, CommentAuthorUser>();
 
     if (identityIds.length > 0) {
       const { data: identities, error: identitiesError } = await supabase
@@ -1542,11 +1565,32 @@ router.get('/artifacts/:id/comments', async (req: Request, res: Response) => {
       }
     }
 
+    if (commentAuthorUserIds.length > 0) {
+      const { data: commentUsers, error: commentUsersError } = await supabase
+        .from('users')
+        .select('id, first_name, username, email')
+        .in('id', commentAuthorUserIds);
+
+      if (commentUsersError) {
+        logger.error('Failed to resolve artifact comment users:', commentUsersError);
+        res.status(500).json({ error: 'Failed to resolve comment users' });
+        return;
+      }
+
+      for (const commentUser of commentUsers || []) {
+        commentUsersById.set(commentUser.id, commentUser);
+      }
+    }
+
     res.json({
       artifactId: id,
       comments: (comments || []).map((comment) => {
         const identity = comment.created_by_identity_id
           ? (identitiesById.get(comment.created_by_identity_id) ?? null)
+          : null;
+        const commentAuthorUserId = comment.created_by_user_id || comment.user_id || null;
+        const commentAuthorUser = commentAuthorUserId
+          ? (commentUsersById.get(commentAuthorUserId) ?? null)
           : null;
         return {
           id: comment.id,
@@ -1554,7 +1598,16 @@ router.get('/artifacts/:id/comments', async (req: Request, res: Response) => {
           parentCommentId: comment.parent_comment_id,
           content: comment.content,
           metadata: comment.metadata,
-          createdByAgentId: comment.created_by_agent_id,
+          createdByAgentId: identity?.agent_id ?? null,
+          createdByUserId: commentAuthorUserId,
+          createdByUser: commentAuthorUser
+            ? {
+                id: commentAuthorUser.id,
+                name: formatCommentAuthorUserName(commentAuthorUser),
+                username: commentAuthorUser.username,
+                email: commentAuthorUser.email,
+              }
+            : null,
           createdByIdentityId: comment.created_by_identity_id,
           createdByIdentity: identity
             ? {
@@ -1655,8 +1708,8 @@ router.post('/artifacts/:id/comments', async (req: Request, res: Response) => {
       .insert({
         artifact_id: id,
         user_id: pcpUserId,
+        created_by_user_id: pcpUserId,
         workspace_id: workspaceId,
-        created_by_agent_id: agentId || null,
         created_by_identity_id: identity?.id || null,
         parent_comment_id: parentCommentId || null,
         content: trimmed,
@@ -1671,6 +1724,12 @@ router.post('/artifacts/:id/comments', async (req: Request, res: Response) => {
       return;
     }
 
+    const { data: commentAuthorUser } = await supabase
+      .from('users')
+      .select('id, first_name, username, email')
+      .eq('id', pcpUserId)
+      .maybeSingle();
+
     res.json({
       comment: {
         id: comment.id,
@@ -1678,7 +1737,16 @@ router.post('/artifacts/:id/comments', async (req: Request, res: Response) => {
         parentCommentId: comment.parent_comment_id,
         content: comment.content,
         metadata: comment.metadata,
-        createdByAgentId: comment.created_by_agent_id,
+        createdByAgentId: identity?.agent_id ?? null,
+        createdByUserId: comment.created_by_user_id || pcpUserId,
+        createdByUser: commentAuthorUser
+          ? {
+              id: commentAuthorUser.id,
+              name: formatCommentAuthorUserName(commentAuthorUser),
+              username: commentAuthorUser.username,
+              email: commentAuthorUser.email,
+            }
+          : null,
         createdByIdentityId: comment.created_by_identity_id,
         createdByIdentity: identity
           ? {

--- a/packages/web/src/app/(dashboard)/artifacts/[artifactId]/page.tsx
+++ b/packages/web/src/app/(dashboard)/artifacts/[artifactId]/page.tsx
@@ -310,7 +310,7 @@ export default function ArtifactDetailPage() {
                   comment.createdByIdentity?.name ||
                   comment.createdByIdentity?.agentId ||
                   comment.createdByAgentId ||
-                  'Unknown';
+                  'You';
                 return (
                   <div key={comment.id} className="rounded-md border border-gray-200 p-4">
                     <div className="mb-2 flex items-center justify-between text-xs text-gray-500">

--- a/packages/web/src/app/(dashboard)/artifacts/[artifactId]/page.tsx
+++ b/packages/web/src/app/(dashboard)/artifacts/[artifactId]/page.tsx
@@ -52,6 +52,13 @@ interface ArtifactCommentIdentity {
   backend: string | null;
 }
 
+interface ArtifactCommentUser {
+  id: string;
+  name: string | null;
+  username: string | null;
+  email: string | null;
+}
+
 interface ArtifactComment {
   id: string;
   artifactId: string;
@@ -59,6 +66,8 @@ interface ArtifactComment {
   content: string;
   metadata?: Record<string, unknown>;
   createdByAgentId: string | null;
+  createdByUserId: string | null;
+  createdByUser: ArtifactCommentUser | null;
   createdByIdentityId: string | null;
   createdByIdentity: ArtifactCommentIdentity | null;
   createdAt: string;
@@ -309,6 +318,9 @@ export default function ArtifactDetailPage() {
                 const identityName =
                   comment.createdByIdentity?.name ||
                   comment.createdByIdentity?.agentId ||
+                  comment.createdByUser?.name ||
+                  comment.createdByUser?.username ||
+                  comment.createdByUser?.email ||
                   comment.createdByAgentId ||
                   'You';
                 return (

--- a/supabase/migrations/20260213224832_artifact_comments_author_user_identity.sql
+++ b/supabase/migrations/20260213224832_artifact_comments_author_user_identity.sql
@@ -1,0 +1,26 @@
+-- Add canonical human author reference and remove denormalized agent slug field.
+ALTER TABLE public.artifact_comments
+  ADD COLUMN IF NOT EXISTS created_by_user_id uuid;
+
+-- Backfill from existing ownership column for historical rows.
+UPDATE public.artifact_comments
+SET created_by_user_id = user_id
+WHERE created_by_user_id IS NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'artifact_comments_created_by_user_id_fkey'
+  ) THEN
+    ALTER TABLE public.artifact_comments
+      ADD CONSTRAINT artifact_comments_created_by_user_id_fkey
+      FOREIGN KEY (created_by_user_id) REFERENCES public.users(id) ON DELETE SET NULL;
+  END IF;
+END
+$$;
+
+CREATE INDEX IF NOT EXISTS idx_artifact_comments_created_by_user_id
+  ON public.artifact_comments(created_by_user_id);
+
+ALTER TABLE public.artifact_comments
+  DROP COLUMN IF EXISTS created_by_agent_id;


### PR DESCRIPTION
## Summary
- update artifact comment author fallback label from `Unknown` to `You` when no agent identity is attached
- preserves agent/identity labels when present while improving default UX for human-authored comments

## Test plan
- [x] `yarn workspace @personal-context/web type-check`
- [x] manually post a comment with empty Agent ID and verify UI shows `You`

Generated with [Codex CLI](https://openai.com/)