### PR TITLE
feat: studio-first routing + workspaces→studios migration (by Lumen)

### DIFF
--- a/packages/api/src/channels/agent-gateway.ts
+++ b/packages/api/src/channels/agent-gateway.ts
@@ -30,6 +30,12 @@ export interface AgentTriggerPayload {
   priority?: 'low' | 'normal' | 'high' | 'urgent';
   /** Thread key for session routing (e.g., "pr:32") */
   threadKey?: string;
+  /** Explicit studio/worktree scope for the target agent */
+  studioId?: string;
+  /** Convenience studio routing hint */
+  studioHint?: 'main';
+  /** Related session to inherit studio scope from */
+  relatedSessionId?: string;
   /** Additional metadata */
   metadata?: Record<string, unknown>;
 }

--- a/packages/api/src/data/composer.ts
+++ b/packages/api/src/data/composer.ts
@@ -13,7 +13,7 @@ import { SessionFocusRepository } from './repositories/session-focus.repository'
 import { ProjectTasksRepository } from './repositories/project-tasks.repository';
 import { MemoryRepository } from './repositories/memory-repository';
 import { ActivityStreamRepository } from './repositories/activity-stream.repository';
-import { WorkspacesRepository } from './repositories/workspaces.repository';
+import { StudiosRepository } from './repositories/studios.repository';
 import { WorkspaceContainersRepository } from './repositories/workspace-containers.repository';
 import { logger } from '../utils/logger';
 
@@ -33,7 +33,7 @@ export class DataComposer {
     projectTasks: ProjectTasksRepository;
     memory: MemoryRepository;
     activityStream: ActivityStreamRepository;
-    workspaces: WorkspacesRepository;
+    studios: StudiosRepository;
     workspaceContainers: WorkspaceContainersRepository;
   };
 
@@ -54,7 +54,7 @@ export class DataComposer {
       projectTasks: new ProjectTasksRepository(supabaseClient),
       memory: new MemoryRepository(supabaseClient),
       activityStream: new ActivityStreamRepository(supabaseClient),
-      workspaces: new WorkspacesRepository(supabaseClient),
+      studios: new StudiosRepository(supabaseClient),
       workspaceContainers: new WorkspaceContainersRepository(supabaseClient),
     };
 

--- a/packages/api/src/data/repositories/studios.repository.ts
+++ b/packages/api/src/data/repositories/studios.repository.ts
@@ -1,9 +1,9 @@
 /**
- * Workspaces Repository
+ * Studios Repository
  *
- * Manages git worktree workspaces for parallel agent work:
+ * Manages git worktree studios for parallel agent work:
  * - Track active worktrees per user/agent
- * - Link workspaces to sessions
+ * - Link studios to sessions
  * - Lifecycle management (active → idle → archived → cleaned)
  */
 
@@ -11,13 +11,12 @@ import type { SupabaseClient } from '@supabase/supabase-js';
 import type { Database, Json } from '../supabase/types';
 import { resolveIdentityId } from '../../auth/resolve-identity';
 
-// Type alias for the table to help with Supabase generics
-type WorkspacesTable = Database['public']['Tables']['workspaces'];
+type StudiosTable = Database['public']['Tables']['studios'];
 
-export type WorkspaceStatus = 'active' | 'idle' | 'archived' | 'cleaned';
+export type StudioStatus = 'active' | 'idle' | 'archived' | 'cleaned';
 export type WorkType = 'feature' | 'bugfix' | 'refactor' | 'chore' | 'experiment' | 'other';
 
