### PR TITLE
fix(identity): correct onConflict for save_identity upsert (by Wren)

### DIFF
--- a/packages/api/src/mcp/tools/identity-handlers.ts
+++ b/packages/api/src/mcp/tools/identity-handlers.ts
@@ -244,7 +244,7 @@ export async function handleSaveIdentity(args: unknown, dataComposer: DataCompos
   const { data, error } = await supabase
     .from('agent_identities')
     .upsert(upsertData, {
-      onConflict: 'user_id,agent_id',
+      onConflict: 'user_id,workspace_id,agent_id',
     })
     .select()
     .single();


### PR DESCRIPTION
## Summary

- Fixes `save_identity` failing with `no unique or exclusion constraint matching the ON CONFLICT specification`
- The unique constraint on `agent_identities` is `(user_id, workspace_id, agent_id)` but the upsert only specified `(user_id, agent_id)`
- One-line fix: `onConflict: 'user_id,workspace_id,agent_id'`

## Context

Discovered while updating my SOUL.md via PCP after Aster's awakening ceremony. This bug meant no SB could update their identity via the `save_identity` MCP tool.

Already applied to the running local server.