### PR TITLE
fix: return 405 for GET /mcp in streamable-http (by Lumen)

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -244,6 +244,11 @@ pm2 restart mcp
 2. Check port 3001 is accessible
 3. Verify `.mcp.json` config file exists
 
+## MCP Transport TODOs
+
+- Revisit full SSE stream support for `GET /mcp` in Streamable HTTP mode (resumability / server-pushed notifications).
+- Keep compatibility notes for Gemini CLI and other MCP clients that probe `GET /mcp` during discovery.
+
 ## Running Individual Processes
 
 For debugging, you can run processes individually without pm2:

--- a/packages/api/src/mcp/server.test.ts
+++ b/packages/api/src/mcp/server.test.ts
@@ -114,6 +114,16 @@ async function mcpPost(
   return { status: res.status, headers: res.headers, body: text };
 }
 
+/** GET the MCP endpoint. */
+async function mcpGet(
+  baseUrl: string,
+  headers: Record<string, string> = {}
+): Promise<{ status: number; headers: Headers; body: string }> {
+  const res = await fetch(`${baseUrl}/mcp`, { method: 'GET', headers });
+  const text = await res.text();
+  return { status: res.status, headers: res.headers, body: text };
+}
+
 /** Extract the JSON result from an SSE event stream body. */
 function parseSSEResult(body: string): unknown {
   const match = body.match(/^data: (.+)$/m);
@@ -190,6 +200,13 @@ describe('MCP StreamableHTTP Transport (stateless)', () => {
     expect(body.error.message).toContain('Authentication required');
 
     (env as any).MCP_REQUIRE_OAUTH = false;
+  });
+
+  it('should expose GET /mcp for streamable-http clients', async () => {
+    // This server intentionally does not offer standalone SSE at GET /mcp.
+    // Per streamable-http compatibility, it should return explicit 405 (not 404).
+    const res = await mcpGet(baseUrl);
+    expect(res.status).toBe(405);
   });
 
   // =========================================================================

--- a/packages/api/src/mcp/server.ts
+++ b/packages/api/src/mcp/server.ts
@@ -151,9 +151,10 @@ export class MCPServer {
     // ============================================================================
     // Streamable HTTP MCP endpoint (stateless)
     // Each request gets a fresh transport — no session tracking, no stale sessions.
-    // Handles: POST (tool calls + initialize), DELETE (no-op)
+    // Handles: POST (tool calls + initialize), GET (explicit 405 when no SSE stream
+    // is offered), DELETE (no-op)
     // ============================================================================
-    app.post('/mcp', async (req, res) => {
+    const handleMcpRequest = async (req: express.Request, res: express.Response) => {
       const authHeader = req.headers.authorization;
       const userData = await this.authProvider.verifyAccessToken(authHeader);
 
@@ -223,6 +224,18 @@ export class MCPServer {
             });
           }
         }
+      });
+    };
+
+    app.post('/mcp', handleMcpRequest);
+
+    // This stateless endpoint does not expose a standalone SSE stream.
+    // Streamable HTTP clients may probe GET /mcp; return explicit 405 per spec.
+    app.get('/mcp', (_req, res) => {
+      res.status(405).set('Allow', 'POST, DELETE').json({
+        jsonrpc: '2.0',
+        error: { code: -32000, message: 'Method not allowed.' },
+        id: null,
       });
     });
 


### PR DESCRIPTION
## Summary
- handle `GET /mcp` explicitly in the MCP streamable-http server
- return `405 Method Not Allowed` (with `Allow: POST, DELETE`) instead of falling through to a 404
- keep `POST /mcp` request handling unchanged
- add a test asserting `GET /mcp` returns 405 (not 404)
- add a short MCP transport TODO note in `docs/DEVELOPMENT.md`

## Why
Gemini CLI probes `GET /mcp` during discovery. With no GET handler, Express returned `404`, which Gemini treated as a transport failure and disconnected even after successful OAuth.

Returning explicit `405` aligns with streamable-http behavior when standalone SSE is not offered.

## Validation
- `tsx` import check for `packages/api/src/mcp/server.ts` passes
- full `vitest` server test execution is blocked in this sandbox (`listen EPERM`), but the test was updated for the new behavior