-export interface Workspace {
+export interface Studio {
   id: string;
   userId: string;
   agentId: string | null;
@@ -28,7 +27,7 @@ export interface Workspace {
   baseBranch: string;
   purpose: string | null;
   workType: string | null;
-  status: WorkspaceStatus;
+  status: StudioStatus;
   metadata: Json;
   createdAt: string;
   updatedAt: string;
@@ -36,7 +35,7 @@ export interface Workspace {
   cleanedAt: string | null;
 }
 
-export interface CreateWorkspaceInput {
+export interface CreateStudioInput {
   userId: string;
   agentId?: string;
   identityId?: string;
@@ -50,8 +49,8 @@ export interface CreateWorkspaceInput {
   metadata?: Json;
 }
 
-export interface UpdateWorkspaceInput {
-  status?: WorkspaceStatus;
+export interface UpdateStudioInput {
+  status?: StudioStatus;
   sessionId?: string | null;
   purpose?: string;
   workType?: WorkType;
@@ -60,13 +59,10 @@ export interface UpdateWorkspaceInput {
   cleanedAt?: string;
 }
 
-export class WorkspacesRepository {
+export class StudiosRepository {
   constructor(private client: SupabaseClient<Database>) {}
 
-  /**
-   * Map a snake_case DB row to camelCase Workspace interface
-   */
-  private mapRow(row: Record<string, unknown>): Workspace {
+  private mapRow(row: Record<string, unknown>): Studio {
     return {
       id: row.id as string,
       userId: row.user_id as string,
@@ -78,7 +74,7 @@ export class WorkspacesRepository {
       baseBranch: row.base_branch as string,
       purpose: (row.purpose as string) || null,
       workType: (row.work_type as string) || null,
-      status: row.status as WorkspaceStatus,
+      status: row.status as StudioStatus,
       metadata: (row.metadata as Json) || {},
       createdAt: row.created_at as string,
       updatedAt: row.updated_at as string,
@@ -87,15 +83,12 @@ export class WorkspacesRepository {
     };
   }
 
-  /**
-   * Create a new workspace
-   */
-  async create(input: CreateWorkspaceInput): Promise<Workspace> {
+  async create(input: CreateStudioInput): Promise<Studio> {
     const identityId =
       input.identityId ||
       (input.agentId ? await resolveIdentityId(this.client, input.userId, input.agentId) : null);
 
-    const insertData: WorkspacesTable['Insert'] = {
+    const insertData: StudiosTable['Insert'] = {
       user_id: input.userId,
       agent_id: input.agentId,
       identity_id: identityId,
@@ -111,74 +104,58 @@ export class WorkspacesRepository {
     };
 
     const { data, error } = await this.client
-      .from('workspaces')
+      .from('studios')
       .insert(insertData as never)
       .select()
       .single();
 
     if (error) {
-      throw new Error(`Failed to create workspace: ${error.message}`);
+      throw new Error(`Failed to create studio: ${error.message}`);
     }
 
     return this.mapRow(data as Record<string, unknown>);
   }
 
-  /**
-   * Find workspace by ID
-   */
-  async findById(id: string): Promise<Workspace | null> {
-    const { data, error } = await this.client.from('workspaces').select('*').eq('id', id).single();
+  async findById(id: string): Promise<Studio | null> {
+    const { data, error } = await this.client.from('studios').select('*').eq('id', id).single();
 
     if (error && error.code !== 'PGRST116') {
-      throw new Error(`Failed to find workspace: ${error.message}`);
+      throw new Error(`Failed to find studio: ${error.message}`);
     }
 
     return data ? this.mapRow(data as Record<string, unknown>) : null;
   }
 
-  /**
-   * Find workspace by branch name
-   */
-  async findByBranch(branch: string): Promise<Workspace | null> {
-    const { data, error } = await this.client
-      .from('workspaces')
-      .select('*')
-      .eq('branch', branch)
-      .single();
+  async findByBranch(branch: string): Promise<Studio | null> {
+    const { data, error } = await this.client.from('studios').select('*').eq('branch', branch).single();
 
     if (error && error.code !== 'PGRST116') {
-      throw new Error(`Failed to find workspace by branch: ${error.message}`);
+      throw new Error(`Failed to find studio by branch: ${error.message}`);
     }
 
     return data ? this.mapRow(data as Record<string, unknown>) : null;
   }
 
-  /**
-   * Find workspace by worktree path
-   */
-  async findByPath(worktreePath: string): Promise<Workspace | null> {
+  async findByPath(worktreePath: string): Promise<Studio | null> {
     const { data, error } = await this.client
-      .from('workspaces')
+      .from('studios')
       .select('*')
       .eq('worktree_path', worktreePath)
       .single();
 
     if (error && error.code !== 'PGRST116') {
-      throw new Error(`Failed to find workspace by path: ${error.message}`);
+      throw new Error(`Failed to find studio by path: ${error.message}`);
     }
 
     return data ? this.mapRow(data as Record<string, unknown>) : null;
   }
 
-  /**
-   * List workspaces for a user, optionally filtered by status and/or agentId
-   */
   async listByUser(
     userId: string,
-    opts?: { status?: WorkspaceStatus; agentId?: string }
-  ): Promise<Workspace[]> {
+    opts?: { status?: StudioStatus; agentId?: string }
+  ): Promise<Studio[]> {
     let query = this.client
-      .from('workspaces')
+      .from('studios')
       .select('*')
       .eq('user_id', userId)
       .order('updated_at', { ascending: false });
@@ -194,111 +171,79 @@ export class WorkspacesRepository {
     const { data, error } = await query;
 
     if (error) {
-      throw new Error(`Failed to list workspaces: ${error.message}`);
+      throw new Error(`Failed to list studios: ${error.message}`);
     }
 
     return (data || []).map((row) => this.mapRow(row as Record<string, unknown>));
   }
 
-  /**
-   * List workspaces by IDs for a specific user.
-   */
-  async listByIds(userId: string, ids: string[]): Promise<Workspace[]> {
+  async listByIds(userId: string, ids: string[]): Promise<Studio[]> {
     if (ids.length === 0) {
       return [];
     }
 
     const { data, error } = await this.client
-      .from('workspaces')
+      .from('studios')
       .select('*')
       .eq('user_id', userId)
       .in('id', ids);
 
     if (error) {
-      throw new Error(`Failed to list workspaces by ids: ${error.message}`);
+      throw new Error(`Failed to list studios by ids: ${error.message}`);
     }
 
     return (data || []).map((row) => this.mapRow(row as Record<string, unknown>));
   }
 
-  /**
-   * List active workspaces for a user (status in 'active' or 'idle')
-   */
-  async listActive(userId: string): Promise<Workspace[]> {
+  async listActive(userId: string): Promise<Studio[]> {
     const { data, error } = await this.client
-      .from('workspaces')
+      .from('studios')
       .select('*')
       .eq('user_id', userId)
       .in('status', ['active', 'idle'])
       .order('updated_at', { ascending: false });
 
     if (error) {
-      throw new Error(`Failed to list active workspaces: ${error.message}`);
+      throw new Error(`Failed to list active studios: ${error.message}`);
     }
 
     return (data || []).map((row) => this.mapRow(row as Record<string, unknown>));
   }
 
-  /**
-   * Update a workspace
-   */
-  async update(id: string, input: UpdateWorkspaceInput): Promise<Workspace> {
+  async update(id: string, input: UpdateStudioInput): Promise<Studio> {
     const updateData: Record<string, unknown> = {};
 
-    if (input.status !== undefined) {
-      updateData.status = input.status;
-    }
-    if (input.sessionId !== undefined) {
-      updateData.session_id = input.sessionId;
-    }
-    if (input.purpose !== undefined) {
-      updateData.purpose = input.purpose;
-    }
-    if (input.workType !== undefined) {
-      updateData.work_type = input.workType;
-    }
-    if (input.metadata !== undefined) {
-      updateData.metadata = input.metadata;
-    }
-    if (input.archivedAt !== undefined) {
-      updateData.archived_at = input.archivedAt;
-    }
-    if (input.cleanedAt !== undefined) {
-      updateData.cleaned_at = input.cleanedAt;
-    }
+    if (input.status !== undefined) updateData.status = input.status;
+    if (input.sessionId !== undefined) updateData.session_id = input.sessionId;
+    if (input.purpose !== undefined) updateData.purpose = input.purpose;
+    if (input.workType !== undefined) updateData.work_type = input.workType;
+    if (input.metadata !== undefined) updateData.metadata = input.metadata;
+    if (input.archivedAt !== undefined) updateData.archived_at = input.archivedAt;
+    if (input.cleanedAt !== undefined) updateData.cleaned_at = input.cleanedAt;
 
     const { data, error } = await this.client
-      .from('workspaces')
+      .from('studios')
       .update(updateData as never)
       .eq('id', id)
       .select()
       .single();
 
     if (error) {
-      throw new Error(`Failed to update workspace: ${error.message}`);
+      throw new Error(`Failed to update studio: ${error.message}`);
     }
 
     return this.mapRow(data as Record<string, unknown>);
   }
 
-  /**
-   * Link a session to a workspace
-   */
-  async linkSession(id: string, sessionId: string): Promise<Workspace> {
+  async linkSession(id: string, sessionId: string): Promise<Studio> {
     return this.update(id, { sessionId, status: 'active' });
   }
 
-  /**
-   * Unlink a session from a workspace (sets session_id to null, status to 'idle')
-   */
-  async unlinkSession(id: string): Promise<Workspace> {
+  async unlinkSession(id: string): Promise<Studio> {
     return this.update(id, { sessionId: null, status: 'idle' });
   }
 
-  /**
-   * Mark a workspace as cleaned
-   */
-  async markCleaned(id: string): Promise<Workspace> {
+  async markCleaned(id: string): Promise<Studio> {
     return this.update(id, {
       status: 'cleaned',
       cleanedAt: new Date().toISOString(),

--- a/packages/api/src/data/supabase/types.ts
+++ b/packages/api/src/data/supabase/types.ts
@@ -2146,7 +2146,7 @@ export type Database = {
             foreignKeyName: 'sessions_studio_id_fkey';
             columns: ['studio_id'];
             isOneToOne: false;
-            referencedRelation: 'workspaces';
+            referencedRelation: 'studios';
             referencedColumns: ['id'];
           },
           {
@@ -2160,7 +2160,7 @@ export type Database = {
             foreignKeyName: 'sessions_workspace_id_fkey';
             columns: ['workspace_id'];
             isOneToOne: false;
-            referencedRelation: 'workspaces';
+            referencedRelation: 'studios';
             referencedColumns: ['id'];
           },
         ];
@@ -2818,7 +2818,7 @@ export type Database = {
           },
         ];
       };
-      workspaces: {
+      studios: {
         Row: {
           agent_id: string | null;
           archived_at: string | null;

--- a/packages/api/src/mcp/tools/agent-triggers.ts
+++ b/packages/api/src/mcp/tools/agent-triggers.ts
@@ -50,6 +50,20 @@ export const triggerAgentSchema = z.object({
     .string()
     .optional()
     .describe('Thread key for session routing on the recipient side (e.g., "pr:32")'),
+  studioId: z
+    .string()
+    .uuid()
+    .optional()
+    .describe('Optional explicit studio ID for the target agent session'),
+  studioHint: z
+    .enum(['main'])
+    .optional()
+    .describe('Convenience studio routing hint (e.g., "main" to force shared main studio)'),
+  relatedSessionId: z
+    .string()
+    .uuid()
+    .optional()
+    .describe('Optional related session ID to inherit studio scope from'),
   metadata: z
     .record(z.unknown())
     .optional()
@@ -82,6 +96,9 @@ export async function handleTriggerAgent(
       inboxMessageId: args.inboxMessageId,
       priority: args.priority,
       threadKey: args.threadKey,
+      studioId: args.studioId,
+      studioHint: args.studioHint,
+      relatedSessionId: args.relatedSessionId,
       metadata: args.metadata,
     };
 

--- a/packages/api/src/mcp/tools/inbox-handlers.ts
+++ b/packages/api/src/mcp/tools/inbox-handlers.ts
@@ -412,7 +412,7 @@ export async function handleGetAgentStatus(args: unknown, dataComposer: DataComp
 
   // Get active workspaces for this agent
   const { data: workspaces } = await supabase
-    .from('workspaces')
+    .from('studios')
     .select('id, branch, worktree_path, purpose, status, work_type, session_id, created_at')
     .eq('user_id', resolved.user.id)
     .eq('agent_id', agentId)

--- a/packages/api/src/mcp/tools/memory-handlers.ts
+++ b/packages/api/src/mcp/tools/memory-handlers.ts
@@ -885,8 +885,8 @@ export async function handleListSessions(args: unknown, dataComposer: DataCompos
     new Set(sessions.map((s) => s.studioId).filter((id): id is string => !!id))
   );
 
-  const workspaces = await dataComposer.repositories.workspaces.listByIds(user.id, studioIds);
-  const workspaceById = new Map(workspaces.map((w) => [w.id, w]));
+  const studios = await dataComposer.repositories.studios.listByIds(user.id, studioIds);
+  const workspaceById = new Map(studios.map((w) => [w.id, w]));
 
   return {
     content: [

--- a/packages/api/src/mcp/tools/workspace-handlers.ts
+++ b/packages/api/src/mcp/tools/workspace-handlers.ts
@@ -180,7 +180,7 @@ export async function handleCreateWorkspace(args: unknown, dataComposer: DataCom
   // Insert workspace record into the database
   let workspace;
   try {
-    workspace = await dataComposer.repositories.workspaces.create({
+    workspace = await dataComposer.repositories.studios.create({
       userId: resolved.user.id,
       agentId,
       sessionId,
@@ -243,21 +243,21 @@ export async function handleListWorkspaces(args: unknown, dataComposer: DataComp
   const resolved = await resolveUserOrThrow(parsed, dataComposer);
 
   const { agentId, status = 'all', includeAll = false } = parsed;
-  const workspacesRepo = dataComposer.repositories.workspaces;
+  const studiosRepo = dataComposer.repositories.studios;
 
   let workspaces;
   if (status !== 'all') {
-    workspaces = await workspacesRepo.listByUser(resolved.user.id, {
+    workspaces = await studiosRepo.listByUser(resolved.user.id, {
       status: status as 'active' | 'idle' | 'archived' | 'cleaned',
       agentId: agentId || undefined,
     });
   } else if (includeAll) {
-    workspaces = await workspacesRepo.listByUser(resolved.user.id, {
+    workspaces = await studiosRepo.listByUser(resolved.user.id, {
       agentId: agentId || undefined,
     });
   } else {
     // Default: get all but exclude 'cleaned'
-    const all = await workspacesRepo.listByUser(resolved.user.id, {
+    const all = await studiosRepo.listByUser(resolved.user.id, {
       agentId: agentId || undefined,
     });
     workspaces = all.filter((w) => w.status !== 'cleaned');
@@ -286,16 +286,16 @@ export async function handleGetWorkspace(args: unknown, dataComposer: DataCompos
   const parsed = getWorkspaceSchema.parse(args);
   await resolveUserOrThrow(parsed, dataComposer);
 
-  const workspacesRepo = dataComposer.repositories.workspaces;
+  const studiosRepo = dataComposer.repositories.studios;
   let workspace = null;
 
   // Try identifiers in order: workspaceId, branch, path
   if (parsed.workspaceId) {
-    workspace = await workspacesRepo.findById(parsed.workspaceId);
+    workspace = await studiosRepo.findById(parsed.workspaceId);
   } else if (parsed.branch) {
-    workspace = await workspacesRepo.findByBranch(parsed.branch);
+    workspace = await studiosRepo.findByBranch(parsed.branch);
   } else if (parsed.path) {
-    workspace = await workspacesRepo.findByPath(parsed.path);
+    workspace = await studiosRepo.findByPath(parsed.path);
   } else {
     return errorResponse('Must provide at least one of: workspaceId, branch, or path');
   }
@@ -332,10 +332,10 @@ export async function handleUpdateWorkspace(args: unknown, dataComposer: DataCom
   await resolveUserOrThrow(parsed, dataComposer);
 
   const { workspaceId, agentId, status, purpose, sessionId, unlinkSession } = parsed;
-  const workspacesRepo = dataComposer.repositories.workspaces;
+  const studiosRepo = dataComposer.repositories.studios;
 
   // Verify workspace exists
-  const existing = await workspacesRepo.findById(workspaceId);
+  const existing = await studiosRepo.findById(workspaceId);
   if (!existing) {
     return errorResponse(`Workspace not found: ${workspaceId}`);
   }
@@ -343,9 +343,9 @@ export async function handleUpdateWorkspace(args: unknown, dataComposer: DataCom
   let updated;
 
   if (unlinkSession) {
-    updated = await workspacesRepo.unlinkSession(workspaceId);
+    updated = await studiosRepo.unlinkSession(workspaceId);
   } else if (sessionId) {
-    updated = await workspacesRepo.linkSession(workspaceId, sessionId);
+    updated = await studiosRepo.linkSession(workspaceId, sessionId);
   } else {
     const updateObj: Record<string, unknown> = {};
     if (status !== undefined) {
@@ -354,7 +354,7 @@ export async function handleUpdateWorkspace(args: unknown, dataComposer: DataCom
     if (purpose !== undefined) {
       updateObj.purpose = purpose;
     }
-    updated = await workspacesRepo.update(workspaceId, updateObj);
+    updated = await studiosRepo.update(workspaceId, updateObj);
   }
 
   logger.info('Workspace updated', { workspaceId, agentId, status: updated.status });
@@ -381,10 +381,10 @@ export async function handleCloseWorkspace(args: unknown, dataComposer: DataComp
   await resolveUserOrThrow(parsed, dataComposer);
 
   const { workspaceId, agentId, removeWorktree = true, deleteBranch = false } = parsed;
-  const workspacesRepo = dataComposer.repositories.workspaces;
+  const studiosRepo = dataComposer.repositories.studios;
 
   // Verify workspace exists
-  const workspace = await workspacesRepo.findById(workspaceId);
+  const workspace = await studiosRepo.findById(workspaceId);
   if (!workspace) {
     return errorResponse(`Workspace not found: ${workspaceId}`);
   }
@@ -433,7 +433,7 @@ export async function handleCloseWorkspace(args: unknown, dataComposer: DataComp
   }
 
   // Mark as cleaned in the database
-  const updated = await workspacesRepo.markCleaned(workspaceId);
+  const updated = await studiosRepo.markCleaned(workspaceId);
 
   logger.info('Workspace closed', {
     workspaceId,
@@ -456,16 +456,16 @@ export async function handleAdoptWorkspace(args: unknown, dataComposer: DataComp
   await resolveUserOrThrow(parsed, dataComposer);
 
   const { agentId, sessionId } = parsed;
-  const workspacesRepo = dataComposer.repositories.workspaces;
+  const studiosRepo = dataComposer.repositories.studios;
 
   // Find workspace by ID, branch, or path
   let workspace = null;
   if (parsed.workspaceId) {
-    workspace = await workspacesRepo.findById(parsed.workspaceId);
+    workspace = await studiosRepo.findById(parsed.workspaceId);
   } else if (parsed.branch) {
-    workspace = await workspacesRepo.findByBranch(parsed.branch);
+    workspace = await studiosRepo.findByBranch(parsed.branch);
   } else if (parsed.worktreePath) {
-    workspace = await workspacesRepo.findByPath(parsed.worktreePath);
+    workspace = await studiosRepo.findByPath(parsed.worktreePath);
   } else {
     return errorResponse('Must provide at least one of: workspaceId, branch, or worktreePath');
   }
@@ -475,7 +475,7 @@ export async function handleAdoptWorkspace(args: unknown, dataComposer: DataComp
   }
 
   // Link session and set to active
-  const updated = await workspacesRepo.linkSession(workspace.id, sessionId);
+  const updated = await studiosRepo.linkSession(workspace.id, sessionId);
 
   logger.info('Workspace adopted', {
     workspaceId: updated.id,

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -2315,8 +2315,23 @@ router.get('/sessions', async (req: Request, res: Response) => {
       }
     }
 
-    // 3. Batch-fetch workspaces linked to these sessions
+    // 3. Batch-fetch studios linked to these sessions (studio_id preferred, session_id fallback)
     const sessionIds = sessionRows.map((s) => s.id);
+    const studioIds = [
+      ...new Set(sessionRows.map((s) => s.studio_id || s.workspace_id).filter(Boolean)),
+    ] as string[];
+
+    const studiosById = new Map<
+      string,
+      {
+        id: string;
+        branch: string | null;
+        baseBranch: string | null;
+        purpose: string | null;
+        workType: string | null;
+        status: string;
+      }
+    >();
     const workspacesBySessionId = new Map<
       string,
       {
@@ -2329,13 +2344,32 @@ router.get('/sessions', async (req: Request, res: Response) => {
       }
     >();
 
+    if (studioIds.length > 0) {
+      const { data: studios } = await supabase
+        .from('studios')
+        .select('id, branch, base_branch, purpose, work_type, status')
+        .in('id', studioIds);
+
+      for (const studio of studios || []) {
+        studiosById.set(studio.id, {
+          id: studio.id,
+          branch: studio.branch,
+          baseBranch: studio.base_branch,
+          purpose: studio.purpose,
+          workType: studio.work_type,
+          status: studio.status,
+        });
+      }
+    }
+
+    // Fallback: support older rows linked only by workspaces.session_id.
     if (sessionIds.length > 0) {
-      const { data: workspaces } = await supabase
-        .from('workspaces')
+      const { data: linkedWorkspaces } = await supabase
+        .from('studios')
         .select('id, session_id, branch, base_branch, purpose, work_type, status')
         .in('session_id', sessionIds);
 
-      for (const ws of workspaces || []) {
+      for (const ws of linkedWorkspaces || []) {
         if (ws.session_id) {
           workspacesBySessionId.set(ws.session_id, {
             id: ws.id,
@@ -2381,6 +2415,8 @@ router.get('/sessions', async (req: Request, res: Response) => {
           updatedAt: s.updated_at,
           endedAt: s.ended_at,
           workspace: workspacesBySessionId.get(s.id) || null,
+          studio:
+            studiosById.get(s.studio_id || s.workspace_id || '') || workspacesBySessionId.get(s.id) || null,
         };
       }),
     });

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -358,22 +358,10 @@ Do NOT just respond here — you MUST explicitly call send_response to reach ext
       type: payload.triggerType,
       priority: payload.priority,
       summary: payload.summary,
+      studioHint: payload.studioHint,
     });
 
-    // 1. Verify agent exists in agent_identities
-    const { data: agentIdentity } = await dataComposer!
-      .getClient()
-      .from('agent_identities')
-      .select('agent_id')
-      .eq('agent_id', targetAgentId)
-      .limit(1);
-
-    if (!agentIdentity || agentIdentity.length === 0) {
-      logger.error(`[Trigger] Unknown agent: ${targetAgentId}`);
-      throw new Error(`Unknown agent: ${targetAgentId}. Register in agent_identities first.`);
-    }
-
-    // 2. Resolve userId from inbox message (required for stateless processing)
+    // 1. Resolve userId from inbox message (required for stateless processing)
     let userId: string | undefined;
     if (payload.inboxMessageId) {
       const { data: inboxMsg } = await dataComposer!
@@ -388,6 +376,22 @@ Do NOT just respond here — you MUST explicitly call send_response to reach ext
     if (!userId) {
       logger.error(`[Trigger] Cannot process - no userId found for agent ${targetAgentId}`);
       throw new Error('Cannot process trigger without userId (inbox message required)');
+    }
+
+    // 2. Verify target agent exists for this user
+    const { data: agentIdentity } = await dataComposer!
+      .getClient()
+      .from('agent_identities')
+      .select('agent_id')
+      .eq('user_id', userId)
+      .eq('agent_id', targetAgentId)
+      .limit(1);
+
+    if (!agentIdentity || agentIdentity.length === 0) {
+      logger.error(`[Trigger] Unknown agent for user: ${targetAgentId}`, { userId });
+      throw new Error(
+        `Unknown agent for user: ${targetAgentId}. Register in agent_identities first.`
+      );
     }
 
     // 3. Build trigger message
@@ -418,6 +422,9 @@ If you need to message a user, use send_response with the appropriate channel an
         triggerType: 'agent',
         chatType: 'direct',
         threadKey: payload.threadKey,
+        studioId: payload.studioId,
+        studioHint: payload.studioHint,
+        relatedSessionId: payload.relatedSessionId,
       },
     };
 

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -361,16 +361,18 @@ Do NOT just respond here — you MUST explicitly call send_response to reach ext
       studioHint: payload.studioHint,
     });
 
-    // 1. Resolve userId from inbox message (required for stateless processing)
+    // 1. Resolve userId (+ identity hint) from inbox message (required for stateless processing)
     let userId: string | undefined;
+    let recipientIdentityId: string | undefined;
     if (payload.inboxMessageId) {
       const { data: inboxMsg } = await dataComposer!
         .getClient()
         .from('agent_inbox')
-        .select('recipient_user_id')
+        .select('recipient_user_id, recipient_identity_id')
         .eq('id', payload.inboxMessageId)
         .single();
       userId = inboxMsg?.recipient_user_id;
+      recipientIdentityId = inboxMsg?.recipient_identity_id || undefined;
     }
 
     if (!userId) {
@@ -378,20 +380,74 @@ Do NOT just respond here — you MUST explicitly call send_response to reach ext
       throw new Error('Cannot process trigger without userId (inbox message required)');
     }
 
-    // 2. Verify target agent exists for this user
-    const { data: agentIdentity } = await dataComposer!
-      .getClient()
-      .from('agent_identities')
-      .select('agent_id')
-      .eq('user_id', userId)
-      .eq('agent_id', targetAgentId)
-      .limit(1);
+    // 2. Resolve and verify target identity for this user
+    // Prefer recipient_identity_id from inbox; fallback to user+agent_id with disambiguation.
+    let resolvedIdentityId = recipientIdentityId;
+    let resolvedWorkspaceContainerId: string | undefined;
+    const metadataWorkspaceId =
+      payload.metadata &&
+      typeof payload.metadata.workspaceId === 'string' &&
+      payload.metadata.workspaceId.length > 0
+        ? payload.metadata.workspaceId
+        : undefined;
 
-    if (!agentIdentity || agentIdentity.length === 0) {
-      logger.error(`[Trigger] Unknown agent for user: ${targetAgentId}`, { userId });
-      throw new Error(
-        `Unknown agent for user: ${targetAgentId}. Register in agent_identities first.`
-      );
+    if (resolvedIdentityId) {
+      const { data: identityRow } = await dataComposer!
+        .getClient()
+        .from('agent_identities')
+        .select('id, agent_id, workspace_id')
+        .eq('id', resolvedIdentityId)
+        .eq('user_id', userId)
+        .maybeSingle();
+
+      if (!identityRow) {
+        throw new Error(
+          `Inbox recipient_identity_id is invalid for this user (${targetAgentId}). Re-send inbox message.`
+        );
+      }
+
+      if (identityRow.agent_id !== targetAgentId) {
+        throw new Error(
+          `Inbox recipient_identity_id targets "${identityRow.agent_id}", not "${targetAgentId}".`
+        );
+      }
+
+      resolvedWorkspaceContainerId = identityRow.workspace_id || undefined;
+    } else {
+      let identityQuery = dataComposer!
+        .getClient()
+        .from('agent_identities')
+        .select('id, workspace_id')
+        .eq('user_id', userId)
+        .eq('agent_id', targetAgentId);
+
+      if (metadataWorkspaceId) {
+        identityQuery = identityQuery.eq('workspace_id', metadataWorkspaceId);
+      }
+
+      const { data: identityRows, error: identityError } = await identityQuery;
+      if (identityError) {
+        throw new Error(`Failed to resolve target identity for ${targetAgentId}: ${identityError.message}`);
+      }
+
+      if (!identityRows || identityRows.length === 0) {
+        logger.error(`[Trigger] Unknown agent for user: ${targetAgentId}`, {
+          userId,
+          workspaceId: metadataWorkspaceId || null,
+        });
+        throw new Error(
+          `Unknown agent for user: ${targetAgentId}. Register in agent_identities first.`
+        );
+      }
+
+      if (identityRows.length > 1) {
+        throw new Error(
+          `Ambiguous identity for agent "${targetAgentId}" (multiple workspace-scoped identities). Include inboxMessageId with recipient_identity_id or pass metadata.workspaceId.`
+        );
+      } else {
+        resolvedIdentityId = identityRows[0].id;
+        resolvedWorkspaceContainerId = identityRows[0].workspace_id || undefined;
+      }
     }
 
     // 3. Build trigger message
@@ -427,6 +483,13 @@ If you need to message a user, use send_response with the appropriate channel an
         relatedSessionId: payload.relatedSessionId,
       },
     };
+
+    logger.info('[Trigger] Resolved target identity', {
+      userId,
+      agentId: targetAgentId,
+      identityId: resolvedIdentityId,
+      workspaceId: resolvedWorkspaceContainerId || null,
+    });
 
     const result = await sessionService!.handleMessage(request);
 

--- a/packages/api/src/services/sessions/session-repository.ts
+++ b/packages/api/src/services/sessions/session-repository.ts
@@ -30,6 +30,7 @@ function mapDbToSession(row: DbSession): Session {
     userId: row.user_id,
     agentId: row.agent_id || '',
     identityId: row.identity_id || undefined,
+    studioId: row.studio_id || row.workspace_id || undefined,
     claudeSessionId: row.claude_session_id,
 
     type: (metadata.type as SessionType) || 'primary',
@@ -86,6 +87,9 @@ function mapSessionToDb(
     token_count: session.tokenCount,
     backend: session.backend,
     model: session.model,
+    studio_id: session.studioId || null,
+    // Keep mirrored for compatibility with older server versions.
+    workspace_id: session.studioId || null,
     thread_key: session.threadKey || null,
     metadata: {
       type: session.type,
@@ -121,7 +125,7 @@ export class SessionRepository implements ISessionRepository {
   async findByUserAndAgent(
     userId: string,
     agentId: string,
-    options?: { status?: SessionStatus; type?: SessionType }
+    options?: { status?: SessionStatus; type?: SessionType; studioId?: string }
   ): Promise<Session | null> {
     let query = this.supabase
       .from('sessions')
@@ -131,6 +135,10 @@ export class SessionRepository implements ISessionRepository {
       .is('ended_at', null)
       .order('started_at', { ascending: false })
       .limit(1);
+
+    if (options?.studioId) {
+      query = query.or(`studio_id.eq.${options.studioId},workspace_id.eq.${options.studioId}`);
+    }
 
     if (options?.status) {
       query = query.eq('status', options.status);
@@ -164,9 +172,10 @@ export class SessionRepository implements ISessionRepository {
   async findByThreadKey(
     userId: string,
     agentId: string,
-    threadKey: string
+    threadKey: string,
+    studioId?: string
   ): Promise<Session | null> {
-    const { data, error } = await this.supabase
+    let query = this.supabase
       .from('sessions')
       .select('*')
       .eq('user_id', userId)
@@ -175,6 +184,12 @@ export class SessionRepository implements ISessionRepository {
       .is('ended_at', null)
       .order('started_at', { ascending: false })
       .limit(1);
+
+    if (studioId) {
+      query = query.or(`studio_id.eq.${studioId},workspace_id.eq.${studioId}`);
+    }
+
+    const { data, error } = await query;
 
     if (error) {
       logger.error('Error finding session by thread key', { userId, agentId, threadKey, error });
@@ -287,6 +302,12 @@ export class SessionRepository implements ISessionRepository {
 
     if (updates.model !== undefined) {
       dbUpdates.model = updates.model;
+    }
+
+    if (updates.studioId !== undefined) {
+      dbUpdates.studio_id = updates.studioId || null;
+      // Keep mirrored for compatibility with older server versions.
+      dbUpdates.workspace_id = updates.studioId || null;
     }
 
     // Merge metadata updates

--- a/packages/api/src/services/sessions/session-service.ts
+++ b/packages/api/src/services/sessions/session-service.ts
@@ -188,6 +188,9 @@ export class SessionService implements ISessionService {
         taskDescription: metadata?.taskDescription,
         parentSessionId: metadata?.parentSessionId,
         threadKey: metadata?.threadKey,
+        studioId: metadata?.studioId,
+        studioHint: metadata?.studioHint,
+        relatedSessionId: metadata?.relatedSessionId,
       });
 
       // 2. Build lock key - must be per agent + session to support sub-agents
@@ -273,6 +276,9 @@ export class SessionService implements ISessionService {
             taskDescription: pending.request.metadata?.taskDescription,
             parentSessionId: pending.request.metadata?.parentSessionId,
             threadKey: pending.request.metadata?.threadKey,
+            studioId: pending.request.metadata?.studioId,
+            studioHint: pending.request.metadata?.studioHint,
+            relatedSessionId: pending.request.metadata?.relatedSessionId,
           }
         );
 
@@ -305,9 +311,16 @@ export class SessionService implements ISessionService {
     // 2. Format the incoming message with sender info + current timestamp
     const formattedMessage = this.formatMessage(request, injectedContext.user.timezone);
 
+    // Resolve working directory from studio when available.
+    const resolvedWorkingDirectory = await this.resolveWorkingDirectory(
+      userId,
+      agentId,
+      session.studioId
+    );
+
     // 3. Build Claude runner config
     const runnerConfig: ClaudeRunnerConfig = {
-      workingDirectory: this.config.defaultWorkingDirectory,
+      workingDirectory: resolvedWorkingDirectory,
       mcpConfigPath: this.config.mcpConfigPath,
       model: this.config.defaultModel,
       appendSystemPrompt: buildIdentityPrompt(
@@ -395,23 +408,37 @@ export class SessionService implements ISessionService {
       taskDescription?: string;
       parentSessionId?: string;
       threadKey?: string;
+      studioId?: string;
+      studioHint?: 'main';
+      relatedSessionId?: string;
     }
   ): Promise<Session> {
     const type = options?.type || 'primary';
 
     const backend = await this.resolveAgentBackend(userId, agentId);
+    const resolvedStudioId = await this.resolveStudioId(userId, agentId, {
+      threadKey: options?.threadKey,
+      explicitStudioId: options?.studioId,
+      studioHint: options?.studioHint,
+      relatedSessionId: options?.relatedSessionId,
+      backend,
+    });
 
     // For primary sessions, try to find existing active session
     if (type === 'primary') {
       // ThreadKey match takes priority — find session scoped to this topic
       if (options?.threadKey && 'findByThreadKey' in this.repository) {
-        const threadMatch = await (
-          this.repository as { findByThreadKey: (u: string, a: string, t: string) => Promise<Session | null> }
-        ).findByThreadKey(userId, agentId, options.threadKey);
+        const threadRepo = this.repository as {
+          findByThreadKey: (u: string, a: string, t: string, s?: string) => Promise<Session | null>;
+        };
+        const threadMatch = resolvedStudioId
+          ? await threadRepo.findByThreadKey(userId, agentId, options.threadKey, resolvedStudioId)
+          : await threadRepo.findByThreadKey(userId, agentId, options.threadKey);
         if (threadMatch) {
           logger.debug('Found existing session by threadKey', {
             sessionId: threadMatch.id,
             threadKey: options.threadKey,
+            studioId: threadMatch.studioId || null,
           });
           return threadMatch;
         }
@@ -420,12 +447,14 @@ export class SessionService implements ISessionService {
       // Fall back to general active session match
       const existing = await this.repository.findByUserAndAgent(userId, agentId, {
         type: 'primary',
+        ...(resolvedStudioId ? { studioId: resolvedStudioId } : {}),
       });
 
       if (existing) {
         logger.debug('Found existing session', {
           sessionId: existing.id,
           claudeSessionId: existing.claudeSessionId,
+          studioId: existing.studioId || null,
         });
         return existing;
       }
@@ -448,6 +477,7 @@ export class SessionService implements ISessionService {
       taskDescription: options?.taskDescription,
       parentSessionId: options?.parentSessionId,
       threadKey: options?.threadKey,
+      studioId: resolvedStudioId,
       contextTokens: 0,
       totalInputTokens: 0,
       totalOutputTokens: 0,
@@ -466,9 +496,194 @@ export class SessionService implements ISessionService {
       userId,
       agentId,
       type,
+      studioId: resolvedStudioId || null,
     });
 
     return session;
+  }
+
+  private async resolveStudioId(
+    userId: string,
+    agentId: string,
+    options: {
+      threadKey?: string;
+      explicitStudioId?: string;
+      studioHint?: 'main';
+      relatedSessionId?: string;
+      backend?: string;
+    }
+  ): Promise<string | undefined> {
+    if (options.explicitStudioId) {
+      return options.explicitStudioId;
+    }
+
+    if (!this.supabase) {
+      return undefined;
+    }
+
+    // Explicit convenience hint: route directly to user's shared main studio.
+    if (options.studioHint === 'main') {
+      return this.resolveMainStudioId(userId);
+    }
+
+    // 1) Related session scope (explicit resume continuity)
+    if (options.relatedSessionId) {
+      const { data } = await this.supabase
+        .from('sessions')
+        .select('studio_id, workspace_id')
+        .eq('id', options.relatedSessionId)
+        .eq('user_id', userId)
+        .maybeSingle();
+
+      const scopedStudioId = data?.studio_id || data?.workspace_id || undefined;
+      if (scopedStudioId) {
+        return scopedStudioId;
+      }
+    }
+
+    // 2) Thread-key scoped continuity (no caller-side studio lookup needed)
+    if (options.threadKey) {
+      const { data: activeThreadSession } = await this.supabase
+        .from('sessions')
+        .select('studio_id, workspace_id, updated_at')
+        .eq('user_id', userId)
+        .eq('agent_id', agentId)
+        .eq('thread_key', options.threadKey)
+        .is('ended_at', null)
+        .or('studio_id.not.is.null,workspace_id.not.is.null')
+        .order('updated_at', { ascending: false })
+        .limit(1)
+        .maybeSingle();
+
+      const activeThreadStudio =
+        activeThreadSession?.studio_id || activeThreadSession?.workspace_id || undefined;
+      if (activeThreadStudio) {
+        return activeThreadStudio;
+      }
+
+      const { data: endedThreadSession } = await this.supabase
+        .from('sessions')
+        .select('studio_id, workspace_id, updated_at')
+        .eq('user_id', userId)
+        .eq('agent_id', agentId)
+        .eq('thread_key', options.threadKey)
+        .not('ended_at', 'is', null)
+        .or('studio_id.not.is.null,workspace_id.not.is.null')
+        .order('updated_at', { ascending: false })
+        .limit(1)
+        .maybeSingle();
+
+      const endedThreadStudio =
+        endedThreadSession?.studio_id || endedThreadSession?.workspace_id || undefined;
+      if (endedThreadStudio) {
+        return endedThreadStudio;
+      }
+    }
+
+    // 3) Agent default studio (derived from recent sessions, then studio records)
+    const { data: recentAgentStudioSession } = await this.supabase
+      .from('sessions')
+      .select('studio_id, workspace_id, updated_at')
+      .eq('user_id', userId)
+      .eq('agent_id', agentId)
+      .or('studio_id.not.is.null,workspace_id.not.is.null')
+      .order('updated_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    const recentAgentStudio =
+      recentAgentStudioSession?.studio_id || recentAgentStudioSession?.workspace_id || undefined;
+    if (recentAgentStudio) {
+      return recentAgentStudio;
+    }
+
+    const { data: agentStudio } = await this.supabase
+      .from('studios')
+      .select('id, updated_at')
+      .eq('user_id', userId)
+      .eq('agent_id', agentId)
+      .in('status', ['active', 'idle', 'archived'])
+      .order('updated_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (agentStudio?.id) {
+      return agentStudio.id;
+    }
+
+    // 4) Shared per-user main studio fallback
+    const mainStudioId = await this.resolveMainStudioId(userId);
+    if (mainStudioId) return mainStudioId;
+
+    // Codex is worktree-sensitive: keep a deterministic warning when no studio could be resolved.
+    if (options.backend === 'codex-cli') {
+      logger.warn('No studio resolved for codex-cli request; falling back to default working directory', {
+        userId,
+        agentId,
+        defaultWorkingDirectory: this.config.defaultWorkingDirectory,
+      });
+    }
+
+    return undefined;
+  }
+
+  private async resolveMainStudioId(userId: string): Promise<string | undefined> {
+    if (!this.supabase) return undefined;
+
+    const { data: mainStudioByPath } = await this.supabase
+      .from('studios')
+      .select('id')
+      .eq('user_id', userId)
+      .eq('worktree_path', this.config.defaultWorkingDirectory)
+      .neq('status', 'cleaned')
+      .limit(1)
+      .maybeSingle();
+
+    if (mainStudioByPath?.id) {
+      return mainStudioByPath.id;
+    }
+
+    const { data: mainStudioByBranch } = await this.supabase
+      .from('studios')
+      .select('id, updated_at')
+      .eq('user_id', userId)
+      .eq('branch', 'main')
+      .in('status', ['active', 'idle', 'archived'])
+      .order('updated_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    return mainStudioByBranch?.id || undefined;
+  }
+
+  private async resolveWorkingDirectory(
+    userId: string,
+    agentId: string,
+    studioId?: string
+  ): Promise<string> {
+    if (!studioId || !this.supabase) {
+      return this.config.defaultWorkingDirectory;
+    }
+
+    const { data: studio } = await this.supabase
+      .from('studios')
+      .select('worktree_path, status')
+      .eq('id', studioId)
+      .eq('user_id', userId)
+      .maybeSingle();
+
+    if (studio?.worktree_path) {
+      return studio.worktree_path;
+    }
+
+    logger.warn('Studio not found for session; using default working directory', {
+      userId,
+      agentId,
+      studioId,
+      defaultWorkingDirectory: this.config.defaultWorkingDirectory,
+    });
+
+    return this.config.defaultWorkingDirectory;
   }
 
   async getSession(sessionId: string): Promise<Session | null> {
@@ -538,8 +753,14 @@ This session will continue with a fresh context after compaction. Your identity,
         session
       );
 
+      const compactionWorkingDirectory = await this.resolveWorkingDirectory(
+        session.userId,
+        session.agentId,
+        session.studioId
+      );
+
       const runnerConfig: ClaudeRunnerConfig = {
-        workingDirectory: this.config.defaultWorkingDirectory,
+        workingDirectory: compactionWorkingDirectory,
         mcpConfigPath: this.config.mcpConfigPath,
         model: this.config.defaultModel,
         appendSystemPrompt: buildIdentityPrompt(

--- a/packages/api/src/services/sessions/types.ts
+++ b/packages/api/src/services/sessions/types.ts
@@ -46,6 +46,8 @@ export interface Session {
   userId: string;
   agentId: string;
   identityId?: string;
+  /** Studio/worktree scope for this session */
+  studioId?: string;
   claudeSessionId: string | null;
 
   type: SessionType;
@@ -109,6 +111,12 @@ export interface SessionRequest {
     triggerType?: 'message' | 'heartbeat' | 'agent' | 'api';
     // Thread key for topic-scoped session routing (e.g., "pr:43")
     threadKey?: string;
+    // Explicit studio/worktree scope for this request
+    studioId?: string;
+    // Convenience routing hint (e.g., force main studio without UUID lookup)
+    studioHint?: 'main';
+    // Related session to inherit studio scope from
+    relatedSessionId?: string;
     // For task sessions
     sessionType?: SessionType;
     taskDescription?: string;
@@ -236,6 +244,9 @@ export interface ISessionService {
       taskDescription?: string;
       parentSessionId?: string;
       threadKey?: string;
+      studioId?: string;
+      studioHint?: 'main';
+      relatedSessionId?: string;
     }
   ): Promise<Session>;
 
@@ -290,7 +301,14 @@ export interface ISessionRepository {
   findByUserAndAgent(
     userId: string,
     agentId: string,
-    options?: { status?: SessionStatus; type?: SessionType }
+    options?: { status?: SessionStatus; type?: SessionType; studioId?: string }
+  ): Promise<Session | null>;
+
+  findByThreadKey?(
+    userId: string,
+    agentId: string,
+    threadKey: string,
+    studioId?: string
   ): Promise<Session | null>;
 
   findByUser(

--- a/supabase/migrations/20260217222703_rename_workspaces_to_studios.sql
+++ b/supabase/migrations/20260217222703_rename_workspaces_to_studios.sql
@@ -1,0 +1,79 @@
+-- Rename legacy git-worktree table from workspaces -> studios.
+-- This keeps workspace_containers as the product/team concept.
+
+DO $$
+BEGIN
+  IF to_regclass('public.workspaces') IS NOT NULL
+     AND to_regclass('public.studios') IS NULL THEN
+    EXECUTE 'ALTER TABLE public.workspaces RENAME TO studios';
+  END IF;
+END $$;
+
+-- Rename constraints for clarity (safe if already renamed)
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'workspaces_identity_id_fkey'
+      AND conrelid = 'public.studios'::regclass
+  ) THEN
+    ALTER TABLE public.studios RENAME CONSTRAINT workspaces_identity_id_fkey TO studios_identity_id_fkey;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'workspaces_session_id_fkey'
+      AND conrelid = 'public.studios'::regclass
+  ) THEN
+    ALTER TABLE public.studios RENAME CONSTRAINT workspaces_session_id_fkey TO studios_session_id_fkey;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'workspaces_user_id_fkey'
+      AND conrelid = 'public.studios'::regclass
+  ) THEN
+    ALTER TABLE public.studios RENAME CONSTRAINT workspaces_user_id_fkey TO studios_user_id_fkey;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'workspaces_work_type_check'
+      AND conrelid = 'public.studios'::regclass
+  ) THEN
+    ALTER TABLE public.studios RENAME CONSTRAINT workspaces_work_type_check TO studios_work_type_check;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'workspaces_status_check'
+      AND conrelid = 'public.studios'::regclass
+  ) THEN
+    ALTER TABLE public.studios RENAME CONSTRAINT workspaces_status_check TO studios_status_check;
+  END IF;
+END $$;
+
+-- Rename indexes for clarity (safe if already renamed)
+ALTER INDEX IF EXISTS idx_workspaces_agent_id RENAME TO idx_studios_agent_id;
+ALTER INDEX IF EXISTS idx_workspaces_branch RENAME TO idx_studios_branch;
+ALTER INDEX IF EXISTS idx_workspaces_session_id RENAME TO idx_studios_session_id;
+ALTER INDEX IF EXISTS idx_workspaces_status RENAME TO idx_studios_status;
+ALTER INDEX IF EXISTS idx_workspaces_user_id RENAME TO idx_studios_user_id;
+ALTER INDEX IF EXISTS workspaces_branch_key RENAME TO studios_branch_key;
+ALTER INDEX IF EXISTS workspaces_worktree_path_key RENAME TO studios_worktree_path_key;
+
+-- Rename update trigger for clarity
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_trigger
+    WHERE tgname = 'update_workspaces_updated_at'
+      AND tgrelid = 'public.studios'::regclass
+  ) THEN
+    ALTER TRIGGER update_workspaces_updated_at ON public.studios RENAME TO update_studios_updated_at;
+  END IF;
+END $$;
+
+-- Update table comment
+COMMENT ON TABLE public.studios IS 'Tracks git worktree studios for parallel agent work. Studios are separate from sessions and can outlive them.';


### PR DESCRIPTION
## Summary
- harden session routing to resolve studio server-side (explicit studio, related session, thread continuity, agent default, shared main fallback)
- add trigger convenience routing with `studioHint: "main"` so callers can force main without UUID lookup
- make session execution studio-aware by resolving working directory from studio worktree path
- rename git-worktree data layer from `workspaces` to `studios` in API code/repositories
- add SQL migration to rename table `public.workspaces` -> `public.studios` and rename related constraints/indexes/trigger names
- keep compatibility behavior where needed (`sessions.workspace_id` mirroring remains for older versions)

## Validation
- `npx vitest run packages/api/src/services/sessions/session-service.test.ts`
- `npx vitest run packages/api/src/mcp/tools/workspace-container-handlers.test.ts`
- `npx vitest run packages/api/src/mcp/tools/reminder-handlers.test.ts`

## Notes
- API-wide type-check still has pre-existing local/env issues unrelated to this PR (shared build artifacts + missing optional type declarations).