### PR TITLE
feat(auth): local JWT verification for admin API (by Wren)

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -30,6 +30,7 @@
     "@whiskeysockets/baileys": "^7.0.0-rc.9",
     "bcrypt": "^5.1.1",
     "compression": "^1.7.4",
+    "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "cron-parser": "^5.5.0",
     "discord.js": "^14.25.1",
@@ -53,6 +54,7 @@
   "devDependencies": {
     "@types/bcrypt": "^5.0.2",
     "@types/compression": "^1.7.5",
+    "@types/cookie-parser": "^1.4.10",
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
     "@types/jsonwebtoken": "^9.0.5",

--- a/packages/api/src/auth/pcp-tokens.integration.test.ts
+++ b/packages/api/src/auth/pcp-tokens.integration.test.ts
@@ -1,0 +1,475 @@
+/**
+ * PCP Tokens Integration Tests
+ *
+ * Tests the full token lifecycle against a real Supabase database:
+ * 1. Create refresh token (writes to mcp_tokens)
+ * 2. Exchange refresh token for new access JWT
+ * 3. Verify access JWT locally
+ * 4. Token expiration handling
+ * 5. Client ID isolation
+ *
+ * Run via: yarn workspace @personal-context/api test:integration
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import jwt from 'jsonwebtoken';
+import { getDataComposer, type DataComposer } from '../data/composer';
+import {
+  signPcpAccessToken,
+  verifyPcpAccessToken,
+  createRefreshToken,
+  exchangeRefreshToken,
+} from './pcp-tokens';
+import { env } from '../config/env';
+
+describe('PCP Tokens Integration', () => {
+  let dataComposer: DataComposer;
+  let testUserId: string;
+  let testUserEmail: string;
+  const createdTokenIds: string[] = [];
+
+  beforeAll(async () => {
+    dataComposer = await getDataComposer();
+    const supabase = dataComposer.getClient();
+
+    // Find a test user (use the echo agent's owner from seed data)
+    const { data: echoIdentity, error } = await supabase
+      .from('agent_identities')
+      .select('user_id, users(email)')
+      .eq('agent_id', 'echo')
+      .single();
+
+    if (error || !echoIdentity) {
+      throw new Error(
+        'Echo test agent identity not found. Apply migration 008_add_echo_test_agent.sql first.'
+      );
+    }
+
+    testUserId = echoIdentity.user_id;
+    testUserEmail =
+      (echoIdentity.users as unknown as { email: string | null })?.email || 'test@integration.com';
+  });
+
+  afterAll(async () => {
+    // Clean up all tokens created during tests
+    if (createdTokenIds.length > 0) {
+      const supabase = dataComposer.getClient();
+      await supabase.from('mcp_tokens').delete().in('id', createdTokenIds);
+    }
+
+    // Also clean up by client_id in case IDs weren't tracked
+    const supabase = dataComposer.getClient();
+    await supabase
+      .from('mcp_tokens')
+      .delete()
+      .eq('user_id', testUserId)
+      .in('client_id', ['integration-test', 'integration-test-admin', 'integration-test-isolated']);
+  });
+
+  // =========================================================================
+  // signPcpAccessToken + verifyPcpAccessToken round-trip
+  // =========================================================================
+
+  describe('sign + verify (no DB)', () => {
+    it('should sign and verify an mcp_access token', () => {
+      const token = signPcpAccessToken(
+        { type: 'mcp_access', sub: testUserId, email: testUserEmail, scope: 'mcp:tools' },
+        3600
+      );
+
+      const result = verifyPcpAccessToken(token, 'mcp_access');
+      expect(result).not.toBeNull();
+      expect(result!.sub).toBe(testUserId);
+      expect(result!.email).toBe(testUserEmail);
+      expect(result!.type).toBe('mcp_access');
+    });
+
+    it('should sign and verify a pcp_admin token', () => {
+      const token = signPcpAccessToken(
+        { type: 'pcp_admin', sub: testUserId, email: testUserEmail, scope: 'admin' },
+        3600
+      );
+
+      const result = verifyPcpAccessToken(token, 'pcp_admin');
+      expect(result).not.toBeNull();
+      expect(result!.type).toBe('pcp_admin');
+      expect(result!.scope).toBe('admin');
+    });
+
+    it('should enforce type isolation', () => {
+      const mcpToken = signPcpAccessToken(
+        { type: 'mcp_access', sub: testUserId, email: testUserEmail, scope: 'mcp:tools' },
+        3600
+      );
+      const adminToken = signPcpAccessToken(
+        { type: 'pcp_admin', sub: testUserId, email: testUserEmail, scope: 'admin' },
+        3600
+      );
+
+      // Cross-type verification must fail
+      expect(verifyPcpAccessToken(mcpToken, 'pcp_admin')).toBeNull();
+      expect(verifyPcpAccessToken(adminToken, 'mcp_access')).toBeNull();
+
+      // Same-type verification must succeed
+      expect(verifyPcpAccessToken(mcpToken, 'mcp_access')).not.toBeNull();
+      expect(verifyPcpAccessToken(adminToken, 'pcp_admin')).not.toBeNull();
+    });
+
+    it('should reject expired tokens', () => {
+      const token = signPcpAccessToken(
+        { type: 'pcp_admin', sub: testUserId, email: testUserEmail, scope: 'admin' },
+        0 // expires immediately
+      );
+
+      expect(verifyPcpAccessToken(token)).toBeNull();
+    });
+
+    it('should reject tokens signed with wrong secret', () => {
+      const token = jwt.sign(
+        { type: 'pcp_admin', sub: testUserId, email: testUserEmail, scope: 'admin' },
+        'totally-wrong-secret-that-is-at-least-32-chars',
+        { expiresIn: 3600 }
+      );
+
+      expect(verifyPcpAccessToken(token)).toBeNull();
+    });
+  });
+
+  // =========================================================================
+  // createRefreshToken (writes to DB)
+  // =========================================================================
+
+  describe('createRefreshToken (DB write)', () => {
+    it('should create a refresh token in the mcp_tokens table', async () => {
+      const supabase = dataComposer.getClient();
+
+      const result = await createRefreshToken(
+        supabase,
+        testUserId,
+        'integration-test',
+        ['mcp:tools'],
+        90
+      );
+
+      expect(result.refreshToken).toMatch(/^pcp-rt-/);
+      expect(result.expiresAt).toBeInstanceOf(Date);
+      expect(result.expiresAt.getTime()).toBeGreaterThan(Date.now());
+
+      // Verify it was actually written to the database
+      const { data: dbToken } = await supabase
+        .from('mcp_tokens')
+        .select('*')
+        .eq('refresh_token', result.refreshToken)
+        .single();
+
+      expect(dbToken).not.toBeNull();
+      expect(dbToken!.user_id).toBe(testUserId);
+      expect(dbToken!.client_id).toBe('integration-test');
+      expect(dbToken!.scopes).toEqual(['mcp:tools']);
+      expect(dbToken!.supabase_refresh_token).toBeNull();
+
+      createdTokenIds.push(dbToken!.id);
+    });
+
+    it('should create tokens with admin scopes for dashboard client', async () => {
+      const supabase = dataComposer.getClient();
+
+      const result = await createRefreshToken(
+        supabase,
+        testUserId,
+        'integration-test-admin',
+        ['admin'],
+        90
+      );
+
+      const { data: dbToken } = await supabase
+        .from('mcp_tokens')
+        .select('*')
+        .eq('refresh_token', result.refreshToken)
+        .single();
+
+      expect(dbToken).not.toBeNull();
+      expect(dbToken!.client_id).toBe('integration-test-admin');
+      expect(dbToken!.scopes).toEqual(['admin']);
+
+      createdTokenIds.push(dbToken!.id);
+    });
+  });
+
+  // =========================================================================
+  // exchangeRefreshToken (DB read + JWT sign)
+  // =========================================================================
+
+  describe('exchangeRefreshToken (DB read)', () => {
+    let validRefreshToken: string;
+
+    beforeAll(async () => {
+      // Create a fresh refresh token to use for exchange tests
+      const supabase = dataComposer.getClient();
+      const result = await createRefreshToken(
+        supabase,
+        testUserId,
+        'integration-test',
+        ['mcp:tools'],
+        90
+      );
+      validRefreshToken = result.refreshToken;
+
+      // Track for cleanup
+      const { data: dbToken } = await supabase
+        .from('mcp_tokens')
+        .select('id')
+        .eq('refresh_token', validRefreshToken)
+        .single();
+      if (dbToken) createdTokenIds.push(dbToken.id);
+    });
+
+    it('should exchange a valid refresh token for a new access JWT', async () => {
+      const supabase = dataComposer.getClient();
+
+      const result = await exchangeRefreshToken(
+        supabase,
+        validRefreshToken,
+        'integration-test',
+        'mcp_access',
+        3600
+      );
+
+      expect(result).not.toBeNull();
+      expect(result!.userId).toBe(testUserId);
+      expect(result!.email).toBe(testUserEmail);
+
+      // The returned access token should be a valid JWT
+      const decoded = verifyPcpAccessToken(result!.accessToken, 'mcp_access');
+      expect(decoded).not.toBeNull();
+      expect(decoded!.sub).toBe(testUserId);
+      expect(decoded!.type).toBe('mcp_access');
+    });
+
+    it('should exchange for pcp_admin token type', async () => {
+      const supabase = dataComposer.getClient();
+
+      // Create admin refresh token
+      const { refreshToken: adminRefresh } = await createRefreshToken(
+        supabase,
+        testUserId,
+        'integration-test-admin',
+        ['admin'],
+        90
+      );
+
+      const { data: dbToken } = await supabase
+        .from('mcp_tokens')
+        .select('id')
+        .eq('refresh_token', adminRefresh)
+        .single();
+      if (dbToken) createdTokenIds.push(dbToken.id);
+
+      const result = await exchangeRefreshToken(
+        supabase,
+        adminRefresh,
+        'integration-test-admin',
+        'pcp_admin',
+        3600
+      );
+
+      expect(result).not.toBeNull();
+      const decoded = verifyPcpAccessToken(result!.accessToken, 'pcp_admin');
+      expect(decoded).not.toBeNull();
+      expect(decoded!.type).toBe('pcp_admin');
+      expect(decoded!.scope).toBe('admin');
+    });
+
+    it('should update last_used_at on successful exchange', async () => {
+      const supabase = dataComposer.getClient();
+
+      const before = new Date();
+
+      await exchangeRefreshToken(
+        supabase,
+        validRefreshToken,
+        'integration-test',
+        'mcp_access',
+        3600
+      );
+
+      const { data: dbToken } = await supabase
+        .from('mcp_tokens')
+        .select('last_used_at')
+        .eq('refresh_token', validRefreshToken)
+        .single();
+
+      expect(dbToken).not.toBeNull();
+      expect(dbToken!.last_used_at).not.toBeNull();
+      expect(new Date(dbToken!.last_used_at!).getTime()).toBeGreaterThanOrEqual(
+        before.getTime() - 1000
+      );
+    });
+
+    it('should return null for nonexistent refresh token', async () => {
+      const supabase = dataComposer.getClient();
+
+      const result = await exchangeRefreshToken(
+        supabase,
+        'pcp-rt-does-not-exist',
+        'integration-test',
+        'mcp_access',
+        3600
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null for client_id mismatch', async () => {
+      const supabase = dataComposer.getClient();
+
+      const result = await exchangeRefreshToken(
+        supabase,
+        validRefreshToken,
+        'wrong-client-id',
+        'mcp_access',
+        3600
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null and delete expired refresh token', async () => {
+      const supabase = dataComposer.getClient();
+
+      // Create an already-expired token directly in the DB
+      const { data: expiredToken } = await supabase
+        .from('mcp_tokens')
+        .insert({
+          user_id: testUserId,
+          client_id: 'integration-test',
+          refresh_token: `pcp-rt-expired-${Date.now()}`,
+          supabase_refresh_token: null,
+          scopes: ['mcp:tools'],
+          expires_at: new Date(Date.now() - 86400000).toISOString(), // yesterday
+        })
+        .select('id, refresh_token')
+        .single();
+
+      expect(expiredToken).not.toBeNull();
+
+      const result = await exchangeRefreshToken(
+        supabase,
+        expiredToken!.refresh_token,
+        'integration-test',
+        'mcp_access',
+        3600
+      );
+
+      expect(result).toBeNull();
+
+      // Token should have been deleted from DB
+      const { data: deleted } = await supabase
+        .from('mcp_tokens')
+        .select('id')
+        .eq('id', expiredToken!.id)
+        .single();
+
+      expect(deleted).toBeNull();
+    });
+
+    it('should enforce client_id isolation between MCP and dashboard tokens', async () => {
+      const supabase = dataComposer.getClient();
+
+      // Create tokens with different client IDs
+      const { refreshToken: mcpRefresh } = await createRefreshToken(
+        supabase,
+        testUserId,
+        'integration-test-isolated',
+        ['mcp:tools'],
+        90
+      );
+
+      // Track for cleanup
+      const { data: t1 } = await supabase
+        .from('mcp_tokens')
+        .select('id')
+        .eq('refresh_token', mcpRefresh)
+        .single();
+      if (t1) createdTokenIds.push(t1.id);
+
+      // MCP refresh token should NOT work with dashboard client_id
+      const crossResult = await exchangeRefreshToken(
+        supabase,
+        mcpRefresh,
+        'dashboard',
+        'pcp_admin',
+        3600
+      );
+      expect(crossResult).toBeNull();
+
+      // Should still work with its own client_id
+      const sameResult = await exchangeRefreshToken(
+        supabase,
+        mcpRefresh,
+        'integration-test-isolated',
+        'mcp_access',
+        3600
+      );
+      expect(sameResult).not.toBeNull();
+    });
+  });
+
+  // =========================================================================
+  // Full lifecycle: create → exchange → verify → type check
+  // =========================================================================
+
+  describe('full token lifecycle', () => {
+    it('should complete the admin auth token lifecycle end-to-end', async () => {
+      const supabase = dataComposer.getClient();
+
+      // Step 1: Create refresh token (happens on first Supabase login via Tier 3)
+      const { refreshToken } = await createRefreshToken(
+        supabase,
+        testUserId,
+        'integration-test-admin',
+        ['admin'],
+        90
+      );
+
+      // Track for cleanup
+      const { data: t } = await supabase
+        .from('mcp_tokens')
+        .select('id')
+        .eq('refresh_token', refreshToken)
+        .single();
+      if (t) createdTokenIds.push(t.id);
+
+      // Step 2: Sign initial access token (happens in Tier 3 cookie issuance)
+      const initialAccessToken = signPcpAccessToken(
+        { type: 'pcp_admin', sub: testUserId, email: testUserEmail, scope: 'admin' },
+        3600
+      );
+
+      // Step 3: Verify the access token (Tier 1 on next request)
+      const tier1Result = verifyPcpAccessToken(initialAccessToken, 'pcp_admin');
+      expect(tier1Result).not.toBeNull();
+      expect(tier1Result!.sub).toBe(testUserId);
+      expect(tier1Result!.type).toBe('pcp_admin');
+
+      // Step 4: Exchange refresh token (Tier 2 when access token expires)
+      const tier2Result = await exchangeRefreshToken(
+        supabase,
+        refreshToken,
+        'integration-test-admin',
+        'pcp_admin',
+        3600
+      );
+      expect(tier2Result).not.toBeNull();
+
+      // Step 5: Verify the refreshed access token (next Tier 1)
+      const refreshedVerify = verifyPcpAccessToken(tier2Result!.accessToken, 'pcp_admin');
+      expect(refreshedVerify).not.toBeNull();
+      expect(refreshedVerify!.sub).toBe(testUserId);
+      expect(refreshedVerify!.type).toBe('pcp_admin');
+
+      // Step 6: Ensure the token is NOT accepted as mcp_access
+      expect(verifyPcpAccessToken(tier2Result!.accessToken, 'mcp_access')).toBeNull();
+    });
+  });
+});

--- a/packages/api/src/auth/pcp-tokens.test.ts
+++ b/packages/api/src/auth/pcp-tokens.test.ts
@@ -1,0 +1,687 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import jwt from 'jsonwebtoken';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockInsert = vi.fn();
+const mockUpdate = vi.fn();
+const mockDelete = vi.fn();
+
+function mockChain(terminalData: unknown = null, terminalError: unknown = null) {
+  const chain: Record<string, any> = {};
+  chain.select = vi.fn(() => chain);
+  chain.insert = mockInsert.mockReturnValue(chain);
+  chain.update = mockUpdate.mockReturnValue(chain);
+  chain.delete = mockDelete.mockReturnValue(chain);
+  chain.eq = vi.fn(() => chain);
+  chain.single = vi.fn(() => Promise.resolve({ data: terminalData, error: terminalError }));
+  return chain;
+}
+
+let currentMcpTokensChain: ReturnType<typeof mockChain>;
+
+const mockFrom = vi.fn((table: string) => {
+  if (table === 'mcp_tokens') return currentMcpTokensChain;
+  return mockChain();
+});
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(() => ({
+    from: mockFrom,
+  })),
+}));
+
+const TEST_JWT_SECRET = 'test-jwt-secret-that-is-at-least-32-characters-long';
+
+vi.mock('../config/env', () => ({
+  env: {
+    SUPABASE_URL: 'http://localhost:54321',
+    SUPABASE_SECRET_KEY: 'test-key',
+    JWT_SECRET: 'test-jwt-secret-that-is-at-least-32-characters-long',
+  },
+}));
+
+vi.mock('../utils/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+
+import {
+  signPcpAccessToken,
+  verifyPcpAccessToken,
+  createRefreshToken,
+  exchangeRefreshToken,
+  type PcpTokenPayload,
+} from './pcp-tokens';
+import { createClient } from '@supabase/supabase-js';
+
+// Helper to create a mock Supabase client
+function getMockSupabase() {
+  return createClient('http://localhost:54321', 'test-key') as any;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('pcp-tokens', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    currentMcpTokensChain = mockChain();
+  });
+
+  // =========================================================================
+  // signPcpAccessToken
+  // =========================================================================
+
+  describe('signPcpAccessToken', () => {
+    it('should return a valid JWT with correct payload', () => {
+      const payload: PcpTokenPayload = {
+        type: 'mcp_access',
+        sub: 'user-123',
+        email: 'test@example.com',
+        scope: 'mcp:tools',
+      };
+
+      const token = signPcpAccessToken(payload, 3600);
+
+      // Valid JWT format
+      expect(token.split('.')).toHaveLength(3);
+
+      // Correct payload
+      const decoded = jwt.verify(token, TEST_JWT_SECRET) as Record<string, unknown>;
+      expect(decoded.type).toBe('mcp_access');
+      expect(decoded.sub).toBe('user-123');
+      expect(decoded.email).toBe('test@example.com');
+      expect(decoded.scope).toBe('mcp:tools');
+    });
+
+    it('should sign pcp_admin tokens', () => {
+      const payload: PcpTokenPayload = {
+        type: 'pcp_admin',
+        sub: 'user-456',
+        email: 'admin@example.com',
+        scope: 'admin',
+      };
+
+      const token = signPcpAccessToken(payload, 3600);
+      const decoded = jwt.verify(token, TEST_JWT_SECRET) as Record<string, unknown>;
+      expect(decoded.type).toBe('pcp_admin');
+      expect(decoded.sub).toBe('user-456');
+      expect(decoded.scope).toBe('admin');
+    });
+
+    it('should respect expiresInSeconds', () => {
+      const payload: PcpTokenPayload = {
+        type: 'mcp_access',
+        sub: 'user-123',
+        email: 'test@example.com',
+        scope: 'mcp:tools',
+      };
+
+      const token = signPcpAccessToken(payload, 60); // 1 minute
+      const decoded = jwt.verify(token, TEST_JWT_SECRET) as Record<string, unknown>;
+      const exp = decoded.exp as number;
+      const iat = decoded.iat as number;
+      expect(exp - iat).toBe(60);
+    });
+
+    it('should produce unique tokens for same payload', () => {
+      const payload: PcpTokenPayload = {
+        type: 'mcp_access',
+        sub: 'user-123',
+        email: 'test@example.com',
+        scope: 'mcp:tools',
+      };
+
+      const token1 = signPcpAccessToken(payload, 3600);
+      // iat is per-second so tokens in the same second will match;
+      // we're just testing they're real JWTs — not testing randomness here.
+      expect(token1.split('.')).toHaveLength(3);
+    });
+  });
+
+  // =========================================================================
+  // verifyPcpAccessToken
+  // =========================================================================
+
+  describe('verifyPcpAccessToken', () => {
+    it('should verify a valid mcp_access token', () => {
+      const token = jwt.sign(
+        { type: 'mcp_access', sub: 'user-123', email: 'test@example.com', scope: 'mcp:tools' },
+        TEST_JWT_SECRET,
+        { expiresIn: '1h' }
+      );
+
+      const result = verifyPcpAccessToken(token);
+      expect(result).toMatchObject({
+        type: 'mcp_access',
+        sub: 'user-123',
+        email: 'test@example.com',
+        scope: 'mcp:tools',
+      });
+    });
+
+    it('should verify a valid pcp_admin token', () => {
+      const token = jwt.sign(
+        { type: 'pcp_admin', sub: 'user-456', email: 'admin@example.com', scope: 'admin' },
+        TEST_JWT_SECRET,
+        { expiresIn: '1h' }
+      );
+
+      const result = verifyPcpAccessToken(token);
+      expect(result).not.toBeNull();
+      expect(result!.type).toBe('pcp_admin');
+      expect(result!.sub).toBe('user-456');
+    });
+
+    it('should filter by expectedType when provided', () => {
+      const mcpToken = jwt.sign(
+        { type: 'mcp_access', sub: 'user-123', email: 'test@example.com', scope: 'mcp:tools' },
+        TEST_JWT_SECRET,
+        { expiresIn: '1h' }
+      );
+
+      // Should pass when expectedType matches
+      expect(verifyPcpAccessToken(mcpToken, 'mcp_access')).not.toBeNull();
+
+      // Should fail when expectedType doesn't match
+      expect(verifyPcpAccessToken(mcpToken, 'pcp_admin')).toBeNull();
+    });
+
+    it('should reject pcp_admin token when mcp_access expected', () => {
+      const adminToken = jwt.sign(
+        { type: 'pcp_admin', sub: 'user-456', email: 'admin@example.com', scope: 'admin' },
+        TEST_JWT_SECRET,
+        { expiresIn: '1h' }
+      );
+
+      expect(verifyPcpAccessToken(adminToken, 'mcp_access')).toBeNull();
+    });
+
+    it('should accept any valid type when expectedType is omitted', () => {
+      const mcpToken = jwt.sign(
+        { type: 'mcp_access', sub: 'user-123', email: 'test@example.com', scope: 'mcp:tools' },
+        TEST_JWT_SECRET,
+        { expiresIn: '1h' }
+      );
+      const adminToken = jwt.sign(
+        { type: 'pcp_admin', sub: 'user-456', email: 'admin@example.com', scope: 'admin' },
+        TEST_JWT_SECRET,
+        { expiresIn: '1h' }
+      );
+
+      expect(verifyPcpAccessToken(mcpToken)).not.toBeNull();
+      expect(verifyPcpAccessToken(adminToken)).not.toBeNull();
+    });
+
+    it('should return null for expired token', () => {
+      const token = jwt.sign(
+        { type: 'mcp_access', sub: 'user-123', email: 'test@example.com', scope: 'mcp:tools' },
+        TEST_JWT_SECRET,
+        { expiresIn: 0 }
+      );
+
+      expect(verifyPcpAccessToken(token)).toBeNull();
+    });
+
+    it('should return null for wrong secret', () => {
+      const token = jwt.sign(
+        { type: 'mcp_access', sub: 'user-123', email: 'test@example.com', scope: 'mcp:tools' },
+        'wrong-secret-that-is-at-least-32-characters-long',
+        { expiresIn: '1h' }
+      );
+
+      expect(verifyPcpAccessToken(token)).toBeNull();
+    });
+
+    it('should return null for malformed token', () => {
+      expect(verifyPcpAccessToken('not-a-jwt')).toBeNull();
+      expect(verifyPcpAccessToken('')).toBeNull();
+    });
+
+    it('should return null for JWT with missing sub', () => {
+      const token = jwt.sign(
+        { type: 'mcp_access', email: 'test@example.com', scope: 'mcp:tools' },
+        TEST_JWT_SECRET,
+        { expiresIn: '1h' }
+      );
+
+      expect(verifyPcpAccessToken(token)).toBeNull();
+    });
+
+    it('should return null for JWT with missing type', () => {
+      const token = jwt.sign(
+        { sub: 'user-123', email: 'test@example.com', scope: 'mcp:tools' },
+        TEST_JWT_SECRET,
+        { expiresIn: '1h' }
+      );
+
+      expect(verifyPcpAccessToken(token)).toBeNull();
+    });
+
+    it('should return null for string payload JWT', () => {
+      // jwt.sign can produce a token with string payload
+      const token = jwt.sign('string-payload', TEST_JWT_SECRET);
+      expect(verifyPcpAccessToken(token)).toBeNull();
+    });
+
+    it('should not make any network or DB calls', () => {
+      const token = jwt.sign(
+        { type: 'mcp_access', sub: 'user-123', email: 'test@example.com', scope: 'mcp:tools' },
+        TEST_JWT_SECRET,
+        { expiresIn: '1h' }
+      );
+
+      verifyPcpAccessToken(token);
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+  });
+
+  // =========================================================================
+  // createRefreshToken
+  // =========================================================================
+
+  describe('createRefreshToken', () => {
+    it('should create a refresh token and store it in the database', async () => {
+      mockInsert.mockReturnValue({ error: null });
+
+      const result = await createRefreshToken(
+        getMockSupabase(),
+        'user-123',
+        'test-client',
+        ['mcp:tools'],
+        90
+      );
+
+      expect(result.refreshToken).toMatch(/^pcp-rt-/);
+      expect(result.expiresAt).toBeInstanceOf(Date);
+      expect(result.expiresAt.getTime()).toBeGreaterThan(Date.now());
+
+      // Verify DB insert was called
+      expect(mockFrom).toHaveBeenCalledWith('mcp_tokens');
+      expect(mockInsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          user_id: 'user-123',
+          client_id: 'test-client',
+          scopes: ['mcp:tools'],
+          supabase_refresh_token: null,
+        })
+      );
+    });
+
+    it('should set correct expiration based on lifetimeDays', async () => {
+      mockInsert.mockReturnValue({ error: null });
+
+      const before = Date.now();
+      const result = await createRefreshToken(
+        getMockSupabase(),
+        'user-123',
+        'dashboard',
+        ['admin'],
+        30
+      );
+      const after = Date.now();
+
+      const expectedMs = 30 * 24 * 60 * 60 * 1000;
+      expect(result.expiresAt.getTime()).toBeGreaterThanOrEqual(before + expectedMs);
+      expect(result.expiresAt.getTime()).toBeLessThanOrEqual(after + expectedMs);
+    });
+
+    it('should throw when database insert fails', async () => {
+      mockInsert.mockReturnValue({ error: { message: 'DB error' } });
+
+      await expect(
+        createRefreshToken(getMockSupabase(), 'user-123', 'test-client', ['mcp:tools'], 90)
+      ).rejects.toThrow('Failed to create refresh token');
+    });
+
+    it('should generate unique refresh tokens', async () => {
+      mockInsert.mockReturnValue({ error: null });
+
+      const result1 = await createRefreshToken(
+        getMockSupabase(),
+        'user-123',
+        'client',
+        ['mcp:tools'],
+        90
+      );
+      const result2 = await createRefreshToken(
+        getMockSupabase(),
+        'user-123',
+        'client',
+        ['mcp:tools'],
+        90
+      );
+
+      expect(result1.refreshToken).not.toBe(result2.refreshToken);
+    });
+
+    it('should store admin scopes for dashboard client', async () => {
+      mockInsert.mockReturnValue({ error: null });
+
+      await createRefreshToken(getMockSupabase(), 'user-123', 'dashboard', ['admin'], 90);
+
+      expect(mockInsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          client_id: 'dashboard',
+          scopes: ['admin'],
+        })
+      );
+    });
+  });
+
+  // =========================================================================
+  // exchangeRefreshToken
+  // =========================================================================
+
+  describe('exchangeRefreshToken', () => {
+    it('should return new access JWT on valid refresh', async () => {
+      const futureDate = new Date(Date.now() + 86400000).toISOString();
+      currentMcpTokensChain = mockChain({
+        id: 'token-1',
+        user_id: 'user-123',
+        client_id: 'test-client',
+        refresh_token: 'pcp-rt-abc',
+        scopes: ['mcp:tools'],
+        expires_at: futureDate,
+        users: { email: 'test@example.com' },
+      });
+
+      mockUpdate.mockReturnValue({
+        eq: vi.fn(() => ({ error: null })),
+      });
+
+      const result = await exchangeRefreshToken(
+        getMockSupabase(),
+        'pcp-rt-abc',
+        'test-client',
+        'mcp_access',
+        2592000
+      );
+
+      expect(result).not.toBeNull();
+      expect(result!.userId).toBe('user-123');
+      expect(result!.email).toBe('test@example.com');
+
+      // Access token should be a valid JWT
+      const decoded = jwt.verify(result!.accessToken, TEST_JWT_SECRET) as Record<string, unknown>;
+      expect(decoded.type).toBe('mcp_access');
+      expect(decoded.sub).toBe('user-123');
+      expect(decoded.email).toBe('test@example.com');
+    });
+
+    it('should sign pcp_admin tokens when tokenType is pcp_admin', async () => {
+      const futureDate = new Date(Date.now() + 86400000).toISOString();
+      currentMcpTokensChain = mockChain({
+        id: 'token-1',
+        user_id: 'user-456',
+        client_id: 'dashboard',
+        refresh_token: 'pcp-rt-admin',
+        scopes: ['admin'],
+        expires_at: futureDate,
+        users: { email: 'admin@example.com' },
+      });
+
+      mockUpdate.mockReturnValue({
+        eq: vi.fn(() => ({ error: null })),
+      });
+
+      const result = await exchangeRefreshToken(
+        getMockSupabase(),
+        'pcp-rt-admin',
+        'dashboard',
+        'pcp_admin',
+        3600
+      );
+
+      expect(result).not.toBeNull();
+      const decoded = jwt.verify(result!.accessToken, TEST_JWT_SECRET) as Record<string, unknown>;
+      expect(decoded.type).toBe('pcp_admin');
+      expect(decoded.scope).toBe('admin');
+    });
+
+    it('should respect accessTokenLifetimeSeconds', async () => {
+      const futureDate = new Date(Date.now() + 86400000).toISOString();
+      currentMcpTokensChain = mockChain({
+        id: 'token-1',
+        user_id: 'user-123',
+        client_id: 'dashboard',
+        refresh_token: 'pcp-rt-abc',
+        scopes: ['admin'],
+        expires_at: futureDate,
+        users: { email: 'test@example.com' },
+      });
+
+      mockUpdate.mockReturnValue({
+        eq: vi.fn(() => ({ error: null })),
+      });
+
+      const result = await exchangeRefreshToken(
+        getMockSupabase(),
+        'pcp-rt-abc',
+        'dashboard',
+        'pcp_admin',
+        3600 // 1 hour
+      );
+
+      const decoded = jwt.verify(result!.accessToken, TEST_JWT_SECRET) as Record<string, unknown>;
+      const exp = decoded.exp as number;
+      const iat = decoded.iat as number;
+      expect(exp - iat).toBe(3600);
+    });
+
+    it('should return null for unknown refresh token', async () => {
+      currentMcpTokensChain = mockChain(null, { code: 'PGRST116' });
+
+      const result = await exchangeRefreshToken(
+        getMockSupabase(),
+        'pcp-rt-nonexistent',
+        'test-client',
+        'mcp_access',
+        3600
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null for client_id mismatch', async () => {
+      const futureDate = new Date(Date.now() + 86400000).toISOString();
+      currentMcpTokensChain = mockChain({
+        id: 'token-1',
+        user_id: 'user-123',
+        client_id: 'original-client',
+        refresh_token: 'pcp-rt-abc',
+        scopes: ['mcp:tools'],
+        expires_at: futureDate,
+        users: { email: 'test@example.com' },
+      });
+
+      const result = await exchangeRefreshToken(
+        getMockSupabase(),
+        'pcp-rt-abc',
+        'different-client',
+        'mcp_access',
+        3600
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null and delete expired refresh token', async () => {
+      const pastDate = new Date(Date.now() - 86400000).toISOString();
+      currentMcpTokensChain = mockChain({
+        id: 'token-1',
+        user_id: 'user-123',
+        client_id: 'test-client',
+        refresh_token: 'pcp-rt-abc',
+        scopes: ['mcp:tools'],
+        expires_at: pastDate,
+        users: { email: 'test@example.com' },
+      });
+
+      mockDelete.mockReturnValue({
+        eq: vi.fn(() => ({ error: null })),
+      });
+
+      const result = await exchangeRefreshToken(
+        getMockSupabase(),
+        'pcp-rt-abc',
+        'test-client',
+        'mcp_access',
+        3600
+      );
+
+      expect(result).toBeNull();
+      // Should have deleted the expired token
+      expect(mockFrom).toHaveBeenCalledWith('mcp_tokens');
+    });
+
+    it('should update last_used_at on successful exchange', async () => {
+      const futureDate = new Date(Date.now() + 86400000).toISOString();
+      currentMcpTokensChain = mockChain({
+        id: 'token-1',
+        user_id: 'user-123',
+        client_id: 'test-client',
+        refresh_token: 'pcp-rt-abc',
+        scopes: ['mcp:tools'],
+        expires_at: futureDate,
+        users: { email: 'test@example.com' },
+      });
+
+      mockUpdate.mockReturnValue({
+        eq: vi.fn(() => ({ error: null })),
+      });
+
+      await exchangeRefreshToken(
+        getMockSupabase(),
+        'pcp-rt-abc',
+        'test-client',
+        'mcp_access',
+        3600
+      );
+
+      // update() should have been called for last_used_at
+      expect(mockUpdate).toHaveBeenCalled();
+    });
+
+    it('should not make any Supabase auth calls', async () => {
+      const futureDate = new Date(Date.now() + 86400000).toISOString();
+      currentMcpTokensChain = mockChain({
+        id: 'token-1',
+        user_id: 'user-123',
+        client_id: 'test-client',
+        refresh_token: 'pcp-rt-abc',
+        scopes: ['mcp:tools'],
+        expires_at: futureDate,
+        users: { email: 'test@example.com' },
+      });
+
+      mockUpdate.mockReturnValue({
+        eq: vi.fn(() => ({ error: null })),
+      });
+
+      const supabase = getMockSupabase();
+      await exchangeRefreshToken(supabase, 'pcp-rt-abc', 'test-client', 'mcp_access', 3600);
+
+      // Supabase auth methods should never be called
+      expect(supabase.auth).toBeUndefined();
+    });
+
+    it('should handle missing user email gracefully', async () => {
+      const futureDate = new Date(Date.now() + 86400000).toISOString();
+      currentMcpTokensChain = mockChain({
+        id: 'token-1',
+        user_id: 'user-123',
+        client_id: 'test-client',
+        refresh_token: 'pcp-rt-abc',
+        scopes: ['mcp:tools'],
+        expires_at: futureDate,
+        users: { email: null },
+      });
+
+      mockUpdate.mockReturnValue({
+        eq: vi.fn(() => ({ error: null })),
+      });
+
+      const result = await exchangeRefreshToken(
+        getMockSupabase(),
+        'pcp-rt-abc',
+        'test-client',
+        'mcp_access',
+        3600
+      );
+
+      expect(result).not.toBeNull();
+      expect(result!.email).toBe('');
+    });
+  });
+
+  // =========================================================================
+  // Cross-function: sign → verify round-trip
+  // =========================================================================
+
+  describe('sign + verify round-trip', () => {
+    it('should verify a token signed by signPcpAccessToken', () => {
+      const payload: PcpTokenPayload = {
+        type: 'mcp_access',
+        sub: 'user-123',
+        email: 'test@example.com',
+        scope: 'mcp:tools',
+      };
+
+      const token = signPcpAccessToken(payload, 3600);
+      const result = verifyPcpAccessToken(token);
+
+      expect(result).not.toBeNull();
+      expect(result!.type).toBe('mcp_access');
+      expect(result!.sub).toBe('user-123');
+      expect(result!.email).toBe('test@example.com');
+    });
+
+    it('should verify pcp_admin round-trip', () => {
+      const payload: PcpTokenPayload = {
+        type: 'pcp_admin',
+        sub: 'user-456',
+        email: 'admin@example.com',
+        scope: 'admin',
+      };
+
+      const token = signPcpAccessToken(payload, 3600);
+      const result = verifyPcpAccessToken(token, 'pcp_admin');
+
+      expect(result).not.toBeNull();
+      expect(result!.type).toBe('pcp_admin');
+    });
+
+    it('should enforce type isolation: mcp_access token rejected as pcp_admin', () => {
+      const token = signPcpAccessToken(
+        { type: 'mcp_access', sub: 'user-123', email: 'test@example.com', scope: 'mcp:tools' },
+        3600
+      );
+
+      expect(verifyPcpAccessToken(token, 'mcp_access')).not.toBeNull();
+      expect(verifyPcpAccessToken(token, 'pcp_admin')).toBeNull();
+    });
+
+    it('should enforce type isolation: pcp_admin token rejected as mcp_access', () => {
+      const token = signPcpAccessToken(
+        { type: 'pcp_admin', sub: 'user-456', email: 'admin@example.com', scope: 'admin' },
+        3600
+      );
+
+      expect(verifyPcpAccessToken(token, 'pcp_admin')).not.toBeNull();
+      expect(verifyPcpAccessToken(token, 'mcp_access')).toBeNull();
+    });
+  });
+});

--- a/packages/api/src/auth/pcp-tokens.ts
+++ b/packages/api/src/auth/pcp-tokens.ts
@@ -1,0 +1,169 @@
+/**
+ * Shared PCP Token Utilities
+ *
+ * Self-issued JWT operations used by both MCP auth and admin dashboard auth.
+ * All verification is local (jwt.verify with JWT_SECRET) — no network calls.
+ * Refresh tokens are opaque strings backed by the mcp_tokens table.
+ */
+
+import crypto from 'crypto';
+import jwt from 'jsonwebtoken';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { env } from '../config/env';
+import { logger } from '../utils/logger';
+import type { Database } from '../data/supabase/types';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface PcpTokenPayload {
+  type: 'mcp_access' | 'pcp_admin';
+  sub: string; // PCP user ID
+  email: string;
+  scope: string;
+}
+
+// ============================================================================
+// Sign
+// ============================================================================
+
+/**
+ * Sign a PCP access token (self-issued JWT).
+ * Both MCP and admin auth use this to issue access tokens.
+ */
+export function signPcpAccessToken(payload: PcpTokenPayload, expiresInSeconds: number): string {
+  return jwt.sign(payload, env.JWT_SECRET, {
+    expiresIn: expiresInSeconds,
+  });
+}
+
+// ============================================================================
+// Verify
+// ============================================================================
+
+/**
+ * Verify a PCP access token (local jwt.verify, ~0ms).
+ * Returns the payload if valid, null otherwise.
+ *
+ * @param token      Raw JWT string (not "Bearer ...")
+ * @param expectedType  If provided, only accept tokens whose `type` field matches
+ */
+export function verifyPcpAccessToken(
+  token: string,
+  expectedType?: PcpTokenPayload['type']
+): PcpTokenPayload | null {
+  try {
+    const decoded = jwt.verify(token, env.JWT_SECRET);
+    if (typeof decoded === 'string') return null;
+
+    const payload = decoded as PcpTokenPayload;
+    if (!payload.type || !payload.sub) return null;
+
+    if (expectedType && payload.type !== expectedType) return null;
+
+    return payload;
+  } catch {
+    return null;
+  }
+}
+
+// ============================================================================
+// Refresh Tokens (DB-backed)
+// ============================================================================
+
+/**
+ * Create a refresh token in the mcp_tokens table.
+ * Used for both MCP and admin auth — the `client_id` distinguishes them.
+ */
+export async function createRefreshToken(
+  supabase: SupabaseClient<Database>,
+  userId: string,
+  clientId: string,
+  scopes: string[],
+  lifetimeDays: number
+): Promise<{ refreshToken: string; expiresAt: Date }> {
+  const refreshToken = `pcp-rt-${crypto.randomBytes(32).toString('hex')}`;
+  const expiresAt = new Date(Date.now() + lifetimeDays * 24 * 60 * 60 * 1000);
+
+  const { error } = await supabase.from('mcp_tokens').insert({
+    user_id: userId,
+    client_id: clientId,
+    refresh_token: refreshToken,
+    supabase_refresh_token: null,
+    scopes,
+    expires_at: expiresAt.toISOString(),
+  });
+
+  if (error) {
+    logger.error('Failed to store refresh token', { error, clientId });
+    throw new Error('Failed to create refresh token');
+  }
+
+  return { refreshToken, expiresAt };
+}
+
+/**
+ * Exchange a refresh token for a new access JWT.
+ * Looks up the token in mcp_tokens, verifies expiry, signs a fresh JWT.
+ *
+ * @returns  Access token + user info on success, null on failure
+ */
+export async function exchangeRefreshToken(
+  supabase: SupabaseClient<Database>,
+  refreshToken: string,
+  clientId: string,
+  tokenType: PcpTokenPayload['type'],
+  accessTokenLifetimeSeconds: number
+): Promise<{ accessToken: string; userId: string; email: string } | null> {
+  const { data: tokenRecord, error: lookupError } = await supabase
+    .from('mcp_tokens')
+    .select('*, users(email)')
+    .eq('refresh_token', refreshToken)
+    .single();
+
+  if (lookupError || !tokenRecord) {
+    logger.warn('Refresh token not found', { clientId });
+    return null;
+  }
+
+  if (tokenRecord.client_id !== clientId) {
+    logger.warn('Refresh token client_id mismatch', {
+      expected: tokenRecord.client_id,
+      received: clientId,
+    });
+    return null;
+  }
+
+  if (new Date(tokenRecord.expires_at) < new Date()) {
+    logger.warn('Refresh token expired', { userId: tokenRecord.user_id });
+    await supabase.from('mcp_tokens').delete().eq('id', tokenRecord.id);
+    return null;
+  }
+
+  const userEmail = (tokenRecord.users as unknown as { email: string | null })?.email || '';
+
+  const scope = tokenRecord.scopes?.join(' ') || 'mcp:tools';
+
+  const accessToken = signPcpAccessToken(
+    {
+      type: tokenType,
+      sub: tokenRecord.user_id,
+      email: userEmail,
+      scope,
+    },
+    accessTokenLifetimeSeconds
+  );
+
+  // Update last_used_at
+  await supabase
+    .from('mcp_tokens')
+    .update({ last_used_at: new Date().toISOString() })
+    .eq('id', tokenRecord.id);
+
+  return {
+    accessToken,
+    userId: tokenRecord.user_id,
+    email: userEmail,
+  };
+}

--- a/packages/api/src/mcp/auth/pcp-auth-provider.test.ts
+++ b/packages/api/src/mcp/auth/pcp-auth-provider.test.ts
@@ -675,7 +675,7 @@ describe('PcpAuthProvider', () => {
 
       expect(result).toEqual({
         error: 'invalid_grant',
-        error_description: 'Refresh token expired',
+        error_description: 'Invalid refresh token',
       });
     });
   });

