### PR TITLE
feat: harden SB handoff routing + provenance stamping (by Lumen)

### DIFF
--- a/packages/api/src/mcp/tools/inbox-handlers.test.ts
+++ b/packages/api/src/mcp/tools/inbox-handlers.test.ts
@@ -334,24 +334,6 @@ describe('handleSendToInbox - threadKey', () => {
     );
   });
 
-  it('should require routing anchor for non-message cross-agent handoffs', async () => {
-    const mockSb = createMockSupabase();
-    const mockDc = createMockDataComposer(mockSb);
-
-    await expect(
-      handleSendToInbox(
-        {
-          email: 'test@test.com',
-          recipientAgentId: 'lumen',
-          senderAgentId: 'wren',
-          messageType: 'task_request',
-          content: 'Please do this work',
-        },
-        mockDc as never
-      )
-    ).rejects.toThrow('Missing routing anchor');
-  });
-
   it('should trigger without senderAgentId using system sender', async () => {
     const { getAgentGateway } = await import('../../channels/agent-gateway.js');
     const mockGateway = (getAgentGateway as ReturnType<typeof vi.fn>)();
@@ -363,6 +345,7 @@ describe('handleSendToInbox - threadKey', () => {
       {
         email: 'test@test.com',
         recipientAgentId: 'lumen',
+        messageType: 'task_request',
         content: 'Human-sent coordination message',
       },
       mockDc as never
@@ -373,5 +356,52 @@ describe('handleSendToInbox - threadKey', () => {
         fromAgentId: 'system',
       })
     );
+  });
+
+  it('should not trigger by default for message type', async () => {
+    const { getAgentGateway } = await import('../../channels/agent-gateway.js');
+    const mockGateway = (getAgentGateway as ReturnType<typeof vi.fn>)();
+
+    const mockSb = createMockSupabase();
+    const mockDc = createMockDataComposer(mockSb);
+
+    const result = await handleSendToInbox(
+      {
+        email: 'test@test.com',
+        recipientAgentId: 'lumen',
+        senderAgentId: 'wren',
+        messageType: 'message',
+        content: 'casual ping',
+      },
+      mockDc as never
+    );
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.trigger.triggered).toBe(false);
+    expect(mockGateway.processTrigger).not.toHaveBeenCalled();
+  });
+
+  it('should deliver actionable handoff without anchor and return routing hint', async () => {
+    const { getAgentGateway } = await import('../../channels/agent-gateway.js');
+    const mockGateway = (getAgentGateway as ReturnType<typeof vi.fn>)();
+
+    const mockSb = createMockSupabase();
+    const mockDc = createMockDataComposer(mockSb);
+
+    const result = await handleSendToInbox(
+      {
+        email: 'test@test.com',
+        recipientAgentId: 'lumen',
+        senderAgentId: 'wren',
+        messageType: 'task_request',
+        content: 'Please do this work',
+      },
+      mockDc as never
+    );
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.success).toBe(true);
+    expect(parsed.routingHint).toContain('routing anchor');
+    expect(mockGateway.processTrigger).toHaveBeenCalled();
   });
 });

--- a/packages/api/src/mcp/tools/inbox-handlers.test.ts
+++ b/packages/api/src/mcp/tools/inbox-handlers.test.ts
@@ -264,6 +264,7 @@ describe('handleSendToInbox - threadKey', () => {
         recipientAgentId: 'myra',
         senderAgentId: 'wren',
         messageType: 'notification',
+        threadKey: 'pr:32',
         content: 'FYI',
       },
       mockDc as never
@@ -300,6 +301,55 @@ describe('handleSendToInbox - threadKey', () => {
         relatedSessionId: 'b85490f5-0836-4bdd-8193-f6cfa2562a41',
       })
     );
