### PR TITLE
feat(mcp): integration health table + MCP tools (by Wren)

### DIFF
--- a/packages/api/src/data/supabase/types.ts
+++ b/packages/api/src/data/supabase/types.ts
@@ -415,77 +415,6 @@ export type Database = {
           },
         ];
       };
-      artifact_history: {
-        Row: {
-          artifact_id: string;
-          change_summary: string | null;
-          change_type: string | null;
-          changed_by_agent_id: string | null;
-          changed_by_user_id: string | null;
-          content: string;
-          created_at: string | null;
-          id: string;
-          title: string;
-          version: number;
-          workspace_id: string | null;
-        };
-        Insert: {
-          artifact_id: string;
-          change_summary?: string | null;
-          change_type?: string | null;
-          changed_by_agent_id?: string | null;
-          changed_by_user_id?: string | null;
-          content: string;
-          created_at?: string | null;
-          id?: string;
-          title: string;
-          version: number;
-          workspace_id?: string | null;
-        };
-        Update: {
-          artifact_id?: string;
-          change_summary?: string | null;
-          change_type?: string | null;
-          changed_by_agent_id?: string | null;
-          changed_by_user_id?: string | null;
-          content?: string;
-          created_at?: string | null;
-          id?: string;
-          title?: string;
-          version?: number;
-          workspace_id?: string | null;
-        };
-        Relationships: [
-          {
-            foreignKeyName: 'artifact_history_artifact_id_fkey';
-            columns: ['artifact_id'];
-            isOneToOne: false;
-            referencedRelation: 'artifacts';
-            referencedColumns: ['id'];
-          },
-          {
-            foreignKeyName: 'artifact_history_changed_by_user_id_fkey';
-            columns: ['changed_by_user_id'];
-            isOneToOne: false;
-            referencedRelation: 'users';
-            referencedColumns: ['id'];
-          },
-          {
-            foreignKeyName: 'artifact_history_changed_by_identity_id_fkey';
-            columns: ['changed_by_identity_id'];
-            isOneToOne: false;
-            referencedRelation: 'agent_identities';
-            referencedColumns: ['id'];
-          },
-          {
-            foreignKeyName: 'artifact_history_workspace_id_fkey';
-            columns: ['workspace_id'];
-            isOneToOne: false;
-            referencedRelation: 'workspace_containers';
-            referencedColumns: ['id'];
-          },
-        ];
-      };
       artifact_comments: {
         Row: {
           artifact_id: string;
@@ -574,6 +503,80 @@ export type Database = {
           },
         ];
       };