--- a/packages/api/src/mcp/auth/pcp-auth-provider.ts
+++ b/packages/api/src/mcp/auth/pcp-auth-provider.ts
@@ -14,6 +14,12 @@ import jwt from 'jsonwebtoken';
 import { env } from '../../config/env';
 import { logger } from '../../utils/logger';
 import type { Database } from '../../data/supabase/types';
+import {
+  signPcpAccessToken,
+  verifyPcpAccessToken,
+  createRefreshToken,
+  exchangeRefreshToken as exchangeRefreshTokenShared,
+} from '../../auth/pcp-tokens';
 
 // ============================================================================
 // Types
@@ -34,14 +40,6 @@ interface PendingAuthPayload {
   codeChallenge: string;
   redirectUri: string;
   state: string;
-}
-
-/** JWT payload for self-issued MCP access tokens */
-interface McpAccessTokenPayload {
-  type: 'mcp_access';
-  sub: string; // PCP user ID
-  email: string;
-  scope: string;
 }
 
 export interface AuthCode {
@@ -78,7 +76,6 @@ export interface AuthCallbackResult {
 
 const ACCESS_TOKEN_LIFETIME_SECONDS = 30 * 24 * 60 * 60; // 30 days
 const REFRESH_TOKEN_LIFETIME_DAYS = 90;
-const REFRESH_TOKEN_LIFETIME_MS = REFRESH_TOKEN_LIFETIME_DAYS * 24 * 60 * 60 * 1000;
 const AUTH_CODE_LIFETIME_MS = 10 * 60 * 1000; // 10 minutes
 const PENDING_AUTH_LIFETIME_SECONDS = 600; // 10 minutes
 
@@ -282,22 +279,20 @@ export class PcpAuthProvider {
       }
     }
 
-    // Generate our opaque refresh token
-    const refreshToken = `pcp-rt-${crypto.randomBytes(32).toString('hex')}`;
-    const expiresAt = new Date(Date.now() + REFRESH_TOKEN_LIFETIME_MS);
-
-    // Store in database
-    const { error: dbError } = await this.supabase.from('mcp_tokens').insert({
-      user_id: codeData.userId,
-      client_id: clientId,
-      refresh_token: refreshToken,
-      supabase_refresh_token: null,
-      scopes: ['mcp:tools'],
-      expires_at: expiresAt.toISOString(),
-    });
-
-    if (dbError) {
-      logger.error('Failed to store MCP token', { error: dbError });
+    // Create refresh token in database
+    let refreshToken: string;
+    let expiresAt: Date;
+    try {
+      const result = await createRefreshToken(
+        this.supabase,
+        codeData.userId,
+        clientId,
+        ['mcp:tools'],
+        REFRESH_TOKEN_LIFETIME_DAYS
+      );
+      refreshToken = result.refreshToken;
+      expiresAt = result.expiresAt;
+    } catch {
       return { error: 'server_error', error_description: 'Failed to create token' };
     }
 
@@ -305,15 +300,14 @@ export class PcpAuthProvider {
     this.authCodes.delete(params.code);
 
     // Sign our own JWT as the access token
-    const accessToken = jwt.sign(
+    const accessToken = signPcpAccessToken(
       {
         type: 'mcp_access',
         sub: codeData.userId,
         email: codeData.userEmail,
         scope: 'mcp:tools',
-      } satisfies McpAccessTokenPayload,
-      env.JWT_SECRET,
-      { expiresIn: ACCESS_TOKEN_LIFETIME_SECONDS }
+      },
+      ACCESS_TOKEN_LIFETIME_SECONDS
     );
 
     logger.info('MCP tokens issued', {
@@ -340,66 +334,29 @@ export class PcpAuthProvider {
     refreshToken: string;
     clientId: string;
   }): Promise<OAuthTokenResponse | OAuthErrorResponse> {
-    // Look up token in database, joining users table for email
-    const { data: tokenRecord, error: lookupError } = await this.supabase
-      .from('mcp_tokens')
-      .select('*, users(email)')
-      .eq('refresh_token', params.refreshToken)
-      .single();
-
-    if (lookupError || !tokenRecord) {
-      logger.warn('MCP refresh token not found', { clientId: params.clientId });
-      return { error: 'invalid_grant', error_description: 'Invalid refresh token' };
-    }
-
-    // Verify client_id matches
-    if (tokenRecord.client_id !== params.clientId) {
-      logger.warn('MCP refresh token client_id mismatch', {
-        expected: tokenRecord.client_id,
-        received: params.clientId,
-      });
-      return { error: 'invalid_grant', error_description: 'Invalid refresh token' };
-    }
-
-    // Check expiration
-    if (new Date(tokenRecord.expires_at) < new Date()) {
-      logger.warn('MCP refresh token expired', { userId: tokenRecord.user_id });
-      await this.supabase.from('mcp_tokens').delete().eq('id', tokenRecord.id);
-      return { error: 'invalid_grant', error_description: 'Refresh token expired' };
-    }
-
-    // Resolve user email from the join
-    const userEmail = (tokenRecord.users as unknown as { email: string | null })?.email || '';
-
-    // Sign a fresh self-issued JWT — no Supabase call needed
-    const accessToken = jwt.sign(
-      {
-        type: 'mcp_access',
-        sub: tokenRecord.user_id,
-        email: userEmail,
-        scope: 'mcp:tools',
-      } satisfies McpAccessTokenPayload,
-      env.JWT_SECRET,
-      { expiresIn: ACCESS_TOKEN_LIFETIME_SECONDS }
+    const result = await exchangeRefreshTokenShared(
+      this.supabase,
+      params.refreshToken,
+      params.clientId,
+      'mcp_access',
+      ACCESS_TOKEN_LIFETIME_SECONDS
     );
 
-    // Update last_used_at
-    await this.supabase
-      .from('mcp_tokens')
-      .update({ last_used_at: new Date().toISOString() })
-      .eq('id', tokenRecord.id);
+    if (!result) {
+      return { error: 'invalid_grant', error_description: 'Invalid refresh token' };
+    }
 
     logger.info('MCP token refreshed', {
-      userId: tokenRecord.user_id,
+      userId: result.userId,
       clientId: params.clientId,
     });
 
     return {
-      access_token: accessToken,
+      access_token: result.accessToken,
       refresh_token: params.refreshToken,
       token_type: 'Bearer',
       expires_in: ACCESS_TOKEN_LIFETIME_SECONDS,
-      scope: tokenRecord.scopes?.join(' ') || 'mcp:tools',
+      scope: 'mcp:tools',
     };
   }
 
@@ -411,16 +368,10 @@ export class PcpAuthProvider {
     if (!authHeader?.startsWith('Bearer ')) return null;
     const token = authHeader.substring(7);
 
-    try {
-      const decoded = jwt.verify(token, env.JWT_SECRET);
-      if (typeof decoded === 'string' || (decoded as McpAccessTokenPayload).type !== 'mcp_access') {
-        return null;
-      }
-      const payload = decoded as McpAccessTokenPayload;
-      return { userId: payload.sub, email: payload.email };
-    } catch {
-      return null;
-    }
+    const payload = verifyPcpAccessToken(token, 'mcp_access');
+    if (!payload) return null;
+
+    return { userId: payload.sub, email: payload.email };
   }
 
   // --------------------------------------------------------------------------

--- a/packages/api/src/mcp/server.ts
+++ b/packages/api/src/mcp/server.ts
@@ -3,6 +3,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import express from 'express';
 import cors from 'cors';
+import cookieParser from 'cookie-parser';
 import type { Server } from 'http';
 import { MCP_SERVER_NAME, MCP_SERVER_VERSION, MCP_SERVER_DESCRIPTION } from '../config/constants';
 import { env } from '../config/env';
@@ -470,6 +471,7 @@ export class MCPServer {
     // Admin & Agent routes
     // ============================================================================
     app.use(express.json());
+    app.use(cookieParser());
     app.use('/api/admin', adminRouter);
     logger.info('Admin API routes registered at /api/admin');
 

--- a/packages/api/src/routes/admin-auth.test.ts
+++ b/packages/api/src/routes/admin-auth.test.ts
@@ -146,6 +146,7 @@ interface MockResponse extends Response {
   _status: number;
   _json: unknown;
   _cookies: Record<string, { value: string; options: Record<string, unknown> }>;
+  _clearedCookies: Record<string, { options: Record<string, unknown> }>;
 }
 
 function createMockRes(): MockResponse {
@@ -153,6 +154,7 @@ function createMockRes(): MockResponse {
     _status: 200,
     _json: null,
     _cookies: {} as Record<string, { value: string; options: Record<string, unknown> }>,
+    _clearedCookies: {} as Record<string, { options: Record<string, unknown> }>,
     status(code: number) {
       res._status = code;
       return res;
@@ -163,6 +165,10 @@ function createMockRes(): MockResponse {
     },
     cookie(name: string, value: string, options: Record<string, unknown>) {
       (res._cookies as Record<string, unknown>)[name] = { value, options };
+      return res;
+    },
+    clearCookie(name: string, options: Record<string, unknown>) {
+      (res._clearedCookies as Record<string, unknown>)[name] = { options };
       return res;
     },
   };
@@ -877,5 +883,123 @@ describe('adminAuthMiddleware', () => {
       expect(res._cookies['pcp-admin-token']).toBeDefined();
       expect(res._cookies['pcp-admin-refresh']).toBeUndefined();
     });
+  });
+});
+
+// =============================================================================
+// Logout endpoint
+// =============================================================================
+
+describe('POST /auth/logout', () => {
+  /** Extract the logout route handler from the router stack */
+  function getLogoutHandler(): (req: Request, res: Response) => Promise<void> {
+    const layer = (router as any).stack.find(
+      (entry: any) => entry.route?.path === '/auth/logout' && entry.route?.methods?.post
+    );
+    if (!layer) {
+      throw new Error('POST /auth/logout route not found in router stack');
+    }
+    // Express stores route handlers in route.stack[0].handle
+    return layer.route.stack[0].handle;
+  }
+
+  let logoutHandler: ReturnType<typeof getLogoutHandler>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    logoutHandler = getLogoutHandler();
+  });
+
+  it('should clear both admin cookies', async () => {
+    const req = createMockReq({ body: {}, cookies: {} });
+    const res = createMockRes();
+
+    await logoutHandler(req, res);
+
+    expect(res._json).toEqual({ success: true });
+    expect(res._clearedCookies['pcp-admin-token']).toBeDefined();
+    expect(res._clearedCookies['pcp-admin-token'].options.path).toBe('/api/admin');
+    expect(res._clearedCookies['pcp-admin-refresh']).toBeDefined();
+    expect(res._clearedCookies['pcp-admin-refresh'].options.path).toBe('/api/admin');
+  });
+
+  it('should revoke refresh token from DB when provided in body', async () => {
+    const deleteChain: Record<string, any> = {};
+    deleteChain.delete = vi.fn(() => deleteChain);
+    deleteChain.eq = vi.fn(() => deleteChain);
+    mockSupabaseFrom.mockReturnValue(deleteChain);
+
+    const req = createMockReq({
+      body: { refreshToken: 'pcp-rt-to-revoke' },
+      cookies: {},
+    });
+    const res = createMockRes();
+
+    await logoutHandler(req, res);
+
+    expect(mockSupabaseFrom).toHaveBeenCalledWith('mcp_tokens');
+    expect(deleteChain.delete).toHaveBeenCalled();
+    expect(deleteChain.eq).toHaveBeenCalledWith('refresh_token', 'pcp-rt-to-revoke');
+    expect(deleteChain.eq).toHaveBeenCalledWith('client_id', 'dashboard');
+    expect(res._json).toEqual({ success: true });
+  });
+
+  it('should revoke refresh token from cookie when not in body', async () => {
+    const deleteChain: Record<string, any> = {};
+    deleteChain.delete = vi.fn(() => deleteChain);
+    deleteChain.eq = vi.fn(() => deleteChain);
+    mockSupabaseFrom.mockReturnValue(deleteChain);
+
+    const req = createMockReq({
+      body: {},
+      cookies: { 'pcp-admin-refresh': 'pcp-rt-from-cookie' },
+    });
+    const res = createMockRes();
+
+    await logoutHandler(req, res);
+
+    expect(deleteChain.eq).toHaveBeenCalledWith('refresh_token', 'pcp-rt-from-cookie');
+    expect(res._json).toEqual({ success: true });
+  });
+
+  it('should succeed even with no refresh token (just clears cookies)', async () => {
+    const req = createMockReq({ body: {}, cookies: {} });
+    const res = createMockRes();
+
+    await logoutHandler(req, res);
+
+    expect(res._json).toEqual({ success: true });
+    expect(mockSupabaseFrom).not.toHaveBeenCalled();
+  });
+
+  it('should still clear cookies and return success when DB revocation fails', async () => {
+    mockSupabaseFrom.mockImplementation(() => {
+      throw new Error('DB connection error');
+    });
+
+    const req = createMockReq({
+      body: { refreshToken: 'pcp-rt-fail' },
+      cookies: {},
+    });
+    const res = createMockRes();
+
+    await logoutHandler(req, res);
+
+    expect(res._json).toEqual({ success: true });
+    expect(res._clearedCookies['pcp-admin-token']).toBeDefined();
+    expect(res._clearedCookies['pcp-admin-refresh']).toBeDefined();
+  });
+
+  it('should not require authentication', async () => {
+    // Verify the logout route is registered BEFORE the auth middleware
+    const stack = (router as any).stack;
+    const logoutIndex = stack.findIndex((entry: any) => entry.route?.path === '/auth/logout');
+    const middlewareIndex = stack.findIndex(
+      (entry: any) =>
+        entry.name === 'adminAuthMiddleware' || entry.handle?.name === 'adminAuthMiddleware'
+    );
+
+    expect(logoutIndex).toBeGreaterThanOrEqual(0);
+    expect(middlewareIndex).toBeGreaterThan(logoutIndex);
   });
 });

--- a/packages/api/src/routes/admin-auth.test.ts
+++ b/packages/api/src/routes/admin-auth.test.ts
@@ -1,0 +1,881 @@
+/**
+ * Admin Auth Middleware Tests
+ *
+ * Tests the three-tier authentication flow:
+ * - Tier 1: PCP admin access JWT (local verify, ~0ms)
+ * - Tier 2: Refresh token exchange via cookie (1 DB call)
+ * - Tier 3: Supabase verification (network call, first login only)
+ *
+ * Also tests cookie issuance, workspace resolution, and edge cases.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Request, Response, NextFunction } from 'express';
+
+// ---------------------------------------------------------------------------
+// Mocks for pcp-tokens (the shared auth module)
+// ---------------------------------------------------------------------------
+
+const mockVerifyPcpAccessToken = vi.fn();
+const mockExchangeRefreshToken = vi.fn();
+const mockSignPcpAccessToken = vi.fn();
+const mockCreateRefreshToken = vi.fn();
+
+vi.mock('../auth/pcp-tokens', () => ({
+  verifyPcpAccessToken: (...args: unknown[]) => mockVerifyPcpAccessToken(...args),
+  exchangeRefreshToken: (...args: unknown[]) => mockExchangeRefreshToken(...args),
+  signPcpAccessToken: (...args: unknown[]) => mockSignPcpAccessToken(...args),
+  createRefreshToken: (...args: unknown[]) => mockCreateRefreshToken(...args),
+}));
+
+// ---------------------------------------------------------------------------
+// Mocks for Supabase
+// ---------------------------------------------------------------------------
+
+const mockGetUser = vi.fn();
+const mockSupabaseFrom = vi.fn();
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(() => ({
+    auth: { getUser: mockGetUser },
+    from: mockSupabaseFrom,
+  })),
+}));
+
+// ---------------------------------------------------------------------------
+// Mocks for data layer
+// ---------------------------------------------------------------------------
+
+const mockFindById = vi.fn();
+const mockFindRawById = vi.fn();
+const mockEnsurePersonalWorkspace = vi.fn();
+const mockListTrustedUsers = vi.fn();
+
+vi.mock('../data/composer', () => ({
+  getDataComposer: vi.fn(async () => ({
+    repositories: {
+      workspaceContainers: {
+        findById: mockFindById,
+        findRawById: mockFindRawById,
+        ensurePersonalWorkspace: mockEnsurePersonalWorkspace,
+      },
+    },
+  })),
+}));
+
+vi.mock('../services/authorization', () => ({
+  getAuthorizationService: vi.fn(() => ({
+    listTrustedUsers: mockListTrustedUsers,
+  })),
+}));
+
+vi.mock('../services/oauth', () => ({
+  getOAuthService: vi.fn(() => ({})),
+}));
+
+// ---------------------------------------------------------------------------
+// Mocks for env, logger, request-context
+// ---------------------------------------------------------------------------
+
+vi.mock('../config/env', () => ({
+  env: {
+    SUPABASE_URL: 'http://localhost:54321',
+    SUPABASE_SECRET_KEY: 'test-secret',
+    JWT_SECRET: 'test-jwt-secret-that-is-at-least-32-characters-long',
+    NODE_ENV: 'development',
+    MCP_HTTP_PORT: 3001,
+  },
+}));
+
+vi.mock('../utils/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+let capturedRunContext: Record<string, unknown> | null = null;
+vi.mock('../utils/request-context', () => ({
+  runWithRequestContext: (context: Record<string, unknown>, fn: () => void) => {
+    capturedRunContext = context;
+    fn();
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+
+import router from './admin';
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/** Extract the adminAuthMiddleware from the router's stack */
+function getMiddleware(): (req: Request, res: Response, next: NextFunction) => Promise<void> {
+  // The middleware is the first non-route handler in the router stack
+  const layer = (router as any).stack.find(
+    (entry: any) =>
+      entry.name === 'adminAuthMiddleware' || (!entry.route && entry.handle?.length === 3)
+  );
+  if (!layer) {
+    throw new Error('adminAuthMiddleware not found in router stack');
+  }
+  return layer.handle;
+}
+
+function createMockReq(overrides: Record<string, unknown> = {}): Request {
+  return {
+    headers: { authorization: 'Bearer test-token' },
+    cookies: {},
+    params: {},
+    body: {},
+    path: '/test',
+    header: vi.fn((name: string) => {
+      const headers = (overrides.headers || {}) as Record<string, string>;
+      return headers[name.toLowerCase()] || headers[name];
+    }),
+    ...overrides,
+  } as unknown as Request;
+}
+
+interface MockResponse extends Response {
+  _status: number;
+  _json: unknown;
+  _cookies: Record<string, { value: string; options: Record<string, unknown> }>;
+}
+
+function createMockRes(): MockResponse {
+  const res: Record<string, unknown> = {
+    _status: 200,
+    _json: null,
+    _cookies: {} as Record<string, { value: string; options: Record<string, unknown> }>,
+    status(code: number) {
+      res._status = code;
+      return res;
+    },
+    json(payload: unknown) {
+      res._json = payload;
+      return res;
+    },
+    cookie(name: string, value: string, options: Record<string, unknown>) {
+      (res._cookies as Record<string, unknown>)[name] = { value, options };
+      return res;
+    },
+  };
+  return res as unknown as MockResponse;
+}
+
+/** Set up mocks for Supabase queries used during Tier 3 (user lookup) */
+function mockSupabaseUserLookup(pcpUser: Record<string, unknown>) {
+  const userChain: Record<string, any> = {};
+  userChain.select = vi.fn(() => userChain);
+  userChain.insert = vi.fn(() => userChain);
+  userChain.update = vi.fn(() => userChain);
+  userChain.eq = vi.fn(() => userChain);
+  userChain.single = vi.fn(() => Promise.resolve({ data: pcpUser, error: null }));
+
+  mockSupabaseFrom.mockImplementation((table: string) => {
+    if (table === 'users') return userChain;
+    return userChain; // fallback
+  });
+
+  return userChain;
+}
+
+/** Standard workspace mock that returns a personal workspace */
+function mockDefaultWorkspace() {
+  mockEnsurePersonalWorkspace.mockResolvedValue({ id: 'workspace-1' });
+  mockFindById.mockResolvedValue(null);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('adminAuthMiddleware', () => {
+  let middleware: ReturnType<typeof getMiddleware>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedRunContext = null;
+    middleware = getMiddleware();
+    mockDefaultWorkspace();
+  });
+
+  // =========================================================================
+  // OAuth callback bypass
+  // =========================================================================
+
+  describe('OAuth callback bypass', () => {
+    it('should skip auth for OAuth callback routes', async () => {
+      const req = createMockReq({ path: '/oauth/google/callback', headers: {} });
+      const res = createMockRes();
+      const next = vi.fn();
+
+      await middleware(req, res, next);
+
+      expect(next).toHaveBeenCalled();
+      expect(res._status).toBe(200); // not 401
+    });
+  });
+
+  // =========================================================================
+  // Missing auth
+  // =========================================================================
+
+  describe('missing authorization', () => {
+    it('should return 401 for missing authorization header', async () => {
+      const req = createMockReq({ headers: {} });
+      const res = createMockRes();
+      const next = vi.fn();
+
+      await middleware(req, res, next);
+
+      expect(res._status).toBe(401);
+      expect(res._json).toEqual({ error: 'Missing authorization header' });
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('should return 401 for non-Bearer authorization', async () => {
+      const req = createMockReq({ headers: { authorization: 'Basic abc123' } });
+      const res = createMockRes();
+      const next = vi.fn();
+
+      await middleware(req, res, next);
+
+      expect(res._status).toBe(401);
+      expect(next).not.toHaveBeenCalled();
+    });
+  });
+
+  // =========================================================================
+  // Tier 1: PCP admin JWT
+  // =========================================================================
+
+  describe('Tier 1: PCP admin access JWT', () => {
+    it('should authenticate via valid PCP admin JWT and call next()', async () => {
+      mockVerifyPcpAccessToken.mockReturnValue({
+        type: 'pcp_admin',
+        sub: 'user-123',
+        email: 'test@example.com',
+        scope: 'admin',
+      });
+
+      const req = createMockReq();
+      const res = createMockRes();
+      const next = vi.fn();
+
+      await middleware(req, res, next);
+
+      expect(next).toHaveBeenCalled();
+      expect(mockVerifyPcpAccessToken).toHaveBeenCalledWith('test-token', 'pcp_admin');
+      // Should NOT call Supabase
+      expect(mockGetUser).not.toHaveBeenCalled();
+      // Should NOT issue new cookies
+      expect(Object.keys(res._cookies)).toHaveLength(0);
+    });
+
+    it('should set pcpUserId and email from JWT claims', async () => {
+      mockVerifyPcpAccessToken.mockReturnValue({
+        type: 'pcp_admin',
+        sub: 'user-abc',
+        email: 'admin@test.com',
+        scope: 'admin',
+      });
+
+      const req = createMockReq();
+      const res = createMockRes();
+      const next = vi.fn();
+
+      await middleware(req, res, next);
+
+      const authReq = req as any;
+      expect(authReq.pcpUserId).toBe('user-abc');
+      expect(authReq.user.email).toBe('admin@test.com');
+    });
+
+    it('should set request context with correct userId and email', async () => {
+      mockVerifyPcpAccessToken.mockReturnValue({
+        type: 'pcp_admin',
+        sub: 'user-ctx',
+        email: 'ctx@example.com',
+        scope: 'admin',
+      });
+
+      const req = createMockReq();
+      const res = createMockRes();
+      const next = vi.fn();
+
+      await middleware(req, res, next);
+
+      expect(capturedRunContext).toEqual({
+        userId: 'user-ctx',
+        email: 'ctx@example.com',
+        workspaceId: 'workspace-1',
+      });
+    });
+
+    it('should NOT accept mcp_access tokens as admin auth', async () => {
+      // verifyPcpAccessToken returns null when type doesn't match
+      mockVerifyPcpAccessToken.mockReturnValue(null);
+      // No refresh cookie, no Supabase
+      mockGetUser.mockResolvedValue({ data: { user: null }, error: { message: 'invalid' } });
+
+      const req = createMockReq();
+      const res = createMockRes();
+      const next = vi.fn();
+
+      await middleware(req, res, next);
+
+      expect(res._status).toBe(401);
+      expect(next).not.toHaveBeenCalled();
+    });
+  });
+
+  // =========================================================================
+  // Tier 2: Refresh token exchange
+  // =========================================================================
+
+  describe('Tier 2: Refresh token exchange', () => {
+    beforeEach(() => {
+      // Tier 1 fails
+      mockVerifyPcpAccessToken.mockReturnValue(null);
+    });
+
+    it('should authenticate via refresh cookie and issue new access token cookie', async () => {
+      mockExchangeRefreshToken.mockResolvedValue({
+        accessToken: 'new-access-jwt',
+        userId: 'user-456',
+        email: 'refreshed@example.com',
+      });
+
+      const req = createMockReq({
+        cookies: { 'pcp-admin-refresh': 'pcp-rt-existing' },
+      });
+      const res = createMockRes();
+      const next = vi.fn();
+
+      await middleware(req, res, next);
+
+      expect(next).toHaveBeenCalled();
+
+      // Should have called exchangeRefreshToken with correct args
+      expect(mockExchangeRefreshToken).toHaveBeenCalledWith(
+        expect.anything(), // supabase client
+        'pcp-rt-existing',
+        'dashboard',
+        'pcp_admin',
+        3600
+      );
+
+      // Should set new access token cookie
+      expect(res._cookies['pcp-admin-token']).toBeDefined();
+      expect(res._cookies['pcp-admin-token'].value).toBe('new-access-jwt');
+      expect(res._cookies['pcp-admin-token'].options).toMatchObject({
+        httpOnly: true,
+        path: '/api/admin',
+        sameSite: 'lax',
+      });
+
+      // Should NOT call Supabase auth
+      expect(mockGetUser).not.toHaveBeenCalled();
+
+      // Should NOT issue a new refresh cookie (stays the same)
+      expect(res._cookies['pcp-admin-refresh']).toBeUndefined();
+    });
+
+    it('should set correct user context from refresh exchange', async () => {
+      mockExchangeRefreshToken.mockResolvedValue({
+        accessToken: 'new-access-jwt',
+        userId: 'user-refreshed',
+        email: 'refreshed@test.com',
+      });
+
+      const req = createMockReq({
+        cookies: { 'pcp-admin-refresh': 'pcp-rt-test' },
+      });
+      const res = createMockRes();
+      const next = vi.fn();
+
+      await middleware(req, res, next);
+
+      const authReq = req as any;
+      expect(authReq.pcpUserId).toBe('user-refreshed');
+      expect(authReq.user.email).toBe('refreshed@test.com');
+    });
+
+    it('should fall through to Tier 3 when refresh exchange fails', async () => {
+      mockExchangeRefreshToken.mockResolvedValue(null);
+      mockGetUser.mockResolvedValue({ data: { user: null }, error: { message: 'invalid' } });
+
+      const req = createMockReq({
+        cookies: { 'pcp-admin-refresh': 'pcp-rt-expired' },
+      });
+      const res = createMockRes();
+      const next = vi.fn();
+
+      await middleware(req, res, next);
+
+      expect(mockExchangeRefreshToken).toHaveBeenCalled();
+      expect(mockGetUser).toHaveBeenCalled(); // Fell through to Tier 3
+      expect(res._status).toBe(401);
+    });
+
+    it('should fall through to Tier 3 when no refresh cookie exists', async () => {
+      mockGetUser.mockResolvedValue({ data: { user: null }, error: { message: 'invalid' } });
+
+      const req = createMockReq(); // No cookies
+      const res = createMockRes();
+      const next = vi.fn();
+
+      await middleware(req, res, next);
+
+      expect(mockExchangeRefreshToken).not.toHaveBeenCalled();
+      expect(mockGetUser).toHaveBeenCalled(); // Fell through to Tier 3
+    });
+  });
+
+  // =========================================================================
+  // Tier 3: Supabase verification (fallback)
+  // =========================================================================
+
+  describe('Tier 3: Supabase verification', () => {
+    beforeEach(() => {
+      // Tiers 1 and 2 fail
+      mockVerifyPcpAccessToken.mockReturnValue(null);
+      mockExchangeRefreshToken.mockResolvedValue(null);
+    });
+
+    it('should authenticate via Supabase and issue PCP cookies', async () => {
+      mockGetUser.mockResolvedValue({
+        data: { user: { email: 'tier3@example.com' } },
+        error: null,
+      });
+      mockSupabaseUserLookup({
+        id: 'user-tier3',
+        telegram_id: null,
+        whatsapp_id: null,
+        last_login_at: null,
+      });
+      mockSignPcpAccessToken.mockReturnValue('signed-admin-jwt');
+      mockCreateRefreshToken.mockResolvedValue({
+        refreshToken: 'pcp-rt-new',
+        expiresAt: new Date(Date.now() + 90 * 24 * 60 * 60 * 1000),
+      });
+
+      const req = createMockReq();
+      const res = createMockRes();
+      const next = vi.fn();
+
+      await middleware(req, res, next);
+
+      expect(next).toHaveBeenCalled();
+      expect(mockGetUser).toHaveBeenCalledWith('test-token');
+
+      // Should issue both cookies
+      expect(res._cookies['pcp-admin-token']).toBeDefined();
+      expect(res._cookies['pcp-admin-token'].value).toBe('signed-admin-jwt');
+      expect(res._cookies['pcp-admin-token'].options).toMatchObject({
+        httpOnly: true,
+        path: '/api/admin',
+        sameSite: 'lax',
+      });
+
+      expect(res._cookies['pcp-admin-refresh']).toBeDefined();
+      expect(res._cookies['pcp-admin-refresh'].value).toBe('pcp-rt-new');
+      expect(res._cookies['pcp-admin-refresh'].options).toMatchObject({
+        httpOnly: true,
+        path: '/api/admin',
+        sameSite: 'lax',
+      });
+
+      // Should sign with correct payload
+      expect(mockSignPcpAccessToken).toHaveBeenCalledWith(
+        { type: 'pcp_admin', sub: 'user-tier3', email: 'tier3@example.com', scope: 'admin' },
+        3600
+      );
+
+      // Should create refresh token with dashboard client
+      expect(mockCreateRefreshToken).toHaveBeenCalledWith(
+        expect.anything(),
+        'user-tier3',
+        'dashboard',
+        ['admin'],
+        90
+      );
+    });
+
+    it('should return 401 when Supabase getUser fails', async () => {
+      mockGetUser.mockResolvedValue({
+        data: { user: null },
+        error: { message: 'Token expired' },
+      });
+
+      const req = createMockReq();
+      const res = createMockRes();
+      const next = vi.fn();
+
+      await middleware(req, res, next);
+
+      expect(res._status).toBe(401);
+      expect(res._json).toEqual({ error: 'Invalid token' });
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('should auto-provision PCP user on first login', async () => {
+      mockGetUser.mockResolvedValue({
+        data: { user: { email: 'new@example.com' } },
+        error: null,
+      });
+
+      // First query: user not found. Second query (insert): returns new user.
+      let callCount = 0;
+      const chain: Record<string, any> = {};
+      chain.select = vi.fn(() => chain);
+      chain.insert = vi.fn(() => chain);
+      chain.update = vi.fn(() => chain);
+      chain.eq = vi.fn(() => chain);
+      chain.single = vi.fn(() => {
+        callCount++;
+        if (callCount === 1) {
+          return Promise.resolve({ data: null, error: null }); // Not found
+        }
+        return Promise.resolve({
+          data: { id: 'new-user', telegram_id: null, whatsapp_id: null, last_login_at: null },
+          error: null,
+        });
+      });
+      mockSupabaseFrom.mockReturnValue(chain);
+
+      mockSignPcpAccessToken.mockReturnValue('admin-jwt');
+      mockCreateRefreshToken.mockResolvedValue({
+        refreshToken: 'pcp-rt-new',
+        expiresAt: new Date(),
+      });
+
+      const req = createMockReq();
+      const res = createMockRes();
+      const next = vi.fn();
+
+      await middleware(req, res, next);
+
+      expect(next).toHaveBeenCalled();
+      expect(chain.insert).toHaveBeenCalled();
+    });
+
+    it('should still call next() even if cookie creation fails', async () => {
+      mockGetUser.mockResolvedValue({
+        data: { user: { email: 'test@example.com' } },
+        error: null,
+      });
+      mockSupabaseUserLookup({
+        id: 'user-123',
+        telegram_id: null,
+        whatsapp_id: null,
+        last_login_at: null,
+      });
+      mockSignPcpAccessToken.mockReturnValue('signed-jwt');
+      mockCreateRefreshToken.mockRejectedValue(new Error('DB error'));
+
+      const req = createMockReq();
+      const res = createMockRes();
+      const next = vi.fn();
+
+      await middleware(req, res, next);
+
+      // Auth succeeded — next() should be called despite cookie failure
+      expect(next).toHaveBeenCalled();
+    });
+  });
+
+  // =========================================================================
+  // Workspace resolution
+  // =========================================================================
+
+  describe('workspace resolution', () => {
+    beforeEach(() => {
+      // Use Tier 1 for simplicity
+      mockVerifyPcpAccessToken.mockReturnValue({
+        type: 'pcp_admin',
+        sub: 'user-ws',
+        email: 'ws@example.com',
+        scope: 'admin',
+      });
+    });
+
+    it('should use personal workspace when no x-pcp-workspace-id header', async () => {
+      mockEnsurePersonalWorkspace.mockResolvedValue({ id: 'personal-ws' });
+
+      const req = createMockReq();
+      const res = createMockRes();
+      const next = vi.fn();
+
+      await middleware(req, res, next);
+
+      expect(mockEnsurePersonalWorkspace).toHaveBeenCalledWith('user-ws');
+      expect((req as any).pcpWorkspaceId).toBe('personal-ws');
+      expect((req as any).pcpWorkspaceRole).toBe('member');
+    });
+
+    it('should use requested workspace when user is a member', async () => {
+      mockFindById.mockResolvedValue({ id: 'requested-ws' });
+
+      const req = createMockReq({
+        header: vi.fn((name: string) => {
+          if (name === 'x-pcp-workspace-id') return 'requested-ws';
+          return undefined;
+        }),
+      });
+      const res = createMockRes();
+      const next = vi.fn();
+
+      await middleware(req, res, next);
+
+      expect((req as any).pcpWorkspaceId).toBe('requested-ws');
+      expect((req as any).pcpWorkspaceRole).toBe('member');
+    });
+
+    it('should return 404 when requested workspace does not exist', async () => {
+      mockFindById.mockResolvedValue(null);
+      mockFindRawById.mockResolvedValue(null);
+
+      const req = createMockReq({
+        header: vi.fn((name: string) => {
+          if (name === 'x-pcp-workspace-id') return 'nonexistent-ws';
+          return undefined;
+        }),
+      });
+      const res = createMockRes();
+      const next = vi.fn();
+
+      await middleware(req, res, next);
+
+      expect(res._status).toBe(404);
+      expect(res._json).toEqual({ error: 'Workspace not found' });
+      expect(next).not.toHaveBeenCalled();
+    });
+  });
+
+  // =========================================================================
+  // Cookie properties
+  // =========================================================================
+
+  describe('cookie security properties', () => {
+    it('should set httpOnly on all admin cookies', async () => {
+      mockVerifyPcpAccessToken.mockReturnValue(null);
+      mockExchangeRefreshToken.mockResolvedValue(null);
+      mockGetUser.mockResolvedValue({
+        data: { user: { email: 'test@example.com' } },
+        error: null,
+      });
+      mockSupabaseUserLookup({
+        id: 'user-cookie',
+        telegram_id: null,
+        whatsapp_id: null,
+        last_login_at: null,
+      });
+      mockSignPcpAccessToken.mockReturnValue('jwt');
+      mockCreateRefreshToken.mockResolvedValue({ refreshToken: 'rt', expiresAt: new Date() });
+
+      const req = createMockReq();
+      const res = createMockRes();
+      const next = vi.fn();
+
+      await middleware(req, res, next);
+
+      expect(res._cookies['pcp-admin-token'].options.httpOnly).toBe(true);
+      expect(res._cookies['pcp-admin-refresh'].options.httpOnly).toBe(true);
+    });
+
+    it('should scope cookies to /api/admin path', async () => {
+      mockVerifyPcpAccessToken.mockReturnValue(null);
+      mockExchangeRefreshToken.mockResolvedValue(null);
+      mockGetUser.mockResolvedValue({
+        data: { user: { email: 'test@example.com' } },
+        error: null,
+      });
+      mockSupabaseUserLookup({
+        id: 'user-path',
+        telegram_id: null,
+        whatsapp_id: null,
+        last_login_at: null,
+      });
+      mockSignPcpAccessToken.mockReturnValue('jwt');
+      mockCreateRefreshToken.mockResolvedValue({ refreshToken: 'rt', expiresAt: new Date() });
+
+      const req = createMockReq();
+      const res = createMockRes();
+      const next = vi.fn();
+
+      await middleware(req, res, next);
+
+      expect(res._cookies['pcp-admin-token'].options.path).toBe('/api/admin');
+      expect(res._cookies['pcp-admin-refresh'].options.path).toBe('/api/admin');
+    });
+
+    it('should set sameSite=lax on all admin cookies', async () => {
+      mockVerifyPcpAccessToken.mockReturnValue(null);
+      mockExchangeRefreshToken.mockResolvedValue(null);
+      mockGetUser.mockResolvedValue({
+        data: { user: { email: 'test@example.com' } },
+        error: null,
+      });
+      mockSupabaseUserLookup({
+        id: 'user-same',
+        telegram_id: null,
+        whatsapp_id: null,
+        last_login_at: null,
+      });
+      mockSignPcpAccessToken.mockReturnValue('jwt');
+      mockCreateRefreshToken.mockResolvedValue({ refreshToken: 'rt', expiresAt: new Date() });
+
+      const req = createMockReq();
+      const res = createMockRes();
+      const next = vi.fn();
+
+      await middleware(req, res, next);
+
+      expect(res._cookies['pcp-admin-token'].options.sameSite).toBe('lax');
+      expect(res._cookies['pcp-admin-refresh'].options.sameSite).toBe('lax');
+    });
+
+    it('should set access token maxAge to 1 hour', async () => {
+      mockVerifyPcpAccessToken.mockReturnValue(null);
+      mockExchangeRefreshToken.mockResolvedValue(null);
+      mockGetUser.mockResolvedValue({
+        data: { user: { email: 'test@example.com' } },
+        error: null,
+      });
+      mockSupabaseUserLookup({
+        id: 'user-maxage',
+        telegram_id: null,
+        whatsapp_id: null,
+        last_login_at: null,
+      });
+      mockSignPcpAccessToken.mockReturnValue('jwt');
+      mockCreateRefreshToken.mockResolvedValue({ refreshToken: 'rt', expiresAt: new Date() });
+
+      const req = createMockReq();
+      const res = createMockRes();
+      const next = vi.fn();
+
+      await middleware(req, res, next);
+
+      expect(res._cookies['pcp-admin-token'].options.maxAge).toBe(3600 * 1000); // 1 hour in ms
+    });
+
+    it('should set refresh token maxAge to 90 days', async () => {
+      mockVerifyPcpAccessToken.mockReturnValue(null);
+      mockExchangeRefreshToken.mockResolvedValue(null);
+      mockGetUser.mockResolvedValue({
+        data: { user: { email: 'test@example.com' } },
+        error: null,
+      });
+      mockSupabaseUserLookup({
+        id: 'user-refresh-age',
+        telegram_id: null,
+        whatsapp_id: null,
+        last_login_at: null,
+      });
+      mockSignPcpAccessToken.mockReturnValue('jwt');
+      mockCreateRefreshToken.mockResolvedValue({ refreshToken: 'rt', expiresAt: new Date() });
+
+      const req = createMockReq();
+      const res = createMockRes();
+      const next = vi.fn();
+
+      await middleware(req, res, next);
+
+      expect(res._cookies['pcp-admin-refresh'].options.maxAge).toBe(90 * 24 * 60 * 60 * 1000);
+    });
+  });
+
+  // =========================================================================
+  // Tier priority / isolation
+  // =========================================================================
+
+  describe('tier priority', () => {
+    it('should not call Tier 2 or Tier 3 when Tier 1 succeeds', async () => {
+      mockVerifyPcpAccessToken.mockReturnValue({
+        type: 'pcp_admin',
+        sub: 'user-fast',
+        email: 'fast@example.com',
+        scope: 'admin',
+      });
+
+      const req = createMockReq({
+        cookies: { 'pcp-admin-refresh': 'some-refresh-token' },
+      });
+      const res = createMockRes();
+      const next = vi.fn();
+
+      await middleware(req, res, next);
+
+      expect(mockExchangeRefreshToken).not.toHaveBeenCalled();
+      expect(mockGetUser).not.toHaveBeenCalled();
+    });
+
+    it('should not call Tier 3 when Tier 2 succeeds', async () => {
+      mockVerifyPcpAccessToken.mockReturnValue(null);
+      mockExchangeRefreshToken.mockResolvedValue({
+        accessToken: 'new-jwt',
+        userId: 'user-mid',
+        email: 'mid@example.com',
+      });
+
+      const req = createMockReq({
+        cookies: { 'pcp-admin-refresh': 'valid-refresh' },
+      });
+      const res = createMockRes();
+      const next = vi.fn();
+
+      await middleware(req, res, next);
+
+      expect(mockGetUser).not.toHaveBeenCalled();
+    });
+
+    it('should not issue new cookies when Tier 1 succeeds', async () => {
+      mockVerifyPcpAccessToken.mockReturnValue({
+        type: 'pcp_admin',
+        sub: 'user-no-cookies',
+        email: 'nc@example.com',
+        scope: 'admin',
+      });
+
+      const req = createMockReq();
+      const res = createMockRes();
+      const next = vi.fn();
+
+      await middleware(req, res, next);
+
+      expect(Object.keys(res._cookies)).toHaveLength(0);
+      expect(mockSignPcpAccessToken).not.toHaveBeenCalled();
+      expect(mockCreateRefreshToken).not.toHaveBeenCalled();
+    });
+
+    it('should not issue refresh cookie when Tier 2 succeeds (only access cookie)', async () => {
+      mockVerifyPcpAccessToken.mockReturnValue(null);
+      mockExchangeRefreshToken.mockResolvedValue({
+        accessToken: 'refreshed-jwt',
+        userId: 'user-t2',
+        email: 't2@example.com',
+      });
+
+      const req = createMockReq({
+        cookies: { 'pcp-admin-refresh': 'existing-refresh' },
+      });
+      const res = createMockRes();
+      const next = vi.fn();
+
+      await middleware(req, res, next);
+
+      // Only access token cookie, not refresh
+      expect(res._cookies['pcp-admin-token']).toBeDefined();
+      expect(res._cookies['pcp-admin-refresh']).toBeUndefined();
+    });
+  });
+});

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -357,7 +357,45 @@ async function adminAuthMiddleware(req: Request, res: Response, next: NextFuncti
 
 const router = Router();
 
-// Apply auth middleware to all routes
+// =============================================================================
+// Auth Logout (before auth middleware — doesn't require active session)
+// =============================================================================
+
+/**
+ * POST /api/admin/auth/logout
+ * Revoke PCP admin refresh token and clear auth cookies.
+ * Accepts refresh token via request body (server action) or cookie (direct browser call).
+ */
+router.post('/auth/logout', async (req: Request, res: Response) => {
+  try {
+    const refreshToken = req.body?.refreshToken || req.cookies?.['pcp-admin-refresh'];
+
+    if (refreshToken) {
+      const supabase = createClient(env.SUPABASE_URL, env.SUPABASE_SECRET_KEY, {
+        auth: { autoRefreshToken: false, persistSession: false },
+      });
+      await supabase
+        .from('mcp_tokens')
+        .delete()
+        .eq('refresh_token', refreshToken)
+        .eq('client_id', ADMIN_CLIENT_ID);
+    }
+
+    // Clear cookies regardless (same options used when setting them)
+    res.clearCookie('pcp-admin-token', { path: '/api/admin' });
+    res.clearCookie('pcp-admin-refresh', { path: '/api/admin' });
+
+    res.json({ success: true });
+  } catch (error) {
+    logger.error('Admin logout error:', error);
+    // Still clear cookies even if DB revocation fails
+    res.clearCookie('pcp-admin-token', { path: '/api/admin' });
+    res.clearCookie('pcp-admin-refresh', { path: '/api/admin' });
+    res.json({ success: true });
+  }
+});
+
+// Apply auth middleware to all subsequent routes
 router.use(adminAuthMiddleware);
 
 // =============================================================================

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -19,6 +19,12 @@ import { getDataComposer } from '../data/composer';
 import crypto from 'crypto';
 import type { WorkspaceMemberRole } from '../data/repositories/workspace-containers.repository';
 import { slugifyWorkspaceName } from '../utils/workspace-slug';
+import {
+  signPcpAccessToken,
+  verifyPcpAccessToken,
+  createRefreshToken,
+  exchangeRefreshToken,
+} from '../auth/pcp-tokens';
 
 // WhatsApp listener reference (set via setWhatsAppListener)
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -39,6 +45,9 @@ type CommentAuthorUser = {
 };
 
 const LAST_LOGIN_UPDATE_INTERVAL_MS = 24 * 60 * 60 * 1000;
+const ADMIN_ACCESS_TOKEN_LIFETIME_SECONDS = 3600; // 1 hour
+const ADMIN_REFRESH_TOKEN_LIFETIME_DAYS = 90;
+const ADMIN_CLIENT_ID = 'dashboard';
 
 function formatCommentAuthorUserName(user: CommentAuthorUser | null): string | null {
   if (!user) return null;
@@ -57,9 +66,13 @@ export function setWhatsAppListener(listener: any): void {
 }
 
 /**
- * Admin auth middleware
- * Validates Supabase JWT and ensures user is a trusted admin/owner
- * Skips authentication for OAuth callback routes (they use state tokens)
+ * Admin auth middleware — three-tier verification:
+ *
+ * Tier 1: PCP admin access JWT (local jwt.verify, ~0ms)
+ * Tier 2: Refresh token exchange (1 DB call, ~once/hour)
+ * Tier 3: Supabase verification (network call, first login only)
+ *
+ * Skips authentication for OAuth callback routes (they use state tokens).
  */
 async function adminAuthMiddleware(req: Request, res: Response, next: NextFunction): Promise<void> {
   // Skip auth for OAuth callbacks (they use state tokens for security)
@@ -77,100 +90,165 @@ async function adminAuthMiddleware(req: Request, res: Response, next: NextFuncti
 
     const token = authHeader.substring(7);
 
-    // Verify the JWT with Supabase
     const supabase = createClient(env.SUPABASE_URL, env.SUPABASE_SECRET_KEY, {
       auth: { autoRefreshToken: false, persistSession: false },
     });
-    const {
-      data: { user },
-      error,
-    } = await supabase.auth.getUser(token);
 
-    if (error || !user) {
-      res.status(401).json({ error: 'Invalid token' });
-      return;
+    let pcpUserId: string | undefined;
+    let userEmail: string | undefined;
+    let issueTokenCookies = false;
+
+    // --- Tier 1: PCP admin access JWT (local, ~0ms) ---
+    const payload = verifyPcpAccessToken(token, 'pcp_admin');
+    if (payload) {
+      pcpUserId = payload.sub;
+      userEmail = payload.email;
     }
 
-    // Look up (or create) PCP user by email.
-    // For newly signed-up users, this auto-provisions PCP identity on first authenticated request.
-    const normalizedEmail = user.email?.toLowerCase() ?? null;
-    let { data: pcpUser } = await supabase
-      .from('users')
-      .select('id, telegram_id, whatsapp_id, last_login_at')
-      .eq('email', normalizedEmail)
-      .single();
+    // --- Tier 2: Refresh token exchange (1 DB call, ~once/hour) ---
+    if (!pcpUserId) {
+      const refreshCookie = req.cookies?.['pcp-admin-refresh'];
+      if (refreshCookie) {
+        const result = await exchangeRefreshToken(
+          supabase,
+          refreshCookie,
+          ADMIN_CLIENT_ID,
+          'pcp_admin',
+          ADMIN_ACCESS_TOKEN_LIFETIME_SECONDS
+        );
+        if (result) {
+          pcpUserId = result.userId;
+          userEmail = result.email;
+          // Set new access token cookie (refresh token stays the same)
+          res.cookie('pcp-admin-token', result.accessToken, {
+            httpOnly: true,
+            secure: env.NODE_ENV === 'production',
+            sameSite: 'lax',
+            path: '/api/admin',
+            maxAge: ADMIN_ACCESS_TOKEN_LIFETIME_SECONDS * 1000,
+          });
+        }
+      }
+    }
 
-    if (!pcpUser) {
-      if (!normalizedEmail) {
-        res.status(403).json({ error: 'User email not available for PCP provisioning' });
+    // --- Tier 3: Supabase verification (network call, first login only) ---
+    if (!pcpUserId) {
+      const {
+        data: { user },
+        error,
+      } = await supabase.auth.getUser(token);
+
+      if (error || !user) {
+        res.status(401).json({ error: 'Invalid token' });
         return;
       }
 
-      const { data: createdUser, error: createUserError } = await supabase
+      // Look up (or create) PCP user by email.
+      const normalizedEmail = user.email?.toLowerCase() ?? null;
+      let { data: pcpUser } = await supabase
         .from('users')
-        .insert({ email: normalizedEmail })
         .select('id, telegram_id, whatsapp_id, last_login_at')
+        .eq('email', normalizedEmail)
         .single();
 
-      if (createUserError) {
-        // Handle race where parallel requests created the PCP user first.
-        const { data: racedUser } = await supabase
-          .from('users')
-          .select('id, telegram_id, whatsapp_id, last_login_at')
-          .eq('email', normalizedEmail)
-          .single();
-
-        if (!racedUser) {
-          logger.error('Failed to auto-provision PCP user during admin auth', {
-            email: normalizedEmail,
-            error: createUserError.message,
-          });
-          res.status(500).json({ error: 'Failed to provision PCP user' });
+      if (!pcpUser) {
+        if (!normalizedEmail) {
+          res.status(403).json({ error: 'User email not available for PCP provisioning' });
           return;
         }
 
-        pcpUser = racedUser;
-      } else {
-        pcpUser = createdUser;
+        const { data: createdUser, error: createUserError } = await supabase
+          .from('users')
+          .insert({ email: normalizedEmail })
+          .select('id, telegram_id, whatsapp_id, last_login_at')
+          .single();
+
+        if (createUserError) {
+          const { data: racedUser } = await supabase
+            .from('users')
+            .select('id, telegram_id, whatsapp_id, last_login_at')
+            .eq('email', normalizedEmail)
+            .single();
+
+          if (!racedUser) {
+            logger.error('Failed to auto-provision PCP user during admin auth', {
+              email: normalizedEmail,
+              error: createUserError.message,
+            });
+            res.status(500).json({ error: 'Failed to provision PCP user' });
+            return;
+          }
+
+          pcpUser = racedUser;
+        } else {
+          pcpUser = createdUser;
+        }
       }
+
+      const lastLoginAtMs = pcpUser.last_login_at ? new Date(pcpUser.last_login_at).getTime() : NaN;
+      const shouldUpdateLastLoginAt =
+        !pcpUser.last_login_at ||
+        Number.isNaN(lastLoginAtMs) ||
+        Date.now() - lastLoginAtMs >= LAST_LOGIN_UPDATE_INTERVAL_MS;
+
+      if (shouldUpdateLastLoginAt) {
+        const loginTimestamp = new Date().toISOString();
+        const { error: loginUpdateError } = await supabase
+          .from('users')
+          .update({ last_login_at: loginTimestamp })
+          .eq('id', pcpUser.id);
+        if (loginUpdateError) {
+          logger.warn('Failed to update users.last_login_at during admin auth', {
+            userId: pcpUser.id,
+            error: loginUpdateError.message,
+          });
+        }
+      }
+
+      pcpUserId = pcpUser.id;
+      userEmail = normalizedEmail || user.email || undefined;
+      issueTokenCookies = true;
     }
 
-    const lastLoginAtMs = pcpUser.last_login_at ? new Date(pcpUser.last_login_at).getTime() : NaN;
-    const shouldUpdateLastLoginAt =
-      !pcpUser.last_login_at ||
-      Number.isNaN(lastLoginAtMs) ||
-      Date.now() - lastLoginAtMs >= LAST_LOGIN_UPDATE_INTERVAL_MS;
-
-    if (shouldUpdateLastLoginAt) {
-      const loginTimestamp = new Date().toISOString();
-      const { error: loginUpdateError } = await supabase
-        .from('users')
-        .update({ last_login_at: loginTimestamp })
-        .eq('id', pcpUser.id);
-      if (loginUpdateError) {
-        logger.warn('Failed to update users.last_login_at during admin auth', {
-          userId: pcpUser.id,
-          error: loginUpdateError.message,
-        });
-      }
-    }
-
-    // Resolve active workspace container from header (or default to personal).
+    // --- Workspace resolution (all tiers, 1 DB query) ---
     const dataComposer = await getDataComposer();
     const workspaceRepo = dataComposer.repositories.workspaceContainers;
     const requestedWorkspaceId = req.header('x-pcp-workspace-id')?.trim();
 
+    // For trusted-user resolution we need telegram/whatsapp IDs.
+    // Tier 1/2 don't have them in JWT claims, so fetch when needed.
+    let pcpUserRecord: {
+      id: string;
+      telegram_id: string | null;
+      whatsapp_id: string | null;
+    } | null = null;
+
+    const getPcpUserRecord = async () => {
+      if (!pcpUserRecord) {
+        const { data } = await supabase
+          .from('users')
+          .select('id, telegram_id, whatsapp_id')
+          .eq('id', pcpUserId!)
+          .single();
+        pcpUserRecord = data;
+      }
+      return pcpUserRecord;
+    };
+
     const hasTrustedAdminAccess = async (workspaceId: string): Promise<boolean> => {
+      const record = await getPcpUserRecord();
+      if (!record) return false;
+
       const authService = getAuthorizationService();
       const trustedUsers = await authService.listTrustedUsers(undefined, workspaceId);
 
       return trustedUsers.some((tu) => {
         if (tu.trustLevel === 'member') return false;
-        if (tu.userId === pcpUser.id) return true;
-        if (tu.platform === 'telegram' && pcpUser.telegram_id?.toString() === tu.platformUserId) {
+        if (tu.userId === record.id) return true;
+        if (tu.platform === 'telegram' && record.telegram_id?.toString() === tu.platformUserId) {
           return true;
         }
-        if (tu.platform === 'whatsapp' && pcpUser.whatsapp_id === tu.platformUserId) {
+        if (tu.platform === 'whatsapp' && record.whatsapp_id === tu.platformUserId) {
           return true;
         }
         return false;
@@ -182,7 +260,7 @@ async function adminAuthMiddleware(req: Request, res: Response, next: NextFuncti
     let hasDirectMembership = false;
 
     if (requestedWorkspaceId) {
-      const requestedWorkspace = await workspaceRepo.findById(requestedWorkspaceId, pcpUser.id);
+      const requestedWorkspace = await workspaceRepo.findById(requestedWorkspaceId, pcpUserId!);
       if (requestedWorkspace) {
         activeWorkspaceId = requestedWorkspace.id;
         hasDirectMembership = true;
@@ -203,8 +281,7 @@ async function adminAuthMiddleware(req: Request, res: Response, next: NextFuncti
         activeWorkspaceRole = 'trusted';
       }
     } else {
-      // Ensure every user always has at least one workspace container.
-      const personalWorkspace = await workspaceRepo.ensurePersonalWorkspace(pcpUser.id);
+      const personalWorkspace = await workspaceRepo.ensurePersonalWorkspace(pcpUserId!);
       activeWorkspaceId = personalWorkspace.id;
       hasDirectMembership = true;
     }
@@ -221,23 +298,53 @@ async function adminAuthMiddleware(req: Request, res: Response, next: NextFuncti
       activeWorkspaceRole = 'member';
     }
 
+    // --- Issue cookies (Tier 3 success) ---
+    if (issueTokenCookies && pcpUserId && userEmail) {
+      const accessToken = signPcpAccessToken(
+        { type: 'pcp_admin', sub: pcpUserId, email: userEmail, scope: 'admin' },
+        ADMIN_ACCESS_TOKEN_LIFETIME_SECONDS
+      );
+      try {
+        const { refreshToken } = await createRefreshToken(
+          supabase,
+          pcpUserId,
+          ADMIN_CLIENT_ID,
+          ['admin'],
+          ADMIN_REFRESH_TOKEN_LIFETIME_DAYS
+        );
+        res.cookie('pcp-admin-token', accessToken, {
+          httpOnly: true,
+          secure: env.NODE_ENV === 'production',
+          sameSite: 'lax',
+          path: '/api/admin',
+          maxAge: ADMIN_ACCESS_TOKEN_LIFETIME_SECONDS * 1000,
+        });
+        res.cookie('pcp-admin-refresh', refreshToken, {
+          httpOnly: true,
+          secure: env.NODE_ENV === 'production',
+          sameSite: 'lax',
+          path: '/api/admin',
+          maxAge: ADMIN_REFRESH_TOKEN_LIFETIME_DAYS * 24 * 60 * 60 * 1000,
+        });
+      } catch (cookieError) {
+        // Non-fatal: auth succeeded, just couldn't issue PCP cookies.
+        // Next request will hit Tier 3 again.
+        logger.warn('Failed to issue PCP admin cookies', { error: cookieError });
+      }
+    }
+
     // Attach user + PCP context to request
-    const authReq = req as Request & {
-      user: typeof user;
-      pcpUserId: string;
-      pcpWorkspaceId: string;
-      pcpWorkspaceRole: WorkspaceMemberRole | 'trusted';
-    };
-    authReq.user = user;
-    authReq.pcpUserId = pcpUser.id;
+    const authReq = req as AdminAuthRequest;
+    authReq.user = { email: userEmail || null };
+    authReq.pcpUserId = pcpUserId!;
     authReq.pcpWorkspaceId = activeWorkspaceId;
     authReq.pcpWorkspaceRole = activeWorkspaceRole || 'trusted';
 
     // Wrap the rest of the request in context
     runWithRequestContext(
       {
-        userId: pcpUser.id,
-        email: user.email || undefined,
+        userId: pcpUserId!,
+        email: userEmail,
         workspaceId: activeWorkspaceId,
       },
       () => next()
@@ -270,7 +377,9 @@ router.get('/workspaces', async (req: Request, res: Response) => {
       includeArchived: false,
     });
 
-    const currentWorkspaceMembership = workspaces.find((workspace) => workspace.id === authReq.pcpWorkspaceId);
+    const currentWorkspaceMembership = workspaces.find(
+      (workspace) => workspace.id === authReq.pcpWorkspaceId
+    );
     const currentWorkspaceRole = currentWorkspaceMembership?.role || authReq.pcpWorkspaceRole;
 
     res.json({

--- a/packages/web/src/lib/auth/actions.test.ts
+++ b/packages/web/src/lib/auth/actions.test.ts
@@ -13,6 +13,16 @@ vi.mock('next/navigation', () => ({
   },
 }));
 
+// Mock next/headers cookies
+const mockCookieGet = vi.fn();
+const mockCookieDelete = vi.fn();
+vi.mock('next/headers', () => ({
+  cookies: vi.fn().mockResolvedValue({
+    get: (...args: unknown[]) => mockCookieGet(...args),
+    delete: (...args: unknown[]) => mockCookieDelete(...args),
+  }),
+}));
+
 // Mock Supabase server client
 const mockSignInWithPassword = vi.fn();
 const mockSignInWithOtp = vi.fn();
@@ -121,10 +131,77 @@ describe('auth server actions', () => {
   });
 
   describe('signOut', () => {
+    beforeEach(() => {
+      mockCookieGet.mockReturnValue(undefined);
+      mockCookieDelete.mockReturnValue(undefined);
+      vi.spyOn(global, 'fetch').mockResolvedValue(new Response('{}'));
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
     it('calls supabase signOut and redirects to /login', async () => {
       mockSignOut.mockResolvedValue({ error: null });
 
       await expect(signOut()).rejects.toThrow('NEXT_REDIRECT');
+      expect(mockSignOut).toHaveBeenCalled();
+      expect(mockRedirect).toHaveBeenCalledWith('/login');
+    });
+
+    it('clears PCP admin cookies on signOut', async () => {
+      mockSignOut.mockResolvedValue({ error: null });
+
+      await expect(signOut()).rejects.toThrow('NEXT_REDIRECT');
+
+      expect(mockCookieDelete).toHaveBeenCalledWith({
+        name: 'pcp-admin-token',
+        path: '/api/admin',
+      });
+      expect(mockCookieDelete).toHaveBeenCalledWith({
+        name: 'pcp-admin-refresh',
+        path: '/api/admin',
+      });
+    });
+
+    it('calls logout API to revoke refresh token when cookie exists', async () => {
+      mockSignOut.mockResolvedValue({ error: null });
+      mockCookieGet.mockImplementation((name: string) => {
+        if (name === 'pcp-admin-refresh') return { value: 'pcp-rt-test-token' };
+        return undefined;
+      });
+
+      await expect(signOut()).rejects.toThrow('NEXT_REDIRECT');
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/admin/auth/logout'),
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ refreshToken: 'pcp-rt-test-token' }),
+        })
+      );
+    });
+
+    it('does not call logout API when no refresh cookie exists', async () => {
+      mockSignOut.mockResolvedValue({ error: null });
+      mockCookieGet.mockReturnValue(undefined);
+
+      await expect(signOut()).rejects.toThrow('NEXT_REDIRECT');
+
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('still signs out even if logout API call fails', async () => {
+      mockSignOut.mockResolvedValue({ error: null });
+      mockCookieGet.mockImplementation((name: string) => {
+        if (name === 'pcp-admin-refresh') return { value: 'pcp-rt-fail' };
+        return undefined;
+      });
+      vi.spyOn(global, 'fetch').mockRejectedValue(new Error('Network error'));
+
+      await expect(signOut()).rejects.toThrow('NEXT_REDIRECT');
+
+      // Supabase signOut should still be called
       expect(mockSignOut).toHaveBeenCalled();
       expect(mockRedirect).toHaveBeenCalledWith('/login');
     });

--- a/packages/web/src/lib/auth/actions.ts
+++ b/packages/web/src/lib/auth/actions.ts
@@ -105,6 +105,29 @@ export async function signUpWithPassword(
 }
 
 export async function signOut(): Promise<never> {
+  // Revoke PCP admin tokens (self-issued JWTs independent of Supabase session)
+  const { cookies } = await import('next/headers');
+  const cookieStore = await cookies();
+  const refreshToken = cookieStore.get('pcp-admin-refresh')?.value;
+
+  if (refreshToken) {
+    const apiUrl = process.env.API_URL || `http://localhost:${process.env.PCP_PORT_BASE || 3001}`;
+    try {
+      await fetch(`${apiUrl}/api/admin/auth/logout`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ refreshToken }),
+      });
+    } catch {
+      // Best-effort revocation — cookies are cleared below regardless
+    }
+  }
+
+  // Clear PCP admin cookies from browser
+  cookieStore.delete({ name: 'pcp-admin-token', path: '/api/admin' });
+  cookieStore.delete({ name: 'pcp-admin-refresh', path: '/api/admin' });
+
+  // Clear Supabase session
   const supabase = await createClient();
   await supabase.auth.signOut();
   redirect('/login');

--- a/packages/web/src/lib/supabase/middleware.ts
+++ b/packages/web/src/lib/supabase/middleware.ts
@@ -31,26 +31,32 @@ export async function updateSession(request: NextRequest) {
   const isProxiedApiRoute = path.startsWith('/api/') && !path.startsWith('/api/auth/');
 
   // Fast-path for proxied API routes: inject bearer token only.
-  // Skip getUser() to avoid duplicate Supabase round-trips on every API request.
+  // Prefers PCP admin JWT (local verification, no Supabase dependency).
   if (isProxiedApiRoute) {
+    const pcpToken = request.cookies.get('pcp-admin-token')?.value;
+
+    if (pcpToken) {
+      // PCP admin JWT available — use it directly, skip Supabase entirely.
+      const requestHeaders = new Headers(request.headers);
+      requestHeaders.set('Authorization', `Bearer ${pcpToken}`);
+      const response = NextResponse.next({ request: { headers: requestHeaders } });
+      supabaseResponse.cookies.getAll().forEach((cookie) => {
+        response.cookies.set(cookie.name, cookie.value, cookie);
+      });
+      return response;
+    }
+
+    // No PCP JWT — fall back to Supabase session token (first request after login).
     const {
       data: { session },
     } = await supabase.auth.getSession();
     if (session?.access_token) {
       const requestHeaders = new Headers(request.headers);
       requestHeaders.set('Authorization', `Bearer ${session.access_token}`);
-
-      const response = NextResponse.next({
-        request: {
-          headers: requestHeaders,
-        },
-      });
-
-      // Copy session-refresh cookies from supabaseResponse
+      const response = NextResponse.next({ request: { headers: requestHeaders } });
       supabaseResponse.cookies.getAll().forEach((cookie) => {
         response.cookies.set(cookie.name, cookie.value, cookie);
       });
-
       return response;
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2031,6 +2031,7 @@ __metadata:
     "@supabase/supabase-js": "npm:^2.39.3"
     "@types/bcrypt": "npm:^5.0.2"
     "@types/compression": "npm:^1.7.5"
+    "@types/cookie-parser": "npm:^1.4.10"
     "@types/cors": "npm:^2.8.17"
     "@types/express": "npm:^4.17.21"
     "@types/jsonwebtoken": "npm:^9.0.5"
@@ -2043,6 +2044,7 @@ __metadata:
     "@whiskeysockets/baileys": "npm:^7.0.0-rc.9"
     bcrypt: "npm:^5.1.1"
     compression: "npm:^1.7.4"
+    cookie-parser: "npm:^1.4.7"
     cors: "npm:^2.8.5"
     cron-parser: "npm:^5.5.0"
     discord.js: "npm:^14.25.1"
@@ -3521,6 +3523,15 @@ __metadata:
   dependencies:
     "@types/node": "npm:*"
   checksum: 10/7eb1bc5342a9604facd57598a6c62621e244822442976c443efb84ff745246b10d06e8b309b6e80130026a396f19bf6793b7cecd7380169f369dac3bfc46fb99
+  languageName: node
+  linkType: hard
+
+"@types/cookie-parser@npm:^1.4.10":
+  version: 1.4.10
+  resolution: "@types/cookie-parser@npm:1.4.10"
+  peerDependencies:
+    "@types/express": "*"
+  checksum: 10/1f37b5a4115dbfd4b7bbea2d874fbf9495eca8c3e8c87fa7e38c50f9fff66222377c911cfdc7a1ea08855e822919c5534ebbcc4bf25b596bc6f7270e403483d9
   languageName: node
   linkType: hard
 
@@ -5518,6 +5529,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cookie-parser@npm:^1.4.7":
+  version: 1.4.7
+  resolution: "cookie-parser@npm:1.4.7"
+  dependencies:
+    cookie: "npm:0.7.2"
+    cookie-signature: "npm:1.0.6"
+  checksum: 10/243fa13f217e793d20a57675e6552beea08c5989fcc68495d543997a31646875335e0e82d687b42dcfd466df57891d22bae7f5ba6ab33b7705ed2dd6eb989105
+  languageName: node
+  linkType: hard
+
+"cookie-signature@npm:1.0.6":
+  version: 1.0.6
+  resolution: "cookie-signature@npm:1.0.6"
+  checksum: 10/f4e1b0a98a27a0e6e66fd7ea4e4e9d8e038f624058371bf4499cfcd8f3980be9a121486995202ba3fca74fbed93a407d6d54d43a43f96fd28d0bd7a06761591a
+  languageName: node
+  linkType: hard
+
 "cookie-signature@npm:^1.2.1":
   version: 1.2.2
   resolution: "cookie-signature@npm:1.2.2"
@@ -5532,7 +5560,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cookie@npm:^0.7.0, cookie@npm:^0.7.1, cookie@npm:~0.7.1":
+"cookie@npm:0.7.2, cookie@npm:^0.7.0, cookie@npm:^0.7.1, cookie@npm:~0.7.1":
   version: 0.7.2
   resolution: "cookie@npm:0.7.2"
   checksum: 10/24b286c556420d4ba4e9bc09120c9d3db7d28ace2bd0f8ccee82422ce42322f73c8312441271e5eefafbead725980e5996cc02766dbb89a90ac7f5636ede608f


### PR DESCRIPTION
## Summary

- **Extract shared token utilities** into `packages/api/src/auth/pcp-tokens.ts` — sign, verify, create refresh, exchange refresh — used by both MCP and admin auth
- **Refactor `PcpAuthProvider`** to use shared utilities instead of inline `jwt.sign()`/`jwt.verify()` calls
- **Restructure admin auth middleware** into three tiers: PCP JWT (local, ~0ms) → refresh cookie exchange (1 DB call) → Supabase fallback (network call, first login only)
- **Update Next.js middleware** to prefer `pcp-admin-token` cookie over `supabase.auth.getSession()`, skipping Supabase entirely when PCP JWT is available

### Per-request cost

| | Before | After (Tier 1) | After (Tier 2) |
|---|---|---|---|
| Supabase getUser | 1 network | 0 | 0 |
| Middleware getSession | 0-1 network | 0 | 0 |
| PCP user lookup | 1 DB query | 0 | 0 |
| Refresh token exchange | 0 | 0 | 1 DB query |
| Workspace resolution | 1 DB query | 1 DB query | 1 DB query |
| **Total** | **3-5 calls** | **1 DB query** | **2 DB queries** |

## Test plan

- [x] 34 unit tests for `pcp-tokens.ts` (sign, verify, type isolation, refresh create/exchange)
- [x] 27 unit tests for admin auth middleware (all three tiers, cookie security, tier priority)
- [x] 15 integration tests against real Supabase (full token lifecycle with DB writes)
- [x] All 722 unit tests pass (`yarn workspace @personal-context/api test`)
- [x] All 33 integration tests pass (`yarn workspace @personal-context/api test:integration`)
- [x] Build clean — no new type errors
- [ ] Manual: login → Tier 3 fires → cookies set → subsequent requests hit Tier 1
- [ ] Manual: delete `pcp-admin-token` cookie → Tier 2 refresh → new access cookie
- [ ] Manual: delete both cookies → Tier 3 fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)