+  });
+
+  it('should support recipientSessionId as preferred routing field', async () => {
+    const { getAgentGateway } = await import('../../channels/agent-gateway.js');
+    const mockGateway = (getAgentGateway as ReturnType<typeof vi.fn>)();
+
+    const mockSb = createMockSupabase();
+    const mockDc = createMockDataComposer(mockSb);
+
+    await handleSendToInbox(
+      {
+        email: 'test@test.com',
+        recipientAgentId: 'lumen',
+        senderAgentId: 'wren',
+        messageType: 'session_resume',
+        recipientSessionId: 'b85490f5-0836-4bdd-8193-f6cfa2562a41',
+        content: 'Resume this session',
+      },
+      mockDc as never
+    );
+
+    expect(mockSb._chainable.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        related_session_id: 'b85490f5-0836-4bdd-8193-f6cfa2562a41',
+      })
+    );
+    expect(mockGateway.processTrigger).toHaveBeenCalledWith(
+      expect.objectContaining({
+        relatedSessionId: 'b85490f5-0836-4bdd-8193-f6cfa2562a41',
+      })
+    );
+  });
+
+  it('should require routing anchor for non-message cross-agent handoffs', async () => {
+    const mockSb = createMockSupabase();
+    const mockDc = createMockDataComposer(mockSb);
+
+    await expect(
+      handleSendToInbox(
+        {
+          email: 'test@test.com',
+          recipientAgentId: 'lumen',
+          senderAgentId: 'wren',
+          messageType: 'task_request',
+          content: 'Please do this work',
+        },
+        mockDc as never
+      )
+    ).rejects.toThrow('Missing routing anchor');
   });
 
   it('should trigger without senderAgentId using system sender', async () => {

--- a/packages/api/src/mcp/tools/inbox-handlers.test.ts
+++ b/packages/api/src/mcp/tools/inbox-handlers.test.ts
@@ -277,7 +277,26 @@ describe('handleSendToInbox - threadKey', () => {
     );
   });
 
-  it('should pass relatedSessionId through trigger payload', async () => {
+  it('should reject deprecated relatedSessionId input', async () => {
+    const mockSb = createMockSupabase();
+    const mockDc = createMockDataComposer(mockSb);
+
+    await expect(
+      handleSendToInbox(
+        {
+          email: 'test@test.com',
+          recipientAgentId: 'lumen',
+          senderAgentId: 'wren',
+          messageType: 'session_resume',
+          relatedSessionId: 'b85490f5-0836-4bdd-8193-f6cfa2562a41',
+          content: 'Resume this session',
+        },
+        mockDc as never
+      )
+    ).rejects.toThrow('relatedSessionId');
+  });
+
+  it('should pass recipientSessionId through trigger payload', async () => {
     const { getAgentGateway } = await import('../../channels/agent-gateway.js');
     const mockGateway = (getAgentGateway as ReturnType<typeof vi.fn>)();
 
@@ -290,7 +309,7 @@ describe('handleSendToInbox - threadKey', () => {
         recipientAgentId: 'lumen',
         senderAgentId: 'wren',
         messageType: 'session_resume',
-        relatedSessionId: 'b85490f5-0836-4bdd-8193-f6cfa2562a41',
+        recipientSessionId: 'b85490f5-0836-4bdd-8193-f6cfa2562a41',
         content: 'Resume this session',
       },
       mockDc as never
@@ -310,7 +329,7 @@ describe('handleSendToInbox - threadKey', () => {
     const mockSb = createMockSupabase();
     const mockDc = createMockDataComposer(mockSb);
 
-    await handleSendToInbox(
+    const result = await handleSendToInbox(
       {
         email: 'test@test.com',
         recipientAgentId: 'lumen',
@@ -332,6 +351,8 @@ describe('handleSendToInbox - threadKey', () => {
         relatedSessionId: 'b85490f5-0836-4bdd-8193-f6cfa2562a41',
       })
     );
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.recipientSessionId).toBe('b85490f5-0836-4bdd-8193-f6cfa2562a41');
   });
 
   it('should trigger without senderAgentId using system sender', async () => {

--- a/packages/api/src/mcp/tools/inbox-handlers.ts
+++ b/packages/api/src/mcp/tools/inbox-handlers.ts
@@ -67,7 +67,7 @@ const sendToInboxSchema = userIdentifierBaseSchema.extend({
     .boolean()
     .optional()
     .describe(
-      'If true, automatically trigger the recipient agent after sending. Defaults to true for all message types.'
+      'If true, automatically trigger the recipient agent after sending. Defaults to true for task_request, session_resume, and notification; false for message.'
     ),
   triggerType: z
     .enum(['task_complete', 'approval_needed', 'message', 'error', 'custom'])
@@ -131,19 +131,24 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
   const effectiveRecipientSessionId = recipientSessionId || relatedSessionId;
 
   // Default trigger behavior:
-  // Always wake the recipient unless the caller explicitly opts out with trigger=false.
-  // This keeps SB-to-SB coordination immediate by default.
-  const shouldTriggerByDefault = true;
+  // Wake recipient by default for actionable handoffs, but not for casual messages.
+  const shouldTriggerByDefault =
+    messageType === 'task_request' ||
+    messageType === 'session_resume' ||
+    messageType === 'notification';
   const trigger = parsed.trigger ?? shouldTriggerByDefault;
 
   const hasRoutingAnchor = Boolean(
     threadKey || effectiveRecipientSessionId || recipientStudioId || recipientStudioHint
   );
   const requiresRoutingAnchor = Boolean(senderAgentId) && messageType !== 'message';
-  if (requiresRoutingAnchor && !hasRoutingAnchor) {
-    throw new Error(
-      'Missing routing anchor. Provide one of: threadKey, recipientSessionId, recipientStudioId, or recipientStudioHint.'
-    );
+  const missingRoutingAnchor = requiresRoutingAnchor && !hasRoutingAnchor;
+  if (missingRoutingAnchor) {
+    logger.warn('send_to_inbox missing routing anchor for actionable handoff', {
+      messageType,
+      recipientAgentId,
+      senderAgentId,
+    });
   }
 
   const reqCtx = getRequestContext();
@@ -291,6 +296,12 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
           trigger: triggerResult,
           // Backward compatibility
           relatedSessionId: effectiveRecipientSessionId || null,
+          ...(missingRoutingAnchor
+            ? {
+                routingHint:
+                  'Actionable handoff is missing a routing anchor. Add one of: threadKey, recipientSessionId, recipientStudioId, or recipientStudioHint.',
+              }
+            : {}),
           ...(!threadKey
             ? {
                 hint: 'Consider adding a threadKey (e.g., "pr:32", "spec:cli-hooks") so the recipient can resume the same session for follow-up messages on this topic.',
@@ -535,7 +546,7 @@ export const inboxToolDefinitions = [
   {
     name: 'send_to_inbox',
     description:
-      "Send a message to another agent's inbox. Use for cross-agent communication, task handoff, or session resume requests.\n\nMessage types:\n- message: General communication\n- task_request: Request another agent to do work\n- session_resume: Request agent to resume a specific session\n- notification: FYI, no response needed\n\nUser can be identified by ONE of: userId, email, phone, or platform + platformId",
+      "Send a message to another agent's inbox. Use for cross-agent communication, task handoff, or session resume requests.\n\nMessage types:\n- message: General communication\n- task_request: Request another agent to do work\n- session_resume: Request agent to resume a specific session\n- notification: FYI, no response needed\n\nTrigger defaults:\n- task_request / session_resume / notification: wake recipient by default\n- message: no automatic wake by default\n- override with `trigger` boolean\n\nUser can be identified by ONE of: userId, email, phone, or platform + platformId",
     schema: sendToInboxSchema,
     handler: handleSendToInbox,
   },

--- a/packages/api/src/mcp/tools/inbox-handlers.ts
+++ b/packages/api/src/mcp/tools/inbox-handlers.ts
@@ -12,6 +12,7 @@ import { resolveIdentityId } from '../../auth/resolve-identity';
 import { getEffectiveAgentId } from '../../auth/enforce-identity';
 import { logger } from '../../utils/logger';
 import type { Json } from '../../data/supabase/types';
+import { getRequestContext, getSessionContext } from '../../utils/request-context';
 import { getAgentGateway, type AgentTriggerPayload } from '../../channels/agent-gateway.js';
 
 // ============== Schemas ==============
@@ -33,11 +34,25 @@ const sendToInboxSchema = userIdentifierBaseSchema.extend({
     .optional()
     .default('normal')
     .describe('Message priority'),
+  recipientSessionId: z
+    .string()
+    .uuid()
+    .optional()
+    .describe('Recipient session ID to resume/route to (preferred)'),
   relatedSessionId: z
     .string()
     .uuid()
     .optional()
-    .describe('Related session ID (for resume requests)'),
+    .describe('Deprecated alias for recipientSessionId'),
+  recipientStudioId: z
+    .string()
+    .uuid()
+    .optional()
+    .describe('Recipient studio ID hint for session routing'),
+  recipientStudioHint: z
+    .enum(['main'])
+    .optional()
+    .describe('Recipient studio routing hint (e.g., "main")'),
   relatedArtifactUri: z.string().optional().describe('Related artifact URI'),
   metadata: z.record(z.unknown()).optional().describe('Additional metadata'),
   expiresAt: z.string().datetime().optional().describe('When this message expires'),
@@ -99,7 +114,10 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
     content,
     messageType = 'message',
     priority = 'normal',
+    recipientSessionId,
     relatedSessionId,
+    recipientStudioId,
+    recipientStudioHint,
     relatedArtifactUri,
     metadata = {},
     expiresAt,
@@ -110,12 +128,51 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
   // Enforce identity on sender (who is performing the action), not recipient (target)
   const senderAgentId = getEffectiveAgentId(parsed.senderAgentId);
   const triggerSenderId = senderAgentId || 'system';
+  const effectiveRecipientSessionId = recipientSessionId || relatedSessionId;
 
   // Default trigger behavior:
   // Always wake the recipient unless the caller explicitly opts out with trigger=false.
   // This keeps SB-to-SB coordination immediate by default.
   const shouldTriggerByDefault = true;
   const trigger = parsed.trigger ?? shouldTriggerByDefault;
+
+  const hasRoutingAnchor = Boolean(
+    threadKey || effectiveRecipientSessionId || recipientStudioId || recipientStudioHint
+  );
+  const requiresRoutingAnchor = Boolean(senderAgentId) && messageType !== 'message';
+  if (requiresRoutingAnchor && !hasRoutingAnchor) {
+    throw new Error(
+      'Missing routing anchor. Provide one of: threadKey, recipientSessionId, recipientStudioId, or recipientStudioHint.'
+    );
+  }
+
+  const reqCtx = getRequestContext();
+  const sessCtx = getSessionContext();
+  const senderSessionId = reqCtx?.sessionId || sessCtx?.sessionId || null;
+  const senderStudioId = reqCtx?.workspaceId || sessCtx?.workspaceId || null;
+  const metadataRecord =
+    metadata && typeof metadata === 'object' ? (metadata as Record<string, unknown>) : {};
+  const existingPcp =
+    metadataRecord.pcp && typeof metadataRecord.pcp === 'object'
+      ? (metadataRecord.pcp as Record<string, unknown>)
+      : {};
+  const enrichedMetadata = {
+    ...metadataRecord,
+    pcp: {
+      ...existingPcp,
+      sender: {
+        agentId: triggerSenderId,
+        sessionId: senderSessionId,
+        studioId: senderStudioId,
+      },
+      recipient: {
+        threadKey: threadKey || null,
+        sessionId: effectiveRecipientSessionId || null,
+        studioId: recipientStudioId || null,
+        studioHint: recipientStudioHint || null,
+      },
+    },
+  };
 
   // Resolve canonical identity UUIDs for sender and recipient
   const recipientIdentityId = await resolveIdentityId(supabase, resolved.user.id, recipientAgentId);
@@ -136,9 +193,9 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
       content,
       message_type: messageType,
       priority,
-      related_session_id: relatedSessionId || null,
+      related_session_id: effectiveRecipientSessionId || null,
       related_artifact_uri: relatedArtifactUri || null,
-      metadata: metadata as Json,
+      metadata: enrichedMetadata as Json,
       expires_at: expiresAt || null,
       thread_key: threadKey || null,
     })
@@ -171,13 +228,6 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
 
   if (trigger) {
     const gateway = getAgentGateway();
-    const metadataStudioId =
-      metadata && typeof metadata.studioId === 'string' && metadata.studioId.length > 0
-        ? metadata.studioId
-        : undefined;
-    const metadataStudioHint =
-      metadata && metadata.studioHint === 'main' ? ('main' as const) : undefined;
-
     const payload: AgentTriggerPayload = {
       fromAgentId: triggerSenderId,
       toAgentId: recipientAgentId,
@@ -186,9 +236,9 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
       summary: triggerSummary || subject || `New ${messageType} from ${triggerSenderId}`,
       priority,
       threadKey,
-      relatedSessionId,
-      studioId: metadataStudioId,
-      studioHint: metadataStudioHint,
+      relatedSessionId: effectiveRecipientSessionId,
+      studioId: recipientStudioId,
+      studioHint: recipientStudioHint,
     };
 
     // Fire-and-forget: don't await the trigger processing
@@ -234,8 +284,13 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
           messageType,
           priority,
           threadKey: threadKey || null,
+          recipientSessionId: effectiveRecipientSessionId || null,
+          recipientStudioId: recipientStudioId || null,
+          recipientStudioHint: recipientStudioHint || null,
           createdAt: message.created_at,
           trigger: triggerResult,
+          // Backward compatibility
+          relatedSessionId: effectiveRecipientSessionId || null,
           ...(!threadKey
             ? {
                 hint: 'Consider adding a threadKey (e.g., "pr:32", "spec:cli-hooks") so the recipient can resume the same session for follow-up messages on this topic.',

--- a/packages/api/src/mcp/tools/inbox-handlers.ts
+++ b/packages/api/src/mcp/tools/inbox-handlers.ts
@@ -39,11 +39,6 @@ const sendToInboxSchema = userIdentifierBaseSchema.extend({
     .uuid()
     .optional()
     .describe('Recipient session ID to resume/route to (preferred)'),
-  relatedSessionId: z
-    .string()
-    .uuid()
-    .optional()
-    .describe('Deprecated alias for recipientSessionId'),
   recipientStudioId: z
     .string()
     .uuid()
@@ -104,6 +99,17 @@ const getAgentStatusSchema = userIdentifierBaseSchema.extend({
 // ============== Handlers ==============
 
 export async function handleSendToInbox(args: unknown, dataComposer: DataComposer) {
+  if (
+    args &&
+    typeof args === 'object' &&
+    !Array.isArray(args) &&
+    Object.prototype.hasOwnProperty.call(args, 'relatedSessionId')
+  ) {
+    throw new Error(
+      '`relatedSessionId` has been retired for send_to_inbox. Use `recipientSessionId`.'
+    );
+  }
+
   const supabase = dataComposer.getClient();
   const parsed = sendToInboxSchema.parse(args);
   const resolved = await resolveUserOrThrow(parsed, dataComposer);
@@ -115,7 +121,6 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
     messageType = 'message',
     priority = 'normal',
     recipientSessionId,
-    relatedSessionId,
     recipientStudioId,
     recipientStudioHint,
     relatedArtifactUri,
@@ -128,7 +133,7 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
   // Enforce identity on sender (who is performing the action), not recipient (target)
   const senderAgentId = getEffectiveAgentId(parsed.senderAgentId);
   const triggerSenderId = senderAgentId || 'system';
-  const effectiveRecipientSessionId = recipientSessionId || relatedSessionId;
+  const effectiveRecipientSessionId = recipientSessionId;
 
   // Default trigger behavior:
   // Wake recipient by default for actionable handoffs, but not for casual messages.
@@ -294,8 +299,6 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
           recipientStudioHint: recipientStudioHint || null,
           createdAt: message.created_at,
           trigger: triggerResult,
-          // Backward compatibility
-          relatedSessionId: effectiveRecipientSessionId || null,
           ...(missingRoutingAnchor
             ? {
                 routingHint:

--- a/packages/api/src/mcp/tools/index.ts
+++ b/packages/api/src/mcp/tools/index.ts
@@ -3245,6 +3245,11 @@ Message types:
 - session_resume: Request agent to resume a specific session
 - notification: FYI, no response needed
 
+Trigger defaults:
+- task_request / session_resume / notification: trigger recipient wake-up by default
+- message: does not trigger by default
+- Any default can be overridden with the `trigger` boolean flag
+
 User can be identified by ONE of: userId, email, phone, or platform + platformId`,
       inputSchema: inboxToolDefinitions[0].schema,
     },


### PR DESCRIPTION
## Summary
- enforce routing anchors for actionable cross-agent handoffs (`task_request`, `session_resume`, `notification`)
  - accepted anchors: `threadKey` (preferred), `recipientSessionId`, `recipientStudioId`, `recipientStudioHint`
- add directional naming support in `send_to_inbox`:
  - `recipientSessionId` (preferred) with backward-compatible `relatedSessionId` alias
  - `recipientStudioId`, `recipientStudioHint`
- default trigger behavior remains immediate (`trigger=true` by default), while preserving explicit `trigger: false` opt-out
- stamp server-side provenance into `metadata.pcp`:
  - sender: `agentId`, `sessionId`, `studioId`
  - recipient routing intent: `threadKey`, `sessionId`, `studioId`, `studioHint`
- forward recipient routing fields into trigger payload so session routing can consistently reattach context

## Validation
- `npx vitest run packages/api/src/mcp/tools/inbox-handlers.test.ts`
- `npx vitest run packages/api/src/services/sessions/session-service.test.ts`

## Notes
- `relatedSessionId` remains in responses for compatibility, while canonical naming shifts toward sender/recipient terminology.