### PR TITLE
feat(web): add sessions dashboard with live agent status

### DIFF
--- a/packages/api/src/mcp/tools/index.ts
+++ b/packages/api/src/mcp/tools/index.ts
@@ -1013,7 +1013,7 @@ User can be identified by ONE of: userId, email, phone, or platform + platformId
           .enum(['low', 'medium', 'high', 'critical'])
           .optional()
           .describe('Importance level (default: medium)'),
-        topics: z.array(z.string()).optional().describe('Topics for categorization'),
+        topics: z.union([z.string(), z.array(z.string())]).optional().describe('Topics for categorization'),
         metadata: z.record(z.unknown()).optional().describe('Additional metadata'),
         expiresAt: z.string().datetime().optional().describe('Optional expiration date (ISO 8601)'),
         agentId: z
@@ -1075,7 +1075,7 @@ User can be identified by ONE of: userId, email, phone, or platform + platformId
           .enum(['low', 'medium', 'high', 'critical'])
           .optional()
           .describe('Filter by salience'),
-        topics: z.array(z.string()).optional().describe('Filter by topics (any match)'),
+        topics: z.union([z.string(), z.array(z.string())]).optional().describe('Filter by topics (any match)'),
         limit: z.number().min(1).max(100).optional().describe('Max results (default: 20)'),
         includeExpired: z.boolean().optional().describe('Include expired memories'),
         agentId: z
@@ -1158,7 +1158,7 @@ User can be identified by ONE of: userId, email, phone, or platform + platformId
           .enum(['low', 'medium', 'high', 'critical'])
           .optional()
           .describe('New salience level'),
-        topics: z.array(z.string()).optional().describe('New topics'),
+        topics: z.union([z.string(), z.array(z.string())]).optional().describe('New topics'),
         metadata: z.record(z.unknown()).optional().describe('Metadata to merge'),
       },
     },

--- a/packages/api/src/mcp/tools/memory-handlers.ts
+++ b/packages/api/src/mcp/tools/memory-handlers.ts
@@ -38,6 +38,14 @@ function resolveStudioId(params: { studioId?: string; workspaceId?: string }): s
   return params.studioId ?? params.workspaceId;
 }
 
+/** Coerce a comma-separated string into a string array so callers can pass either format. */
+const topicsSchema = z
+  .preprocess(
+    (val) => (typeof val === 'string' ? val.split(',').map((s) => s.trim()).filter(Boolean) : val),
+    z.array(z.string())
+  )
+  .optional();
+
 // =====================================================
 // MEMORY TOOLS
 // =====================================================
