### PR TITLE
feat: workspace creation + collaborator invites across API/Web/CLI (by Lumen)

### DIFF
--- a/packages/api/src/data/repositories/workspace-containers.repository.ts
+++ b/packages/api/src/data/repositories/workspace-containers.repository.ts
@@ -39,6 +39,7 @@ export interface WorkspaceMemberUser {
   email: string | null;
   firstName: string | null;
   username: string | null;
+  lastLoginAt: string | null;
 }
 
 export interface WorkspaceMemberWithUser extends WorkspaceMember {
@@ -362,7 +363,7 @@ export class WorkspaceContainersRepository {
     const uniqueUserIds = Array.from(new Set(members.map((member) => member.userId)));
     const { data: users, error } = await this.client
       .from('users')
-      .select('id, email, first_name, username')
+      .select('id, email, first_name, username, last_login_at')
       .in('id', uniqueUserIds);
 
     if (error) {
@@ -377,6 +378,7 @@ export class WorkspaceContainersRepository {
           email: user.email,
           firstName: user.first_name,
           username: user.username,
+          lastLoginAt: user.last_login_at,
         } as WorkspaceMemberUser,
       ])
     );

--- a/packages/api/src/data/repositories/workspace-containers.repository.ts
+++ b/packages/api/src/data/repositories/workspace-containers.repository.ts
@@ -34,6 +34,22 @@ export interface WorkspaceMember {
   createdAt: string;
 }
 
+export interface WorkspaceMemberUser {
+  id: string;
+  email: string | null;
+  firstName: string | null;
+  username: string | null;
+}
+
+export interface WorkspaceMemberWithUser extends WorkspaceMember {
+  user: WorkspaceMemberUser | null;
+}
+
+export interface WorkspaceContainerMembership extends WorkspaceContainer {
+  role: WorkspaceMemberRole;
+  membershipCreatedAt: string;
+}
+
 export interface CreateWorkspaceContainerInput {
   userId: string;
   name: string;
@@ -80,6 +96,45 @@ export class WorkspaceContainersRepository {
     };
   }
 
