### PR TITLE
fix: OAuth auto-resolution in tool descriptions + CLI cwd crash guard (by Wren)

### DIFF
--- a/packages/api/src/mcp/tools/activity-stream-handlers.ts
+++ b/packages/api/src/mcp/tools/activity-stream-handlers.ts
@@ -18,11 +18,25 @@ import type {
 } from '../../data/repositories/activity-stream.repository';
 
 // User identification fields (without platform to avoid conflict with activity platform)
+// Usually unnecessary — userId and email are auto-resolved from OAuth token.
 const userIdentifierFields = {
-  userId: z.string().uuid().optional().describe('User UUID (if known)'),
-  email: z.string().email().optional().describe('User email address'),
+  userId: z
+    .string()
+    .uuid()
+    .optional()
+    .describe('User UUID — usually unnecessary, auto-resolved from OAuth token'),
+  email: z
+    .string()
+    .email()
+    .optional()
+    .describe('User email — usually unnecessary, auto-resolved from OAuth token'),
   phone: z.string().optional().describe('Phone number in E.164 format (e.g., +14155551234)'),
-  platformId: z.string().optional().describe('Platform-specific user ID (requires userPlatform)'),
+  platformId: z
+    .string()
+    .optional()
+    .describe(
+      'Platform-specific user ID — only needed with userPlatform for platform-based lookup'
+    ),
   userPlatform: z
     .enum(['telegram', 'whatsapp', 'discord'])
     .optional()

--- a/packages/api/src/mcp/tools/index.ts
+++ b/packages/api/src/mcp/tools/index.ts
@@ -248,16 +248,28 @@ export { setTelegramListener, registerChannelListener } from './chat-context-han
 export { setMiniAppsRegistry } from './skill-handlers';
 
 // Shared schema for flexible user identification
-// Users can be identified by: userId, email, phone, or platform+platformId
+// Usually unnecessary — userId and email are auto-resolved from OAuth token.
+// Only needed for platform-based lookups or when operating without authentication.
 const userIdentifierFields = {
-  userId: z.string().uuid().optional().describe('User UUID (if known)'),
-  email: z.string().email().optional().describe('User email address'),
+  userId: z
+    .string()
+    .uuid()
+    .optional()
+    .describe('User UUID — usually unnecessary, auto-resolved from OAuth token'),
+  email: z
+    .string()
+    .email()
+    .optional()
+    .describe('User email — usually unnecessary, auto-resolved from OAuth token'),
   phone: z.string().optional().describe('Phone number in E.164 format (e.g., +14155551234)'),
   platform: z
     .enum(['telegram', 'whatsapp', 'discord'])
     .optional()
-    .describe('Platform name for lookup'),
-  platformId: z.string().optional().describe('Platform-specific user ID or username'),
+    .describe('Platform name — only needed for platform-based user lookup'),
+  platformId: z
+    .string()
+    .optional()
+    .describe('Platform-specific user ID — only needed for platform-based user lookup'),
 };
 
 export function registerAllTools(server: McpServer, dataComposer: DataComposer): void {

--- a/packages/api/src/mcp/tools/reminder-handlers.ts
+++ b/packages/api/src/mcp/tools/reminder-handlers.ts
@@ -13,11 +13,26 @@ import { env } from '../../config/env';
 import type { Database } from '../../data/supabase/types';
 
 // Common user identifier schema
+// Usually unnecessary — userId and email are auto-resolved from OAuth token.
 const userIdentifierSchema = z.object({
-  userId: z.string().uuid().optional().describe('Direct user UUID'),
-  email: z.string().email().optional().describe('User email address'),
-  platform: z.enum(['telegram', 'whatsapp', 'discord']).optional(),
-  platformId: z.string().optional().describe('Platform-specific user ID'),
+  userId: z
+    .string()
+    .uuid()
+    .optional()
+    .describe('User UUID — usually unnecessary, auto-resolved from OAuth token'),
+  email: z
+    .string()
+    .email()
+    .optional()
+    .describe('User email — usually unnecessary, auto-resolved from OAuth token'),
+  platform: z
+    .enum(['telegram', 'whatsapp', 'discord'])
+    .optional()
+    .describe('Platform name — only needed for platform-based user lookup'),
+  platformId: z
+    .string()
+    .optional()
+    .describe('Platform-specific user ID — only needed for platform-based user lookup'),
 });
 
 type McpResponse = {
@@ -103,7 +118,9 @@ export const createReminderSchema = z.object({
   agentId: z
     .string()
     .optional()
-    .describe('Agent that should handle this reminder (e.g., "myra", "lumen"). Resolved to identity_id.'),
+    .describe(
+      'Agent that should handle this reminder (e.g., "myra", "lumen"). Resolved to identity_id.'
+    ),
   identityId: z
     .string()
     .uuid()
@@ -219,7 +236,10 @@ export async function handleCreateReminder(
         identityId = identity.id;
       } else {
         return mcpResponse(
-          { success: false, error: `Unknown agent "${args.agentId}" for this user. Check agent_identities table.` },
+          {
+            success: false,
+            error: `Unknown agent "${args.agentId}" for this user. Check agent_identities table.`,
+          },
           true
         );
       }
@@ -274,7 +294,9 @@ export async function handleCreateReminder(
         isRecurring: !!data.cron_expression,
       },
       ...(!identityId
-        ? { hint: 'Consider adding agentId (e.g., "myra") to route this reminder to a specific agent.' }
+        ? {
+            hint: 'Consider adding agentId (e.g., "myra") to route this reminder to a specific agent.',
+          }
         : {}),
     });
   } catch (error) {
@@ -294,7 +316,10 @@ export async function handleCreateReminder(
 
 export const listRemindersSchema = z.object({
   ...userIdentifierSchema.shape,
-  agentId: z.string().optional().describe('Filter reminders assigned to a specific agent (e.g., "myra")'),
+  agentId: z
+    .string()
+    .optional()
+    .describe('Filter reminders assigned to a specific agent (e.g., "myra")'),
   status: z
     .enum(['active', 'paused', 'completed', 'failed'])
     .optional()

--- a/packages/api/src/mcp/tools/task-handlers.ts
+++ b/packages/api/src/mcp/tools/task-handlers.ts
@@ -11,11 +11,26 @@ import type { TaskStatus, TaskPriority } from '../../data/repositories/project-t
 import { resolveUser, type UserIdentifier } from '../../services/user-resolver';
 
 // Common user identifier schema
+// Usually unnecessary — userId and email are auto-resolved from OAuth token.
 const userIdentifierSchema = z.object({
-  userId: z.string().uuid().optional().describe('Direct user UUID'),
-  email: z.string().email().optional().describe('User email address'),
-  platform: z.enum(['telegram', 'whatsapp', 'discord']).optional(),
-  platformId: z.string().optional().describe('Platform-specific user ID'),
+  userId: z
+    .string()
+    .uuid()
+    .optional()
+    .describe('User UUID — usually unnecessary, auto-resolved from OAuth token'),
+  email: z
+    .string()
+    .email()
+    .optional()
+    .describe('User email — usually unnecessary, auto-resolved from OAuth token'),
+  platform: z
+    .enum(['telegram', 'whatsapp', 'discord'])
+    .optional()
+    .describe('Platform name — only needed for platform-based user lookup'),
+  platformId: z
+    .string()
+    .optional()
+    .describe('Platform-specific user ID — only needed for platform-based user lookup'),
 });
 
 // ============================================================================

--- a/packages/api/src/mcp/tools/user-identity-handlers.ts
+++ b/packages/api/src/mcp/tools/user-identity-handlers.ts
@@ -11,15 +11,27 @@ import { logger } from '../../utils/logger';
 import { resolveUserOrThrow } from '../../services/user-resolver';
 
 // User identification fields
+// Usually unnecessary — userId and email are auto-resolved from OAuth token.
 const userIdentifierFields = {
-  userId: z.string().uuid().optional().describe('User UUID (if known)'),
-  email: z.string().email().optional().describe('User email address'),
+  userId: z
+    .string()
+    .uuid()
+    .optional()
+    .describe('User UUID — usually unnecessary, auto-resolved from OAuth token'),
+  email: z
+    .string()
+    .email()
+    .optional()
+    .describe('User email — usually unnecessary, auto-resolved from OAuth token'),
   phone: z.string().optional().describe('Phone number in E.164 format'),
-  platformId: z.string().optional().describe('Platform-specific user ID'),
+  platformId: z
+    .string()
+    .optional()
+    .describe('Platform-specific user ID — only needed for platform-based user lookup'),
   platform: z
     .enum(['telegram', 'whatsapp', 'discord'])
     .optional()
-    .describe('Platform for user lookup'),
+    .describe('Platform name — only needed for platform-based user lookup'),
   workspaceId: z.string().uuid().optional().describe('Optional product workspace container scope'),
 };
 

--- a/packages/api/src/services/user-resolver.ts
+++ b/packages/api/src/services/user-resolver.ts
@@ -10,17 +10,31 @@ import { getUserFromContext } from '../utils/request-context';
  */
 export const userIdentifierFields = {
   // Direct UUID lookup
-  userId: z.string().uuid().optional().describe('User UUID (if known)'),
+  userId: z
+    .string()
+    .uuid()
+    .optional()
+    .describe('User UUID — usually unnecessary, auto-resolved from OAuth token'),
 
   // Email lookup
-  email: z.string().email().optional().describe('User email address'),
+  email: z
+    .string()
+    .email()
+    .optional()
+    .describe('User email — usually unnecessary, auto-resolved from OAuth token'),
 
   // Phone lookup
   phone: z.string().optional().describe('Phone number in E.164 format (e.g., +14155551234)'),
 
   // Platform-based lookup
-  platform: z.enum(['telegram', 'whatsapp', 'discord']).optional().describe('Platform name'),
-  platformId: z.string().optional().describe('Platform-specific user ID or username'),
+  platform: z
+    .enum(['telegram', 'whatsapp', 'discord'])
+    .optional()
+    .describe('Platform name — only needed for platform-based user lookup'),
+  platformId: z
+    .string()
+    .optional()
+    .describe('Platform-specific user ID — only needed for platform-based user lookup'),
 };
 
 /**

--- a/packages/cli/src/backends/identity.ts
+++ b/packages/cli/src/backends/identity.ts
@@ -38,7 +38,10 @@ export function resolveAgentId(cliAgent?: string): string {
   try {
     cwd = process.cwd();
   } catch {
-    /* cwd deleted — skip local identity lookup */
+    console.warn(
+      'warning: could not read current directory — you may be in an orphan directory.\n' +
+        '  Try: cd .. && cd -\n'
+    );
   }
 
   if (cwd) {

--- a/packages/cli/src/backends/identity.ts
+++ b/packages/cli/src/backends/identity.ts
@@ -32,13 +32,24 @@ export function resolveAgentId(cliAgent?: string): string {
     return cliAgent;
   }
 
-  const localIdentity = join(process.cwd(), '.pcp', 'identity.json');
-  if (existsSync(localIdentity)) {
-    try {
-      const identity: IdentityJson = JSON.parse(readFileSync(localIdentity, 'utf-8'));
-      if (identity.agentId) return identity.agentId;
-    } catch {
-      /* ignore */
+  // process.cwd() throws ENOENT if the working directory has been deleted
+  // (e.g., git worktree removed while a session was open)
+  let cwd: string | null = null;
+  try {
+    cwd = process.cwd();
+  } catch {
+    /* cwd deleted — skip local identity lookup */
+  }
+
+  if (cwd) {
+    const localIdentity = join(cwd, '.pcp', 'identity.json');
+    if (existsSync(localIdentity)) {
+      try {
+        const identity: IdentityJson = JSON.parse(readFileSync(localIdentity, 'utf-8'));
+        if (identity.agentId) return identity.agentId;
+      } catch {
+        /* ignore */
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- **Tool descriptions**: Updated `.describe()` text across all 6 user identifier schema definition sites to note that `userId` and `email` are "usually unnecessary, auto-resolved from OAuth token". This stops LLMs from wasting tokens filling in user identifiers (and sometimes filling in *wrong* values — see Myra's 2.5-day "User not found" outage where she passed the wrong email).

- **CLI crash guard**: Wrapped `process.cwd()` in `resolveAgentId()` with try/catch to prevent the `uv_cwd` ENOENT crash when the working directory has been deleted (e.g., git worktree removed while a session was open in it).

## Files changed

| File | Change |
|------|--------|
| `packages/api/src/services/user-resolver.ts` | Base `userIdentifierFields` descriptions |
| `packages/api/src/mcp/tools/index.ts` | Local `userIdentifierFields` copy |
| `packages/api/src/mcp/tools/activity-stream-handlers.ts` | Local `userIdentifierFields` copy |
| `packages/api/src/mcp/tools/reminder-handlers.ts` | Local `userIdentifierSchema` |
| `packages/api/src/mcp/tools/task-handlers.ts` | Local `userIdentifierSchema` |
| `packages/api/src/mcp/tools/user-identity-handlers.ts` | Local `userIdentifierFields` |
| `packages/cli/src/backends/identity.ts` | `process.cwd()` try/catch guard |

## Test plan

- [x] `yarn workspace @personal-context/api build` — same pre-existing errors, no new ones
- [x] `yarn workspace @personal-context/cli build` — clean
- [x] All 766 API tests pass
- [ ] Verify tool descriptions show correctly in MCP client tool listings
- [ ] Verify CLI doesn't crash when started from a deleted directory