### PR TITLE
fix(schema): add missing users.last_login_at column (by Wren)

### DIFF
--- a/packages/api/src/routes/admin-auth.test.ts
+++ b/packages/api/src/routes/admin-auth.test.ts
@@ -465,7 +465,6 @@ describe('adminAuthMiddleware', () => {
         id: 'user-tier3',
         telegram_id: null,
         whatsapp_id: null,
-        last_login_at: null,
       });
       mockSignPcpAccessToken.mockReturnValue('signed-admin-jwt');
       mockCreateRefreshToken.mockResolvedValue({
@@ -551,7 +550,7 @@ describe('adminAuthMiddleware', () => {
           return Promise.resolve({ data: null, error: null }); // Not found
         }
         return Promise.resolve({
-          data: { id: 'new-user', telegram_id: null, whatsapp_id: null, last_login_at: null },
+          data: { id: 'new-user', telegram_id: null, whatsapp_id: null },
           error: null,
         });
       });
@@ -582,7 +581,6 @@ describe('adminAuthMiddleware', () => {
         id: 'user-123',
         telegram_id: null,
         whatsapp_id: null,
-        last_login_at: null,
       });
       mockSignPcpAccessToken.mockReturnValue('signed-jwt');
       mockCreateRefreshToken.mockRejectedValue(new Error('DB error'));
@@ -682,7 +680,6 @@ describe('adminAuthMiddleware', () => {
         id: 'user-cookie',
         telegram_id: null,
         whatsapp_id: null,
-        last_login_at: null,
       });
       mockSignPcpAccessToken.mockReturnValue('jwt');
       mockCreateRefreshToken.mockResolvedValue({ refreshToken: 'rt', expiresAt: new Date() });
@@ -708,7 +705,6 @@ describe('adminAuthMiddleware', () => {
         id: 'user-path',
         telegram_id: null,
         whatsapp_id: null,
-        last_login_at: null,
       });
       mockSignPcpAccessToken.mockReturnValue('jwt');
       mockCreateRefreshToken.mockResolvedValue({ refreshToken: 'rt', expiresAt: new Date() });
@@ -734,7 +730,6 @@ describe('adminAuthMiddleware', () => {
         id: 'user-same',
         telegram_id: null,
         whatsapp_id: null,
-        last_login_at: null,
       });
       mockSignPcpAccessToken.mockReturnValue('jwt');
       mockCreateRefreshToken.mockResolvedValue({ refreshToken: 'rt', expiresAt: new Date() });
@@ -760,7 +755,6 @@ describe('adminAuthMiddleware', () => {
         id: 'user-maxage',
         telegram_id: null,
         whatsapp_id: null,
-        last_login_at: null,
       });
       mockSignPcpAccessToken.mockReturnValue('jwt');
       mockCreateRefreshToken.mockResolvedValue({ refreshToken: 'rt', expiresAt: new Date() });
@@ -785,7 +779,6 @@ describe('adminAuthMiddleware', () => {
         id: 'user-refresh-age',
         telegram_id: null,
         whatsapp_id: null,
-        last_login_at: null,
       });
       mockSignPcpAccessToken.mockReturnValue('jwt');
       mockCreateRefreshToken.mockResolvedValue({ refreshToken: 'rt', expiresAt: new Date() });

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -44,7 +44,6 @@ type CommentAuthorUser = {
   email: string | null;
 };
 
-const LAST_LOGIN_UPDATE_INTERVAL_MS = 24 * 60 * 60 * 1000;
 const ADMIN_ACCESS_TOKEN_LIFETIME_SECONDS = 3600; // 1 hour
 const ADMIN_REFRESH_TOKEN_LIFETIME_DAYS = 90;
 const ADMIN_CLIENT_ID = 'dashboard';
@@ -147,7 +146,7 @@ async function adminAuthMiddleware(req: Request, res: Response, next: NextFuncti
       const normalizedEmail = user.email?.toLowerCase() ?? null;
       let { data: pcpUser } = await supabase
         .from('users')
-        .select('id, telegram_id, whatsapp_id, last_login_at')
+        .select('id, telegram_id, whatsapp_id')
         .eq('email', normalizedEmail)
         .single();
 
@@ -159,14 +158,14 @@ async function adminAuthMiddleware(req: Request, res: Response, next: NextFuncti
 
         const { data: createdUser, error: createUserError } = await supabase
           .from('users')
-          .insert({ email: normalizedEmail })
-          .select('id, telegram_id, whatsapp_id, last_login_at')
+          .insert({ email: normalizedEmail, last_login_at: new Date().toISOString() })
+          .select('id, telegram_id, whatsapp_id')
           .single();
 
         if (createUserError) {
           const { data: racedUser } = await supabase
             .from('users')
-            .select('id, telegram_id, whatsapp_id, last_login_at')
+            .select('id, telegram_id, whatsapp_id')
             .eq('email', normalizedEmail)
             .single();
 
@@ -185,25 +184,11 @@ async function adminAuthMiddleware(req: Request, res: Response, next: NextFuncti
         }
       }
 
-      const lastLoginAtMs = pcpUser.last_login_at ? new Date(pcpUser.last_login_at).getTime() : NaN;
-      const shouldUpdateLastLoginAt =
-        !pcpUser.last_login_at ||
-        Number.isNaN(lastLoginAtMs) ||
-        Date.now() - lastLoginAtMs >= LAST_LOGIN_UPDATE_INTERVAL_MS;
-
-      if (shouldUpdateLastLoginAt) {
-        const loginTimestamp = new Date().toISOString();
-        const { error: loginUpdateError } = await supabase
-          .from('users')
-          .update({ last_login_at: loginTimestamp })
-          .eq('id', pcpUser.id);
-        if (loginUpdateError) {
-          logger.warn('Failed to update users.last_login_at during admin auth', {
-            userId: pcpUser.id,
-            error: loginUpdateError.message,
-          });
-        }
-      }
+      // Update last_login_at — Tier 3 only runs on actual login (Supabase token verification)
+      await supabase
+        .from('users')
+        .update({ last_login_at: new Date().toISOString() })
+        .eq('id', pcpUser.id);
 
       pcpUserId = pcpUser.id;
       userEmail = normalizedEmail || user.email || undefined;
@@ -2311,10 +2296,7 @@ router.get('/sessions', async (req: Request, res: Response) => {
 
     // 2. Batch-fetch agent identities for unique agent_ids
     const uniqueAgentIds = [...new Set(sessionRows.map((s) => s.agent_id).filter(Boolean))];
-    const identitiesByAgentId = new Map<
-      string,
-      { name: string; role: string | null }
-    >();
+    const identitiesByAgentId = new Map<string, { name: string; role: string | null }>();
 
     if (uniqueAgentIds.length > 0) {
       // Look up identities by user_id (not workspace container) so names resolve
@@ -2369,7 +2351,9 @@ router.get('/sessions', async (req: Request, res: Response) => {
 
     // 4. Compute stats
     const stats = {
-      active: sessionRows.filter((s) => s.status === 'active' && !s.current_phase?.startsWith('blocked')).length,
+      active: sessionRows.filter(
+        (s) => s.status === 'active' && !s.current_phase?.startsWith('blocked')
+      ).length,
       blocked: sessionRows.filter((s) => s.current_phase?.startsWith('blocked')).length,
       paused: sessionRows.filter((s) => s.status === 'paused').length,
       total: sessionRows.length,

--- a/supabase/migrations/20260216210758_add_users_last_login_at.sql
+++ b/supabase/migrations/20260216210758_add_users_last_login_at.sql
@@ -1,0 +1,2 @@
+-- Add last_login_at to users table for login tracking
+ALTER TABLE users ADD COLUMN IF NOT EXISTS last_login_at timestamptz;


### PR DESCRIPTION
## Summary

- **Fixes "Failed to provision PCP user" on all dashboard endpoints** — the admin auth middleware referenced `users.last_login_at` but the column never existed (schema drift from the squashed baseline migration)
- Adds `last_login_at timestamptz` to users table via migration (already applied to live DB)
- Scopes `last_login_at` updates to actual login/signup events only — Tier 3 (Supabase verification) and user creation, not on general authenticated access (Tier 1 JWT / Tier 2 refresh token)
- Removes the `LAST_LOGIN_UPDATE_INTERVAL_MS` throttle — unnecessary since Tier 3 only runs on real login events

## Test plan

- [x] All 746 tests pass (`yarn workspace @personal-context/api test`)
- [x] Migration applied to live DB, column verified
- [x] Dashboard endpoints working after fix
- [ ] Verify `last_login_at` updates on fresh login (clear cookies, re-authenticate)
- [ ] Verify `last_login_at` does NOT update on normal page navigation (Tier 1/2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)