+  async findRawById(id: string): Promise<WorkspaceContainer | null> {
+    const { data, error } = await this.client
+      .from('workspace_containers')
+      .select('*')
+      .eq('id', id)
+      .single();
+
+    if (error && error.code !== 'PGRST116') {
+      throw new Error(`Failed to find workspace container: ${error.message}`);
+    }
+
+    return data ? this.mapContainerRow(data as Record<string, unknown>) : null;
+  }
+
+  async findMembership(workspaceId: string, userId: string): Promise<WorkspaceMember | null> {
+    const { data, error } = await this.client
+      .from('workspace_members')
+      .select('*')
+      .eq('workspace_id', workspaceId)
+      .eq('user_id', userId)
+      .maybeSingle();
+
+    if (error) {
+      throw new Error(`Failed to find workspace membership: ${error.message}`);
+    }
+
+    return data ? this.mapMemberRow(data as Record<string, unknown>) : null;
+  }
+
+  async getMemberRole(workspaceId: string, userId: string): Promise<WorkspaceMemberRole | null> {
+    const membership = await this.findMembership(workspaceId, userId);
+    return membership?.role ?? null;
+  }
+
+  async canManageWorkspace(workspaceId: string, userId: string): Promise<boolean> {
+    const role = await this.getMemberRole(workspaceId, userId);
+    return role === 'owner' || role === 'admin';
+  }
+
   async create(input: CreateWorkspaceContainerInput): Promise<WorkspaceContainer> {
     const insertData: WorkspaceContainersTable['Insert'] = {
       user_id: input.userId,
@@ -104,31 +159,40 @@ export class WorkspaceContainersRepository {
   }
 
   async findById(id: string, userId: string): Promise<WorkspaceContainer | null> {
-    const { data, error } = await this.client
-      .from('workspace_containers')
-      .select('*')
-      .eq('id', id)
-      .eq('user_id', userId)
-      .single();
-
-    if (error && error.code !== 'PGRST116') {
-      throw new Error(`Failed to find workspace container: ${error.message}`);
+    const membership = await this.findMembership(id, userId);
+    if (!membership) {
+      return null;
     }
 
-    return data ? this.mapContainerRow(data as Record<string, unknown>) : null;
+    return this.findRawById(id);
   }
 
-  async listByUser(
+  async listMembershipsByUser(
     userId: string,
     opts?: {
       type?: WorkspaceContainerType;
       includeArchived?: boolean;
     }
-  ): Promise<WorkspaceContainer[]> {
+  ): Promise<WorkspaceContainerMembership[]> {
+    const { data: membershipRows, error: membershipError } = await this.client
+      .from('workspace_members')
+      .select('*')
+      .eq('user_id', userId);
+
+    if (membershipError) {
+      throw new Error(`Failed to list workspace memberships: ${membershipError.message}`);
+    }
+
+    const memberships = (membershipRows || []).map((row) => this.mapMemberRow(row as Record<string, unknown>));
+    if (memberships.length === 0) {
+      return [];
+    }
+
+    const workspaceIds = Array.from(new Set(memberships.map((membership) => membership.workspaceId)));
     let query = this.client
       .from('workspace_containers')
       .select('*')
-      .eq('user_id', userId)
+      .in('id', workspaceIds)
       .order('updated_at', { ascending: false });
 
     if (opts?.type) {
@@ -139,13 +203,56 @@ export class WorkspaceContainersRepository {
       query = query.is('archived_at', null);
     }
 
-    const { data, error } = await query;
-
-    if (error) {
-      throw new Error(`Failed to list workspace containers: ${error.message}`);
+    const { data: workspaceRows, error: workspaceError } = await query;
+    if (workspaceError) {
+      throw new Error(`Failed to list workspace containers: ${workspaceError.message}`);
     }
 
-    return (data || []).map((row) => this.mapContainerRow(row as Record<string, unknown>));
+    const workspaceById = new Map<string, WorkspaceContainer>();
+    for (const row of workspaceRows || []) {
+      const workspace = this.mapContainerRow(row as Record<string, unknown>);
+      workspaceById.set(workspace.id, workspace);
+    }
+
+    const membershipByWorkspaceId = new Map<string, WorkspaceMember>();
+    for (const membership of memberships) {
+      membershipByWorkspaceId.set(membership.workspaceId, membership);
+    }
+
+    const results: WorkspaceContainerMembership[] = [];
+    for (const workspace of workspaceById.values()) {
+      const membership = membershipByWorkspaceId.get(workspace.id);
+      if (!membership) continue;
+      results.push({
+        ...workspace,
+        role: membership.role,
+        membershipCreatedAt: membership.createdAt,
+      });
+    }
+
+    return results;
+  }
+
+  async listByUser(
+    userId: string,
+    opts?: {
+      type?: WorkspaceContainerType;
+      includeArchived?: boolean;
+    }
+  ): Promise<WorkspaceContainer[]> {
+    const memberships = await this.listMembershipsByUser(userId, opts);
+    return memberships.map((membership) => ({
+      id: membership.id,
+      userId: membership.userId,
+      name: membership.name,
+      slug: membership.slug,
+      type: membership.type,
+      description: membership.description,
+      metadata: membership.metadata,
+      createdAt: membership.createdAt,
+      updatedAt: membership.updatedAt,
+      archivedAt: membership.archivedAt,
+    }));
   }
 
   async update(
@@ -218,7 +325,10 @@ export class WorkspaceContainersRepository {
 
     const { data, error } = await this.client
       .from('workspace_members')
-      .insert(insertData)
+      .upsert(insertData, {
+        onConflict: 'workspace_id,user_id',
+        ignoreDuplicates: false,
+      })
       .select()
       .single();
 
@@ -241,5 +351,39 @@ export class WorkspaceContainersRepository {
     }
 
     return (data || []).map((row) => this.mapMemberRow(row as Record<string, unknown>));
+  }
+
+  async listMembersWithUsers(workspaceId: string): Promise<WorkspaceMemberWithUser[]> {
+    const members = await this.listMembers(workspaceId);
+    if (members.length === 0) {
+      return [];
+    }
+
+    const uniqueUserIds = Array.from(new Set(members.map((member) => member.userId)));
+    const { data: users, error } = await this.client
+      .from('users')
+      .select('id, email, first_name, username')
+      .in('id', uniqueUserIds);
+
+    if (error) {
+      throw new Error(`Failed to resolve workspace member profiles: ${error.message}`);
+    }
+
+    const usersById = new Map(
+      (users || []).map((user) => [
+        user.id,
+        {
+          id: user.id,
+          email: user.email,
+          firstName: user.first_name,
+          username: user.username,
+        } as WorkspaceMemberUser,
+      ])
+    );
+
+    return members.map((member) => ({
+      ...member,
+      user: usersById.get(member.userId) ?? null,
+    }));
   }
 }

--- a/packages/api/src/data/supabase/types.ts
+++ b/packages/api/src/data/supabase/types.ts
@@ -2553,6 +2553,7 @@ export type Database = {
           email: string | null;
           first_name: string | null;
           id: string;
+          last_login_at: string | null;
           last_name: string | null;
           phone_number: string | null;
           preferences: Json | null;
@@ -2569,6 +2570,7 @@ export type Database = {
           email?: string | null;
           first_name?: string | null;
           id?: string;
+          last_login_at?: string | null;
           last_name?: string | null;
           phone_number?: string | null;
           preferences?: Json | null;
@@ -2585,6 +2587,7 @@ export type Database = {
           email?: string | null;
           first_name?: string | null;
           id?: string;
+          last_login_at?: string | null;
           last_name?: string | null;
           phone_number?: string | null;
           preferences?: Json | null;

--- a/packages/api/src/mcp/tools/index.ts
+++ b/packages/api/src/mcp/tools/index.ts
@@ -223,10 +223,12 @@ import {
   handleListWorkspaceContainers,
   handleGetWorkspaceContainer,
   handleUpdateWorkspaceContainer,
+  handleAddWorkspaceMember,
   createWorkspaceContainerSchema,
   listWorkspaceContainersSchema,
   getWorkspaceContainerSchema,
   updateWorkspaceContainerSchema,
+  addWorkspaceMemberSchema,
 } from './workspace-container-handlers';
 
 import { handleCreateKindleToken, createKindleTokenSchema } from './kindle-handlers';
@@ -4128,6 +4130,36 @@ User can be identified by ONE of: userId, email, phone, or platform + platformId
         return await handleUpdateWorkspaceContainer(args, dataComposer);
       } catch (error) {
         logger.error('Error in update_workspace_container:', error);
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                success: false,
+                error: error instanceof Error ? error.message : 'Unknown error',
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  server.registerTool(
+    'add_workspace_member',
+    {
+      description: `Invite/add a collaborator to a workspace container by email.
+Creates a placeholder PCP user if needed, then grants workspace membership.
+
+User can be identified by ONE of: userId, email, phone, or platform + platformId`,
+      inputSchema: addWorkspaceMemberSchema,
+    },
+    async (args: Record<string, unknown>) => {
+      try {
+        return await handleAddWorkspaceMember(args, dataComposer);
+      } catch (error) {
+        logger.error('Error in add_workspace_member:', error);
         return {
           content: [
             {

--- a/packages/api/src/mcp/tools/workspace-container-handlers.test.ts
+++ b/packages/api/src/mcp/tools/workspace-container-handlers.test.ts
@@ -32,6 +32,7 @@ function createMockDataComposer() {
         listMembershipsByUser: vi.fn(),
         findById: vi.fn(),
         canManageWorkspace: vi.fn(),
+        getMemberRole: vi.fn(),
         update: vi.fn(),
         listMembers: vi.fn(),
         listMembersWithUsers: vi.fn(),
@@ -229,6 +230,7 @@ describe('workspace-container handlers', () => {
       archivedAt: null,
     });
     mockDataComposer.repositories.workspaceContainers.canManageWorkspace.mockResolvedValue(true);
+    mockDataComposer.repositories.workspaceContainers.getMemberRole.mockResolvedValue('owner');
     mockDataComposer.repositories.users.findByEmail.mockResolvedValue({
       id: 'user-456',
       email: 'co@test.com',
@@ -259,5 +261,37 @@ describe('workspace-container handlers', () => {
       'user-456',
       'admin'
     );
+  });
+
+  it('add-member handler blocks admins from assigning owner role', async () => {
+    mockDataComposer.repositories.workspaceContainers.findById.mockResolvedValue({
+      id: 'ws-1',
+      userId: 'user-123',
+      name: 'PCP Team',
+      slug: 'pcp-team',
+      type: 'team',
+      description: null,
+      metadata: {},
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      archivedAt: null,
+    });
+    mockDataComposer.repositories.workspaceContainers.canManageWorkspace.mockResolvedValue(true);
+    mockDataComposer.repositories.workspaceContainers.getMemberRole.mockResolvedValue('admin');
+
+    const result = await handleAddWorkspaceMember(
+      {
+        email: 'owner@test.com',
+        workspaceId: '11111111-1111-1111-1111-111111111111',
+        inviteeEmail: 'co@test.com',
+        role: 'owner',
+      },
+      mockDataComposer as never
+    );
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.success).toBe(false);
+    expect(parsed.error).toContain('Only workspace owners can grant owner role');
+    expect(result.isError).toBe(true);
   });
 });

--- a/packages/api/src/mcp/tools/workspace-container-handlers.test.ts
+++ b/packages/api/src/mcp/tools/workspace-container-handlers.test.ts
@@ -6,6 +6,8 @@ import {
   handleListWorkspaceContainers,
   handleGetWorkspaceContainer,
   handleUpdateWorkspaceContainer,
+  handleAddWorkspaceMember,
+  addWorkspaceMemberSchema,
 } from './workspace-container-handlers';
 
 vi.mock('../../services/user-resolver', async (importOriginal) => {
@@ -27,9 +29,16 @@ function createMockDataComposer() {
         addMember: vi.fn(),
         ensurePersonalWorkspace: vi.fn(),
         listByUser: vi.fn(),
+        listMembershipsByUser: vi.fn(),
         findById: vi.fn(),
+        canManageWorkspace: vi.fn(),
         update: vi.fn(),
         listMembers: vi.fn(),
+        listMembersWithUsers: vi.fn(),
+      },
+      users: {
+        findByEmail: vi.fn(),
+        create: vi.fn(),
       },
     },
   };
@@ -56,6 +65,19 @@ describe('workspace-container schemas', () => {
     expect(parsed.success).toBe(true);
     if (parsed.success) {
       expect(parsed.data.ensurePersonal).toBe(true);
+    }
+  });
+
+  it('accepts add-member payload and defaults role', () => {
+    const parsed = addWorkspaceMemberSchema.safeParse({
+      email: 'owner@test.com',
+      workspaceId: '11111111-1111-1111-1111-111111111111',
+      inviteeEmail: 'co@test.com',
+    });
+
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.role).toBe('member');
     }
   });
 });
@@ -109,7 +131,7 @@ describe('workspace-container handlers', () => {
     mockDataComposer.repositories.workspaceContainers.ensurePersonalWorkspace.mockResolvedValue({
       id: 'personal-1',
     });
-    mockDataComposer.repositories.workspaceContainers.listByUser.mockResolvedValue([]);
+    mockDataComposer.repositories.workspaceContainers.listMembershipsByUser.mockResolvedValue([]);
 
     const result = await handleListWorkspaceContainers(
       { email: 'test@test.com' },
@@ -121,7 +143,7 @@ describe('workspace-container handlers', () => {
     expect(
       mockDataComposer.repositories.workspaceContainers.ensurePersonalWorkspace
     ).toHaveBeenCalledWith('user-123');
-    expect(mockDataComposer.repositories.workspaceContainers.listByUser).toHaveBeenCalled();
+    expect(mockDataComposer.repositories.workspaceContainers.listMembershipsByUser).toHaveBeenCalled();
   });
 
   it('get handler returns workspace when found', async () => {
@@ -191,5 +213,51 @@ describe('workspace-container handlers', () => {
     expect(parsed.success).toBe(true);
     expect(parsed.workspace.name).toBe('PCP Team Updated');
     expect(mockDataComposer.repositories.workspaceContainers.update).toHaveBeenCalled();
+  });
+
+  it('add-member handler adds collaborator by email', async () => {
+    mockDataComposer.repositories.workspaceContainers.findById.mockResolvedValue({
+      id: 'ws-1',
+      userId: 'user-123',
+      name: 'PCP Team',
+      slug: 'pcp-team',
+      type: 'team',
+      description: null,
+      metadata: {},
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      archivedAt: null,
+    });
+    mockDataComposer.repositories.workspaceContainers.canManageWorkspace.mockResolvedValue(true);
+    mockDataComposer.repositories.users.findByEmail.mockResolvedValue({
+      id: 'user-456',
+      email: 'co@test.com',
+    });
+    mockDataComposer.repositories.workspaceContainers.addMember.mockResolvedValue({
+      id: 'member-2',
+      workspaceId: 'ws-1',
+      userId: 'user-456',
+      role: 'admin',
+      createdAt: '2026-01-01T00:00:00.000Z',
+    });
+
+    const result = await handleAddWorkspaceMember(
+      {
+        email: 'owner@test.com',
+        workspaceId: '11111111-1111-1111-1111-111111111111',
+        inviteeEmail: 'co@test.com',
+        role: 'admin',
+      },
+      mockDataComposer as never
+    );
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.success).toBe(true);
+    expect(parsed.member.role).toBe('admin');
+    expect(mockDataComposer.repositories.workspaceContainers.addMember).toHaveBeenCalledWith(
+      'ws-1',
+      'user-456',
+      'admin'
+    );
   });
 });

--- a/packages/api/src/mcp/tools/workspace-container-handlers.ts
+++ b/packages/api/src/mcp/tools/workspace-container-handlers.ts
@@ -12,6 +12,7 @@ import type {
   WorkspaceMemberRole,
 } from '../../data/repositories/workspace-containers.repository';
 import type { Json } from '../../data/supabase/types';
+import { slugifyWorkspaceName } from '../../utils/workspace-slug';
 
 const workspaceContainerTypeSchema = z.enum(['personal', 'team']);
 const workspaceMemberRoleSchema = z.enum(['owner', 'admin', 'member', 'viewer']);
@@ -62,16 +63,6 @@ export const addWorkspaceMemberSchema = userIdentifierBaseSchema.extend({
   role: workspaceMemberRoleSchema.optional().default('member'),
 });
 
-function slugify(name: string): string {
-  const slug = name
-    .toLowerCase()
-    .trim()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
-    .slice(0, 64);
-  return slug || 'workspace';
-}
-
 function successResponse(data: Record<string, unknown>) {
   return {
     content: [{ type: 'text' as const, text: JSON.stringify({ success: true, ...data }) }],
@@ -96,7 +87,7 @@ export async function handleCreateWorkspaceContainer(args: unknown, dataComposer
   const workspace = await dataComposer.repositories.workspaceContainers.create({
     userId: user.id,
     name: params.name,
-    slug: params.slug || slugify(params.name),
+    slug: params.slug || slugifyWorkspaceName(params.name),
     type: (params.type || 'personal') as WorkspaceContainerType,
     description: params.description,
     metadata: toJsonObject(params.metadata),
@@ -267,6 +258,14 @@ export async function handleAddWorkspaceMember(args: unknown, dataComposer: Data
   );
   if (!canManage) {
     return errorResponse('Only workspace owners/admins can add collaborators');
+  }
+
+  const actingRole = await dataComposer.repositories.workspaceContainers.getMemberRole(
+    workspace.id,
+    user.id
+  );
+  if (params.role === 'owner' && actingRole !== 'owner') {
+    return errorResponse('Only workspace owners can grant owner role');
   }
 
   const normalizedInviteeEmail = params.inviteeEmail.trim().toLowerCase();

--- a/packages/api/src/mcp/tools/workspace-container-handlers.ts
+++ b/packages/api/src/mcp/tools/workspace-container-handlers.ts
@@ -7,10 +7,14 @@
 import { z } from 'zod';
 import type { DataComposer } from '../../data/composer';
 import { resolveUserOrThrow, userIdentifierBaseSchema } from '../../services/user-resolver';
-import type { WorkspaceContainerType } from '../../data/repositories/workspace-containers.repository';
+import type {
+  WorkspaceContainerType,
+  WorkspaceMemberRole,
+} from '../../data/repositories/workspace-containers.repository';
 import type { Json } from '../../data/supabase/types';
 
 const workspaceContainerTypeSchema = z.enum(['personal', 'team']);
+const workspaceMemberRoleSchema = z.enum(['owner', 'admin', 'member', 'viewer']);
 
 export const createWorkspaceContainerSchema = userIdentifierBaseSchema.extend({
   name: z.string().min(1).describe('Workspace display name (e.g., "Personal", "PCP Team")'),
@@ -38,18 +42,24 @@ export const listWorkspaceContainersSchema = userIdentifierBaseSchema.extend({
 });
 
 export const getWorkspaceContainerSchema = userIdentifierBaseSchema.extend({
-  workspaceId: z.string().uuid().describe('Workspace container UUID'),
+  workspaceId: z.string().uuid().describe('Workspace UUID'),
   includeMembers: z.boolean().optional().default(false).describe('Include workspace members'),
 });
 
 export const updateWorkspaceContainerSchema = userIdentifierBaseSchema.extend({
-  workspaceId: z.string().uuid().describe('Workspace container UUID'),
+  workspaceId: z.string().uuid().describe('Workspace UUID'),
   name: z.string().min(1).optional(),
   slug: z.string().min(1).optional(),
   type: workspaceContainerTypeSchema.optional(),
   description: z.string().nullable().optional(),
   metadata: z.record(z.unknown()).optional(),
   archived: z.boolean().optional().describe('Set true to archive, false to unarchive'),
+});
+
+export const addWorkspaceMemberSchema = userIdentifierBaseSchema.extend({
+  workspaceId: z.string().uuid().describe('Workspace UUID'),
+  inviteeEmail: z.string().email().describe('Email address of collaborator to add'),
+  role: workspaceMemberRoleSchema.optional().default('member'),
 });
 
 function slugify(name: string): string {
@@ -65,6 +75,13 @@ function slugify(name: string): string {
 function successResponse(data: Record<string, unknown>) {
   return {
     content: [{ type: 'text' as const, text: JSON.stringify({ success: true, ...data }) }],
+  };
+}
+
+function errorResponse(message: string) {
+  return {
+    content: [{ type: 'text' as const, text: JSON.stringify({ success: false, error: message }) }],
+    isError: true,
   };
 }
 
@@ -112,7 +129,7 @@ export async function handleListWorkspaceContainers(args: unknown, dataComposer:
     await dataComposer.repositories.workspaceContainers.ensurePersonalWorkspace(user.id);
   }
 
-  const workspaces = await dataComposer.repositories.workspaceContainers.listByUser(user.id, {
+  const workspaces = await dataComposer.repositories.workspaceContainers.listMembershipsByUser(user.id, {
     type: params.type as WorkspaceContainerType | undefined,
     includeArchived: params.includeArchived,
   });
@@ -128,6 +145,8 @@ export async function handleListWorkspaceContainers(args: unknown, dataComposer:
       type: w.type,
       description: w.description,
       metadata: w.metadata,
+      role: w.role,
+      membershipCreatedAt: w.membershipCreatedAt,
       createdAt: w.createdAt,
       updatedAt: w.updatedAt,
       archivedAt: w.archivedAt,
@@ -156,7 +175,7 @@ export async function handleGetWorkspaceContainer(args: unknown, dataComposer: D
   }
 
   const members = params.includeMembers
-    ? await dataComposer.repositories.workspaceContainers.listMembers(workspace.id)
+    ? await dataComposer.repositories.workspaceContainers.listMembersWithUsers(workspace.id)
     : undefined;
 
   return successResponse({
@@ -177,6 +196,14 @@ export async function handleGetWorkspaceContainer(args: unknown, dataComposer: D
         userId: m.userId,
         role: m.role,
         createdAt: m.createdAt,
+        user: m.user
+          ? {
+              id: m.user.id,
+              email: m.user.email,
+              firstName: m.user.firstName,
+              username: m.user.username,
+            }
+          : null,
       })),
     },
   });
@@ -217,6 +244,66 @@ export async function handleUpdateWorkspaceContainer(args: unknown, dataComposer
       createdAt: updated.createdAt,
       updatedAt: updated.updatedAt,
       archivedAt: updated.archivedAt,
+    },
+  });
+}
+
+export async function handleAddWorkspaceMember(args: unknown, dataComposer: DataComposer) {
+  const params = addWorkspaceMemberSchema.parse(args);
+  const { user, resolvedBy } = await resolveUserOrThrow(params, dataComposer);
+
+  const workspace = await dataComposer.repositories.workspaceContainers.findById(
+    params.workspaceId,
+    user.id
+  );
+  if (!workspace) {
+    return errorResponse('Workspace not found or not accessible');
+  }
+
+  const canManage = await dataComposer.repositories.workspaceContainers.canManageWorkspace(
+    workspace.id,
+    user.id
+  );
+  if (!canManage) {
+    return errorResponse('Only workspace owners/admins can add collaborators');
+  }
+
+  const normalizedInviteeEmail = params.inviteeEmail.trim().toLowerCase();
+  let invitedUser = await dataComposer.repositories.users.findByEmail(normalizedInviteeEmail);
+  let userWasCreated = false;
+
+  if (!invitedUser) {
+    invitedUser = await dataComposer.repositories.users.create({
+      email: normalizedInviteeEmail,
+    });
+    userWasCreated = true;
+  }
+
+  const member = await dataComposer.repositories.workspaceContainers.addMember(
+    workspace.id,
+    invitedUser.id,
+    (params.role || 'member') as WorkspaceMemberRole
+  );
+
+  return successResponse({
+    user: { id: user.id, resolvedBy },
+    workspace: {
+      id: workspace.id,
+      name: workspace.name,
+      slug: workspace.slug,
+      type: workspace.type,
+    },
+    member: {
+      id: member.id,
+      workspaceId: member.workspaceId,
+      userId: member.userId,
+      role: member.role,
+      createdAt: member.createdAt,
+      user: {
+        id: invitedUser.id,
+        email: invitedUser.email,
+      },
+      userWasCreated,
     },
   });
 }

--- a/packages/api/src/mcp/tools/workspace-container-handlers.ts
+++ b/packages/api/src/mcp/tools/workspace-container-handlers.ts
@@ -202,6 +202,7 @@ export async function handleGetWorkspaceContainer(args: unknown, dataComposer: D
               email: m.user.email,
               firstName: m.user.firstName,
               username: m.user.username,
+              lastLoginAt: m.user.lastLoginAt,
             }
           : null,
       })),

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -145,16 +145,15 @@ async function adminAuthMiddleware(req: Request, res: Response, next: NextFuncti
       });
     };
 
-    // Ensure every user always has at least one workspace container.
-    const personalWorkspace = await workspaceRepo.ensurePersonalWorkspace(pcpUser.id);
+    let activeWorkspaceId = '';
+    let activeWorkspaceRole: WorkspaceMemberRole | 'trusted' = 'trusted';
+    let hasDirectMembership = false;
 
-    let activeWorkspaceId = personalWorkspace.id;
-    let activeWorkspaceRole = await workspaceRepo.getMemberRole(activeWorkspaceId, pcpUser.id);
     if (requestedWorkspaceId) {
       const requestedWorkspace = await workspaceRepo.findById(requestedWorkspaceId, pcpUser.id);
       if (requestedWorkspace) {
         activeWorkspaceId = requestedWorkspace.id;
-        activeWorkspaceRole = await workspaceRepo.getMemberRole(activeWorkspaceId, pcpUser.id);
+        hasDirectMembership = true;
       } else {
         const requestedWorkspaceExists = await workspaceRepo.findRawById(requestedWorkspaceId);
         if (!requestedWorkspaceExists) {
@@ -169,16 +168,25 @@ async function adminAuthMiddleware(req: Request, res: Response, next: NextFuncti
         }
 
         activeWorkspaceId = requestedWorkspaceId;
-        activeWorkspaceRole = null;
+        activeWorkspaceRole = 'trusted';
       }
+    } else {
+      // Ensure every user always has at least one workspace container.
+      const personalWorkspace = await workspaceRepo.ensurePersonalWorkspace(pcpUser.id);
+      activeWorkspaceId = personalWorkspace.id;
+      hasDirectMembership = true;
     }
 
-    if (!activeWorkspaceRole) {
+    if (!hasDirectMembership) {
       const trustedForActiveWorkspace = await hasTrustedAdminAccess(activeWorkspaceId);
       if (!trustedForActiveWorkspace) {
         res.status(403).json({ error: 'Insufficient permissions' });
         return;
       }
+    }
+
+    if (hasDirectMembership) {
+      activeWorkspaceRole = 'member';
     }
 
     // Attach user + PCP context to request
@@ -230,9 +238,12 @@ router.get('/workspaces', async (req: Request, res: Response) => {
       includeArchived: false,
     });
 
+    const currentWorkspaceMembership = workspaces.find((workspace) => workspace.id === authReq.pcpWorkspaceId);
+    const currentWorkspaceRole = currentWorkspaceMembership?.role || authReq.pcpWorkspaceRole;
+
     res.json({
       currentWorkspaceId: authReq.pcpWorkspaceId,
-      currentWorkspaceRole: authReq.pcpWorkspaceRole,
+      currentWorkspaceRole,
       workspaces: workspaces.map((w) => ({
         id: w.id,
         name: w.name,
@@ -406,6 +417,7 @@ router.post('/workspaces/:workspaceId/members', async (req: Request, res: Respon
         email: rawEmail,
       });
       userWasCreated = true;
+      await workspaceRepo.ensurePersonalWorkspace(inviteeUser.id);
     }
 
     const membership = await workspaceRepo.addMember(workspaceId, inviteeUser.id, memberRole);

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -18,6 +18,7 @@ import { runWithRequestContext } from '../utils/request-context';
 import { getDataComposer } from '../data/composer';
 import crypto from 'crypto';
 import type { WorkspaceMemberRole } from '../data/repositories/workspace-containers.repository';
+import { slugifyWorkspaceName } from '../utils/workspace-slug';
 
 // WhatsApp listener reference (set via setWhatsAppListener)
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -37,23 +38,14 @@ type CommentAuthorUser = {
   email: string | null;
 };
 
+const LAST_LOGIN_UPDATE_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
 function formatCommentAuthorUserName(user: CommentAuthorUser | null): string | null {
   if (!user) return null;
   if (user.first_name?.trim()) return user.first_name.trim();
   if (user.username?.trim()) return user.username.trim();
   if (user.email?.trim()) return user.email.trim();
   return null;
-}
-
-function slugifyWorkspaceName(name: string): string {
-  const slug = name
-    .toLowerCase()
-    .trim()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
-    .slice(0, 64);
-
-  return slug || 'workspace';
 }
 
 /**
@@ -111,16 +103,24 @@ async function adminAuthMiddleware(req: Request, res: Response, next: NextFuncti
       return;
     }
 
-    const loginTimestamp = new Date().toISOString();
-    const { error: loginUpdateError } = await supabase
-      .from('users')
-      .update({ last_login_at: loginTimestamp })
-      .eq('id', pcpUser.id);
-    if (loginUpdateError) {
-      logger.warn('Failed to update users.last_login_at during admin auth', {
-        userId: pcpUser.id,
-        error: loginUpdateError.message,
-      });
+    const lastLoginAtMs = pcpUser.last_login_at ? new Date(pcpUser.last_login_at).getTime() : NaN;
+    const shouldUpdateLastLoginAt =
+      !pcpUser.last_login_at ||
+      Number.isNaN(lastLoginAtMs) ||
+      Date.now() - lastLoginAtMs >= LAST_LOGIN_UPDATE_INTERVAL_MS;
+
+    if (shouldUpdateLastLoginAt) {
+      const loginTimestamp = new Date().toISOString();
+      const { error: loginUpdateError } = await supabase
+        .from('users')
+        .update({ last_login_at: loginTimestamp })
+        .eq('id', pcpUser.id);
+      if (loginUpdateError) {
+        logger.warn('Failed to update users.last_login_at during admin auth', {
+          userId: pcpUser.id,
+          error: loginUpdateError.message,
+        });
+      }
     }
 
     // Resolve active workspace container from header (or default to personal).
@@ -380,6 +380,7 @@ router.post('/workspaces/:workspaceId/members', async (req: Request, res: Respon
       res.status(403).json({ error: 'Only workspace owners/admins can invite collaborators' });
       return;
     }
+    const actingRole = await workspaceRepo.getMemberRole(workspaceId, authReq.pcpUserId);
 
     const rawEmail = typeof req.body?.email === 'string' ? req.body.email.trim().toLowerCase() : '';
     if (!rawEmail || !rawEmail.includes('@')) {
@@ -392,6 +393,10 @@ router.post('/workspaces/:workspaceId/members', async (req: Request, res: Respon
     const memberRole: WorkspaceMemberRole = allowedRoles.includes(rawRole as WorkspaceMemberRole)
       ? (rawRole as WorkspaceMemberRole)
       : 'member';
+    if (memberRole === 'owner' && actingRole !== 'owner') {
+      res.status(403).json({ error: 'Only workspace owners can grant owner role' });
+      return;
+    }
 
     let inviteeUser = await usersRepo.findByEmail(rawEmail);
     let userWasCreated = false;

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -102,13 +102,25 @@ async function adminAuthMiddleware(req: Request, res: Response, next: NextFuncti
     // Look up the PCP user by email
     const { data: pcpUser } = await supabase
       .from('users')
-      .select('id, telegram_id, whatsapp_id')
+      .select('id, telegram_id, whatsapp_id, last_login_at')
       .eq('email', user.email)
       .single();
 
     if (!pcpUser) {
       res.status(403).json({ error: 'User not found in PCP system' });
       return;
+    }
+
+    const loginTimestamp = new Date().toISOString();
+    const { error: loginUpdateError } = await supabase
+      .from('users')
+      .update({ last_login_at: loginTimestamp })
+      .eq('id', pcpUser.id);
+    if (loginUpdateError) {
+      logger.warn('Failed to update users.last_login_at during admin auth', {
+        userId: pcpUser.id,
+        error: loginUpdateError.message,
+      });
     }
 
     // Resolve active workspace container from header (or default to personal).
@@ -405,6 +417,7 @@ router.post('/workspaces/:workspaceId/members', async (req: Request, res: Respon
           email: inviteeUser.email,
           firstName: inviteeUser.first_name,
           username: inviteeUser.username,
+          lastLoginAt: inviteeUser.last_login_at,
         },
         userWasCreated,
       },

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -17,6 +17,7 @@ import { env } from '../config/env';
 import { runWithRequestContext } from '../utils/request-context';
 import { getDataComposer } from '../data/composer';
 import crypto from 'crypto';
+import type { WorkspaceMemberRole } from '../data/repositories/workspace-containers.repository';
 
 // WhatsApp listener reference (set via setWhatsAppListener)
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -26,6 +27,7 @@ type AdminAuthRequest = Request & {
   user: { email?: string | null };
   pcpUserId: string;
   pcpWorkspaceId: string;
+  pcpWorkspaceRole: WorkspaceMemberRole | 'trusted';
 };
 
 type CommentAuthorUser = {
@@ -41,6 +43,17 @@ function formatCommentAuthorUserName(user: CommentAuthorUser | null): string | n
   if (user.username?.trim()) return user.username.trim();
   if (user.email?.trim()) return user.email.trim();
   return null;
+}
+
+function slugifyWorkspaceName(name: string): string {
+  const slug = name
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 64);
+
+  return slug || 'workspace';
 }
 
 /**
@@ -73,7 +86,9 @@ async function adminAuthMiddleware(req: Request, res: Response, next: NextFuncti
     const token = authHeader.substring(7);
 
     // Verify the JWT with Supabase
-    const supabase = createClient(env.SUPABASE_URL, env.SUPABASE_SECRET_KEY);
+    const supabase = createClient(env.SUPABASE_URL, env.SUPABASE_SECRET_KEY, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
     const {
       data: { user },
       error,
@@ -101,35 +116,57 @@ async function adminAuthMiddleware(req: Request, res: Response, next: NextFuncti
     const workspaceRepo = dataComposer.repositories.workspaceContainers;
     const requestedWorkspaceId = req.header('x-pcp-workspace-id')?.trim();
 
+    const hasTrustedAdminAccess = async (workspaceId: string): Promise<boolean> => {
+      const authService = getAuthorizationService();
+      const trustedUsers = await authService.listTrustedUsers(undefined, workspaceId);
+
+      return trustedUsers.some((tu) => {
+        if (tu.trustLevel === 'member') return false;
+        if (tu.userId === pcpUser.id) return true;
+        if (tu.platform === 'telegram' && pcpUser.telegram_id?.toString() === tu.platformUserId) {
+          return true;
+        }
+        if (tu.platform === 'whatsapp' && pcpUser.whatsapp_id === tu.platformUserId) {
+          return true;
+        }
+        return false;
+      });
+    };
+
     // Ensure every user always has at least one workspace container.
     const personalWorkspace = await workspaceRepo.ensurePersonalWorkspace(pcpUser.id);
 
     let activeWorkspaceId = personalWorkspace.id;
+    let activeWorkspaceRole = await workspaceRepo.getMemberRole(activeWorkspaceId, pcpUser.id);
     if (requestedWorkspaceId) {
       const requestedWorkspace = await workspaceRepo.findById(requestedWorkspaceId, pcpUser.id);
-      if (!requestedWorkspace) {
-        res.status(403).json({ error: 'Workspace not found or not accessible' });
-        return;
+      if (requestedWorkspace) {
+        activeWorkspaceId = requestedWorkspace.id;
+        activeWorkspaceRole = await workspaceRepo.getMemberRole(activeWorkspaceId, pcpUser.id);
+      } else {
+        const requestedWorkspaceExists = await workspaceRepo.findRawById(requestedWorkspaceId);
+        if (!requestedWorkspaceExists) {
+          res.status(404).json({ error: 'Workspace not found' });
+          return;
+        }
+
+        const trustedForRequestedWorkspace = await hasTrustedAdminAccess(requestedWorkspaceId);
+        if (!trustedForRequestedWorkspace) {
+          res.status(403).json({ error: 'Workspace not found or not accessible' });
+          return;
+        }
+
+        activeWorkspaceId = requestedWorkspaceId;
+        activeWorkspaceRole = null;
       }
-      activeWorkspaceId = requestedWorkspace.id;
     }
 
-    // Check trusted-user access at the selected workspace scope.
-    const authService = getAuthorizationService();
-    const trustedUsers = await authService.listTrustedUsers(undefined, activeWorkspaceId);
-
-    const isTrusted = trustedUsers.some((tu) => {
-      if (tu.trustLevel === 'member') return false;
-      if (tu.userId === pcpUser.id) return true;
-      if (tu.platform === 'telegram' && pcpUser.telegram_id?.toString() === tu.platformUserId)
-        return true;
-      if (tu.platform === 'whatsapp' && pcpUser.whatsapp_id === tu.platformUserId) return true;
-      return false;
-    });
-
-    if (!isTrusted) {
-      res.status(403).json({ error: 'Insufficient permissions' });
-      return;
+    if (!activeWorkspaceRole) {
+      const trustedForActiveWorkspace = await hasTrustedAdminAccess(activeWorkspaceId);
+      if (!trustedForActiveWorkspace) {
+        res.status(403).json({ error: 'Insufficient permissions' });
+        return;
+      }
     }
 
     // Attach user + PCP context to request
@@ -137,10 +174,12 @@ async function adminAuthMiddleware(req: Request, res: Response, next: NextFuncti
       user: typeof user;
       pcpUserId: string;
       pcpWorkspaceId: string;
+      pcpWorkspaceRole: WorkspaceMemberRole | 'trusted';
     };
     authReq.user = user;
     authReq.pcpUserId = pcpUser.id;
     authReq.pcpWorkspaceId = activeWorkspaceId;
+    authReq.pcpWorkspaceRole = activeWorkspaceRole || 'trusted';
 
     // Wrap the rest of the request in context
     runWithRequestContext(
@@ -175,17 +214,20 @@ router.get('/workspaces', async (req: Request, res: Response) => {
     const authReq = req as AdminAuthRequest;
     const dataComposer = await getDataComposer();
     const workspaceRepo = dataComposer.repositories.workspaceContainers;
-    const workspaces = await workspaceRepo.listByUser(authReq.pcpUserId, {
+    const workspaces = await workspaceRepo.listMembershipsByUser(authReq.pcpUserId, {
       includeArchived: false,
     });
 
     res.json({
       currentWorkspaceId: authReq.pcpWorkspaceId,
+      currentWorkspaceRole: authReq.pcpWorkspaceRole,
       workspaces: workspaces.map((w) => ({
         id: w.id,
         name: w.name,
         slug: w.slug,
         type: w.type,
+        role: w.role,
+        membershipCreatedAt: w.membershipCreatedAt,
         description: w.description,
         metadata: w.metadata,
         createdAt: w.createdAt,
@@ -196,6 +238,180 @@ router.get('/workspaces', async (req: Request, res: Response) => {
   } catch (error) {
     logger.error('Failed to list workspace containers:', error);
     res.status(500).json({ error: 'Failed to list workspace containers' });
+  }
+});
+
+/**
+ * POST /api/admin/workspaces
+ * Create a new workspace container and make the caller owner.
+ */
+router.post('/workspaces', async (req: Request, res: Response) => {
+  try {
+    const authReq = req as AdminAuthRequest;
+    const dataComposer = await getDataComposer();
+    const workspaceRepo = dataComposer.repositories.workspaceContainers;
+
+    const rawName = typeof req.body?.name === 'string' ? req.body.name.trim() : '';
+    if (!rawName) {
+      res.status(400).json({ error: 'name is required' });
+      return;
+    }
+
+    const rawType = req.body?.type;
+    const workspaceType = rawType === 'team' ? 'team' : 'personal';
+    const workspaceDescription =
+      typeof req.body?.description === 'string' && req.body.description.trim()
+        ? req.body.description.trim()
+        : undefined;
+    const workspaceSlug =
+      typeof req.body?.slug === 'string' && req.body.slug.trim()
+        ? slugifyWorkspaceName(req.body.slug)
+        : slugifyWorkspaceName(rawName);
+
+    const createdWorkspace = await workspaceRepo.create({
+      userId: authReq.pcpUserId,
+      name: rawName,
+      slug: workspaceSlug,
+      type: workspaceType,
+      description: workspaceDescription,
+    });
+
+    await workspaceRepo.addMember(createdWorkspace.id, authReq.pcpUserId, 'owner');
+
+    res.status(201).json({
+      workspace: {
+        id: createdWorkspace.id,
+        name: createdWorkspace.name,
+        slug: createdWorkspace.slug,
+        type: createdWorkspace.type,
+        role: 'owner',
+        description: createdWorkspace.description,
+        metadata: createdWorkspace.metadata,
+        createdAt: createdWorkspace.createdAt,
+        updatedAt: createdWorkspace.updatedAt,
+        archivedAt: createdWorkspace.archivedAt,
+      },
+    });
+  } catch (error) {
+    logger.error('Failed to create workspace container:', error);
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    if (message.toLowerCase().includes('duplicate')) {
+      res.status(409).json({ error: 'A workspace with that slug already exists for this owner' });
+      return;
+    }
+    res.status(500).json({ error: 'Failed to create workspace container' });
+  }
+});
+
+/**
+ * GET /api/admin/workspaces/:workspaceId/members
+ * List collaborators for a workspace.
+ */
+router.get('/workspaces/:workspaceId/members', async (req: Request, res: Response) => {
+  try {
+    const authReq = req as AdminAuthRequest;
+    const dataComposer = await getDataComposer();
+    const workspaceRepo = dataComposer.repositories.workspaceContainers;
+    const workspaceId = req.params.workspaceId;
+
+    const workspace = await workspaceRepo.findById(workspaceId, authReq.pcpUserId);
+    if (!workspace) {
+      res.status(404).json({ error: 'Workspace not found or not accessible' });
+      return;
+    }
+
+    const canManage = await workspaceRepo.canManageWorkspace(workspaceId, authReq.pcpUserId);
+    const members = await workspaceRepo.listMembersWithUsers(workspaceId);
+
+    res.json({
+      workspace: {
+        id: workspace.id,
+        name: workspace.name,
+        slug: workspace.slug,
+        type: workspace.type,
+      },
+      canManage,
+      members: members.map((member) => ({
+        id: member.id,
+        userId: member.userId,
+        role: member.role,
+        createdAt: member.createdAt,
+        user: member.user,
+      })),
+    });
+  } catch (error) {
+    logger.error('Failed to list workspace members:', error);
+    res.status(500).json({ error: 'Failed to list workspace members' });
+  }
+});
+
+/**
+ * POST /api/admin/workspaces/:workspaceId/members
+ * Invite/add collaborator by email to workspace.
+ */
+router.post('/workspaces/:workspaceId/members', async (req: Request, res: Response) => {
+  try {
+    const authReq = req as AdminAuthRequest;
+    const dataComposer = await getDataComposer();
+    const workspaceRepo = dataComposer.repositories.workspaceContainers;
+    const usersRepo = dataComposer.repositories.users;
+    const workspaceId = req.params.workspaceId;
+
+    const workspace = await workspaceRepo.findById(workspaceId, authReq.pcpUserId);
+    if (!workspace) {
+      res.status(404).json({ error: 'Workspace not found or not accessible' });
+      return;
+    }
+
+    const canManage = await workspaceRepo.canManageWorkspace(workspaceId, authReq.pcpUserId);
+    if (!canManage) {
+      res.status(403).json({ error: 'Only workspace owners/admins can invite collaborators' });
+      return;
+    }
+
+    const rawEmail = typeof req.body?.email === 'string' ? req.body.email.trim().toLowerCase() : '';
+    if (!rawEmail || !rawEmail.includes('@')) {
+      res.status(400).json({ error: 'A valid email is required' });
+      return;
+    }
+
+    const rawRole = typeof req.body?.role === 'string' ? req.body.role : 'member';
+    const allowedRoles: WorkspaceMemberRole[] = ['owner', 'admin', 'member', 'viewer'];
+    const memberRole: WorkspaceMemberRole = allowedRoles.includes(rawRole as WorkspaceMemberRole)
+      ? (rawRole as WorkspaceMemberRole)
+      : 'member';
+
+    let inviteeUser = await usersRepo.findByEmail(rawEmail);
+    let userWasCreated = false;
+
+    if (!inviteeUser) {
+      inviteeUser = await usersRepo.create({
+        email: rawEmail,
+      });
+      userWasCreated = true;
+    }
+
+    const membership = await workspaceRepo.addMember(workspaceId, inviteeUser.id, memberRole);
+
+    res.status(201).json({
+      member: {
+        id: membership.id,
+        workspaceId: membership.workspaceId,
+        userId: membership.userId,
+        role: membership.role,
+        createdAt: membership.createdAt,
+        user: {
+          id: inviteeUser.id,
+          email: inviteeUser.email,
+          firstName: inviteeUser.first_name,
+          username: inviteeUser.username,
+        },
+        userWasCreated,
+      },
+    });
+  } catch (error) {
+    logger.error('Failed to add workspace member:', error);
+    res.status(500).json({ error: 'Failed to add workspace member' });
   }
 });
 

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -91,16 +91,48 @@ async function adminAuthMiddleware(req: Request, res: Response, next: NextFuncti
       return;
     }
 
-    // Look up the PCP user by email
-    const { data: pcpUser } = await supabase
+    // Look up (or create) PCP user by email.
+    // For newly signed-up users, this auto-provisions PCP identity on first authenticated request.
+    const normalizedEmail = user.email?.toLowerCase() ?? null;
+    let { data: pcpUser } = await supabase
       .from('users')
       .select('id, telegram_id, whatsapp_id, last_login_at')
-      .eq('email', user.email)
+      .eq('email', normalizedEmail)
       .single();
 
     if (!pcpUser) {
-      res.status(403).json({ error: 'User not found in PCP system' });
-      return;
+      if (!normalizedEmail) {
+        res.status(403).json({ error: 'User email not available for PCP provisioning' });
+        return;
+      }
+
+      const { data: createdUser, error: createUserError } = await supabase
+        .from('users')
+        .insert({ email: normalizedEmail })
+        .select('id, telegram_id, whatsapp_id, last_login_at')
+        .single();
+
+      if (createUserError) {
+        // Handle race where parallel requests created the PCP user first.
+        const { data: racedUser } = await supabase
+          .from('users')
+          .select('id, telegram_id, whatsapp_id, last_login_at')
+          .eq('email', normalizedEmail)
+          .single();
+
+        if (!racedUser) {
+          logger.error('Failed to auto-provision PCP user during admin auth', {
+            email: normalizedEmail,
+            error: createUserError.message,
+          });
+          res.status(500).json({ error: 'Failed to provision PCP user' });
+          return;
+        }
+
+        pcpUser = racedUser;
+      } else {
+        pcpUser = createdUser;
+      }
     }
 
     const lastLoginAtMs = pcpUser.last_login_at ? new Date(pcpUser.last_login_at).getTime() : NaN;

--- a/packages/api/src/utils/workspace-slug.ts
+++ b/packages/api/src/utils/workspace-slug.ts
@@ -1,0 +1,10 @@
+export function slugifyWorkspaceName(name: string): string {
+  const slug = name
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 64);
+
+  return slug || 'workspace';
+}

--- a/packages/cli/src/commands/workspace-container.ts
+++ b/packages/cli/src/commands/workspace-container.ts
@@ -1,5 +1,5 @@
 /**
- * Workspace Container Commands
+ * Workspace Commands
  *
  * Manage product-level workspaces (personal/team scope).
  * These are distinct from local git worktree studios (`sb studio ...`).
@@ -23,6 +23,7 @@ interface WorkspaceContainer {
   name: string;
   slug: string;
   type: 'personal' | 'team';
+  role?: 'owner' | 'admin' | 'member' | 'viewer';
   description?: string | null;
   archivedAt?: string | null;
 }
@@ -136,19 +137,20 @@ async function listWorkspaceContainers(options: {
   }
 
   if (workspaces.length === 0) {
-    console.log(chalk.yellow('No workspace containers found.'));
+    console.log(chalk.yellow('No workspaces found.'));
     return;
   }
 
-  console.log(chalk.bold('\nWorkspace Containers:\n'));
+  console.log(chalk.bold('\nWorkspaces:\n'));
 
   for (const workspace of workspaces) {
     const selected = config.workspaceId === workspace.id;
     const marker = selected ? chalk.green('●') : chalk.dim('○');
     const type = workspace.type === 'team' ? chalk.blue('team') : chalk.gray('personal');
+    const role = workspace.role ? chalk.magenta(workspace.role) : chalk.dim('member');
 
     console.log(
-      `  ${marker} ${chalk.cyan(workspace.name)} ${chalk.dim(`(${workspace.slug})`)} ${type}`
+      `  ${marker} ${chalk.cyan(workspace.name)} ${chalk.dim(`(${workspace.slug})`)} ${type} ${role}`
     );
     console.log(chalk.dim(`      id: ${workspace.id}`));
     if (workspace.description) {
@@ -206,6 +208,212 @@ async function useWorkspaceContainer(workspaceRef: string): Promise<void> {
   console.log(chalk.dim(`  id: ${match.id}`));
 }
 
+async function resolveWorkspaceByRef(
+  workspaceRef: string,
+  config: PcpConfig
+): Promise<WorkspaceContainer> {
+  const response = await fetchPcp('/api/mcp/call', {
+    method: 'POST',
+    body: JSON.stringify({
+      tool: 'list_workspace_containers',
+      args: {
+        email: config.email,
+        includeArchived: false,
+        ensurePersonal: true,
+      },
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to list workspaces: ${await response.text()}`);
+  }
+
+  const raw = (await response.json()) as unknown;
+  const parsed = unwrapToolResult(raw);
+  const workspaces = Array.isArray(parsed.workspaces)
+    ? (parsed.workspaces as WorkspaceContainer[])
+    : [];
+  const match = workspaces.find((workspace) => workspace.id === workspaceRef || workspace.slug === workspaceRef);
+
+  if (!match) {
+    throw new Error(`Workspace not found: ${workspaceRef}`);
+  }
+
+  return match;
+}
+
+async function createWorkspaceContainer(
+  name: string,
+  options: { type?: 'personal' | 'team'; description?: string; slug?: string; use?: boolean }
+): Promise<void> {
+  const config = getPcpConfig();
+  if (!config?.email) {
+    console.error(chalk.red('PCP not configured. Run: sb init'));
+    process.exit(1);
+  }
+
+  const response = await fetchPcp('/api/mcp/call', {
+    method: 'POST',
+    body: JSON.stringify({
+      tool: 'create_workspace_container',
+      args: {
+        email: config.email,
+        name,
+        type: options.type || 'team',
+        description: options.description,
+        slug: options.slug,
+      },
+    }),
+  });
+
+  if (!response.ok) {
+    console.error(chalk.red(`Failed to create workspace: ${await response.text()}`));
+    process.exit(1);
+  }
+
+  const raw = (await response.json()) as unknown;
+  const parsed = unwrapToolResult(raw);
+  const workspace = parsed.workspace as WorkspaceContainer | undefined;
+
+  if (!workspace?.id) {
+    console.error(chalk.red('Workspace creation failed'));
+    process.exit(1);
+  }
+
+  if (options.use) {
+    savePcpConfig({
+      ...config,
+      workspaceId: workspace.id,
+    });
+  }
+
+  console.log(chalk.green(`Created workspace: ${workspace.name} (${workspace.slug})`));
+  console.log(chalk.dim(`  id: ${workspace.id}`));
+  if (options.use) {
+    console.log(chalk.cyan('Selected as active workspace.'));
+  }
+}
+
+async function inviteWorkspaceMember(
+  workspaceRef: string,
+  inviteeEmail: string,
+  options: { role?: 'owner' | 'admin' | 'member' | 'viewer' }
+): Promise<void> {
+  const config = getPcpConfig();
+  if (!config?.email) {
+    console.error(chalk.red('PCP not configured. Run: sb init'));
+    process.exit(1);
+  }
+
+  let targetWorkspace: WorkspaceContainer;
+  try {
+    targetWorkspace = await resolveWorkspaceByRef(workspaceRef, config);
+  } catch (error) {
+    console.error(chalk.red(error instanceof Error ? error.message : 'Workspace lookup failed'));
+    process.exit(1);
+  }
+
+  const response = await fetchPcp('/api/mcp/call', {
+    method: 'POST',
+    body: JSON.stringify({
+      tool: 'add_workspace_member',
+      args: {
+        email: config.email,
+        workspaceId: targetWorkspace.id,
+        inviteeEmail,
+        role: options.role || 'member',
+      },
+    }),
+  });
+
+  if (!response.ok) {
+    console.error(chalk.red(`Failed to invite member: ${await response.text()}`));
+    process.exit(1);
+  }
+
+  const raw = (await response.json()) as unknown;
+  const parsed = unwrapToolResult(raw);
+
+  if (parsed.success === false) {
+    console.error(chalk.red(`Failed to invite member: ${String(parsed.error || 'unknown error')}`));
+    process.exit(1);
+  }
+
+  const member = parsed.member as
+    | { role?: string; user?: { email?: string | null }; userWasCreated?: boolean }
+    | undefined;
+  console.log(
+    chalk.green(
+      `Added ${member?.user?.email || inviteeEmail} to ${targetWorkspace.name} as ${member?.role || options.role || 'member'}`
+    )
+  );
+  if (member?.userWasCreated) {
+    console.log(chalk.dim('Created placeholder PCP user for this email (will activate on first login).'));
+  }
+}
+
+async function listWorkspaceMembers(workspaceRef?: string): Promise<void> {
+  const config = getPcpConfig();
+  if (!config?.email) {
+    console.error(chalk.red('PCP not configured. Run: sb init'));
+    process.exit(1);
+  }
+
+  const targetRef = workspaceRef || config.workspaceId;
+  if (!targetRef) {
+    console.error(chalk.red('No workspace selected. Pass <id-or-slug> or run `sb workspace use` first.'));
+    process.exit(1);
+  }
+
+  let targetWorkspace: WorkspaceContainer;
+  try {
+    targetWorkspace = await resolveWorkspaceByRef(targetRef, config);
+  } catch (error) {
+    console.error(chalk.red(error instanceof Error ? error.message : 'Workspace lookup failed'));
+    process.exit(1);
+  }
+
+  const response = await fetchPcp('/api/mcp/call', {
+    method: 'POST',
+    body: JSON.stringify({
+      tool: 'get_workspace_container',
+      args: {
+        email: config.email,
+        workspaceId: targetWorkspace.id,
+        includeMembers: true,
+      },
+    }),
+  });
+
+  if (!response.ok) {
+    console.error(chalk.red(`Failed to list workspace members: ${await response.text()}`));
+    process.exit(1);
+  }
+
+  const raw = (await response.json()) as unknown;
+  const parsed = unwrapToolResult(raw);
+  const members = Array.isArray((parsed.workspace as { members?: unknown[] } | undefined)?.members)
+    ? ((parsed.workspace as { members?: unknown[] }).members as Array<{
+        role?: string;
+        user?: { email?: string | null; firstName?: string | null; username?: string | null };
+        userId?: string;
+      }>)
+    : [];
+
+  console.log(chalk.bold(`\nMembers — ${targetWorkspace.name}\n`));
+  if (members.length === 0) {
+    console.log(chalk.yellow('No members found.'));
+    return;
+  }
+
+  for (const member of members) {
+    const label =
+      member.user?.firstName || member.user?.username || member.user?.email || member.userId || 'unknown';
+    console.log(`  ${chalk.cyan(label)} ${chalk.dim(`(${member.role || 'member'})`)}`);
+  }
+  console.log('');
+}
+
 function currentWorkspaceContainer(): void {
   const config = getPcpConfig();
   if (!config) {
@@ -225,7 +433,7 @@ function currentWorkspaceContainer(): void {
 export function registerWorkspaceContainerCommands(program: Command): void {
   const workspace = program
     .command('workspace')
-    .description('Product workspace container management (personal/team scope)');
+    .description('Workspace management (personal/team scope)');
 
   workspace
     .command('list')
@@ -237,11 +445,35 @@ export function registerWorkspaceContainerCommands(program: Command): void {
 
   workspace
     .command('use <workspace-id-or-slug>')
-    .description('Select the active workspace container for this machine')
+    .description('Select the active workspace for this machine')
     .action(useWorkspaceContainer);
 
   workspace
+    .command('create <name>')
+    .description('Create a new workspace container')
+    .option('--type <type>', 'Workspace type (personal|team)', 'team')
+    .option('--description <description>', 'Workspace description')
+    .option('--slug <slug>', 'Workspace slug')
+    .option('--use', 'Select the created workspace after creation')
+    .action((name, options: { type?: 'personal' | 'team'; description?: string; slug?: string; use?: boolean }) =>
+      createWorkspaceContainer(name, options)
+    );
+
+  workspace
+    .command('invite <workspace-id-or-slug> <email>')
+    .description('Invite/add a collaborator to a workspace')
+    .option('--role <role>', 'Role (owner|admin|member|viewer)', 'member')
+    .action((workspaceRef, inviteeEmail, options: { role?: 'owner' | 'admin' | 'member' | 'viewer' }) =>
+      inviteWorkspaceMember(workspaceRef, inviteeEmail, options)
+    );
+
+  workspace
+    .command('members [workspace-id-or-slug]')
+    .description('List collaborators in a workspace')
+    .action(listWorkspaceMembers);
+
+  workspace
     .command('current')
-    .description('Print selected workspace container ID')
+    .description('Print selected workspace ID')
     .action(currentWorkspaceContainer);
 }

--- a/packages/cli/src/commands/workspace-container.ts
+++ b/packages/cli/src/commands/workspace-container.ts
@@ -395,7 +395,12 @@ async function listWorkspaceMembers(workspaceRef?: string): Promise<void> {
   const members = Array.isArray((parsed.workspace as { members?: unknown[] } | undefined)?.members)
     ? ((parsed.workspace as { members?: unknown[] }).members as Array<{
         role?: string;
-        user?: { email?: string | null; firstName?: string | null; username?: string | null };
+        user?: {
+          email?: string | null;
+          firstName?: string | null;
+          username?: string | null;
+          lastLoginAt?: string | null;
+        };
         userId?: string;
       }>)
     : [];
@@ -409,7 +414,10 @@ async function listWorkspaceMembers(workspaceRef?: string): Promise<void> {
   for (const member of members) {
     const label =
       member.user?.firstName || member.user?.username || member.user?.email || member.userId || 'unknown';
-    console.log(`  ${chalk.cyan(label)} ${chalk.dim(`(${member.role || 'member'})`)}`);
+    const joinedLabel = member.user?.lastLoginAt ? 'joined' : 'invited';
+    console.log(
+      `  ${chalk.cyan(label)} ${chalk.dim(`(${member.role || 'member'})`)} ${chalk.gray(`[${joinedLabel}]`)}`
+    );
   }
   console.log('');
 }

--- a/packages/web/src/app/auth/callback/route.ts
+++ b/packages/web/src/app/auth/callback/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
+import { provisionPcpUserAndWorkspace } from '@/lib/auth/provision';
 
 export async function GET(request: Request) {
   const { searchParams, origin } = new URL(request.url);
@@ -28,6 +29,8 @@ export async function GET(request: Request) {
     const { data, error: exchangeError } = await supabase.auth.exchangeCodeForSession(code);
 
     if (!exchangeError && data.session) {
+      await provisionPcpUserAndWorkspace(data.session.access_token);
+
       // If this is MCP auth, redirect to MCP callback with tokens
       if (isMcpAuth) {
         const apiUrl =

--- a/packages/web/src/components/layout/sidebar.tsx
+++ b/packages/web/src/components/layout/sidebar.tsx
@@ -17,12 +17,15 @@ import {
   Plus,
   UserPlus,
   Building2,
+  ChevronDown,
+  Check,
+  Settings,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useRouter } from 'next/navigation';
 import { useApiPost, useApiPostDynamic, useApiQuery, useQueryClient } from '@/lib/api/hooks';
 import { getSelectedWorkspaceId, setSelectedWorkspaceId } from '@/lib/workspace-selection';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { signOut } from '@/lib/auth/actions';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -78,6 +81,14 @@ interface WorkspaceMembersResponse {
   }>;
 }
 
+interface AuthMeResponse {
+  authenticated: boolean;
+  user?: {
+    id: string;
+    email: string | null;
+  };
+}
+
 export function Sidebar() {
   const pathname = usePathname();
   const router = useRouter();
@@ -91,6 +102,9 @@ export function Sidebar() {
   const [inviteEmail, setInviteEmail] = useState('');
   const [inviteRole, setInviteRole] = useState<'owner' | 'admin' | 'member' | 'viewer'>('member');
   const [workspaceError, setWorkspaceError] = useState<string | null>(null);
+  const [isMounted, setIsMounted] = useState(false);
+  const [accountMenuOpen, setAccountMenuOpen] = useState(false);
+  const accountMenuRef = useRef<HTMLDivElement | null>(null);
 
   const { data: workspaceData, isLoading: workspacesLoading } = useApiQuery<WorkspaceListResponse>(
     ['workspace-containers'],
@@ -100,12 +114,19 @@ export function Sidebar() {
     }
   );
 
+  const { data: authMeData } = useApiQuery<AuthMeResponse>(['auth-me'], '/api/auth/me', {
+    retry: false,
+  });
+
   const resolvedWorkspaceId = useMemo(() => {
     if (selectedWorkspaceId) return selectedWorkspaceId;
     return workspaceData?.currentWorkspaceId ?? '';
   }, [selectedWorkspaceId, workspaceData?.currentWorkspaceId]);
 
   const workspaces = workspaceData?.workspaces || [];
+  const selectedWorkspace = workspaces.find((workspace) => workspace.id === resolvedWorkspaceId) || null;
+  const userEmail = authMeData?.user?.email || 'Account';
+  const userInitial = userEmail.charAt(0).toUpperCase();
   const inviteTargetWorkspaceId = inviteWorkspaceId || resolvedWorkspaceId;
   const workspaceMembersPath = inviteTargetWorkspaceId
     ? `/api/admin/workspaces/${inviteTargetWorkspaceId}/members`
@@ -164,6 +185,10 @@ export function Sidebar() {
   );
 
   useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  useEffect(() => {
     const locallySelected = getSelectedWorkspaceId();
     if (locallySelected) {
       setSelectedWorkspaceState(locallySelected);
@@ -184,6 +209,23 @@ export function Sidebar() {
       }
     }
   }, [inviteWorkspaceId, selectedWorkspaceId, workspaceData?.currentWorkspaceId]);
+
+  useEffect(() => {
+    if (!accountMenuOpen) return;
+
+    const handleGlobalMouseDown = (event: MouseEvent) => {
+      if (!accountMenuRef.current) return;
+      const targetNode = event.target as Node | null;
+      if (targetNode && !accountMenuRef.current.contains(targetNode)) {
+        setAccountMenuOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleGlobalMouseDown);
+    return () => {
+      document.removeEventListener('mousedown', handleGlobalMouseDown);
+    };
+  }, [accountMenuOpen]);
 
   const handleWorkspaceChange = (workspaceId: string) => {
     setSelectedWorkspaceId(workspaceId);
@@ -230,8 +272,80 @@ export function Sidebar() {
 
   return (
     <div className="flex h-full w-64 flex-col bg-gray-900">
-      <div className="flex h-16 shrink-0 items-center px-6">
-        <span className="text-xl font-bold text-white">PCP Admin</span>
+      <div className="relative border-b border-gray-800 px-4 py-3" ref={accountMenuRef}>
+        <div className="flex items-center justify-between">
+          <span className="text-lg font-bold text-white">PCP Admin</span>
+          <button
+            onClick={() => setAccountMenuOpen((open) => !open)}
+            className="flex items-center gap-2 rounded-md border border-gray-700 bg-gray-800 px-2 py-1 text-gray-100 hover:bg-gray-700"
+          >
+            <span className="flex h-6 w-6 items-center justify-center rounded bg-gray-600 text-xs font-semibold">
+              {userInitial || 'U'}
+            </span>
+            <ChevronDown className="h-4 w-4" />
+          </button>
+        </div>
+
+        {accountMenuOpen && (
+          <div className="absolute right-4 top-14 z-30 w-72 rounded-md border border-gray-200 bg-white p-3 shadow-xl">
+            <p className="truncate text-sm font-semibold text-gray-900">{userEmail}</p>
+            <p className="mt-1 text-xs text-gray-500">
+              {selectedWorkspace
+                ? `Workspace: ${selectedWorkspace.name} (${selectedWorkspace.role})`
+                : 'No workspace selected'}
+            </p>
+
+            <div className="mt-3 space-y-1 rounded-md border border-gray-200 bg-gray-50 p-2">
+              <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">Workspaces</p>
+              {workspaces.length === 0 && <p className="text-xs text-gray-500">No workspaces yet</p>}
+              {workspaces.map((workspace) => {
+                const isSelected = workspace.id === resolvedWorkspaceId;
+                return (
+                  <button
+                    key={workspace.id}
+                    onClick={() => {
+                      handleWorkspaceChange(workspace.id);
+                      setAccountMenuOpen(false);
+                    }}
+                    className="flex w-full items-center justify-between rounded px-2 py-1 text-left text-sm text-gray-700 hover:bg-gray-100"
+                  >
+                    <span className="truncate">
+                      {workspace.name} <span className="text-xs text-gray-500">({workspace.role})</span>
+                    </span>
+                    {isSelected && <Check className="h-4 w-4 text-gray-700" />}
+                  </button>
+                );
+              })}
+            </div>
+
+            <div className="mt-3 grid grid-cols-2 gap-2">
+              <button
+                onClick={() => {
+                  setWorkspaceManagerOpen(true);
+                  setAccountMenuOpen(false);
+                }}
+                className="rounded border border-gray-300 px-2 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+              >
+                Workspaces
+              </button>
+              <button
+                disabled
+                className="flex items-center justify-center gap-1 rounded border border-gray-200 px-2 py-2 text-sm font-medium text-gray-400"
+              >
+                <Settings className="h-4 w-4" />
+                Settings
+              </button>
+            </div>
+
+            <button
+              onClick={() => signOut()}
+              className="mt-3 flex w-full items-center justify-center gap-2 rounded bg-gray-900 px-3 py-2 text-sm font-medium text-white hover:bg-gray-800"
+            >
+              <LogOut className="h-4 w-4" />
+              Log out
+            </button>
+          </div>
+        )}
       </div>
       <div className="px-4 pb-3">
         <label className="mb-1 block text-xs font-semibold uppercase tracking-wide text-gray-400">
@@ -251,7 +365,19 @@ export function Sidebar() {
           ))}
         </select>
         <div className="mt-2">
-          <Dialog open={workspaceManagerOpen} onOpenChange={setWorkspaceManagerOpen}>
+          {!isMounted && (
+            <Button
+              variant="outline"
+              size="sm"
+              disabled
+              className="w-full border-gray-700 bg-gray-800 text-gray-400"
+            >
+              <Building2 className="h-4 w-4" />
+              Manage Workspaces
+            </Button>
+          )}
+          {isMounted && (
+            <Dialog open={workspaceManagerOpen} onOpenChange={setWorkspaceManagerOpen}>
             <DialogTrigger asChild>
               <Button
                 variant="outline"
@@ -413,7 +539,8 @@ export function Sidebar() {
                 </p>
               )}
             </DialogContent>
-          </Dialog>
+            </Dialog>
+          )}
         </div>
       </div>
       <nav className="flex flex-1 flex-col">

--- a/packages/web/src/components/layout/sidebar.tsx
+++ b/packages/web/src/components/layout/sidebar.tsx
@@ -278,21 +278,24 @@ export function Sidebar() {
   return (
     <div className="flex h-full w-64 flex-col bg-gray-900">
       <div className="relative border-b border-gray-800 px-4 py-3" ref={accountMenuRef}>
-        <div className="flex items-center justify-between">
-          <span className="text-lg font-bold text-white">PCP Admin</span>
-          <button
-            onClick={() => setAccountMenuOpen((open) => !open)}
-            className="flex items-center gap-2 rounded-md border border-gray-700 bg-gray-800 px-2 py-1 text-gray-100 hover:bg-gray-700"
-          >
-            <span className="flex h-6 w-6 items-center justify-center rounded bg-gray-600 text-xs font-semibold">
+        <span className="text-lg font-bold text-white">PCP Admin</span>
+        <button
+          onClick={() => setAccountMenuOpen((open) => !open)}
+          className="mt-3 flex w-full items-center justify-between rounded-md border border-gray-700 bg-gray-800 px-3 py-2 text-gray-100 hover:bg-gray-700"
+        >
+          <span className="flex min-w-0 items-center gap-2">
+            <span className="flex h-7 w-7 items-center justify-center rounded bg-gray-600 text-xs font-semibold">
               {userInitial || 'U'}
             </span>
-            <ChevronDown className="h-4 w-4" />
-          </button>
-        </div>
+            <span className="truncate text-sm font-medium">
+              {selectedWorkspace?.name || 'Personal Workspace'}
+            </span>
+          </span>
+          <ChevronDown className="h-4 w-4 shrink-0" />
+        </button>
 
         {accountMenuOpen && (
-          <div className="absolute left-0 right-0 top-full z-30 border-b border-gray-200 bg-white px-4 py-3 shadow-xl">
+          <div className="absolute left-4 right-4 top-full z-30 mt-2 rounded-xl border border-gray-200 bg-white p-3 shadow-2xl">
             <div className="rounded-md border border-gray-200 bg-gray-50 p-2">
               <p className="truncate text-sm font-semibold text-gray-900">
                 {selectedWorkspace?.name || 'Personal'} Workspace

--- a/packages/web/src/components/layout/sidebar.tsx
+++ b/packages/web/src/components/layout/sidebar.tsx
@@ -125,13 +125,16 @@ export function Sidebar() {
 
   const workspaces = workspaceData?.workspaces || [];
   const selectedWorkspace = workspaces.find((workspace) => workspace.id === resolvedWorkspaceId) || null;
-  const userEmail = authMeData?.user?.email || 'Account';
-  const userInitial = userEmail.charAt(0).toUpperCase();
+  const userEmail = authMeData?.user?.email ?? '';
+  const userInitial = userEmail ? userEmail.charAt(0).toUpperCase() : '';
+  const workspaceName = selectedWorkspace?.name ?? '';
+  const workspaceTriggerLabel = workspaceName || '\u00A0';
+  const workspaceTitleLabel = workspaceName ? `${workspaceName} Workspace` : '\u00A0';
   const selectedWorkspaceRole =
     selectedWorkspace?.role ||
     (workspaceData?.currentWorkspaceRole && workspaceData.currentWorkspaceRole !== 'trusted'
       ? workspaceData.currentWorkspaceRole
-      : 'member');
+      : '');
   const inviteTargetWorkspaceId = inviteWorkspaceId || resolvedWorkspaceId;
   const workspaceMembersPath = inviteTargetWorkspaceId
     ? `/api/admin/workspaces/${inviteTargetWorkspaceId}/members`
@@ -285,10 +288,10 @@ export function Sidebar() {
         >
           <span className="flex min-w-0 items-center gap-2">
             <span className="flex h-7 w-7 items-center justify-center rounded bg-gray-600 text-xs font-semibold">
-              {userInitial || 'U'}
+              {userInitial}
             </span>
             <span className="truncate text-sm font-medium">
-              {selectedWorkspace?.name || 'Personal Workspace'}
+              {workspaceTriggerLabel}
             </span>
           </span>
           <ChevronDown className="h-4 w-4 shrink-0" />
@@ -297,11 +300,11 @@ export function Sidebar() {
         {accountMenuOpen && (
           <div className="absolute left-4 right-4 top-full z-30 mt-2 rounded-xl border border-gray-200 bg-white p-3 shadow-2xl">
             <div className="rounded-md border border-gray-200 bg-gray-50 p-2">
-              <p className="truncate text-sm font-semibold text-gray-900">
-                {selectedWorkspace?.name || 'Personal'} Workspace
+              <p className="truncate text-sm font-semibold text-gray-900">{workspaceTitleLabel}</p>
+              <p className="mt-1 truncate text-xs text-gray-500">{userEmail || '\u00A0'}</p>
+              <p className="truncate text-xs text-gray-500">
+                {selectedWorkspaceRole ? `Role: ${selectedWorkspaceRole}` : '\u00A0'}
               </p>
-              <p className="mt-1 truncate text-xs text-gray-500">{userEmail}</p>
-              <p className="truncate text-xs text-gray-500">Role: {selectedWorkspaceRole}</p>
             </div>
 
             <div className="mt-3 space-y-1 rounded-md border border-gray-200 bg-gray-50 p-2">

--- a/packages/web/src/components/layout/sidebar.tsx
+++ b/packages/web/src/components/layout/sidebar.tsx
@@ -35,7 +35,6 @@ import {
   DialogDescription,
   DialogHeader,
   DialogTitle,
-  DialogTrigger,
 } from '@/components/ui/dialog';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 
@@ -57,7 +56,7 @@ interface WorkspaceOption {
   name: string;
   slug: string;
   type: 'personal' | 'team';
-  role: 'owner' | 'admin' | 'member' | 'viewer';
+  role?: 'owner' | 'admin' | 'member' | 'viewer';
 }
 
 interface WorkspaceListResponse {
@@ -128,6 +127,11 @@ export function Sidebar() {
   const selectedWorkspace = workspaces.find((workspace) => workspace.id === resolvedWorkspaceId) || null;
   const userEmail = authMeData?.user?.email || 'Account';
   const userInitial = userEmail.charAt(0).toUpperCase();
+  const selectedWorkspaceRole =
+    selectedWorkspace?.role ||
+    (workspaceData?.currentWorkspaceRole && workspaceData.currentWorkspaceRole !== 'trusted'
+      ? workspaceData.currentWorkspaceRole
+      : 'member');
   const inviteTargetWorkspaceId = inviteWorkspaceId || resolvedWorkspaceId;
   const workspaceMembersPath = inviteTargetWorkspaceId
     ? `/api/admin/workspaces/${inviteTargetWorkspaceId}/members`
@@ -288,17 +292,21 @@ export function Sidebar() {
         </div>
 
         {accountMenuOpen && (
-          <div className="absolute right-4 top-14 z-30 w-72 rounded-md border border-gray-200 bg-white p-3 shadow-xl">
-            <p className="truncate text-sm font-semibold text-gray-900">{userEmail}</p>
-            <p className="mt-1 text-xs text-gray-500">
-              {selectedWorkspace
-                ? `Workspace: ${selectedWorkspace.name} (${selectedWorkspace.role})`
-                : 'No workspace selected'}
-            </p>
+          <div className="absolute left-0 right-0 top-full z-30 border-b border-gray-200 bg-white px-4 py-3 shadow-xl">
+            <div className="rounded-md border border-gray-200 bg-gray-50 p-2">
+              <p className="truncate text-sm font-semibold text-gray-900">
+                {selectedWorkspace?.name || 'Personal'} Workspace
+              </p>
+              <p className="mt-1 truncate text-xs text-gray-500">{userEmail}</p>
+              <p className="truncate text-xs text-gray-500">Role: {selectedWorkspaceRole}</p>
+            </div>
 
             <div className="mt-3 space-y-1 rounded-md border border-gray-200 bg-gray-50 p-2">
               <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">Workspaces</p>
-              {workspaces.length === 0 && <p className="text-xs text-gray-500">No workspaces yet</p>}
+              {workspacesLoading && <p className="text-xs text-gray-500">Loading workspaces...</p>}
+              {!workspacesLoading && workspaces.length === 0 && (
+                <p className="text-xs text-gray-500">No workspaces yet</p>
+              )}
               {workspaces.map((workspace) => {
                 const isSelected = workspace.id === resolvedWorkspaceId;
                 return (
@@ -311,7 +319,8 @@ export function Sidebar() {
                     className="flex w-full items-center justify-between rounded px-2 py-1 text-left text-sm text-gray-700 hover:bg-gray-100"
                   >
                     <span className="truncate">
-                      {workspace.name} <span className="text-xs text-gray-500">({workspace.role})</span>
+                      {workspace.name}{' '}
+                      <span className="text-xs text-gray-500">({workspace.role || 'member'})</span>
                     </span>
                     {isSelected && <Check className="h-4 w-4 text-gray-700" />}
                   </button>
@@ -327,7 +336,10 @@ export function Sidebar() {
                 }}
                 className="rounded border border-gray-300 px-2 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
               >
-                Workspaces
+                <span className="inline-flex items-center gap-1">
+                  <Building2 className="h-4 w-4" />
+                  Manage
+                </span>
               </button>
               <button
                 disabled
@@ -348,47 +360,8 @@ export function Sidebar() {
           </div>
         )}
       </div>
-      <div className="px-4 pb-3">
-        <label className="mb-1 block text-xs font-semibold uppercase tracking-wide text-gray-400">
-          Workspace
-        </label>
-        <select
-          value={resolvedWorkspaceId}
-          onChange={(e) => handleWorkspaceChange(e.target.value)}
-          disabled={workspacesLoading || workspaces.length === 0}
-          className="w-full rounded-md border border-gray-700 bg-gray-800 px-3 py-2 text-sm text-gray-100 focus:border-gray-500 focus:outline-none"
-        >
-          {workspaces.length === 0 && <option value="">No workspaces</option>}
-          {workspaces.map((workspace) => (
-            <option key={workspace.id} value={workspace.id}>
-              {workspace.name} ({workspace.type})
-            </option>
-          ))}
-        </select>
-        <div className="mt-2">
-          {!isMounted && (
-            <Button
-              variant="outline"
-              size="sm"
-              disabled
-              className="w-full border-gray-700 bg-gray-800 text-gray-400"
-            >
-              <Building2 className="h-4 w-4" />
-              Manage Workspaces
-            </Button>
-          )}
-          {isMounted && (
-            <Dialog open={workspaceManagerOpen} onOpenChange={setWorkspaceManagerOpen}>
-            <DialogTrigger asChild>
-              <Button
-                variant="outline"
-                size="sm"
-                className="w-full border-gray-700 bg-gray-800 text-gray-100 hover:bg-gray-700 hover:text-white"
-              >
-                <Building2 className="h-4 w-4" />
-                Manage Workspaces
-              </Button>
-            </DialogTrigger>
+      {isMounted && (
+        <Dialog open={workspaceManagerOpen} onOpenChange={setWorkspaceManagerOpen}>
             <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-xl">
               <DialogHeader>
                 <DialogTitle>Workspace Studio</DialogTitle>
@@ -543,10 +516,8 @@ export function Sidebar() {
                 </p>
               )}
             </DialogContent>
-            </Dialog>
-          )}
-        </div>
-      </div>
+        </Dialog>
+      )}
       <nav className="flex flex-1 flex-col">
         <ul className="flex flex-1 flex-col gap-y-1 px-3">
           {navigation.map((item) => {

--- a/packages/web/src/components/layout/sidebar.tsx
+++ b/packages/web/src/components/layout/sidebar.tsx
@@ -14,13 +14,27 @@ import {
   FileText,
   Puzzle,
   MessageSquare,
+  Plus,
+  UserPlus,
+  Building2,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useRouter } from 'next/navigation';
-import { useApiQuery, useQueryClient } from '@/lib/api/hooks';
+import { useApiPost, useApiPostDynamic, useApiQuery, useQueryClient } from '@/lib/api/hooks';
 import { getSelectedWorkspaceId, setSelectedWorkspaceId } from '@/lib/workspace-selection';
 import { useEffect, useMemo, useState } from 'react';
 import { signOut } from '@/lib/auth/actions';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 
 const navigation = [
   { name: 'Dashboard', href: '/', icon: Home },
@@ -40,11 +54,28 @@ interface WorkspaceOption {
   name: string;
   slug: string;
   type: 'personal' | 'team';
+  role: 'owner' | 'admin' | 'member' | 'viewer';
 }
 
 interface WorkspaceListResponse {
   currentWorkspaceId: string;
+  currentWorkspaceRole: 'owner' | 'admin' | 'member' | 'viewer' | 'trusted';
   workspaces: WorkspaceOption[];
+}
+
+interface WorkspaceMembersResponse {
+  canManage: boolean;
+  members: Array<{
+    id: string;
+    userId: string;
+    role: 'owner' | 'admin' | 'member' | 'viewer';
+    user: {
+      id: string;
+      email: string | null;
+      firstName: string | null;
+      username: string | null;
+    } | null;
+  }>;
 }
 
 export function Sidebar() {
@@ -52,6 +83,14 @@ export function Sidebar() {
   const router = useRouter();
   const queryClient = useQueryClient();
   const [selectedWorkspaceId, setSelectedWorkspaceState] = useState<string | null>(null);
+  const [workspaceManagerOpen, setWorkspaceManagerOpen] = useState(false);
+  const [newWorkspaceName, setNewWorkspaceName] = useState('');
+  const [newWorkspaceType, setNewWorkspaceType] = useState<'personal' | 'team'>('team');
+  const [newWorkspaceDescription, setNewWorkspaceDescription] = useState('');
+  const [inviteWorkspaceId, setInviteWorkspaceId] = useState<string>('');
+  const [inviteEmail, setInviteEmail] = useState('');
+  const [inviteRole, setInviteRole] = useState<'owner' | 'admin' | 'member' | 'viewer'>('member');
+  const [workspaceError, setWorkspaceError] = useState<string | null>(null);
 
   const { data: workspaceData, isLoading: workspacesLoading } = useApiQuery<WorkspaceListResponse>(
     ['workspace-containers'],
@@ -61,7 +100,68 @@ export function Sidebar() {
     }
   );
 
+  const resolvedWorkspaceId = useMemo(() => {
+    if (selectedWorkspaceId) return selectedWorkspaceId;
+    return workspaceData?.currentWorkspaceId ?? '';
+  }, [selectedWorkspaceId, workspaceData?.currentWorkspaceId]);
+
   const workspaces = workspaceData?.workspaces || [];
+  const inviteTargetWorkspaceId = inviteWorkspaceId || resolvedWorkspaceId;
+  const workspaceMembersPath = inviteTargetWorkspaceId
+    ? `/api/admin/workspaces/${inviteTargetWorkspaceId}/members`
+    : '/api/admin/workspaces/none/members';
+
+  const { data: workspaceMembersData, isLoading: workspaceMembersLoading } =
+    useApiQuery<WorkspaceMembersResponse>(
+      ['workspace-members', inviteTargetWorkspaceId],
+      workspaceMembersPath,
+      {
+        enabled: workspaceManagerOpen && Boolean(inviteTargetWorkspaceId),
+        retry: 1,
+      }
+    );
+
+  const createWorkspaceMutation = useApiPost<
+    { workspace: WorkspaceOption },
+    { name: string; type: 'personal' | 'team'; description?: string }
+  >('/api/admin/workspaces', {
+    onSuccess: (data) => {
+      const createdWorkspaceId = data.workspace.id;
+      setSelectedWorkspaceId(createdWorkspaceId);
+      setSelectedWorkspaceState(createdWorkspaceId);
+      setInviteWorkspaceId(createdWorkspaceId);
+      setNewWorkspaceName('');
+      setNewWorkspaceDescription('');
+      setWorkspaceError(null);
+      queryClient.invalidateQueries({ queryKey: ['workspace-containers'] });
+      queryClient.invalidateQueries({ queryKey: ['workspace-members', createdWorkspaceId] });
+      router.refresh();
+    },
+    onError: (error) => {
+      setWorkspaceError(error.message || 'Failed to create workspace');
+    },
+  });
+
+  const inviteWorkspaceMemberMutation = useApiPostDynamic<
+    { member: { id: string } },
+    { workspaceId: string; email: string; role: 'owner' | 'admin' | 'member' | 'viewer' }
+  >(
+    (input) => `/api/admin/workspaces/${input.workspaceId}/members`,
+    (input) => ({
+      email: input.email,
+      role: input.role,
+    }),
+    {
+      onSuccess: (_, variables) => {
+        setInviteEmail('');
+        setWorkspaceError(null);
+        queryClient.invalidateQueries({ queryKey: ['workspace-members', variables.workspaceId] });
+      },
+      onError: (error) => {
+        setWorkspaceError(error.message || 'Failed to invite collaborator');
+      },
+    }
+  );
 
   useEffect(() => {
     const locallySelected = getSelectedWorkspaceId();
@@ -76,10 +176,14 @@ export function Sidebar() {
     }
   }, [workspaceData?.currentWorkspaceId]);
 
-  const resolvedWorkspaceId = useMemo(() => {
-    if (selectedWorkspaceId) return selectedWorkspaceId;
-    return workspaceData?.currentWorkspaceId ?? '';
-  }, [selectedWorkspaceId, workspaceData?.currentWorkspaceId]);
+  useEffect(() => {
+    if (!inviteWorkspaceId) {
+      const fallbackWorkspaceId = selectedWorkspaceId || workspaceData?.currentWorkspaceId;
+      if (fallbackWorkspaceId) {
+        setInviteWorkspaceId(fallbackWorkspaceId);
+      }
+    }
+  }, [inviteWorkspaceId, selectedWorkspaceId, workspaceData?.currentWorkspaceId]);
 
   const handleWorkspaceChange = (workspaceId: string) => {
     setSelectedWorkspaceId(workspaceId);
@@ -87,6 +191,41 @@ export function Sidebar() {
     // Force all data queries to refetch with the new workspace header.
     queryClient.invalidateQueries();
     router.refresh();
+  };
+
+  const handleCreateWorkspace = () => {
+    const trimmedWorkspaceName = newWorkspaceName.trim();
+    if (!trimmedWorkspaceName) {
+      setWorkspaceError('Workspace name is required');
+      return;
+    }
+
+    setWorkspaceError(null);
+    createWorkspaceMutation.mutate({
+      name: trimmedWorkspaceName,
+      type: newWorkspaceType,
+      description: newWorkspaceDescription.trim() || undefined,
+    });
+  };
+
+  const handleInviteWorkspaceMember = () => {
+    const trimmedInviteEmail = inviteEmail.trim();
+    if (!trimmedInviteEmail || !trimmedInviteEmail.includes('@')) {
+      setWorkspaceError('Valid collaborator email is required');
+      return;
+    }
+
+    if (!inviteTargetWorkspaceId) {
+      setWorkspaceError('Select a workspace before inviting');
+      return;
+    }
+
+    setWorkspaceError(null);
+    inviteWorkspaceMemberMutation.mutate({
+      workspaceId: inviteTargetWorkspaceId,
+      email: trimmedInviteEmail,
+      role: inviteRole,
+    });
   };
 
   return (
@@ -111,6 +250,171 @@ export function Sidebar() {
             </option>
           ))}
         </select>
+        <div className="mt-2">
+          <Dialog open={workspaceManagerOpen} onOpenChange={setWorkspaceManagerOpen}>
+            <DialogTrigger asChild>
+              <Button
+                variant="outline"
+                size="sm"
+                className="w-full border-gray-700 bg-gray-800 text-gray-100 hover:bg-gray-700 hover:text-white"
+              >
+                <Building2 className="h-4 w-4" />
+                Manage Workspaces
+              </Button>
+            </DialogTrigger>
+            <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-xl">
+              <DialogHeader>
+                <DialogTitle>Workspace Studio</DialogTitle>
+                <DialogDescription>
+                  Create workspaces, add collaborators, and organize teams.
+                </DialogDescription>
+              </DialogHeader>
+
+              <Tabs defaultValue="create" className="w-full">
+                <TabsList className="grid w-full grid-cols-2">
+                  <TabsTrigger value="create">
+                    <Plus className="mr-1 h-4 w-4" />
+                    Create
+                  </TabsTrigger>
+                  <TabsTrigger value="invite">
+                    <UserPlus className="mr-1 h-4 w-4" />
+                    Collaborators
+                  </TabsTrigger>
+                </TabsList>
+
+                <TabsContent value="create" className="space-y-3 pt-2">
+                  <div className="space-y-1">
+                    <label className="text-sm font-medium text-gray-700">Workspace name</label>
+                    <Input
+                      placeholder="e.g., PCP Team"
+                      value={newWorkspaceName}
+                      onChange={(event) => setNewWorkspaceName(event.target.value)}
+                    />
+                  </div>
+
+                  <div className="grid grid-cols-2 gap-3">
+                    <div className="space-y-1">
+                      <label className="text-sm font-medium text-gray-700">Type</label>
+                      <select
+                        value={newWorkspaceType}
+                        onChange={(event) =>
+                          setNewWorkspaceType(event.target.value as 'personal' | 'team')
+                        }
+                        className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+                      >
+                        <option value="team">Team</option>
+                        <option value="personal">Personal</option>
+                      </select>
+                    </div>
+                    <div className="space-y-1">
+                      <label className="text-sm font-medium text-gray-700">Description</label>
+                      <Input
+                        placeholder="Optional"
+                        value={newWorkspaceDescription}
+                        onChange={(event) => setNewWorkspaceDescription(event.target.value)}
+                      />
+                    </div>
+                  </div>
+
+                  <Button
+                    onClick={handleCreateWorkspace}
+                    disabled={createWorkspaceMutation.isPending}
+                    className="w-full"
+                  >
+                    {createWorkspaceMutation.isPending ? 'Creating...' : 'Create workspace'}
+                  </Button>
+                </TabsContent>
+
+                <TabsContent value="invite" className="space-y-3 pt-2">
+                  <div className="space-y-1">
+                    <label className="text-sm font-medium text-gray-700">Workspace</label>
+                    <select
+                      value={inviteTargetWorkspaceId}
+                      onChange={(event) => setInviteWorkspaceId(event.target.value)}
+                      className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+                    >
+                      {workspaces.map((workspace) => (
+                        <option key={workspace.id} value={workspace.id}>
+                          {workspace.name} ({workspace.role})
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+
+                  <div className="grid grid-cols-3 gap-3">
+                    <div className="col-span-2 space-y-1">
+                      <label className="text-sm font-medium text-gray-700">Collaborator email</label>
+                      <Input
+                        placeholder="co@example.com"
+                        value={inviteEmail}
+                        onChange={(event) => setInviteEmail(event.target.value)}
+                      />
+                    </div>
+                    <div className="space-y-1">
+                      <label className="text-sm font-medium text-gray-700">Role</label>
+                      <select
+                        value={inviteRole}
+                        onChange={(event) =>
+                          setInviteRole(event.target.value as 'owner' | 'admin' | 'member' | 'viewer')
+                        }
+                        className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+                      >
+                        <option value="member">member</option>
+                        <option value="admin">admin</option>
+                        <option value="viewer">viewer</option>
+                        <option value="owner">owner</option>
+                      </select>
+                    </div>
+                  </div>
+
+                  <Button
+                    onClick={handleInviteWorkspaceMember}
+                    disabled={inviteWorkspaceMemberMutation.isPending || !workspaceMembersData?.canManage}
+                    className="w-full"
+                  >
+                    {inviteWorkspaceMemberMutation.isPending ? 'Inviting...' : 'Invite collaborator'}
+                  </Button>
+
+                  <div className="rounded-md border p-3">
+                    <p className="mb-2 text-sm font-semibold text-gray-700">Current collaborators</p>
+                    {workspaceMembersLoading && (
+                      <p className="text-sm text-gray-500">Loading collaborators...</p>
+                    )}
+                    {!workspaceMembersLoading && workspaceMembersData?.members?.length === 0 && (
+                      <p className="text-sm text-gray-500">No collaborators yet.</p>
+                    )}
+                    {!workspaceMembersLoading &&
+                      workspaceMembersData?.members?.map((member) => (
+                        <div
+                          key={member.id}
+                          className="flex items-center justify-between border-t py-2 text-sm first:border-t-0"
+                        >
+                          <div>
+                            <p className="font-medium text-gray-900">
+                              {member.user?.firstName ||
+                                member.user?.username ||
+                                member.user?.email ||
+                                member.userId}
+                            </p>
+                            <p className="text-xs text-gray-500">{member.user?.email || member.userId}</p>
+                          </div>
+                          <span className="rounded-full bg-gray-100 px-2 py-1 text-xs text-gray-700">
+                            {member.role}
+                          </span>
+                        </div>
+                      ))}
+                  </div>
+                </TabsContent>
+              </Tabs>
+
+              {workspaceError && (
+                <p className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+                  {workspaceError}
+                </p>
+              )}
+            </DialogContent>
+          </Dialog>
+        </div>
       </div>
       <nav className="flex flex-1 flex-col">
         <ul className="flex flex-1 flex-col gap-y-1 px-3">

--- a/packages/web/src/components/layout/sidebar.tsx
+++ b/packages/web/src/components/layout/sidebar.tsx
@@ -77,6 +77,7 @@ interface WorkspaceMembersResponse {
       email: string | null;
       firstName: string | null;
       username: string | null;
+      lastLoginAt: string | null;
     } | null;
   }>;
 }
@@ -522,7 +523,10 @@ export function Sidebar() {
                                 member.user?.email ||
                                 member.userId}
                             </p>
-                            <p className="text-xs text-gray-500">{member.user?.email || member.userId}</p>
+                            <p className="text-xs text-gray-500">
+                              {member.user?.email || member.userId}
+                              {member.user?.lastLoginAt ? ' · joined' : ' · invited'}
+                            </p>
                           </div>
                           <span className="rounded-full bg-gray-100 px-2 py-1 text-xs text-gray-700">
                             {member.role}

--- a/packages/web/src/lib/auth/actions.ts
+++ b/packages/web/src/lib/auth/actions.ts
@@ -2,6 +2,7 @@
 
 import { redirect } from 'next/navigation';
 import { createClient } from '@/lib/supabase/server';
+import { provisionPcpUserAndWorkspace } from '@/lib/auth/provision';
 
 type AuthResult = { success: true } | { error: string } | { mcpRedirectUrl: string };
 
@@ -19,6 +20,10 @@ export async function signInWithPassword(
 
   if (error) {
     return { error: error.message };
+  }
+
+  if (data.session?.access_token) {
+    await provisionPcpUserAndWorkspace(data.session.access_token);
   }
 
   // MCP OAuth flow: build callback URL with tokens

--- a/packages/web/src/lib/auth/provision.ts
+++ b/packages/web/src/lib/auth/provision.ts
@@ -1,0 +1,28 @@
+/**
+ * Best-effort bootstrap of PCP user + personal workspace after auth.
+ * This intentionally swallows errors so login/signup UX is never blocked.
+ */
+export async function provisionPcpUserAndWorkspace(accessToken: string): Promise<void> {
+  if (!accessToken) return;
+  if (process.env.NODE_ENV === 'test') return;
+
+  const apiUrl = process.env.API_URL || `http://localhost:${process.env.PCP_PORT_BASE || 3001}`;
+
+  try {
+    const response = await fetch(`${apiUrl}/api/admin/workspaces`, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+      cache: 'no-store',
+    });
+
+    if (!response.ok) {
+      console.warn('[auth/provision] failed to provision personal workspace', {
+        status: response.status,
+      });
+    }
+  } catch (error) {
+    console.warn('[auth/provision] failed to provision personal workspace', { error });
+  }
+}

--- a/packages/web/src/lib/supabase/middleware.ts
+++ b/packages/web/src/lib/supabase/middleware.ts
@@ -27,6 +27,36 @@ export async function updateSession(request: NextRequest) {
     }
   );
 
+  const path = request.nextUrl.pathname;
+  const isProxiedApiRoute = path.startsWith('/api/') && !path.startsWith('/api/auth/');
+
+  // Fast-path for proxied API routes: inject bearer token only.
+  // Skip getUser() to avoid duplicate Supabase round-trips on every API request.
+  if (isProxiedApiRoute) {
+    const {
+      data: { session },
+    } = await supabase.auth.getSession();
+    if (session?.access_token) {
+      const requestHeaders = new Headers(request.headers);
+      requestHeaders.set('Authorization', `Bearer ${session.access_token}`);
+
+      const response = NextResponse.next({
+        request: {
+          headers: requestHeaders,
+        },
+      });
+
+      // Copy session-refresh cookies from supabaseResponse
+      supabaseResponse.cookies.getAll().forEach((cookie) => {
+        response.cookies.set(cookie.name, cookie.value, cookie);
+      });
+
+      return response;
+    }
+
+    return supabaseResponse;
+  }
+
   // IMPORTANT: Avoid writing any logic between createServerClient and
   // supabase.auth.getUser(). A simple mistake could make it very hard to debug
   // issues with users being randomly logged out.
@@ -91,33 +121,6 @@ export async function updateSession(request: NextRequest) {
     const url = request.nextUrl.clone();
     url.pathname = '/';
     return NextResponse.redirect(url);
-  }
-
-  // Inject auth header for proxied API routes (admin, chat, kindle)
-  // Skip /api/auth/* (internal Next.js routes, not proxied)
-  const path = request.nextUrl.pathname;
-  if (path.startsWith('/api/') && !path.startsWith('/api/auth/')) {
-    const {
-      data: { session },
-    } = await supabase.auth.getSession();
-    if (session?.access_token) {
-      // Clone the request headers and add Authorization
-      const requestHeaders = new Headers(request.headers);
-      requestHeaders.set('Authorization', `Bearer ${session.access_token}`);
-
-      const response = NextResponse.next({
-        request: {
-          headers: requestHeaders,
-        },
-      });
-
-      // Copy session-refresh cookies from supabaseResponse
-      supabaseResponse.cookies.getAll().forEach((cookie) => {
-        response.cookies.set(cookie.name, cookie.value, cookie);
-      });
-
-      return response;
-    }
   }
 
   return supabaseResponse;

--- a/supabase/migrations/20260214032518_users_last_login_at.sql
+++ b/supabase/migrations/20260214032518_users_last_login_at.sql
@@ -1,0 +1,16 @@
+-- Track whether invited users have actually logged in.
+-- Null last_login_at means invited/placeholder account that has not completed auth yet.
+
+ALTER TABLE public.users
+ADD COLUMN IF NOT EXISTS last_login_at timestamptz;
+
+-- Backfill for existing users that already have a Supabase auth account.
+UPDATE public.users AS u
+SET last_login_at = COALESCE(au.last_sign_in_at, au.created_at)
+FROM auth.users AS au
+WHERE u.last_login_at IS NULL
+  AND u.email IS NOT NULL
+  AND lower(au.email) = lower(u.email);
+
+COMMENT ON COLUMN public.users.last_login_at IS
+  'Most recent successful authenticated login seen by PCP. NULL indicates an invited placeholder user that has never logged in.';


### PR DESCRIPTION
## Summary

- add workspace creation and collaborator invite/list APIs in `packages/api/src/routes/admin.ts`
- make workspace access membership-aware (not owner-only) in `WorkspaceContainersRepository` and admin auth middleware
- add MCP tool `add_workspace_member` (renamed from `add_workspace_container_member`) for clearer future naming
- add CLI commands for workspace collaboration:
  - `sb workspace create <name> [--type ...] [--description ...] [--slug ...] [--use]`
  - `sb workspace invite <workspace-id-or-slug> <email> [--role ...]`
  - `sb workspace members [workspace-id-or-slug]`
- add polished Workspace Studio dialog in the web sidebar for create/invite/member listing
- normalize user-facing strings to “workspace” terminology where possible

## Test plan

- [x] `yarn workspace @personal-context/api test src/mcp/tools/workspace-container-handlers.test.ts`
- [x] `yarn workspace @personal-context/web type-check`
- [x] `yarn workspace @personal-context/cli build`

Generated with Codex