@@ -46,7 +54,7 @@ export const rememberSchema = userIdentifierBaseSchema.extend({
   content: z.string().describe('The content to remember'),
   source: memorySourceSchema.optional().describe('Source of the memory (default: observation)'),
   salience: salienceSchema.optional().describe('Importance level (default: medium)'),
-  topics: z.array(z.string()).optional().describe('Topics for categorization'),
+  topics: topicsSchema.describe('Topics for categorization'),
   metadata: z.record(z.unknown()).optional().describe('Additional metadata'),
   expiresAt: z.string().datetime().optional().describe('Optional expiration date (ISO 8601)'),
   agentId: z
@@ -71,7 +79,7 @@ export const recallSchema = userIdentifierBaseSchema.extend({
   query: z.string().optional().describe('Search query (text search for now, semantic later)'),
   source: memorySourceSchema.optional().describe('Filter by source'),
   salience: salienceSchema.optional().describe('Filter by salience'),
-  topics: z.array(z.string()).optional().describe('Filter by topics (any match)'),
+  topics: topicsSchema.describe('Filter by topics (any match)'),
   limit: z.number().min(1).max(100).optional().describe('Max results (default: 20)'),
   includeExpired: z.boolean().optional().describe('Include expired memories'),
   agentId: z
@@ -91,7 +99,7 @@ export const forgetSchema = userIdentifierBaseSchema.extend({
 export const updateMemorySchema = userIdentifierBaseSchema.extend({
   memoryId: z.string().uuid().describe('ID of the memory to update'),
   salience: salienceSchema.optional().describe('New salience level'),
-  topics: z.array(z.string()).optional().describe('New topics'),
+  topics: topicsSchema.describe('New topics'),
   metadata: z.record(z.unknown()).optional().describe('Additional metadata to merge'),
 });
 

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -2127,6 +2127,137 @@ router.delete('/connected-accounts/:id', async (req: Request, res: Response) => 
 });
 
 // =============================================================================
+// Sessions & Studios
+// =============================================================================
+
+/**
+ * GET /api/admin/sessions
+ * List sessions with linked agent identities and workspaces (studios)
+ */
+router.get('/sessions', async (req: Request, res: Response) => {
+  try {
+    const supabase = createClient(env.SUPABASE_URL, env.SUPABASE_SECRET_KEY);
+    const authReq = req as AdminAuthRequest;
+    const includeCompleted = req.query.includeCompleted === 'true';
+
+    // 1. Fetch sessions for the user
+    let sessionsQuery = supabase
+      .from('sessions')
+      .select('*')
+      .eq('user_id', authReq.pcpUserId)
+      .order('updated_at', { ascending: false })
+      .limit(100);
+
+    if (!includeCompleted) {
+      sessionsQuery = sessionsQuery.in('status', ['active', 'paused']);
+    }
+
+    const { data: sessions, error: sessionsError } = await sessionsQuery;
+
+    if (sessionsError) {
+      logger.error('Failed to list sessions:', sessionsError);
+      res.status(500).json({ error: 'Failed to list sessions' });
+      return;
+    }
+
+    const sessionRows = sessions || [];
+
+    // 2. Batch-fetch agent identities for unique agent_ids
+    const uniqueAgentIds = [...new Set(sessionRows.map((s) => s.agent_id).filter(Boolean))];
+    const identitiesByAgentId = new Map<
+      string,
+      { name: string; role: string | null }
+    >();
+
+    if (uniqueAgentIds.length > 0) {
+      const { data: identities } = await supabase
+        .from('agent_identities')
+        .select('agent_id, name, role')
+        .eq('workspace_id', authReq.pcpWorkspaceId)
+        .in('agent_id', uniqueAgentIds);
+
+      for (const identity of identities || []) {
+        identitiesByAgentId.set(identity.agent_id, {
+          name: identity.name,
+          role: identity.role,
+        });
+      }
+    }
+
+    // 3. Batch-fetch workspaces linked to these sessions
+    const sessionIds = sessionRows.map((s) => s.id);
+    const workspacesBySessionId = new Map<
+      string,
+      {
+        id: string;
+        branch: string | null;
+        baseBranch: string | null;
+        purpose: string | null;
+        workType: string | null;
+        status: string;
+      }
+    >();
+
+    if (sessionIds.length > 0) {
+      const { data: workspaces } = await supabase
+        .from('workspaces')
+        .select('id, session_id, branch, base_branch, purpose, work_type, status')
+        .in('session_id', sessionIds);
+
+      for (const ws of workspaces || []) {
+        if (ws.session_id) {
+          workspacesBySessionId.set(ws.session_id, {
+            id: ws.id,
+            branch: ws.branch,
+            baseBranch: ws.base_branch,
+            purpose: ws.purpose,
+            workType: ws.work_type,
+            status: ws.status,
+          });
+        }
+      }
+    }
+
+    // 4. Compute stats
+    const stats = {
+      active: sessionRows.filter((s) => s.status === 'active' && !s.current_phase?.startsWith('blocked')).length,
+      blocked: sessionRows.filter((s) => s.current_phase?.startsWith('blocked')).length,
+      paused: sessionRows.filter((s) => s.status === 'paused').length,
+      total: sessionRows.length,
+    };
+
+    res.json({
+      stats,
+      sessions: sessionRows.map((s) => {
+        const identity = s.agent_id ? identitiesByAgentId.get(s.agent_id) : null;
+        return {
+          id: s.id,
+          claudeSessionId: s.claude_session_id || null,
+          agentId: s.agent_id,
+          agentName: identity?.name || s.agent_id || 'Unknown',
+          agentRole: identity?.role || null,
+          status: s.status,
+          currentPhase: s.current_phase,
+          summary: s.summary,
+          context: s.context,
+          backend: s.backend,
+          model: s.model,
+          messageCount: s.message_count,
+          tokenCount: s.token_count,
+          startedAt: s.started_at,
+          updatedAt: s.updated_at,
+          endedAt: s.ended_at,
+          workspace: workspacesBySessionId.get(s.id) || null,
+        };
+      }),
+    });
+  } catch (error) {
+    logger.error('Failed to list sessions:', error);
+    res.status(500).json({ error: 'Failed to list sessions' });
+  }
+});
+
+// =============================================================================
 // Skills
 // =============================================================================
 

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -2136,7 +2136,9 @@ router.delete('/connected-accounts/:id', async (req: Request, res: Response) => 
  */
 router.get('/sessions', async (req: Request, res: Response) => {
   try {
-    const supabase = createClient(env.SUPABASE_URL, env.SUPABASE_SECRET_KEY);
+    const supabase = createClient(env.SUPABASE_URL, env.SUPABASE_SECRET_KEY, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
     const authReq = req as AdminAuthRequest;
     const includeCompleted = req.query.includeCompleted === 'true';
 
@@ -2170,10 +2172,12 @@ router.get('/sessions', async (req: Request, res: Response) => {
     >();
 
     if (uniqueAgentIds.length > 0) {
+      // Look up identities by user_id (not workspace container) so names resolve
+      // for sessions across all containers. agent_id is typically unique per user.
       const { data: identities } = await supabase
         .from('agent_identities')
         .select('agent_id, name, role')
-        .eq('workspace_id', authReq.pcpWorkspaceId)
+        .eq('user_id', authReq.pcpUserId)
         .in('agent_id', uniqueAgentIds);
 
       for (const identity of identities || []) {
@@ -2232,7 +2236,7 @@ router.get('/sessions', async (req: Request, res: Response) => {
         const identity = s.agent_id ? identitiesByAgentId.get(s.agent_id) : null;
         return {
           id: s.id,
-          claudeSessionId: s.claude_session_id || null,
+          backendSessionId: s.claude_session_id || null,
           agentId: s.agent_id,
           agentName: identity?.name || s.agent_id || 'Unknown',
           agentRole: identity?.role || null,

--- a/packages/web/src/app/(dashboard)/page.tsx
+++ b/packages/web/src/app/(dashboard)/page.tsx
@@ -1,8 +1,79 @@
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { MessageSquare, Users, UsersRound, Key } from 'lucide-react';
-import Link from 'next/link';
+'use client';
 
-const stats = [
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import {
+  MessageSquare,
+  Users,
+  UsersRound,
+  Key,
+  Activity,
+  GitBranch,
+  ArrowRight,
+  Monitor,
+} from 'lucide-react';
+import Link from 'next/link';
+import { useApiQuery } from '@/lib/api';
+import clsx from 'clsx';
+
+interface SessionWorkspace {
+  id: string;
+  branch: string | null;
+  baseBranch: string | null;
+  purpose: string | null;
+  workType: string | null;
+  status: string;
+}
+
+interface Session {
+  id: string;
+  agentId: string;
+  agentName: string;
+  agentRole: string | null;
+  status: string;
+  currentPhase: string | null;
+  summary: string | null;
+  context: string | null;
+  backend: string | null;
+  model: string | null;
+  messageCount: number | null;
+  tokenCount: number | null;
+  startedAt: string;
+  updatedAt: string;
+  endedAt: string | null;
+  workspace: SessionWorkspace | null;
+}
+
+interface SessionsResponse {
+  stats: { active: number; blocked: number; paused: number; total: number };
+  sessions: Session[];
+}
+
+function formatRelativeTime(date: string): string {
+  const now = new Date();
+  const target = new Date(date);
+  const diffMs = now.getTime() - target.getTime();
+  const diffMins = Math.round(diffMs / 60000);
+  const diffHours = Math.round(diffMs / 3600000);
+  const diffDays = Math.round(diffMs / 86400000);
+
+  if (diffMins < 1) return 'just now';
+  if (diffMins < 60) return `${diffMins}m ago`;
+  if (diffHours < 24) return `${diffHours}h ago`;
+  return `${diffDays}d ago`;
+}
+
+function isBlocked(session: Session): boolean {
+  return session.currentPhase?.startsWith('blocked') ?? false;
+}
+
+const quickLinks = [
+  {
+    name: 'Sessions',
+    description: 'View all agent sessions and studios',
+    href: '/sessions',
+    icon: Activity,
+  },
   {
     name: 'WhatsApp',
     description: 'Manage WhatsApp connection',
@@ -30,18 +101,122 @@ const stats = [
 ];
 
 export default function DashboardPage() {
+  const { data, isLoading } = useApiQuery<SessionsResponse>(
+    ['sessions'],
+    '/api/admin/sessions',
+    { refetchInterval: 30000 }
+  );
+
+  const sessions = data?.sessions ?? [];
+
+  // Sort: blocked first, then active, then paused — then by updatedAt
+  const previewSessions = [...sessions]
+    .sort((a, b) => {
+      const aBlocked = isBlocked(a) ? 0 : 1;
+      const bBlocked = isBlocked(b) ? 0 : 1;
+      if (aBlocked !== bBlocked) return aBlocked - bBlocked;
+      return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
+    })
+    .slice(0, 4);
+
   return (
     <div>
       <h1 className="text-3xl font-bold text-gray-900">Dashboard</h1>
       <p className="mt-2 text-gray-600">
-        Welcome to the PCP Admin Dashboard. Manage your WhatsApp connection, trusted users, and
-        groups.
+        Welcome to the PCP Admin Dashboard. Monitor active sessions and manage your system.
       </p>
 
-      <div className="mt-8 grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
-        {stats.map((item) => (
+      {/* Sessions Preview */}
+      <div className="mt-8">
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-lg font-semibold text-gray-900">Active Sessions</h2>
+          <Link
+            href="/sessions"
+            className="flex items-center gap-1 text-sm text-blue-600 hover:text-blue-800"
+          >
+            View all sessions
+            <ArrowRight className="h-4 w-4" />
+          </Link>
+        </div>
+
+        {isLoading ? (
+          <div className="grid gap-3 sm:grid-cols-2">
+            {[1, 2].map((i) => (
+              <div key={i} className="h-20 rounded-lg border border-gray-200 bg-gray-50 animate-pulse" />
+            ))}
+          </div>
+        ) : previewSessions.length === 0 ? (
+          <Card>
+            <CardContent className="py-6 text-center">
+              <Monitor className="h-8 w-8 mx-auto text-gray-300 mb-2" />
+              <p className="text-sm text-gray-500">No active sessions</p>
+            </CardContent>
+          </Card>
+        ) : (
+          <div className="grid gap-3 sm:grid-cols-2">
+            {previewSessions.map((session) => {
+              const blocked = isBlocked(session);
+              const active = session.status === 'active' && !blocked;
+
+              return (
+                <Link key={session.id} href="/sessions">
+                  <div
+                    className={clsx(
+                      'rounded-lg border p-3 hover:shadow-md transition-shadow cursor-pointer',
+                      blocked && 'border-amber-300 bg-amber-50/50',
+                      active && 'border-green-200 bg-green-50/50',
+                      !blocked && !active && 'border-gray-200'
+                    )}
+                  >
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center gap-2 min-w-0">
+                        <span className="font-medium text-gray-900 truncate">
+                          {session.agentName}
+                        </span>
+                        <Badge
+                          className={clsx(
+                            'text-xs shrink-0',
+                            blocked && 'bg-amber-100 text-amber-700',
+                            active && 'bg-green-100 text-green-700',
+                            !blocked && !active && 'bg-gray-100 text-gray-600'
+                          )}
+                        >
+                          {blocked ? 'Blocked' : session.status}
+                        </Badge>
+                      </div>
+                      <span className="text-xs text-gray-400 shrink-0 ml-2">
+                        {formatRelativeTime(session.updatedAt)}
+                      </span>
+                    </div>
+                    {session.currentPhase && (
+                      <p
+                        className={clsx(
+                          'text-xs mt-1 truncate',
+                          blocked ? 'text-amber-600' : 'text-gray-500'
+                        )}
+                      >
+                        {session.currentPhase}
+                      </p>
+                    )}
+                    {session.workspace?.branch && (
+                      <div className="flex items-center gap-1 mt-1 text-xs text-gray-400">
+                        <GitBranch className="h-3 w-3" />
+                        <span className="truncate">{session.workspace.branch}</span>
+                      </div>
+                    )}
+                  </div>
+                </Link>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      {/* Quick Links */}
+      <div className="mt-8 grid gap-6 sm:grid-cols-2 lg:grid-cols-5">
+        {quickLinks.map((item) => (
           <Link key={item.name} href={item.href}>
-            <Card className="hover:shadow-lg transition-shadow cursor-pointer">
+            <Card className="hover:shadow-lg transition-shadow cursor-pointer h-full">
               <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
                 <CardTitle className="text-sm font-medium">{item.name}</CardTitle>
                 <item.icon className="h-4 w-4 text-muted-foreground" />

--- a/packages/web/src/app/(dashboard)/sessions/page.tsx
+++ b/packages/web/src/app/(dashboard)/sessions/page.tsx
@@ -27,7 +27,7 @@ interface SessionWorkspace {
 
 interface Session {
   id: string;
-  claudeSessionId: string | null;
+  backendSessionId: string | null;
   agentId: string;
   agentName: string;
   agentRole: string | null;
@@ -189,10 +189,10 @@ function SessionCard({ session }: { session: Session }) {
                   <span className="text-gray-400">PCP Session ID: </span>
                   <code className="font-mono select-all">{session.id}</code>
                 </div>
-                {session.claudeSessionId && (
+                {session.backendSessionId && (
                   <div>
                     <span className="text-gray-400">Backend Session ID: </span>
-                    <code className="font-mono select-all">{session.claudeSessionId}</code>
+                    <code className="font-mono select-all">{session.backendSessionId}</code>
                   </div>
                 )}
               </div>

--- a/packages/web/src/app/(dashboard)/sessions/page.tsx
+++ b/packages/web/src/app/(dashboard)/sessions/page.tsx
@@ -1,0 +1,334 @@
+'use client';
+
+import { useState } from 'react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import {
+  Activity,
+  AlertTriangle,
+  Pause,
+  Monitor,
+  GitBranch,
+  ChevronDown,
+  Hash,
+  FolderGit2,
+} from 'lucide-react';
+import { useApiQuery } from '@/lib/api';
+import clsx from 'clsx';
+
+interface SessionWorkspace {
+  id: string;
+  branch: string | null;
+  baseBranch: string | null;
+  purpose: string | null;
+  workType: string | null;
+  status: string;
+}
+
+interface Session {
+  id: string;
+  claudeSessionId: string | null;
+  agentId: string;
+  agentName: string;
+  agentRole: string | null;
+  status: string;
+  currentPhase: string | null;
+  summary: string | null;
+  context: string | null;
+  backend: string | null;
+  model: string | null;
+  messageCount: number | null;
+  tokenCount: number | null;
+  startedAt: string;
+  updatedAt: string;
+  endedAt: string | null;
+  workspace: SessionWorkspace | null;
+}
+
+interface SessionsResponse {
+  stats: { active: number; blocked: number; paused: number; total: number };
+  sessions: Session[];
+}
+
+function formatRelativeTime(date: string): string {
+  const now = new Date();
+  const target = new Date(date);
+  const diffMs = now.getTime() - target.getTime();
+  const diffMins = Math.round(diffMs / 60000);
+  const diffHours = Math.round(diffMs / 3600000);
+  const diffDays = Math.round(diffMs / 86400000);
+
+  if (diffMins < 1) return 'just now';
+  if (diffMins < 60) return `${diffMins}m ago`;
+  if (diffHours < 24) return `${diffHours}h ago`;
+  return `${diffDays}d ago`;
+}
+
+function isBlocked(session: Session): boolean {
+  return session.currentPhase?.startsWith('blocked') ?? false;
+}
+
+function SessionCard({ session }: { session: Session }) {
+  const [expanded, setExpanded] = useState(false);
+  const blocked = isBlocked(session);
+  const active = session.status === 'active' && !blocked;
+  const paused = session.status === 'paused';
+
+  return (
+    <div
+      className={clsx(
+        'rounded-lg border p-4',
+        blocked && 'border-amber-300 bg-amber-50/50',
+        active && 'border-green-200 bg-green-50/50',
+        paused && 'border-gray-200',
+        !blocked && !active && !paused && 'border-gray-200'
+      )}
+    >
+      <div className="flex items-start justify-between">
+        <div className="flex-1">
+          <div className="flex items-center gap-2 flex-wrap">
+            <h3 className="font-semibold text-gray-900">{session.agentName}</h3>
+            <Badge variant="outline" className="text-xs font-mono">
+              {session.agentId}
+            </Badge>
+            <Badge
+              className={clsx(
+                'text-xs',
+                blocked && 'bg-amber-100 text-amber-700',
+                active && 'bg-green-100 text-green-700',
+                paused && 'bg-gray-100 text-gray-600',
+                !blocked && !active && !paused && 'bg-gray-100 text-gray-600'
+              )}
+            >
+              {blocked ? 'Blocked' : session.status}
+            </Badge>
+          </div>
+
+          {/* Phase - prominent for blocked sessions */}
+          {session.currentPhase && (
+            <p
+              className={clsx(
+                'text-sm mt-1',
+                blocked ? 'font-medium text-amber-700' : 'text-gray-600'
+              )}
+            >
+              {session.currentPhase}
+            </p>
+          )}
+
+          {/* Context / Summary */}
+          {session.context && (
+            <p className="text-sm text-gray-500 mt-1 line-clamp-2">
+              {typeof session.context === 'string'
+                ? session.context
+                : JSON.stringify(session.context)}
+            </p>
+          )}
+
+          {/* Workspace info */}
+          {session.workspace && (
+            <div className="flex items-center gap-3 mt-2 text-xs text-gray-500">
+              <span className="flex items-center gap-1">
+                <GitBranch className="h-3 w-3" />
+                {session.workspace.branch || 'no branch'}
+              </span>
+              {session.workspace.purpose && (
+                <span className="truncate max-w-xs">{session.workspace.purpose}</span>
+              )}
+              {session.workspace.workType && (
+                <Badge variant="outline" className="text-xs">
+                  {session.workspace.workType}
+                </Badge>
+              )}
+            </div>
+          )}
+
+          {/* Footer: messages, backend, model */}
+          <div className="flex items-center gap-4 mt-3 text-xs text-gray-400">
+            {session.messageCount != null && session.messageCount > 0 && (
+              <span>{session.messageCount} messages</span>
+            )}
+            {session.backend && <span>{session.backend}</span>}
+            {session.model && <span>{session.model}</span>}
+          </div>
+        </div>
+        <div className="text-right text-sm shrink-0 ml-4">
+          <div className="text-xs text-gray-400">Updated</div>
+          <div className="font-medium text-gray-700">
+            {formatRelativeTime(session.updatedAt)}
+          </div>
+          <div className="text-xs text-gray-400 mt-1">
+            Started {formatRelativeTime(session.startedAt)}
+          </div>
+        </div>
+      </div>
+
+      {/* Expand/collapse toggle */}
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="flex items-center gap-1 mt-3 text-xs text-gray-400 hover:text-gray-600 transition-colors"
+      >
+        <ChevronDown
+          className={clsx('h-3 w-3 transition-transform', expanded && 'rotate-180')}
+        />
+        {expanded ? 'Hide details' : 'Show details'}
+      </button>
+
+      {/* Expanded details */}
+      {expanded && (
+        <div className="mt-3 pt-3 border-t border-gray-200">
+          <div className="rounded-md bg-gray-50 p-3 text-xs space-y-3">
+            {/* Session IDs */}
+            <div>
+              <div className="flex items-center gap-1.5 font-medium text-gray-700 mb-1.5">
+                <Hash className="h-3.5 w-3.5" />
+                Identifiers
+              </div>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-1.5 text-gray-500">
+                <div>
+                  <span className="text-gray-400">PCP Session ID: </span>
+                  <code className="font-mono select-all">{session.id}</code>
+                </div>
+                {session.claudeSessionId && (
+                  <div>
+                    <span className="text-gray-400">Backend Session ID: </span>
+                    <code className="font-mono select-all">{session.claudeSessionId}</code>
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {/* Studio details */}
+            {session.workspace && (
+              <div>
+                <div className="flex items-center gap-1.5 font-medium text-gray-700 mb-1.5">
+                  <FolderGit2 className="h-3.5 w-3.5" />
+                  Studio
+                </div>
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-1.5 text-gray-500">
+                  <div>
+                    <span className="text-gray-400">ID: </span>
+                    <code className="font-mono select-all">{session.workspace.id}</code>
+                  </div>
+                  <div>
+                    <span className="text-gray-400">Status: </span>
+                    <span>{session.workspace.status}</span>
+                  </div>
+                  {session.workspace.branch && (
+                    <div>
+                      <span className="text-gray-400">Branch: </span>
+                      <code className="font-mono">{session.workspace.branch}</code>
+                    </div>
+                  )}
+                  {session.workspace.baseBranch && (
+                    <div>
+                      <span className="text-gray-400">Base: </span>
+                      <code className="font-mono">{session.workspace.baseBranch}</code>
+                    </div>
+                  )}
+                  {session.workspace.purpose && (
+                    <div className="sm:col-span-2">
+                      <span className="text-gray-400">Purpose: </span>
+                      <span>{session.workspace.purpose}</span>
+                    </div>
+                  )}
+                  {session.workspace.workType && (
+                    <div>
+                      <span className="text-gray-400">Type: </span>
+                      <span>{session.workspace.workType}</span>
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function SessionsPage() {
+  const { data, isLoading, error } = useApiQuery<SessionsResponse>(
+    ['sessions'],
+    '/api/admin/sessions',
+    { refetchInterval: 30000 }
+  );
+
+  const stats = data?.stats ?? { active: 0, blocked: 0, paused: 0, total: 0 };
+  const sessions = data?.sessions ?? [];
+
+  return (
+    <div>
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold text-gray-900">Sessions</h1>
+          <p className="mt-2 text-gray-600">
+            Real-time view of all active sessions and their linked studios.
+          </p>
+        </div>
+      </div>
+
+      {error && <div className="mt-4 rounded-md bg-red-50 p-4 text-red-800">{error.message}</div>}
+
+      {/* Stats */}
+      <div className="grid grid-cols-4 gap-4 mt-6">
+        <Card>
+          <CardContent className="p-4 text-center">
+            <Activity className="h-5 w-5 mx-auto text-green-600 mb-1" />
+            <div className="text-2xl font-bold text-green-600">{stats.active}</div>
+            <div className="text-xs text-gray-500">Active</div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-4 text-center">
+            <AlertTriangle className="h-5 w-5 mx-auto text-amber-600 mb-1" />
+            <div className="text-2xl font-bold text-amber-600">{stats.blocked}</div>
+            <div className="text-xs text-gray-500">Blocked</div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-4 text-center">
+            <Pause className="h-5 w-5 mx-auto text-gray-500 mb-1" />
+            <div className="text-2xl font-bold text-gray-500">{stats.paused}</div>
+            <div className="text-xs text-gray-500">Paused</div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-4 text-center">
+            <Monitor className="h-5 w-5 mx-auto text-gray-600 mb-1" />
+            <div className="text-2xl font-bold text-gray-600">{stats.total}</div>
+            <div className="text-xs text-gray-500">Total</div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Sessions List */}
+      <Card className="mt-6">
+        <CardHeader>
+          <CardTitle>All Sessions</CardTitle>
+          <CardDescription>Sorted by most recently updated</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <p className="text-gray-500">Loading...</p>
+          ) : sessions.length === 0 ? (
+            <div className="text-center py-8">
+              <Monitor className="h-12 w-12 mx-auto text-gray-300 mb-3" />
+              <p className="text-gray-500">No active sessions</p>
+              <p className="text-sm text-gray-400 mt-1">
+                Sessions will appear here when agents start working.
+              </p>
+            </div>
+          ) : (
+            <div className="space-y-4">
+              {sessions.map((session) => (
+                <SessionCard key={session.id} session={session} />
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/packages/web/src/components/layout/sidebar.tsx
+++ b/packages/web/src/components/layout/sidebar.tsx
@@ -20,6 +20,7 @@ import {
   ChevronDown,
   Check,
   Settings,
+  Activity,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useRouter } from 'next/navigation';
@@ -41,6 +42,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 const navigation = [
   { name: 'Dashboard', href: '/', icon: Home },
   { name: 'Chat', href: '/chat', icon: MessageSquare },
+  { name: 'Sessions', href: '/sessions', icon: Activity },
   { name: 'Trusted Users', href: '/trusted-users', icon: Users },
   { name: 'Groups', href: '/groups', icon: UsersRound },
   { name: 'Challenge Codes', href: '/challenge-codes', icon: Key },


### PR DESCRIPTION
## Summary

- **New `GET /api/admin/sessions` endpoint** — lists sessions with batch-fetched agent identities and workspace (studio) joins, plus stats (active/blocked/paused/total)
- **Sessions page** (`/sessions`) — full-page view with stat cards, expandable session cards showing agent name/role, phase, workspace branch/purpose, session IDs, and timestamps. Auto-refreshes every 30s.
- **Dashboard preview** — homepage now shows top 4 sessions sorted blocked-first, with color-coded status badges and branch info
- **Sidebar nav** — added Sessions link with Activity icon
- **Topics schema DX fix** — `remember`, `recall`, and `update_memory` tools now accept comma-separated strings in addition to arrays for the `topics` field (e.g. `"architecture,decisions"` instead of requiring `["architecture","decisions"]`)

## Test plan

- [ ] Verify `/api/admin/sessions` returns sessions with correct agent names and workspace data
- [ ] Verify dashboard shows session preview cards with live status
- [ ] Verify `/sessions` page loads with stats and expandable session details
- [ ] Verify topics as comma-separated string works in `remember` tool calls
- [ ] Verify sidebar Sessions link navigates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)