+      artifact_history: {
+        Row: {
+          artifact_id: string;
+          change_summary: string | null;
+          change_type: string | null;
+          changed_by_agent_id: string | null;
+          changed_by_identity_id: string | null;
+          changed_by_user_id: string | null;
+          content: string;
+          created_at: string | null;
+          id: string;
+          title: string;
+          version: number;
+          workspace_id: string | null;
+        };
+        Insert: {
+          artifact_id: string;
+          change_summary?: string | null;
+          change_type?: string | null;
+          changed_by_agent_id?: string | null;
+          changed_by_identity_id?: string | null;
+          changed_by_user_id?: string | null;
+          content: string;
+          created_at?: string | null;
+          id?: string;
+          title: string;
+          version: number;
+          workspace_id?: string | null;
+        };
+        Update: {
+          artifact_id?: string;
+          change_summary?: string | null;
+          change_type?: string | null;
+          changed_by_agent_id?: string | null;
+          changed_by_identity_id?: string | null;
+          changed_by_user_id?: string | null;
+          content?: string;
+          created_at?: string | null;
+          id?: string;
+          title?: string;
+          version?: number;
+          workspace_id?: string | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'artifact_history_artifact_id_fkey';
+            columns: ['artifact_id'];
+            isOneToOne: false;
+            referencedRelation: 'artifacts';
+            referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'artifact_history_changed_by_identity_id_fkey';
+            columns: ['changed_by_identity_id'];
+            isOneToOne: false;
+            referencedRelation: 'agent_identities';
+            referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'artifact_history_changed_by_user_id_fkey';
+            columns: ['changed_by_user_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'artifact_history_workspace_id_fkey';
+            columns: ['workspace_id'];
+            isOneToOne: false;
+            referencedRelation: 'workspace_containers';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
       artifacts: {
         Row: {
           artifact_type: string;
@@ -582,6 +585,7 @@ export type Database = {
           content_type: string | null;
           created_at: string | null;
           created_by_agent_id: string | null;
+          created_by_identity_id: string | null;
           id: string;
           metadata: Json | null;
           tags: string[] | null;
@@ -600,6 +604,7 @@ export type Database = {
           content_type?: string | null;
           created_at?: string | null;
           created_by_agent_id?: string | null;
+          created_by_identity_id?: string | null;
           id?: string;
           metadata?: Json | null;
           tags?: string[] | null;
@@ -618,6 +623,7 @@ export type Database = {
           content_type?: string | null;
           created_at?: string | null;
           created_by_agent_id?: string | null;
+          created_by_identity_id?: string | null;
           id?: string;
           metadata?: Json | null;
           tags?: string[] | null;
@@ -631,17 +637,17 @@ export type Database = {
         };
         Relationships: [
           {
-            foreignKeyName: 'artifacts_user_id_fkey';
-            columns: ['user_id'];
-            isOneToOne: false;
-            referencedRelation: 'users';
-            referencedColumns: ['id'];
-          },
-          {
             foreignKeyName: 'artifacts_created_by_identity_id_fkey';
             columns: ['created_by_identity_id'];
             isOneToOne: false;
             referencedRelation: 'agent_identities';
+            referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'artifacts_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
             referencedColumns: ['id'];
           },
           {
@@ -1144,6 +1150,59 @@ export type Database = {
             foreignKeyName: 'heartbeat_state_user_id_fkey';
             columns: ['user_id'];
             isOneToOne: true;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
+      integration_health: {
+        Row: {
+          created_at: string | null;
+          error_code: string | null;
+          error_message: string | null;
+          id: string;
+          last_check_at: string | null;
+          last_healthy_at: string | null;
+          metadata: Json | null;
+          reported_by_agent_id: string | null;
+          service: string;
+          status: string;
+          updated_at: string | null;
+          user_id: string;
+        };
+        Insert: {
+          created_at?: string | null;
+          error_code?: string | null;
+          error_message?: string | null;
+          id?: string;
+          last_check_at?: string | null;
+          last_healthy_at?: string | null;
+          metadata?: Json | null;
+          reported_by_agent_id?: string | null;
+          service: string;
+          status?: string;
+          updated_at?: string | null;
+          user_id: string;
+        };
+        Update: {
+          created_at?: string | null;
+          error_code?: string | null;
+          error_message?: string | null;
+          id?: string;
+          last_check_at?: string | null;
+          last_healthy_at?: string | null;
+          metadata?: Json | null;
+          reported_by_agent_id?: string | null;
+          service?: string;
+          status?: string;
+          updated_at?: string | null;
+          user_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'integration_health_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
             referencedRelation: 'users';
             referencedColumns: ['id'];
           },
@@ -2011,17 +2070,17 @@ export type Database = {
         };
         Relationships: [
           {
-            foreignKeyName: 'sessions_user_id_fkey';
-            columns: ['user_id'];
-            isOneToOne: false;
-            referencedRelation: 'users';
-            referencedColumns: ['id'];
-          },
-          {
             foreignKeyName: 'sessions_studio_id_fkey';
             columns: ['studio_id'];
             isOneToOne: false;
             referencedRelation: 'workspaces';
+            referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'sessions_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
             referencedColumns: ['id'];
           },
           {
@@ -2421,7 +2480,7 @@ export type Database = {
           {
             foreignKeyName: 'user_identity_user_id_fkey';
             columns: ['user_id'];
-            isOneToOne: true;
+            isOneToOne: false;
             referencedRelation: 'users';
             referencedColumns: ['id'];
           },

--- a/packages/api/src/mcp/tools/index.ts
+++ b/packages/api/src/mcp/tools/index.ts
@@ -231,6 +231,13 @@ import {
 
 import { handleCreateKindleToken, createKindleTokenSchema } from './kindle-handlers';
 
+import {
+  handleUpdateIntegrationHealth,
+  handleGetIntegrationHealth,
+  updateIntegrationHealthSchema,
+  getIntegrationHealthSchema,
+} from './integration-health-handlers';
+
 // Re-export for external use
 export { setResponseCallback, addPendingMessage } from './response-handlers';
 export { setTelegramListener, registerChannelListener } from './chat-context-handlers';
@@ -4514,6 +4521,81 @@ User can be identified by ONE of: userId, email, phone, or platform + platformId
         return await handleCreateKindleToken(args, dataComposer);
       } catch (error) {
         logger.error('Error in create_kindle_token:', error);
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                success: false,
+                error: error instanceof Error ? error.message : 'Unknown error',
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // =====================================================
+  // Integration Health Tools
+  // =====================================================
+
+  server.registerTool(
+    'update_integration_health',
+    {
+      title: 'Update Integration Health',
+      description:
+        'Report the health status of an external service integration (e.g., Google Calendar, Gmail). ' +
+        'Use this when an integration fails, recovers, or is first configured. ' +
+        'Upserts one row per user per service.\n\n' +
+        'User can be identified by ONE of:\n' +
+        '- userId: Direct UUID\n' +
+        '- email: Email address\n' +
+        '- phone: Phone number (E.164 format like +14155551234)\n' +
+        '- platform + platformId: Platform name (telegram/whatsapp/discord) and user ID',
+      inputSchema: updateIntegrationHealthSchema,
+    },
+    async (args) => {
+      try {
+        return await handleUpdateIntegrationHealth(args, dataComposer);
+      } catch (error) {
+        logger.error('Error in update_integration_health:', error);
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                success: false,
+                error: error instanceof Error ? error.message : 'Unknown error',
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  server.registerTool(
+    'get_integration_health',
+    {
+      title: 'Get Integration Health',
+      description:
+        'Check the health status of external service integrations. ' +
+        'Returns all integrations for the user, or filter to a specific service.\n\n' +
+        'User can be identified by ONE of:\n' +
+        '- userId: Direct UUID\n' +
+        '- email: Email address\n' +
+        '- phone: Phone number (E.164 format like +14155551234)\n' +
+        '- platform + platformId: Platform name (telegram/whatsapp/discord) and user ID',
+      inputSchema: getIntegrationHealthSchema,
+    },
+    async (args) => {
+      try {
+        return await handleGetIntegrationHealth(args, dataComposer);
+      } catch (error) {
+        logger.error('Error in get_integration_health:', error);
         return {
           content: [
             {

--- a/packages/api/src/mcp/tools/integration-health-handlers.ts
+++ b/packages/api/src/mcp/tools/integration-health-handlers.ts
@@ -1,0 +1,161 @@
+import { z } from 'zod';
+import type { DataComposer } from '../../data/composer';
+import { logger } from '../../utils/logger';
+import { userIdentifierBaseSchema, resolveUserOrThrow } from '../../services/user-resolver';
+
+const VALID_STATUSES = ['healthy', 'degraded', 'error', 'not_configured'] as const;
+
+// Row type for the integration_health table (not yet in generated types)
+interface IntegrationHealthRow {
+  id: string;
+  user_id: string;
+  service: string;
+  status: string;
+  error_code: string | null;
+  error_message: string | null;
+  last_check_at: string;
+  last_healthy_at: string | null;
+  reported_by_agent_id: string | null;
+  metadata: Record<string, unknown>;
+  created_at: string;
+  updated_at: string;
+}
+
+export const updateIntegrationHealthSchema = userIdentifierBaseSchema.extend({
+  service: z
+    .string()
+    .describe('Service name (e.g., "google_calendar", "google_gmail", "telegram")'),
+  status: z.enum(VALID_STATUSES).describe('Current health status'),
+  errorCode: z
+    .string()
+    .optional()
+    .describe('Structured error code (e.g., "oauth_expired", "rate_limited")'),
+  errorMessage: z.string().optional().describe('Human-readable error description'),
+  agentId: z.string().optional().describe('Which SB is reporting this'),
+  metadata: z.record(z.unknown()).optional().describe('Additional context'),
+});
+
+export const getIntegrationHealthSchema = userIdentifierBaseSchema.extend({
+  service: z.string().optional().describe('Filter to a specific service (omit for all)'),
+});
+
+export async function handleUpdateIntegrationHealth(args: unknown, dataComposer: DataComposer) {
+  const params = updateIntegrationHealthSchema.parse(args);
+  const { user, resolvedBy } = await resolveUserOrThrow(params, dataComposer);
+
+  const now = new Date().toISOString();
+  const isHealthy = params.status === 'healthy';
+
+  const upsertData = {
+    user_id: user.id,
+    service: params.service,
+    status: params.status,
+    error_code: isHealthy ? null : (params.errorCode ?? null),
+    error_message: isHealthy ? null : (params.errorMessage ?? null),
+    last_check_at: now,
+    ...(isHealthy ? { last_healthy_at: now } : {}),
+    reported_by_agent_id: params.agentId ?? null,
+    metadata: params.metadata ?? {},
+    updated_at: now,
+  };
+
+  // Cast through any — integration_health isn't in generated types yet.
+  // Remove after running generate_typescript_types post-migration.
+  const client = dataComposer.getClient() as any;
+  const { data, error } = (await client
+    .from('integration_health')
+    .upsert(upsertData, { onConflict: 'user_id,service' })
+    .select()
+    .single()) as { data: IntegrationHealthRow | null; error: any };
+
+  if (error || !data) {
+    throw new Error(`Failed to update integration health: ${error?.message ?? 'no data returned'}`);
+  }
+
+  logger.info(
+    `Integration health updated: ${params.service}=${params.status} for user ${user.id}`,
+    { service: params.service, status: params.status, resolvedBy }
+  );
+
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: JSON.stringify(
+          {
+            success: true,
+            user: { id: user.id, resolvedBy },
+            health: {
+              id: data.id,
+              service: data.service,
+              status: data.status,
+              errorCode: data.error_code,
+              errorMessage: data.error_message,
+              lastCheckAt: data.last_check_at,
+              lastHealthyAt: data.last_healthy_at,
+              reportedByAgentId: data.reported_by_agent_id,
+            },
+          },
+          null,
+          2
+        ),
+      },
+    ],
+  };
+}
+
+export async function handleGetIntegrationHealth(args: unknown, dataComposer: DataComposer) {
+  const params = getIntegrationHealthSchema.parse(args);
+  const { user, resolvedBy } = await resolveUserOrThrow(params, dataComposer);
+
+  // Cast through any — integration_health isn't in generated types yet.
+  const client = dataComposer.getClient() as any;
+  let query = client.from('integration_health').select('*').eq('user_id', user.id).order('service');
+
+  if (params.service) {
+    query = query.eq('service', params.service);
+  }
+
+  const { data, error } = (await query) as {
+    data: IntegrationHealthRow[] | null;
+    error: any;
+  };
+
+  if (error) {
+    throw new Error(`Failed to get integration health: ${error.message}`);
+  }
+
+  logger.info(`Integration health queried: ${data?.length ?? 0} entries for user ${user.id}`, {
+    resolvedBy,
+    service: params.service,
+  });
+
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: JSON.stringify(
+          {
+            success: true,
+            user: { id: user.id, resolvedBy },
+            count: data?.length ?? 0,
+            integrations: (data ?? []).map((row) => ({
+              id: row.id,
+              service: row.service,
+              status: row.status,
+              errorCode: row.error_code,
+              errorMessage: row.error_message,
+              lastCheckAt: row.last_check_at,
+              lastHealthyAt: row.last_healthy_at,
+              reportedByAgentId: row.reported_by_agent_id,
+              metadata: row.metadata,
+              updatedAt: row.updated_at,
+            })),
+          },
+          null,
+          2
+        ),
+      },
+    ],
+  };
+}

--- a/packages/api/src/mcp/tools/integration-health-handlers.ts
+++ b/packages/api/src/mcp/tools/integration-health-handlers.ts
@@ -1,25 +1,10 @@
 import { z } from 'zod';
 import type { DataComposer } from '../../data/composer';
+import type { Json } from '../../data/supabase/types';
 import { logger } from '../../utils/logger';
 import { userIdentifierBaseSchema, resolveUserOrThrow } from '../../services/user-resolver';
 
 const VALID_STATUSES = ['healthy', 'degraded', 'error', 'not_configured'] as const;
-
-// Row type for the integration_health table (not yet in generated types)
-interface IntegrationHealthRow {
-  id: string;
-  user_id: string;
-  service: string;
-  status: string;
-  error_code: string | null;
-  error_message: string | null;
-  last_check_at: string;
-  last_healthy_at: string | null;
-  reported_by_agent_id: string | null;
-  metadata: Record<string, unknown>;
-  created_at: string;
-  updated_at: string;
-}
 
 export const updateIntegrationHealthSchema = userIdentifierBaseSchema.extend({
   service: z
@@ -53,20 +38,18 @@ export async function handleUpdateIntegrationHealth(args: unknown, dataComposer:
     error_code: isHealthy ? null : (params.errorCode ?? null),
     error_message: isHealthy ? null : (params.errorMessage ?? null),
     last_check_at: now,
-    ...(isHealthy ? { last_healthy_at: now } : {}),
+    last_healthy_at: isHealthy ? now : null,
     reported_by_agent_id: params.agentId ?? null,
-    metadata: params.metadata ?? {},
+    metadata: (params.metadata ?? {}) as Json,
     updated_at: now,
   };
 
-  // Cast through any — integration_health isn't in generated types yet.
-  // Remove after running generate_typescript_types post-migration.
-  const client = dataComposer.getClient() as any;
-  const { data, error } = (await client
+  const { data, error } = await dataComposer
+    .getClient()
     .from('integration_health')
     .upsert(upsertData, { onConflict: 'user_id,service' })
     .select()
-    .single()) as { data: IntegrationHealthRow | null; error: any };
+    .single();
 
   if (error || !data) {
     throw new Error(`Failed to update integration health: ${error?.message ?? 'no data returned'}`);
@@ -108,18 +91,18 @@ export async function handleGetIntegrationHealth(args: unknown, dataComposer: Da
   const params = getIntegrationHealthSchema.parse(args);
   const { user, resolvedBy } = await resolveUserOrThrow(params, dataComposer);
 
-  // Cast through any — integration_health isn't in generated types yet.
-  const client = dataComposer.getClient() as any;
-  let query = client.from('integration_health').select('*').eq('user_id', user.id).order('service');
+  let query = dataComposer
+    .getClient()
+    .from('integration_health')
+    .select('*')
+    .eq('user_id', user.id)
+    .order('service');
 
   if (params.service) {
     query = query.eq('service', params.service);
   }
 
-  const { data, error } = (await query) as {
-    data: IntegrationHealthRow[] | null;
-    error: any;
-  };
+  const { data, error } = await query;
 
   if (error) {
     throw new Error(`Failed to get integration health: ${error.message}`);

--- a/supabase/migrations/20260214000000_integration_health.sql
+++ b/supabase/migrations/20260214000000_integration_health.sql
@@ -1,0 +1,44 @@
+-- Integration Health: tracks the status of external service integrations per user.
+-- SBs report integration failures here via the update_integration_health MCP tool.
+-- One row per user per service (upsert on status change).
+
+CREATE TABLE integration_health (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  service text NOT NULL,
+  status text NOT NULL DEFAULT 'healthy',
+  error_code text,
+  error_message text,
+  last_check_at timestamp with time zone DEFAULT now(),
+  last_healthy_at timestamp with time zone DEFAULT now(),
+  reported_by_agent_id text,
+  metadata jsonb DEFAULT '{}'::jsonb,
+  created_at timestamp with time zone DEFAULT now(),
+  updated_at timestamp with time zone DEFAULT now(),
+  PRIMARY KEY (id),
+  UNIQUE (user_id, service),
+  CONSTRAINT integration_health_status_check CHECK (status IN ('healthy', 'degraded', 'error', 'not_configured'))
+);
+
+-- Index for fast lookup by user
+CREATE INDEX idx_integration_health_user_id ON integration_health(user_id);
+
+-- Index for finding unhealthy integrations
+CREATE INDEX idx_integration_health_status ON integration_health(status) WHERE status != 'healthy';
+
+-- RLS
+ALTER TABLE integration_health ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Service role full access to integration_health" ON integration_health
+FOR ALL
+USING ((auth.jwt() ->> 'role'::text) = 'service_role'::text);
+
+CREATE POLICY "Users can view own integration health" ON integration_health
+FOR SELECT
+USING (auth.uid() = user_id);
+
+-- Updated_at trigger
+CREATE TRIGGER set_integration_health_updated_at
+  BEFORE UPDATE ON integration_health
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at_column();

--- a/supabase/migrations/20260214000000_integration_health.sql
+++ b/supabase/migrations/20260214000000_integration_health.sql
@@ -10,7 +10,7 @@ CREATE TABLE integration_health (
   error_code text,
   error_message text,
   last_check_at timestamp with time zone DEFAULT now(),
-  last_healthy_at timestamp with time zone DEFAULT now(),
+  last_healthy_at timestamp with time zone,
   reported_by_agent_id text,
   metadata jsonb DEFAULT '{}'::jsonb,
   created_at timestamp with time zone DEFAULT now(),


### PR DESCRIPTION
## Summary

- **New `integration_health` table**: one row per user per service, upserted on status change. Statuses: `healthy`, `degraded`, `error`, `not_configured`. Includes `error_code` for structured error categorization (e.g., `oauth_expired`, `rate_limited`).
- **`update_integration_health` MCP tool**: SBs call this when an integration fails or recovers. Clears error fields automatically when status is `healthy`.
- **`get_integration_health` MCP tool**: query all integrations for a user, or filter to a specific service.
- **Regenerated TypeScript types** to include the new table.

Motivated by Myra reporting Google OAuth expiration via free-text Telegram message with no structured way to query or surface it. Now any SB can report integration health programmatically.

This is v1 — just the table and MCP tools. Dashboard widget and proactive notifications are natural fast-follows once SBs are actively reporting.

## Test plan

- [ ] Restart PCP server and verify new tools appear in MCP tool list
- [ ] Call `update_integration_health` with status `error` and verify row created
- [ ] Call `update_integration_health` with status `healthy` for same service and verify error fields cleared
- [ ] Call `get_integration_health` and verify results
- [ ] Verify RLS: service role can read/write, users can only read own rows