### PR TITLE
feat: threaded inbox viewer with routing inspector (by Wren)

### DIFF
--- a/packages/api/src/mcp/tools/index.ts
+++ b/packages/api/src/mcp/tools/index.ts
@@ -3260,7 +3260,7 @@ Message types:
 Trigger defaults:
 - task_request / session_resume / notification: trigger recipient wake-up by default
 - message: does not trigger by default
-- Any default can be overridden with the `trigger` boolean flag
+- Any default can be overridden with the \`trigger\` boolean flag
 
 User can be identified by ONE of: userId, email, phone, or platform + platformId`,
       inputSchema: inboxToolDefinitions[0].schema,

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -1798,6 +1798,7 @@ router.get('/individuals/:agentId/inbox', async (req: Request, res: Response) =>
     const sentQuery = supabase
       .from('agent_inbox')
       .select('*')
+      .eq('recipient_user_id', authReq.pcpUserId)
       .eq('sender_agent_id', agentId)
       .order('created_at', { ascending: false })
       .limit(500);
@@ -1845,6 +1846,7 @@ router.get('/individuals/:agentId/inbox', async (req: Request, res: Response) =>
       let threadQuery = supabase
         .from('agent_inbox')
         .select('*')
+        .eq('recipient_user_id', authReq.pcpUserId)
         .in('thread_key', threadKeys)
         .order('created_at', { ascending: false })
         .limit(500);

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -1785,7 +1785,9 @@ router.get('/individuals/:agentId/inbox', async (req: Request, res: Response) =>
       env.SUPABASE_SECRET_KEY
     );
 
-    let query = supabase
+    // Fetch messages where this agent is either the sender or recipient
+    // to provide a complete inbox view (like email: sent + received)
+    const receivedQuery = supabase
       .from('agent_inbox')
       .select('*')
       .eq('recipient_user_id', authReq.pcpUserId)
@@ -1793,18 +1795,73 @@ router.get('/individuals/:agentId/inbox', async (req: Request, res: Response) =>
       .order('created_at', { ascending: false })
       .limit(500);
 
-    if (status !== 'all') query = query.eq('status', status);
-    if (messageType) query = query.eq('message_type', messageType);
+    const sentQuery = supabase
+      .from('agent_inbox')
+      .select('*')
+      .eq('sender_agent_id', agentId)
+      .order('created_at', { ascending: false })
+      .limit(500);
 
-    const { data: messages, error } = await query;
+    // Apply filters to both queries
+    let filteredReceived = receivedQuery;
+    let filteredSent = sentQuery;
+    if (status !== 'all') {
+      filteredReceived = filteredReceived.eq('status', status);
+      filteredSent = filteredSent.eq('status', status);
+    }
+    if (messageType) {
+      filteredReceived = filteredReceived.eq('message_type', messageType);
+      filteredSent = filteredSent.eq('message_type', messageType);
+    }
 
-    if (error) {
+    const [receivedResult, sentResult] = await Promise.all([filteredReceived, filteredSent]);
+
+    if (receivedResult.error || sentResult.error) {
+      const error = receivedResult.error || sentResult.error;
       logger.error('Failed to fetch inbox:', error);
       res.status(500).json({ error: 'Failed to fetch inbox' });
       return;
     }
 
-    const allMessages = messages || [];
+    // Merge and deduplicate (a message where agent is both sender and recipient would appear in both)
+    const seenIds = new Set<string>();
+    const directMessages = [...(receivedResult.data || []), ...(sentResult.data || [])].filter(
+      (m) => {
+        if (seenIds.has(m.id)) return false;
+        seenIds.add(m.id);
+        return true;
+      }
+    );
+
+    // Second pass: for threads this agent is part of, fetch any cross-agent
+    // messages (e.g., myra → lumen in a thread wren is also in)
+    const threadKeys = [
+      ...new Set(directMessages.map((m) => m.thread_key).filter(Boolean)),
+    ] as string[];
+
+    let allMessages = directMessages;
+
+    if (threadKeys.length > 0) {
+      let threadQuery = supabase
+        .from('agent_inbox')
+        .select('*')
+        .in('thread_key', threadKeys)
+        .order('created_at', { ascending: false })
+        .limit(500);
+
+      if (status !== 'all') threadQuery = threadQuery.eq('status', status);
+      if (messageType) threadQuery = threadQuery.eq('message_type', messageType);
+
+      const threadResult = await threadQuery;
+      if (!threadResult.error && threadResult.data) {
+        for (const m of threadResult.data) {
+          if (!seenIds.has(m.id)) {
+            seenIds.add(m.id);
+            allMessages.push(m);
+          }
+        }
+      }
+    }
 
     interface MappedMessage {
       id: string;
@@ -1814,8 +1871,11 @@ router.get('/individuals/:agentId/inbox', async (req: Request, res: Response) =>
       priority: string;
       status: string;
       senderAgentId: string | null;
+      senderIdentityId: string | null;
+      recipientAgentId: string;
+      recipientIdentityId: string | null;
       threadKey: string | null;
-      relatedSessionId: string | null;
+      recipientSessionId: string | null;
       relatedArtifactUri: string | null;
       metadata: Record<string, unknown> | null;
       createdAt: string;
@@ -1832,8 +1892,11 @@ router.get('/individuals/:agentId/inbox', async (req: Request, res: Response) =>
       priority: m.priority,
       status: m.status,
       senderAgentId: m.sender_agent_id,
+      senderIdentityId: m.sender_identity_id,
+      recipientAgentId: m.recipient_agent_id,
+      recipientIdentityId: m.recipient_identity_id,
       threadKey: m.thread_key,
-      relatedSessionId: m.related_session_id,
+      recipientSessionId: m.recipient_session_id,
       relatedArtifactUri: m.related_artifact_uri,
       metadata: m.metadata as Record<string, unknown> | null,
       createdAt: m.created_at ?? new Date().toISOString(),
@@ -1842,17 +1905,28 @@ router.get('/individuals/:agentId/inbox', async (req: Request, res: Response) =>
       expiresAt: m.expires_at,
     });
 
-    // Group by thread_key — messages without thread_key go to flatMessages
-    // (these are routed to the SB's main process, not a specific thread)
+    // Group by thread_key + counterpart — each 1-1 conversation within a
+    // thread_key gets its own group.  Messages without thread_key go to flatMessages.
     const threadedMap = new Map<string, MappedMessage[]>();
     const flatMessages: MappedMessage[] = [];
 
     for (const m of allMessages) {
       const mapped = mapMessage(m);
       if (m.thread_key) {
-        const existing = threadedMap.get(m.thread_key) || [];
+        // Determine the counterpart: the "other" agent in this 1-1 exchange
+        let counterpart: string;
+        if (m.sender_agent_id === agentId) {
+          counterpart = m.recipient_agent_id;
+        } else if (m.recipient_agent_id === agentId) {
+          counterpart = m.sender_agent_id || 'unknown';
+        } else {
+          // Cross-agent message (from two-pass) — group by sender
+          counterpart = m.sender_agent_id || 'unknown';
+        }
+        const groupKey = `${m.thread_key}|${counterpart}`;
+        const existing = threadedMap.get(groupKey) || [];
         existing.push(mapped);
-        threadedMap.set(m.thread_key, existing);
+        threadedMap.set(groupKey, existing);
       } else {
         flatMessages.push(mapped);
       }
@@ -1860,16 +1934,20 @@ router.get('/individuals/:agentId/inbox', async (req: Request, res: Response) =>
 
     // Build thread groups
     const threads = [];
-    for (const [threadKey, msgs] of threadedMap) {
+    for (const [groupKey, msgs] of threadedMap) {
+      const [threadKey, counterpart] = groupKey.split('|');
       const sorted = msgs.sort(
         (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
       );
       threads.push({
         threadKey,
+        counterpart,
         messageCount: sorted.length,
         unreadCount: sorted.filter((m) => m.status === 'unread').length,
         latestMessage: sorted[sorted.length - 1],
-        participants: [...new Set(sorted.map((m) => m.senderAgentId).filter(Boolean))] as string[],
+        participants: [
+          ...new Set(sorted.flatMap((m) => [m.senderAgentId, m.recipientAgentId]).filter(Boolean)),
+        ] as string[],
         firstMessageAt: sorted[0].createdAt,
         lastMessageAt: sorted[sorted.length - 1].createdAt,
         messages: sorted,
@@ -1880,6 +1958,9 @@ router.get('/individuals/:agentId/inbox', async (req: Request, res: Response) =>
     threads.sort(
       (a, b) => new Date(b.lastMessageAt).getTime() - new Date(a.lastMessageAt).getTime()
     );
+
+    // Sort flat messages by createdAt descending (interleaves sent + received)
+    flatMessages.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
 
     const totalItems = threads.length + flatMessages.length;
     const unreadCount = allMessages.filter((m) => m.status === 'unread').length;

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -149,7 +149,10 @@ function toActivityLogItem(row: {
     role: roleFromActivityType(row.type),
     content: truncateText(combined),
     timestamp: row.created_at,
-    metadata: row.payload && typeof row.payload === 'object' ? (row.payload as Record<string, unknown>) : undefined,
+    metadata:
+      row.payload && typeof row.payload === 'object'
+        ? (row.payload as Record<string, unknown>)
+        : undefined,
   };
 }
 
@@ -320,9 +323,7 @@ async function fetchCloudSessionLogs(
   const activityItems = (activityRows || []).map(toActivityLogItem);
   const sessionItems = (sessionLogRows || [])
     .filter(
-      (
-        row
-      ): row is { id: string; content: string; salience: string; created_at: string } =>
+      (row): row is { id: string; content: string; salience: string; created_at: string } =>
         typeof row.created_at === 'string' && row.created_at.length > 0
     )
     .map(toSessionLogItem);
@@ -1762,6 +1763,158 @@ router.get(
 );
 
 // =============================================================================
+// Agent Inbox
+// =============================================================================
+
+/**
+ * GET /api/admin/individuals/:agentId/inbox
+ * Get threaded inbox view for an agent, grouped by thread_key.
+ * Messages without a thread_key are returned as flat messages (routed to the SB's main process).
+ */
+router.get('/individuals/:agentId/inbox', async (req: Request, res: Response) => {
+  try {
+    const { agentId } = req.params;
+    const authReq = req as AdminAuthRequest;
+    const status = (req.query.status as string) || 'all';
+    const messageType = req.query.messageType as string | undefined;
+    const limit = Math.min(parseInt(req.query.limit as string) || 20, 50);
+    const offset = parseInt(req.query.offset as string) || 0;
+
+    const supabase: SupabaseClient<Database> = createClient(
+      env.SUPABASE_URL,
+      env.SUPABASE_SECRET_KEY
+    );
+
+    let query = supabase
+      .from('agent_inbox')
+      .select('*')
+      .eq('recipient_user_id', authReq.pcpUserId)
+      .eq('recipient_agent_id', agentId)
+      .order('created_at', { ascending: false })
+      .limit(500);
+
+    if (status !== 'all') query = query.eq('status', status);
+    if (messageType) query = query.eq('message_type', messageType);
+
+    const { data: messages, error } = await query;
+
+    if (error) {
+      logger.error('Failed to fetch inbox:', error);
+      res.status(500).json({ error: 'Failed to fetch inbox' });
+      return;
+    }
+
+    const allMessages = messages || [];
+
+    interface MappedMessage {
+      id: string;
+      subject: string | null;
+      content: string;
+      messageType: string;
+      priority: string;
+      status: string;
+      senderAgentId: string | null;
+      threadKey: string | null;
+      relatedSessionId: string | null;
+      relatedArtifactUri: string | null;
+      metadata: Record<string, unknown> | null;
+      createdAt: string;
+      readAt: string | null;
+      acknowledgedAt: string | null;
+      expiresAt: string | null;
+    }
+
+    const mapMessage = (m: (typeof allMessages)[0]): MappedMessage => ({
+      id: m.id,
+      subject: m.subject,
+      content: m.content,
+      messageType: m.message_type,
+      priority: m.priority,
+      status: m.status,
+      senderAgentId: m.sender_agent_id,
+      threadKey: m.thread_key,
+      relatedSessionId: m.related_session_id,
+      relatedArtifactUri: m.related_artifact_uri,
+      metadata: m.metadata as Record<string, unknown> | null,
+      createdAt: m.created_at,
+      readAt: m.read_at,
+      acknowledgedAt: m.acknowledged_at,
+      expiresAt: m.expires_at,
+    });
+
+    // Group by thread_key — messages without thread_key go to flatMessages
+    // (these are routed to the SB's main process, not a specific thread)
+    const threadedMap = new Map<string, MappedMessage[]>();
+    const flatMessages: MappedMessage[] = [];
+
+    for (const m of allMessages) {
+      const mapped = mapMessage(m);
+      if (m.thread_key) {
+        const existing = threadedMap.get(m.thread_key) || [];
+        existing.push(mapped);
+        threadedMap.set(m.thread_key, existing);
+      } else {
+        flatMessages.push(mapped);
+      }
+    }
+
+    // Build thread groups
+    const threads = [];
+    for (const [threadKey, msgs] of threadedMap) {
+      const sorted = msgs.sort(
+        (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+      );
+      threads.push({
+        threadKey,
+        messageCount: sorted.length,
+        unreadCount: sorted.filter((m) => m.status === 'unread').length,
+        latestMessage: sorted[sorted.length - 1],
+        participants: [...new Set(sorted.map((m) => m.senderAgentId).filter(Boolean))] as string[],
+        firstMessageAt: sorted[0].createdAt,
+        lastMessageAt: sorted[sorted.length - 1].createdAt,
+        messages: sorted,
+      });
+    }
+
+    // Sort threads by latest message descending
+    threads.sort(
+      (a, b) => new Date(b.lastMessageAt).getTime() - new Date(a.lastMessageAt).getTime()
+    );
+
+    const totalItems = threads.length + flatMessages.length;
+    const unreadCount = allMessages.filter((m) => m.status === 'unread').length;
+
+    // Paginate: threads first, then flat messages
+    const paginatedThreads = threads.slice(offset, offset + limit);
+    const remainingSlots = limit - paginatedThreads.length;
+    const flatOffset = Math.max(0, offset - threads.length);
+    const paginatedFlat =
+      remainingSlots > 0 ? flatMessages.slice(flatOffset, flatOffset + remainingSlots) : [];
+
+    res.json({
+      agentId,
+      stats: {
+        totalMessages: allMessages.length,
+        unreadCount,
+        threadCount: threads.length,
+        flatCount: flatMessages.length,
+      },
+      threads: paginatedThreads,
+      flatMessages: paginatedFlat,
+      pagination: {
+        limit,
+        offset,
+        totalThreads: totalItems,
+        hasMore: offset + limit < totalItems,
+      },
+    });
+  } catch (error) {
+    logger.error('Failed to get inbox:', error);
+    res.status(500).json({ error: 'Failed to get inbox' });
+  }
+});
+
+// =============================================================================
 // Connected Accounts (OAuth)
 // =============================================================================
 
@@ -2757,7 +2910,9 @@ router.get('/sessions', async (req: Request, res: Response) => {
           preview: previewsBySessionId.get(s.id) || [],
           workspace: workspacesBySessionId.get(s.id) || null,
           studio:
-            studiosById.get(s.studio_id || s.workspace_id || '') || workspacesBySessionId.get(s.id) || null,
+            studiosById.get(s.studio_id || s.workspace_id || '') ||
+            workspacesBySessionId.get(s.id) ||
+            null,
         };
       }),
     });
@@ -2777,7 +2932,11 @@ router.get('/sessions/:id/logs', async (req: Request, res: Response) => {
     const authReq = req as AdminAuthRequest;
     const limit = Math.min(
       MAX_SESSION_LOG_LIMIT,
-      Math.max(1, Number.parseInt(String(req.query.limit || DEFAULT_SESSION_LOG_LIMIT), 10) || DEFAULT_SESSION_LOG_LIMIT)
+      Math.max(
+        1,
+        Number.parseInt(String(req.query.limit || DEFAULT_SESSION_LOG_LIMIT), 10) ||
+          DEFAULT_SESSION_LOG_LIMIT
+      )
     );
     const offset = Math.max(0, Number.parseInt(String(req.query.offset || 0), 10) || 0);
     const includeLocal = req.query.includeLocal !== 'false';
@@ -2788,7 +2947,9 @@ router.get('/sessions/:id/logs', async (req: Request, res: Response) => {
 
     const { data: session, error: sessionError } = await supabase
       .from('sessions')
-      .select('id, agent_id, status, current_phase, started_at, updated_at, ended_at, backend, backend_session_id, claude_session_id')
+      .select(
+        'id, agent_id, status, current_phase, started_at, updated_at, ended_at, backend, backend_session_id, claude_session_id'
+      )
       .eq('id', sessionId)
       .eq('user_id', authReq.pcpUserId)
       .single();
@@ -2801,7 +2962,10 @@ router.get('/sessions/:id/logs', async (req: Request, res: Response) => {
     const [cloudLogs, localLogs] = await Promise.all([
       fetchCloudSessionLogs(supabase, authReq.pcpUserId, sessionId),
       includeLocal
-        ? tryReadLocalTranscript(session.backend_session_id || session.claude_session_id, session.backend)
+        ? tryReadLocalTranscript(
+            session.backend_session_id || session.claude_session_id,
+            session.backend
+          )
         : Promise.resolve([]),
     ]);
 

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -1836,7 +1836,7 @@ router.get('/individuals/:agentId/inbox', async (req: Request, res: Response) =>
       relatedSessionId: m.related_session_id,
       relatedArtifactUri: m.related_artifact_uri,
       metadata: m.metadata as Record<string, unknown> | null,
-      createdAt: m.created_at,
+      createdAt: m.created_at ?? new Date().toISOString(),
       readAt: m.read_at,
       acknowledgedAt: m.acknowledged_at,
       expiresAt: m.expires_at,

--- a/packages/web/src/app/(dashboard)/individuals/[agentId]/inbox/page.tsx
+++ b/packages/web/src/app/(dashboard)/individuals/[agentId]/inbox/page.tsx
@@ -1,21 +1,28 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useParams } from 'next/navigation';
 import Link from 'next/link';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+} from '@/components/ui/sheet';
+import {
   ArrowLeft,
   ChevronRight,
   ChevronLeft,
   Inbox,
+  Info,
   Mail,
   MessageSquare,
   AlertCircle,
   User,
-  X,
 } from 'lucide-react';
 import { useApiQuery } from '@/lib/api';
 import clsx from 'clsx';
@@ -28,8 +35,11 @@ interface InboxMessage {
   priority: string;
   status: string;
   senderAgentId: string | null;
+  senderIdentityId: string | null;
+  recipientAgentId: string;
+  recipientIdentityId: string | null;
   threadKey: string | null;
-  relatedSessionId: string | null;
+  recipientSessionId: string | null;
   relatedArtifactUri: string | null;
   metadata: Record<string, unknown> | null;
   createdAt: string;
@@ -40,6 +50,7 @@ interface InboxMessage {
 
 interface ThreadGroup {
   threadKey: string;
+  counterpart: string;
   messageCount: number;
   unreadCount: number;
   latestMessage: InboxMessage;
@@ -134,9 +145,20 @@ function agentColor(name: string): string {
 // MessageItem — Discord/Slack-style chat bubble
 // ---------------------------------------------------------------------------
 
-function MessageItem({ message, compact }: { message: InboxMessage; compact?: boolean }) {
+function MessageItem({
+  message,
+  compact,
+  inboxAgentId,
+  onShowRouting,
+}: {
+  message: InboxMessage;
+  compact?: boolean;
+  inboxAgentId: string;
+  onShowRouting?: (message: InboxMessage) => void;
+}) {
   const sender = message.senderAgentId || 'unknown';
   const isAgent = !!message.senderAgentId;
+  const isSent = message.senderAgentId === inboxAgentId;
 
   return (
     <div
@@ -164,6 +186,9 @@ function MessageItem({ message, compact }: { message: InboxMessage; compact?: bo
         {!compact && (
           <div className="flex items-baseline gap-2 flex-wrap">
             <span className="text-sm font-semibold text-gray-900">{sender}</span>
+            {isSent && (
+              <span className="text-xs text-gray-400">&rarr; {message.recipientAgentId}</span>
+            )}
             <span className="text-xs text-gray-400">{formatTimestamp(message.createdAt)}</span>
             {message.messageType !== 'message' && (
               <Badge
@@ -185,9 +210,9 @@ function MessageItem({ message, compact }: { message: InboxMessage; compact?: bo
                 {message.priority}
               </Badge>
             )}
-            {message.relatedSessionId && (
+            {message.recipientSessionId && (
               <Link
-                href={`/sessions/${message.relatedSessionId}`}
+                href={`/sessions/${message.recipientSessionId}`}
                 className="text-[10px] text-blue-500 hover:text-blue-700 hover:underline"
               >
                 session
@@ -204,6 +229,20 @@ function MessageItem({ message, compact }: { message: InboxMessage; compact?: bo
           </div>
         )}
       </div>
+
+      {/* Routing info button (hover) */}
+      {onShowRouting && (
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            onShowRouting(message);
+          }}
+          className="shrink-0 self-center rounded p-1 text-gray-300 opacity-0 transition-opacity hover:bg-gray-100 hover:text-gray-500 group-hover:opacity-100"
+          title="Routing details"
+        >
+          <Info className="h-3.5 w-3.5" />
+        </button>
+      )}
 
       {/* Hover timestamp for compact messages */}
       {compact && (
@@ -241,26 +280,23 @@ function ThreadRow({
           : 'border-gray-200 bg-white hover:bg-gray-50/50'
       )}
     >
-      {/* Stacked participant avatars */}
-      <div className="flex -space-x-2 shrink-0">
-        {thread.participants.slice(0, 3).map((p) => (
-          <div
-            key={p}
-            className={clsx(
-              'flex h-7 w-7 items-center justify-center rounded-full text-white text-[10px] font-semibold ring-2 ring-white',
-              agentColor(p)
-            )}
-            title={p}
-          >
-            {p.slice(0, 2).toUpperCase()}
-          </div>
-        ))}
+      {/* Counterpart avatar */}
+      <div
+        className={clsx(
+          'flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-white text-xs font-semibold',
+          agentColor(thread.counterpart)
+        )}
+        title={thread.counterpart}
+      >
+        {thread.counterpart.slice(0, 2).toUpperCase()}
       </div>
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2">
           <Badge variant="outline" className="font-mono text-xs shrink-0">
             {thread.threadKey}
           </Badge>
+          <span className="text-xs text-gray-400">&middot;</span>
+          <span className="text-xs font-medium text-gray-700">{thread.counterpart}</span>
           <span className="text-xs text-gray-500">{thread.messageCount} msgs</span>
           {thread.unreadCount > 0 && (
             <span className="flex h-5 min-w-5 items-center justify-center rounded-full bg-blue-500 px-1.5 text-[10px] font-semibold text-white">
@@ -281,21 +317,20 @@ function ThreadRow({
 }
 
 // ---------------------------------------------------------------------------
-// ThreadPanel — slide-out from right showing full conversation
+// ThreadMessages — chat message list rendered inside the Sheet
 // ---------------------------------------------------------------------------
 
-function ThreadPanel({
+function ThreadMessages({
   thread,
   messages,
   agentId,
-  onClose,
+  onShowRouting,
 }: {
   thread?: ThreadGroup;
   messages?: InboxMessage[];
   agentId: string;
-  onClose: () => void;
+  onShowRouting: (message: InboxMessage) => void;
 }) {
-  const panelRef = useRef<HTMLDivElement>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
 
   // Scroll to bottom when thread changes
@@ -304,44 +339,55 @@ function ThreadPanel({
   }, [thread?.threadKey, messages?.[0]?.id]);
 
   const displayMessages = thread?.messages || messages || [];
-  const title = thread?.threadKey || 'Message';
 
   return (
-    <div
-      ref={panelRef}
-      className="fixed inset-y-0 right-0 z-40 flex w-full max-w-lg flex-col border-l border-gray-200 bg-white shadow-xl animate-in slide-in-from-right duration-500"
-    >
-      {/* Header */}
-      <div className="flex items-center justify-between border-b border-gray-200 px-4 py-3">
-        <div className="min-w-0">
-          <div className="flex items-center gap-2">
-            <MessageSquare className="h-4 w-4 text-gray-500" />
-            <h2 className="text-sm font-semibold text-gray-900 truncate">{title}</h2>
-          </div>
-          {thread && (
-            <div className="mt-0.5 flex items-center gap-2 text-xs text-gray-500">
-              <span>{thread.messageCount} messages</span>
-              <span>&middot;</span>
-              <span>
-                {thread.participants.join(', ')} &rarr; {agentId}
-              </span>
-            </div>
-          )}
-        </div>
-        <Button variant="ghost" size="sm" onClick={onClose} className="shrink-0">
-          <X className="h-4 w-4" />
-        </Button>
-      </div>
+    <div className="flex-1 overflow-y-auto px-1 py-3">
+      {displayMessages.map((msg, i) => {
+        const prevMsg = i > 0 ? displayMessages[i - 1] : null;
+        const sameSender = prevMsg?.senderAgentId === msg.senderAgentId;
+        return (
+          <MessageItem
+            key={msg.id}
+            message={msg}
+            compact={sameSender}
+            inboxAgentId={agentId}
+            onShowRouting={onShowRouting}
+          />
+        );
+      })}
+      <div ref={bottomRef} />
+    </div>
+  );
+}
 
-      {/* Messages */}
-      <div className="flex-1 overflow-y-auto px-1 py-3">
-        {displayMessages.map((msg, i) => {
-          const prevMsg = i > 0 ? displayMessages[i - 1] : null;
-          const sameSender = prevMsg?.senderAgentId === msg.senderAgentId;
-          return <MessageItem key={msg.id} message={msg} compact={sameSender} />;
-        })}
-        <div ref={bottomRef} />
-      </div>
+// ---------------------------------------------------------------------------
+// RoutingField — key/value row for the routing detail sheet
+// ---------------------------------------------------------------------------
+
+function RoutingField({
+  label,
+  value,
+  mono,
+  href,
+}: {
+  label: string;
+  value: string | null | undefined;
+  mono?: boolean;
+  href?: string;
+}) {
+  const display = value || <span className="text-gray-300">--</span>;
+  return (
+    <div>
+      <dt className="text-xs text-gray-500">{label}</dt>
+      <dd className={clsx('mt-0.5', mono && 'font-mono text-xs', !mono && 'text-sm')}>
+        {href ? (
+          <Link href={href} className="text-blue-600 hover:text-blue-800 hover:underline">
+            {display}
+          </Link>
+        ) : (
+          display
+        )}
+      </dd>
     </div>
   );
 }
@@ -363,19 +409,8 @@ export default function InboxPage() {
   const [activeThread, setActiveThread] = useState<string | null>(null);
   const [activeMessage, setActiveMessage] = useState<string | null>(null);
 
-  const closePanel = useCallback(() => {
-    setActiveThread(null);
-    setActiveMessage(null);
-  }, []);
-
-  // Close panel on Escape
-  useEffect(() => {
-    const handleKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') closePanel();
-    };
-    window.addEventListener('keydown', handleKey);
-    return () => window.removeEventListener('keydown', handleKey);
-  }, [closePanel]);
+  // Routing detail sheet
+  const [routingMessage, setRoutingMessage] = useState<InboxMessage | null>(null);
 
   const queryPath = useMemo(() => {
     const qp = new URLSearchParams();
@@ -405,8 +440,9 @@ export default function InboxPage() {
   const flatMessages = data?.flatMessages || [];
   const pagination = data?.pagination;
 
+  const threadGroupKey = (t: ThreadGroup) => `${t.threadKey}|${t.counterpart}`;
   const selectedThread = activeThread
-    ? threads.find((t) => t.threadKey === activeThread)
+    ? threads.find((t) => threadGroupKey(t) === activeThread)
     : undefined;
   const selectedMessage = activeMessage
     ? flatMessages.find((m) => m.id === activeMessage)
@@ -518,17 +554,20 @@ export default function InboxPage() {
                 <CardDescription>Click a thread to view the full conversation.</CardDescription>
               </CardHeader>
               <CardContent className="space-y-2">
-                {threads.map((thread) => (
-                  <ThreadRow
-                    key={thread.threadKey}
-                    thread={thread}
-                    isActive={activeThread === thread.threadKey}
-                    onClick={() => {
-                      setActiveMessage(null);
-                      setActiveThread(activeThread === thread.threadKey ? null : thread.threadKey);
-                    }}
-                  />
-                ))}
+                {threads.map((thread) => {
+                  const gk = threadGroupKey(thread);
+                  return (
+                    <ThreadRow
+                      key={gk}
+                      thread={thread}
+                      isActive={activeThread === gk}
+                      onClick={() => {
+                        setActiveMessage(null);
+                        setActiveThread(activeThread === gk ? null : gk);
+                      }}
+                    />
+                  );
+                })}
               </CardContent>
             </Card>
           )}
@@ -558,7 +597,11 @@ export default function InboxPage() {
                       activeMessage === msg.id && 'ring-1 ring-blue-200 bg-blue-50/50'
                     )}
                   >
-                    <MessageItem message={msg} />
+                    <MessageItem
+                      message={msg}
+                      inboxAgentId={agentId}
+                      onShowRouting={setRoutingMessage}
+                    />
                   </button>
                 ))}
               </CardContent>
@@ -598,21 +641,163 @@ export default function InboxPage() {
         </div>
       )}
 
-      {/* Backdrop */}
-      {panelOpen && (
-        <div
-          className="fixed inset-0 z-30 bg-black/20 animate-in fade-in duration-500"
-          onClick={closePanel}
-        />
-      )}
-
       {/* Slide-out panel */}
-      {selectedThread && (
-        <ThreadPanel thread={selectedThread} agentId={agentId} onClose={closePanel} />
-      )}
-      {selectedMessage && (
-        <ThreadPanel messages={[selectedMessage]} agentId={agentId} onClose={closePanel} />
-      )}
+      <Sheet
+        open={panelOpen}
+        onOpenChange={(open) => {
+          if (!open) {
+            setActiveThread(null);
+            setActiveMessage(null);
+          }
+        }}
+      >
+        <SheetContent side="right" className="flex flex-col p-0">
+          <SheetHeader>
+            <SheetTitle className="flex items-center gap-2">
+              <MessageSquare className="h-4 w-4 text-gray-500" />
+              {selectedThread
+                ? `${selectedThread.threadKey} · ${selectedThread.counterpart}`
+                : 'Message'}
+            </SheetTitle>
+            {selectedThread && (
+              <SheetDescription>
+                {selectedThread.messageCount} messages &middot; {agentId} &harr;{' '}
+                {selectedThread.counterpart}
+              </SheetDescription>
+            )}
+          </SheetHeader>
+          {(selectedThread || selectedMessage) && (
+            <ThreadMessages
+              thread={selectedThread}
+              messages={selectedMessage ? [selectedMessage] : undefined}
+              agentId={agentId}
+              onShowRouting={setRoutingMessage}
+            />
+          )}
+        </SheetContent>
+      </Sheet>
+
+      {/* Routing detail sheet */}
+      <Sheet open={!!routingMessage} onOpenChange={(open) => !open && setRoutingMessage(null)}>
+        <SheetContent side="right" className="p-0">
+          <SheetHeader>
+            <SheetTitle className="flex items-center gap-2">
+              <Info className="h-4 w-4 text-gray-500" />
+              Message Routing
+            </SheetTitle>
+            <SheetDescription>Routing and identity details for debugging.</SheetDescription>
+          </SheetHeader>
+          {routingMessage && (
+            <div className="overflow-y-auto px-6 py-4">
+              <dl className="space-y-4 text-sm">
+                <RoutingField label="Message ID" value={routingMessage.id} mono />
+                <RoutingField label="Status" value={routingMessage.status} />
+                <RoutingField label="Type" value={routingMessage.messageType} />
+                <RoutingField label="Priority" value={routingMessage.priority} />
+                <RoutingField
+                  label="Created"
+                  value={new Date(routingMessage.createdAt).toLocaleString()}
+                />
+
+                <div className="border-t pt-4">
+                  <h3 className="text-xs font-semibold uppercase tracking-wider text-gray-400 mb-3">
+                    Sender
+                  </h3>
+                  <div className="space-y-3">
+                    <RoutingField label="Agent ID" value={routingMessage.senderAgentId} />
+                    <RoutingField
+                      label="Identity ID"
+                      value={routingMessage.senderIdentityId}
+                      mono
+                    />
+                  </div>
+                </div>
+
+                <div className="border-t pt-4">
+                  <h3 className="text-xs font-semibold uppercase tracking-wider text-gray-400 mb-3">
+                    Recipient
+                  </h3>
+                  <div className="space-y-3">
+                    <RoutingField label="Agent ID" value={routingMessage.recipientAgentId} />
+                    <RoutingField
+                      label="Identity ID"
+                      value={routingMessage.recipientIdentityId}
+                      mono
+                    />
+                  </div>
+                </div>
+
+                <div className="border-t pt-4">
+                  <h3 className="text-xs font-semibold uppercase tracking-wider text-gray-400 mb-3">
+                    Routing
+                  </h3>
+                  <div className="space-y-3">
+                    <RoutingField label="Thread Key" value={routingMessage.threadKey} />
+                    <RoutingField
+                      label="Recipient Session"
+                      value={routingMessage.recipientSessionId}
+                      mono
+                      href={
+                        routingMessage.recipientSessionId
+                          ? `/sessions/${routingMessage.recipientSessionId}`
+                          : undefined
+                      }
+                    />
+                    <RoutingField
+                      label="Artifact URI"
+                      value={routingMessage.relatedArtifactUri}
+                      mono
+                    />
+                  </div>
+                </div>
+
+                {routingMessage.metadata && Object.keys(routingMessage.metadata).length > 0 && (
+                  <div className="border-t pt-4">
+                    <h3 className="text-xs font-semibold uppercase tracking-wider text-gray-400 mb-3">
+                      Metadata
+                    </h3>
+                    <pre className="rounded-md bg-gray-50 p-3 text-xs text-gray-700 overflow-x-auto">
+                      {JSON.stringify(routingMessage.metadata, null, 2)}
+                    </pre>
+                  </div>
+                )}
+
+                <div className="border-t pt-4">
+                  <h3 className="text-xs font-semibold uppercase tracking-wider text-gray-400 mb-3">
+                    Timestamps
+                  </h3>
+                  <div className="space-y-3">
+                    <RoutingField
+                      label="Read"
+                      value={
+                        routingMessage.readAt
+                          ? new Date(routingMessage.readAt).toLocaleString()
+                          : null
+                      }
+                    />
+                    <RoutingField
+                      label="Acknowledged"
+                      value={
+                        routingMessage.acknowledgedAt
+                          ? new Date(routingMessage.acknowledgedAt).toLocaleString()
+                          : null
+                      }
+                    />
+                    <RoutingField
+                      label="Expires"
+                      value={
+                        routingMessage.expiresAt
+                          ? new Date(routingMessage.expiresAt).toLocaleString()
+                          : null
+                      }
+                    />
+                  </div>
+                </div>
+              </dl>
+            </div>
+          )}
+        </SheetContent>
+      </Sheet>
     </div>
   );
 }

--- a/packages/web/src/app/(dashboard)/individuals/[agentId]/inbox/page.tsx
+++ b/packages/web/src/app/(dashboard)/individuals/[agentId]/inbox/page.tsx
@@ -1,0 +1,422 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { useParams } from 'next/navigation';
+import Link from 'next/link';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import {
+  ArrowLeft,
+  ChevronDown,
+  ChevronRight,
+  ChevronLeft,
+  Inbox,
+  Mail,
+  MessageSquare,
+  AlertCircle,
+} from 'lucide-react';
+import { useApiQuery } from '@/lib/api';
+import clsx from 'clsx';
+
+interface InboxMessage {
+  id: string;
+  subject: string | null;
+  content: string;
+  messageType: string;
+  priority: string;
+  status: string;
+  senderAgentId: string | null;
+  threadKey: string | null;
+  relatedSessionId: string | null;
+  relatedArtifactUri: string | null;
+  metadata: Record<string, unknown> | null;
+  createdAt: string;
+  readAt: string | null;
+  acknowledgedAt: string | null;
+  expiresAt: string | null;
+}
+
+interface ThreadGroup {
+  threadKey: string;
+  messageCount: number;
+  unreadCount: number;
+  latestMessage: InboxMessage;
+  participants: string[];
+  firstMessageAt: string;
+  lastMessageAt: string;
+  messages: InboxMessage[];
+}
+
+interface InboxResponse {
+  agentId: string;
+  stats: {
+    totalMessages: number;
+    unreadCount: number;
+    threadCount: number;
+    flatCount: number;
+  };
+  threads: ThreadGroup[];
+  flatMessages: InboxMessage[];
+  pagination: {
+    limit: number;
+    offset: number;
+    totalThreads: number;
+    hasMore: boolean;
+  };
+}
+
+interface IndividualsResponse {
+  individuals: { agentId: string; name: string }[];
+}
+
+function formatRelativeTime(date: string): string {
+  const now = new Date();
+  const target = new Date(date);
+  const diffMs = now.getTime() - target.getTime();
+  const diffMins = Math.round(diffMs / 60000);
+  const diffHours = Math.round(diffMs / 3600000);
+  const diffDays = Math.round(diffMs / 86400000);
+
+  if (diffMins < 1) return 'just now';
+  if (diffMins < 60) return `${diffMins}m ago`;
+  if (diffHours < 24) return `${diffHours}h ago`;
+  return `${diffDays}d ago`;
+}
+
+const priorityColors: Record<string, string> = {
+  urgent: 'bg-red-100 text-red-700 border-red-200',
+  high: 'bg-orange-100 text-orange-700 border-orange-200',
+  normal: 'bg-gray-100 text-gray-600 border-gray-200',
+  low: 'bg-gray-50 text-gray-400 border-gray-100',
+};
+
+const statusColors: Record<string, string> = {
+  unread: 'bg-blue-100 text-blue-700',
+  read: 'bg-gray-100 text-gray-600',
+  acknowledged: 'bg-green-100 text-green-700',
+  completed: 'bg-gray-100 text-gray-400',
+};
+
+const typeColors: Record<string, string> = {
+  message: 'bg-slate-100 text-slate-700',
+  task_request: 'bg-purple-100 text-purple-700',
+  session_resume: 'bg-blue-100 text-blue-700',
+  notification: 'bg-amber-100 text-amber-700',
+};
+
+function MessageItem({ message }: { message: InboxMessage }) {
+  return (
+    <div className="rounded-md border border-gray-200 bg-white p-3">
+      <div className="mb-2 flex items-center justify-between text-xs text-gray-500">
+        <div className="flex items-center gap-2">
+          {message.senderAgentId && (
+            <Badge variant="outline" className="font-mono text-xs">
+              {message.senderAgentId}
+            </Badge>
+          )}
+          <Badge
+            className={clsx('text-[10px]', typeColors[message.messageType] || typeColors.message)}
+          >
+            {message.messageType}
+          </Badge>
+          <Badge
+            className={clsx('text-[10px]', statusColors[message.status] || statusColors.unread)}
+          >
+            {message.status}
+          </Badge>
+          {message.priority !== 'normal' && (
+            <Badge
+              className={clsx(
+                'text-[10px]',
+                priorityColors[message.priority] || priorityColors.normal
+              )}
+            >
+              {message.priority}
+            </Badge>
+          )}
+        </div>
+        <span>{formatRelativeTime(message.createdAt)}</span>
+      </div>
+      {message.subject && (
+        <p className="mb-1 text-sm font-medium text-gray-800">{message.subject}</p>
+      )}
+      <p className="whitespace-pre-wrap break-words text-sm text-gray-700">{message.content}</p>
+      {(message.relatedSessionId || message.relatedArtifactUri) && (
+        <div className="mt-2 flex items-center gap-2 text-xs text-gray-400">
+          {message.relatedSessionId && (
+            <Link
+              href={`/sessions/${message.relatedSessionId}`}
+              className="underline hover:text-gray-600"
+            >
+              Session
+            </Link>
+          )}
+          {message.relatedArtifactUri && (
+            <span className="font-mono">{message.relatedArtifactUri}</span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ThreadCard({ thread }: { thread: ThreadGroup }) {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white">
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="flex w-full items-start justify-between p-4 text-left hover:bg-gray-50/50 transition-colors"
+      >
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <Badge variant="outline" className="font-mono text-xs">
+              {thread.threadKey}
+            </Badge>
+            <span className="text-xs text-gray-500">{thread.messageCount} messages</span>
+            {thread.unreadCount > 0 && (
+              <Badge className="bg-blue-100 text-blue-700 text-[10px]">
+                {thread.unreadCount} unread
+              </Badge>
+            )}
+          </div>
+          <div className="mt-1 flex items-center gap-2 text-xs text-gray-500">
+            <span>Participants:</span>
+            {thread.participants.map((p) => (
+              <Badge key={p} variant="outline" className="text-[10px] font-mono">
+                {p}
+              </Badge>
+            ))}
+          </div>
+          <p className="mt-1.5 text-sm text-gray-600 line-clamp-2">
+            {thread.latestMessage.subject || thread.latestMessage.content}
+          </p>
+        </div>
+        <div className="ml-4 flex shrink-0 items-center gap-2">
+          <span className="text-xs text-gray-400">{formatRelativeTime(thread.lastMessageAt)}</span>
+          {expanded ? (
+            <ChevronDown className="h-4 w-4 text-gray-400" />
+          ) : (
+            <ChevronRight className="h-4 w-4 text-gray-400" />
+          )}
+        </div>
+      </button>
+      {expanded && (
+        <div className="border-t border-gray-200 bg-gray-50/30 p-4 space-y-3">
+          {thread.messages.map((msg) => (
+            <MessageItem key={msg.id} message={msg} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function InboxPage() {
+  const params = useParams();
+  const agentId = params.agentId as string;
+
+  const [statusFilter, setStatusFilter] = useState('all');
+  const [typeFilter, setTypeFilter] = useState('');
+  const [offset, setOffset] = useState(0);
+  const limit = 20;
+
+  const queryPath = useMemo(() => {
+    const params = new URLSearchParams();
+    params.set('limit', String(limit));
+    params.set('offset', String(offset));
+    if (statusFilter !== 'all') params.set('status', statusFilter);
+    if (typeFilter) params.set('messageType', typeFilter);
+    return `/api/admin/individuals/${agentId}/inbox?${params.toString()}`;
+  }, [agentId, statusFilter, typeFilter, offset]);
+
+  const { data, isLoading, error } = useApiQuery<InboxResponse>(
+    ['individuals', agentId, 'inbox', statusFilter, typeFilter, offset],
+    queryPath,
+    { refetchInterval: 15000 }
+  );
+
+  const { data: individualsData } = useApiQuery<IndividualsResponse>(
+    ['individuals'],
+    '/api/admin/individuals'
+  );
+
+  const agentName =
+    individualsData?.individuals.find((i) => i.agentId === agentId)?.name || agentId;
+
+  const stats = data?.stats;
+  const threads = data?.threads || [];
+  const flatMessages = data?.flatMessages || [];
+  const pagination = data?.pagination;
+
+  return (
+    <div>
+      <div className="mb-4">
+        <Button variant="ghost" size="sm" asChild>
+          <Link href="/individuals">
+            <ArrowLeft className="mr-1 h-4 w-4" />
+            Back to Individuals
+          </Link>
+        </Button>
+      </div>
+
+      <div className="mb-6">
+        <h1 className="text-3xl font-bold text-gray-900">
+          <Inbox className="mr-2 inline h-8 w-8" />
+          {agentName}&apos;s Inbox
+        </h1>
+        {stats && (
+          <div className="mt-2 flex items-center gap-3">
+            <Badge variant="outline">{stats.totalMessages} total</Badge>
+            {stats.unreadCount > 0 && (
+              <Badge className="bg-blue-100 text-blue-700">{stats.unreadCount} unread</Badge>
+            )}
+            <Badge variant="outline">{stats.threadCount} threads</Badge>
+            <Badge variant="outline">{stats.flatCount} direct</Badge>
+          </div>
+        )}
+      </div>
+
+      {error && (
+        <div className="mb-4 rounded-md bg-red-50 p-4 text-red-700">
+          <AlertCircle className="mr-1 inline h-4 w-4" />
+          {error.message}
+        </div>
+      )}
+
+      {/* Filters */}
+      <div className="mb-4 flex items-center gap-3">
+        <select
+          value={statusFilter}
+          onChange={(e) => {
+            setStatusFilter(e.target.value);
+            setOffset(0);
+          }}
+          className="rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm text-gray-700"
+        >
+          <option value="all">All statuses</option>
+          <option value="unread">Unread</option>
+          <option value="read">Read</option>
+          <option value="acknowledged">Acknowledged</option>
+          <option value="completed">Completed</option>
+        </select>
+        <select
+          value={typeFilter}
+          onChange={(e) => {
+            setTypeFilter(e.target.value);
+            setOffset(0);
+          }}
+          className="rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm text-gray-700"
+        >
+          <option value="">All types</option>
+          <option value="message">Message</option>
+          <option value="task_request">Task Request</option>
+          <option value="session_resume">Session Resume</option>
+          <option value="notification">Notification</option>
+        </select>
+        {(statusFilter !== 'all' || typeFilter) && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => {
+              setStatusFilter('all');
+              setTypeFilter('');
+              setOffset(0);
+            }}
+          >
+            Clear filters
+          </Button>
+        )}
+      </div>
+
+      {isLoading ? (
+        <p className="text-sm text-gray-500">Loading inbox...</p>
+      ) : threads.length === 0 && flatMessages.length === 0 ? (
+        <Card>
+          <CardContent className="py-12 text-center">
+            <Mail className="mx-auto mb-3 h-12 w-12 text-gray-300" />
+            <p className="text-gray-500">No messages found</p>
+            <p className="mt-1 text-sm text-gray-400">
+              Messages will appear here when other SBs send to {agentName}.
+            </p>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="space-y-6">
+          {/* Threaded conversations */}
+          {threads.length > 0 && (
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <MessageSquare className="h-5 w-5" />
+                  Threads
+                </CardTitle>
+                <CardDescription>
+                  Messages grouped by thread key for conversation continuity.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                {threads.map((thread) => (
+                  <ThreadCard key={thread.threadKey} thread={thread} />
+                ))}
+              </CardContent>
+            </Card>
+          )}
+
+          {/* Direct (unthreaded) messages */}
+          {flatMessages.length > 0 && (
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <Mail className="h-5 w-5" />
+                  Direct Messages
+                </CardTitle>
+                <CardDescription>
+                  Messages without a thread key, routed to {agentName}&apos;s main process.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                {flatMessages.map((msg) => (
+                  <MessageItem key={msg.id} message={msg} />
+                ))}
+              </CardContent>
+            </Card>
+          )}
+        </div>
+      )}
+
+      {/* Pagination */}
+      {pagination && pagination.totalThreads > limit && (
+        <div className="mt-4 flex items-center justify-between border-t border-gray-200 pt-4">
+          <p className="text-xs text-gray-500">
+            Showing {pagination.offset + 1} -{' '}
+            {Math.min(pagination.offset + pagination.limit, pagination.totalThreads)} of{' '}
+            {pagination.totalThreads}
+          </p>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={pagination.offset === 0}
+              onClick={() => setOffset(Math.max(0, pagination.offset - pagination.limit))}
+            >
+              <ChevronLeft className="mr-1 h-4 w-4" />
+              Prev
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={!pagination.hasMore}
+              onClick={() => setOffset(pagination.offset + pagination.limit)}
+            >
+              Next
+              <ChevronRight className="ml-1 h-4 w-4" />
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/app/(dashboard)/individuals/[agentId]/inbox/page.tsx
+++ b/packages/web/src/app/(dashboard)/individuals/[agentId]/inbox/page.tsx
@@ -456,7 +456,7 @@ export default function InboxPage() {
             setStatusFilter(e.target.value);
             setOffset(0);
           }}
-          className="rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm text-gray-700"
+          className="appearance-none rounded-md border border-gray-300 bg-white py-1.5 pl-3 pr-8 text-sm text-gray-700 bg-[url('data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20fill%3D%22none%22%20stroke%3D%22%236b7280%22%20stroke-width%3D%222%22%3E%3Cpath%20d%3D%22m4%206%204%204%204-4%22%2F%3E%3C%2Fsvg%3E')] bg-[length:16px] bg-[right_8px_center] bg-no-repeat"
         >
           <option value="all">All statuses</option>
           <option value="unread">Unread</option>
@@ -470,7 +470,7 @@ export default function InboxPage() {
             setTypeFilter(e.target.value);
             setOffset(0);
           }}
-          className="rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm text-gray-700"
+          className="appearance-none rounded-md border border-gray-300 bg-white py-1.5 pl-3 pr-8 text-sm text-gray-700 bg-[url('data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20fill%3D%22none%22%20stroke%3D%22%236b7280%22%20stroke-width%3D%222%22%3E%3Cpath%20d%3D%22m4%206%204%204%204-4%22%2F%3E%3C%2Fsvg%3E')] bg-[length:16px] bg-[right_8px_center] bg-no-repeat"
         >
           <option value="">All types</option>
           <option value="message">Message</option>

--- a/packages/web/src/app/(dashboard)/individuals/[agentId]/inbox/page.tsx
+++ b/packages/web/src/app/(dashboard)/individuals/[agentId]/inbox/page.tsx
@@ -586,14 +586,23 @@ export default function InboxPage() {
               </CardHeader>
               <CardContent className="space-y-1">
                 {flatMessages.map((msg) => (
-                  <button
+                  <div
                     key={msg.id}
+                    role="button"
+                    tabIndex={0}
                     onClick={() => {
                       setActiveThread(null);
                       setActiveMessage(activeMessage === msg.id ? null : msg.id);
                     }}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        setActiveThread(null);
+                        setActiveMessage(activeMessage === msg.id ? null : msg.id);
+                      }
+                    }}
                     className={clsx(
-                      'w-full text-left rounded-md transition-colors',
+                      'w-full text-left rounded-md transition-colors cursor-pointer',
                       activeMessage === msg.id && 'ring-1 ring-blue-200 bg-blue-50/50'
                     )}
                   >
@@ -602,7 +611,7 @@ export default function InboxPage() {
                       inboxAgentId={agentId}
                       onShowRouting={setRoutingMessage}
                     />
-                  </button>
+                  </div>
                 ))}
               </CardContent>
             </Card>

--- a/packages/web/src/app/(dashboard)/individuals/[agentId]/inbox/page.tsx
+++ b/packages/web/src/app/(dashboard)/individuals/[agentId]/inbox/page.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import {
   ArrowLeft,
+  Bot,
   ChevronDown,
   ChevronRight,
   ChevronLeft,
@@ -15,6 +16,7 @@ import {
   Mail,
   MessageSquare,
   AlertCircle,
+  User,
 } from 'lucide-react';
 import { useApiQuery } from '@/lib/api';
 import clsx from 'clsx';
@@ -105,57 +107,120 @@ const typeColors: Record<string, string> = {
   notification: 'bg-amber-100 text-amber-700',
 };
 
-function MessageItem({ message }: { message: InboxMessage }) {
+// Stable color per agent name — deterministic hash to pick from a palette
+const agentColors = [
+  'bg-blue-600',
+  'bg-green-600',
+  'bg-purple-600',
+  'bg-orange-600',
+  'bg-pink-600',
+  'bg-teal-600',
+  'bg-indigo-600',
+  'bg-rose-600',
+];
+
+function agentColor(name: string): string {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) hash = (hash * 31 + name.charCodeAt(i)) | 0;
+  return agentColors[Math.abs(hash) % agentColors.length];
+}
+
+function formatTimestamp(date: string): string {
+  const d = new Date(date);
+  const today = new Date();
+  const isToday = d.toDateString() === today.toDateString();
+  const time = d.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+  return isToday
+    ? `Today at ${time}`
+    : `${d.toLocaleDateString([], { month: 'short', day: 'numeric' })} at ${time}`;
+}
+
+function MessageItem({ message, compact }: { message: InboxMessage; compact?: boolean }) {
+  const sender = message.senderAgentId || 'unknown';
+  const isAgent = !!message.senderAgentId;
+
   return (
-    <div className="rounded-md border border-gray-200 bg-white p-3">
-      <div className="mb-2 flex items-center justify-between text-xs text-gray-500">
-        <div className="flex items-center gap-2">
-          {message.senderAgentId && (
-            <Badge variant="outline" className="font-mono text-xs">
-              {message.senderAgentId}
-            </Badge>
-          )}
-          <Badge
-            className={clsx('text-[10px]', typeColors[message.messageType] || typeColors.message)}
-          >
-            {message.messageType}
-          </Badge>
-          <Badge
-            className={clsx('text-[10px]', statusColors[message.status] || statusColors.unread)}
-          >
-            {message.status}
-          </Badge>
-          {message.priority !== 'normal' && (
-            <Badge
-              className={clsx(
-                'text-[10px]',
-                priorityColors[message.priority] || priorityColors.normal
-              )}
-            >
-              {message.priority}
-            </Badge>
-          )}
-        </div>
-        <span>{formatRelativeTime(message.createdAt)}</span>
-      </div>
-      {message.subject && (
-        <p className="mb-1 text-sm font-medium text-gray-800">{message.subject}</p>
+    <div
+      className={clsx(
+        'group flex gap-3 hover:bg-gray-50/50 rounded-md px-2',
+        compact ? 'py-0.5' : 'py-2'
       )}
-      <p className="whitespace-pre-wrap break-words text-sm text-gray-700">{message.content}</p>
-      {(message.relatedSessionId || message.relatedArtifactUri) && (
-        <div className="mt-2 flex items-center gap-2 text-xs text-gray-400">
-          {message.relatedSessionId && (
-            <Link
-              href={`/sessions/${message.relatedSessionId}`}
-              className="underline hover:text-gray-600"
-            >
-              Session
-            </Link>
+    >
+      {/* Avatar */}
+      {!compact ? (
+        <div
+          className={clsx(
+            'flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-white text-xs font-semibold',
+            isAgent ? agentColor(sender) : 'bg-gray-400'
           )}
-          {message.relatedArtifactUri && (
-            <span className="font-mono">{message.relatedArtifactUri}</span>
-          )}
+        >
+          {isAgent ? sender.slice(0, 2).toUpperCase() : <User className="h-4 w-4" />}
         </div>
+      ) : (
+        <div className="w-9 shrink-0" />
+      )}
+
+      {/* Content */}
+      <div className="min-w-0 flex-1">
+        {!compact && (
+          <div className="flex items-baseline gap-2 flex-wrap">
+            <span className="text-sm font-semibold text-gray-900">{sender}</span>
+            <span className="text-xs text-gray-400">{formatTimestamp(message.createdAt)}</span>
+            {message.messageType !== 'message' && (
+              <Badge
+                className={clsx(
+                  'text-[10px] px-1.5 py-0',
+                  typeColors[message.messageType] || typeColors.message
+                )}
+              >
+                {message.messageType.replace('_', ' ')}
+              </Badge>
+            )}
+            {message.priority !== 'normal' && (
+              <Badge
+                className={clsx(
+                  'text-[10px] px-1.5 py-0',
+                  priorityColors[message.priority] || priorityColors.normal
+                )}
+              >
+                {message.priority}
+              </Badge>
+            )}
+            {message.relatedSessionId && (
+              <Link
+                href={`/sessions/${message.relatedSessionId}`}
+                className="text-[10px] text-blue-500 hover:text-blue-700 hover:underline"
+              >
+                session
+              </Link>
+            )}
+            {message.status === 'unread' && <span className="h-2 w-2 rounded-full bg-blue-500" />}
+          </div>
+        )}
+        {message.subject && <p className="text-sm font-medium text-gray-800">{message.subject}</p>}
+        <p
+          className={clsx(
+            'whitespace-pre-wrap break-words text-sm text-gray-700',
+            compact && 'ml-0'
+          )}
+        >
+          {message.content}
+        </p>
+        {message.relatedArtifactUri && (
+          <div className="mt-1 text-xs text-gray-400">
+            <span className="font-mono">{message.relatedArtifactUri}</span>
+          </div>
+        )}
+      </div>
+
+      {/* Hover timestamp for compact messages */}
+      {compact && (
+        <span className="shrink-0 text-[10px] text-gray-300 opacity-0 group-hover:opacity-100 transition-opacity self-center">
+          {new Date(message.createdAt).toLocaleTimeString([], {
+            hour: 'numeric',
+            minute: '2-digit',
+          })}
+        </span>
       )}
     </div>
   );
@@ -165,49 +230,61 @@ function ThreadCard({ thread }: { thread: ThreadGroup }) {
   const [expanded, setExpanded] = useState(false);
 
   return (
-    <div className="rounded-lg border border-gray-200 bg-white">
+    <div className="rounded-lg border border-gray-200 bg-white overflow-hidden">
       <button
         onClick={() => setExpanded(!expanded)}
-        className="flex w-full items-start justify-between p-4 text-left hover:bg-gray-50/50 transition-colors"
+        className="flex w-full items-center justify-between px-4 py-3 text-left hover:bg-gray-50/50 transition-colors"
       >
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-2 flex-wrap">
-            <Badge variant="outline" className="font-mono text-xs">
-              {thread.threadKey}
-            </Badge>
-            <span className="text-xs text-gray-500">{thread.messageCount} messages</span>
-            {thread.unreadCount > 0 && (
-              <Badge className="bg-blue-100 text-blue-700 text-[10px]">
-                {thread.unreadCount} unread
-              </Badge>
-            )}
-          </div>
-          <div className="mt-1 flex items-center gap-2 text-xs text-gray-500">
-            <span>Participants:</span>
-            {thread.participants.map((p) => (
-              <Badge key={p} variant="outline" className="text-[10px] font-mono">
-                {p}
-              </Badge>
+        <div className="flex items-center gap-3 min-w-0">
+          {/* Stacked participant avatars */}
+          <div className="flex -space-x-2">
+            {thread.participants.slice(0, 3).map((p) => (
+              <div
+                key={p}
+                className={clsx(
+                  'flex h-7 w-7 items-center justify-center rounded-full text-white text-[10px] font-semibold ring-2 ring-white',
+                  agentColor(p)
+                )}
+                title={p}
+              >
+                {p.slice(0, 2).toUpperCase()}
+              </div>
             ))}
           </div>
-          <p className="mt-1.5 text-sm text-gray-600 line-clamp-2">
-            {thread.latestMessage.subject || thread.latestMessage.content}
-          </p>
+          <div className="min-w-0">
+            <div className="flex items-center gap-2">
+              <Badge variant="outline" className="font-mono text-xs shrink-0">
+                {thread.threadKey}
+              </Badge>
+              <span className="text-xs text-gray-500">{thread.messageCount} messages</span>
+              {thread.unreadCount > 0 && (
+                <span className="flex h-5 min-w-5 items-center justify-center rounded-full bg-blue-500 px-1.5 text-[10px] font-semibold text-white">
+                  {thread.unreadCount}
+                </span>
+              )}
+            </div>
+            <p className="mt-0.5 text-sm text-gray-600 line-clamp-1 truncate">
+              {thread.latestMessage.subject || thread.latestMessage.content}
+            </p>
+          </div>
         </div>
         <div className="ml-4 flex shrink-0 items-center gap-2">
           <span className="text-xs text-gray-400">{formatRelativeTime(thread.lastMessageAt)}</span>
-          {expanded ? (
-            <ChevronDown className="h-4 w-4 text-gray-400" />
-          ) : (
-            <ChevronRight className="h-4 w-4 text-gray-400" />
-          )}
+          <ChevronDown
+            className={clsx(
+              'h-4 w-4 text-gray-400 transition-transform',
+              !expanded && '-rotate-90'
+            )}
+          />
         </div>
       </button>
       {expanded && (
-        <div className="border-t border-gray-200 bg-gray-50/30 p-4 space-y-3">
-          {thread.messages.map((msg) => (
-            <MessageItem key={msg.id} message={msg} />
-          ))}
+        <div className="border-t border-gray-100 bg-white px-2 py-2">
+          {thread.messages.map((msg, i) => {
+            const prevMsg = i > 0 ? thread.messages[i - 1] : null;
+            const sameSender = prevMsg?.senderAgentId === msg.senderAgentId;
+            return <MessageItem key={msg.id} message={msg} compact={sameSender} />;
+          })}
         </div>
       )}
     </div>

--- a/packages/web/src/app/(dashboard)/individuals/[agentId]/inbox/page.tsx
+++ b/packages/web/src/app/(dashboard)/individuals/[agentId]/inbox/page.tsx
@@ -309,7 +309,7 @@ function ThreadPanel({
   return (
     <div
       ref={panelRef}
-      className="fixed inset-y-0 right-0 z-40 flex w-full max-w-lg flex-col border-l border-gray-200 bg-white shadow-xl animate-in slide-in-from-right duration-200"
+      className="fixed inset-y-0 right-0 z-40 flex w-full max-w-lg flex-col border-l border-gray-200 bg-white shadow-xl animate-in slide-in-from-right duration-500"
     >
       {/* Header */}
       <div className="flex items-center justify-between border-b border-gray-200 px-4 py-3">
@@ -456,7 +456,7 @@ export default function InboxPage() {
             setStatusFilter(e.target.value);
             setOffset(0);
           }}
-          className="appearance-none rounded-md border border-gray-300 bg-white py-1.5 pl-3 pr-8 text-sm text-gray-700 bg-[url('data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20fill%3D%22none%22%20stroke%3D%22%236b7280%22%20stroke-width%3D%222%22%3E%3Cpath%20d%3D%22m4%206%204%204%204-4%22%2F%3E%3C%2Fsvg%3E')] bg-[length:16px] bg-[right_8px_center] bg-no-repeat"
+          className="cursor-pointer appearance-none rounded-md border border-gray-300 bg-white py-1.5 pl-3 pr-8 text-sm text-gray-700 hover:border-gray-400 bg-[url('data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20fill%3D%22none%22%20stroke%3D%22%236b7280%22%20stroke-width%3D%222%22%3E%3Cpath%20d%3D%22m4%206%204%204%204-4%22%2F%3E%3C%2Fsvg%3E')] bg-[length:16px] bg-[right_8px_center] bg-no-repeat"
         >
           <option value="all">All statuses</option>
           <option value="unread">Unread</option>
@@ -470,7 +470,7 @@ export default function InboxPage() {
             setTypeFilter(e.target.value);
             setOffset(0);
           }}
-          className="appearance-none rounded-md border border-gray-300 bg-white py-1.5 pl-3 pr-8 text-sm text-gray-700 bg-[url('data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20fill%3D%22none%22%20stroke%3D%22%236b7280%22%20stroke-width%3D%222%22%3E%3Cpath%20d%3D%22m4%206%204%204%204-4%22%2F%3E%3C%2Fsvg%3E')] bg-[length:16px] bg-[right_8px_center] bg-no-repeat"
+          className="cursor-pointer appearance-none rounded-md border border-gray-300 bg-white py-1.5 pl-3 pr-8 text-sm text-gray-700 hover:border-gray-400 bg-[url('data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20fill%3D%22none%22%20stroke%3D%22%236b7280%22%20stroke-width%3D%222%22%3E%3Cpath%20d%3D%22m4%206%204%204%204-4%22%2F%3E%3C%2Fsvg%3E')] bg-[length:16px] bg-[right_8px_center] bg-no-repeat"
         >
           <option value="">All types</option>
           <option value="message">Message</option>
@@ -599,7 +599,12 @@ export default function InboxPage() {
       )}
 
       {/* Backdrop */}
-      {panelOpen && <div className="fixed inset-0 z-30 bg-black/20" onClick={closePanel} />}
+      {panelOpen && (
+        <div
+          className="fixed inset-0 z-30 bg-black/20 animate-in fade-in duration-500"
+          onClick={closePanel}
+        />
+      )}
 
       {/* Slide-out panel */}
       {selectedThread && (

--- a/packages/web/src/app/(dashboard)/individuals/[agentId]/inbox/page.tsx
+++ b/packages/web/src/app/(dashboard)/individuals/[agentId]/inbox/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useParams } from 'next/navigation';
 import Link from 'next/link';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -8,8 +8,6 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import {
   ArrowLeft,
-  Bot,
-  ChevronDown,
   ChevronRight,
   ChevronLeft,
   Inbox,
@@ -17,6 +15,7 @@ import {
   MessageSquare,
   AlertCircle,
   User,
+  X,
 } from 'lucide-react';
 import { useApiQuery } from '@/lib/api';
 import clsx from 'clsx';
@@ -72,6 +71,10 @@ interface IndividualsResponse {
   individuals: { agentId: string; name: string }[];
 }
 
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
 function formatRelativeTime(date: string): string {
   const now = new Date();
   const target = new Date(date);
@@ -86,18 +89,21 @@ function formatRelativeTime(date: string): string {
   return `${diffDays}d ago`;
 }
 
-const priorityColors: Record<string, string> = {
-  urgent: 'bg-red-100 text-red-700 border-red-200',
-  high: 'bg-orange-100 text-orange-700 border-orange-200',
-  normal: 'bg-gray-100 text-gray-600 border-gray-200',
-  low: 'bg-gray-50 text-gray-400 border-gray-100',
-};
+function formatTimestamp(date: string): string {
+  const d = new Date(date);
+  const today = new Date();
+  const isToday = d.toDateString() === today.toDateString();
+  const time = d.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+  return isToday
+    ? `Today at ${time}`
+    : `${d.toLocaleDateString([], { month: 'short', day: 'numeric' })} at ${time}`;
+}
 
-const statusColors: Record<string, string> = {
-  unread: 'bg-blue-100 text-blue-700',
-  read: 'bg-gray-100 text-gray-600',
-  acknowledged: 'bg-green-100 text-green-700',
-  completed: 'bg-gray-100 text-gray-400',
+const priorityColors: Record<string, string> = {
+  urgent: 'bg-red-100 text-red-700',
+  high: 'bg-orange-100 text-orange-700',
+  normal: 'bg-gray-100 text-gray-600',
+  low: 'bg-gray-50 text-gray-400',
 };
 
 const typeColors: Record<string, string> = {
@@ -107,8 +113,7 @@ const typeColors: Record<string, string> = {
   notification: 'bg-amber-100 text-amber-700',
 };
 
-// Stable color per agent name — deterministic hash to pick from a palette
-const agentColors = [
+const agentColorPalette = [
   'bg-blue-600',
   'bg-green-600',
   'bg-purple-600',
@@ -122,18 +127,12 @@ const agentColors = [
 function agentColor(name: string): string {
   let hash = 0;
   for (let i = 0; i < name.length; i++) hash = (hash * 31 + name.charCodeAt(i)) | 0;
-  return agentColors[Math.abs(hash) % agentColors.length];
+  return agentColorPalette[Math.abs(hash) % agentColorPalette.length];
 }
 
-function formatTimestamp(date: string): string {
-  const d = new Date(date);
-  const today = new Date();
-  const isToday = d.toDateString() === today.toDateString();
-  const time = d.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
-  return isToday
-    ? `Today at ${time}`
-    : `${d.toLocaleDateString([], { month: 'short', day: 'numeric' })} at ${time}`;
-}
+// ---------------------------------------------------------------------------
+// MessageItem — Discord/Slack-style chat bubble
+// ---------------------------------------------------------------------------
 
 function MessageItem({ message, compact }: { message: InboxMessage; compact?: boolean }) {
   const sender = message.senderAgentId || 'unknown';
@@ -142,7 +141,7 @@ function MessageItem({ message, compact }: { message: InboxMessage; compact?: bo
   return (
     <div
       className={clsx(
-        'group flex gap-3 hover:bg-gray-50/50 rounded-md px-2',
+        'group flex gap-3 rounded-md px-3 hover:bg-gray-50/50',
         compact ? 'py-0.5' : 'py-2'
       )}
     >
@@ -198,14 +197,7 @@ function MessageItem({ message, compact }: { message: InboxMessage; compact?: bo
           </div>
         )}
         {message.subject && <p className="text-sm font-medium text-gray-800">{message.subject}</p>}
-        <p
-          className={clsx(
-            'whitespace-pre-wrap break-words text-sm text-gray-700',
-            compact && 'ml-0'
-          )}
-        >
-          {message.content}
-        </p>
+        <p className="whitespace-pre-wrap break-words text-sm text-gray-700">{message.content}</p>
         {message.relatedArtifactUri && (
           <div className="mt-1 text-xs text-gray-400">
             <span className="font-mono">{message.relatedArtifactUri}</span>
@@ -226,70 +218,137 @@ function MessageItem({ message, compact }: { message: InboxMessage; compact?: bo
   );
 }
 
-function ThreadCard({ thread }: { thread: ThreadGroup }) {
-  const [expanded, setExpanded] = useState(false);
+// ---------------------------------------------------------------------------
+// ThreadRow — clickable row in the list (no expand, opens slide-out)
+// ---------------------------------------------------------------------------
+
+function ThreadRow({
+  thread,
+  isActive,
+  onClick,
+}: {
+  thread: ThreadGroup;
+  isActive: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={clsx(
+        'flex w-full items-center gap-3 rounded-lg border px-4 py-3 text-left transition-colors',
+        isActive
+          ? 'border-blue-300 bg-blue-50/50 ring-1 ring-blue-200'
+          : 'border-gray-200 bg-white hover:bg-gray-50/50'
+      )}
+    >
+      {/* Stacked participant avatars */}
+      <div className="flex -space-x-2 shrink-0">
+        {thread.participants.slice(0, 3).map((p) => (
+          <div
+            key={p}
+            className={clsx(
+              'flex h-7 w-7 items-center justify-center rounded-full text-white text-[10px] font-semibold ring-2 ring-white',
+              agentColor(p)
+            )}
+            title={p}
+          >
+            {p.slice(0, 2).toUpperCase()}
+          </div>
+        ))}
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <Badge variant="outline" className="font-mono text-xs shrink-0">
+            {thread.threadKey}
+          </Badge>
+          <span className="text-xs text-gray-500">{thread.messageCount} msgs</span>
+          {thread.unreadCount > 0 && (
+            <span className="flex h-5 min-w-5 items-center justify-center rounded-full bg-blue-500 px-1.5 text-[10px] font-semibold text-white">
+              {thread.unreadCount}
+            </span>
+          )}
+        </div>
+        <p className="mt-0.5 text-sm text-gray-600 truncate">
+          {thread.latestMessage.subject || thread.latestMessage.content}
+        </p>
+      </div>
+      <div className="shrink-0 text-right">
+        <span className="text-xs text-gray-400">{formatRelativeTime(thread.lastMessageAt)}</span>
+        <ChevronRight className="mt-0.5 ml-auto h-4 w-4 text-gray-300" />
+      </div>
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ThreadPanel — slide-out from right showing full conversation
+// ---------------------------------------------------------------------------
+
+function ThreadPanel({
+  thread,
+  messages,
+  agentId,
+  onClose,
+}: {
+  thread?: ThreadGroup;
+  messages?: InboxMessage[];
+  agentId: string;
+  onClose: () => void;
+}) {
+  const panelRef = useRef<HTMLDivElement>(null);
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  // Scroll to bottom when thread changes
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'instant' });
+  }, [thread?.threadKey, messages?.[0]?.id]);
+
+  const displayMessages = thread?.messages || messages || [];
+  const title = thread?.threadKey || 'Message';
 
   return (
-    <div className="rounded-lg border border-gray-200 bg-white overflow-hidden">
-      <button
-        onClick={() => setExpanded(!expanded)}
-        className="flex w-full items-center justify-between px-4 py-3 text-left hover:bg-gray-50/50 transition-colors"
-      >
-        <div className="flex items-center gap-3 min-w-0">
-          {/* Stacked participant avatars */}
-          <div className="flex -space-x-2">
-            {thread.participants.slice(0, 3).map((p) => (
-              <div
-                key={p}
-                className={clsx(
-                  'flex h-7 w-7 items-center justify-center rounded-full text-white text-[10px] font-semibold ring-2 ring-white',
-                  agentColor(p)
-                )}
-                title={p}
-              >
-                {p.slice(0, 2).toUpperCase()}
-              </div>
-            ))}
+    <div
+      ref={panelRef}
+      className="fixed inset-y-0 right-0 z-40 flex w-full max-w-lg flex-col border-l border-gray-200 bg-white shadow-xl animate-in slide-in-from-right duration-200"
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between border-b border-gray-200 px-4 py-3">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <MessageSquare className="h-4 w-4 text-gray-500" />
+            <h2 className="text-sm font-semibold text-gray-900 truncate">{title}</h2>
           </div>
-          <div className="min-w-0">
-            <div className="flex items-center gap-2">
-              <Badge variant="outline" className="font-mono text-xs shrink-0">
-                {thread.threadKey}
-              </Badge>
-              <span className="text-xs text-gray-500">{thread.messageCount} messages</span>
-              {thread.unreadCount > 0 && (
-                <span className="flex h-5 min-w-5 items-center justify-center rounded-full bg-blue-500 px-1.5 text-[10px] font-semibold text-white">
-                  {thread.unreadCount}
-                </span>
-              )}
+          {thread && (
+            <div className="mt-0.5 flex items-center gap-2 text-xs text-gray-500">
+              <span>{thread.messageCount} messages</span>
+              <span>&middot;</span>
+              <span>
+                {thread.participants.join(', ')} &rarr; {agentId}
+              </span>
             </div>
-            <p className="mt-0.5 text-sm text-gray-600 line-clamp-1 truncate">
-              {thread.latestMessage.subject || thread.latestMessage.content}
-            </p>
-          </div>
+          )}
         </div>
-        <div className="ml-4 flex shrink-0 items-center gap-2">
-          <span className="text-xs text-gray-400">{formatRelativeTime(thread.lastMessageAt)}</span>
-          <ChevronDown
-            className={clsx(
-              'h-4 w-4 text-gray-400 transition-transform',
-              !expanded && '-rotate-90'
-            )}
-          />
-        </div>
-      </button>
-      {expanded && (
-        <div className="border-t border-gray-100 bg-white px-2 py-2">
-          {thread.messages.map((msg, i) => {
-            const prevMsg = i > 0 ? thread.messages[i - 1] : null;
-            const sameSender = prevMsg?.senderAgentId === msg.senderAgentId;
-            return <MessageItem key={msg.id} message={msg} compact={sameSender} />;
-          })}
-        </div>
-      )}
+        <Button variant="ghost" size="sm" onClick={onClose} className="shrink-0">
+          <X className="h-4 w-4" />
+        </Button>
+      </div>
+
+      {/* Messages */}
+      <div className="flex-1 overflow-y-auto px-1 py-3">
+        {displayMessages.map((msg, i) => {
+          const prevMsg = i > 0 ? displayMessages[i - 1] : null;
+          const sameSender = prevMsg?.senderAgentId === msg.senderAgentId;
+          return <MessageItem key={msg.id} message={msg} compact={sameSender} />;
+        })}
+        <div ref={bottomRef} />
+      </div>
     </div>
   );
 }
+
+// ---------------------------------------------------------------------------
+// InboxPage
+// ---------------------------------------------------------------------------
 
 export default function InboxPage() {
   const params = useParams();
@@ -300,13 +359,31 @@ export default function InboxPage() {
   const [offset, setOffset] = useState(0);
   const limit = 20;
 
+  // Panel state: either a thread key or a flat message id
+  const [activeThread, setActiveThread] = useState<string | null>(null);
+  const [activeMessage, setActiveMessage] = useState<string | null>(null);
+
+  const closePanel = useCallback(() => {
+    setActiveThread(null);
+    setActiveMessage(null);
+  }, []);
+
+  // Close panel on Escape
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') closePanel();
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [closePanel]);
+
   const queryPath = useMemo(() => {
-    const params = new URLSearchParams();
-    params.set('limit', String(limit));
-    params.set('offset', String(offset));
-    if (statusFilter !== 'all') params.set('status', statusFilter);
-    if (typeFilter) params.set('messageType', typeFilter);
-    return `/api/admin/individuals/${agentId}/inbox?${params.toString()}`;
+    const qp = new URLSearchParams();
+    qp.set('limit', String(limit));
+    qp.set('offset', String(offset));
+    if (statusFilter !== 'all') qp.set('status', statusFilter);
+    if (typeFilter) qp.set('messageType', typeFilter);
+    return `/api/admin/individuals/${agentId}/inbox?${qp.toString()}`;
   }, [agentId, statusFilter, typeFilter, offset]);
 
   const { data, isLoading, error } = useApiQuery<InboxResponse>(
@@ -327,6 +404,14 @@ export default function InboxPage() {
   const threads = data?.threads || [];
   const flatMessages = data?.flatMessages || [];
   const pagination = data?.pagination;
+
+  const selectedThread = activeThread
+    ? threads.find((t) => t.threadKey === activeThread)
+    : undefined;
+  const selectedMessage = activeMessage
+    ? flatMessages.find((m) => m.id === activeMessage)
+    : undefined;
+  const panelOpen = !!selectedThread || !!selectedMessage;
 
   return (
     <div>
@@ -430,13 +515,19 @@ export default function InboxPage() {
                   <MessageSquare className="h-5 w-5" />
                   Threads
                 </CardTitle>
-                <CardDescription>
-                  Messages grouped by thread key for conversation continuity.
-                </CardDescription>
+                <CardDescription>Click a thread to view the full conversation.</CardDescription>
               </CardHeader>
-              <CardContent className="space-y-3">
+              <CardContent className="space-y-2">
                 {threads.map((thread) => (
-                  <ThreadCard key={thread.threadKey} thread={thread} />
+                  <ThreadRow
+                    key={thread.threadKey}
+                    thread={thread}
+                    isActive={activeThread === thread.threadKey}
+                    onClick={() => {
+                      setActiveMessage(null);
+                      setActiveThread(activeThread === thread.threadKey ? null : thread.threadKey);
+                    }}
+                  />
                 ))}
               </CardContent>
             </Card>
@@ -454,9 +545,21 @@ export default function InboxPage() {
                   Messages without a thread key, routed to {agentName}&apos;s main process.
                 </CardDescription>
               </CardHeader>
-              <CardContent className="space-y-3">
+              <CardContent className="space-y-1">
                 {flatMessages.map((msg) => (
-                  <MessageItem key={msg.id} message={msg} />
+                  <button
+                    key={msg.id}
+                    onClick={() => {
+                      setActiveThread(null);
+                      setActiveMessage(activeMessage === msg.id ? null : msg.id);
+                    }}
+                    className={clsx(
+                      'w-full text-left rounded-md transition-colors',
+                      activeMessage === msg.id && 'ring-1 ring-blue-200 bg-blue-50/50'
+                    )}
+                  >
+                    <MessageItem message={msg} />
+                  </button>
                 ))}
               </CardContent>
             </Card>
@@ -493,6 +596,17 @@ export default function InboxPage() {
             </Button>
           </div>
         </div>
+      )}
+
+      {/* Backdrop */}
+      {panelOpen && <div className="fixed inset-0 z-30 bg-black/20" onClick={closePanel} />}
+
+      {/* Slide-out panel */}
+      {selectedThread && (
+        <ThreadPanel thread={selectedThread} agentId={agentId} onClose={closePanel} />
+      )}
+      {selectedMessage && (
+        <ThreadPanel messages={[selectedMessage]} agentId={agentId} onClose={closePanel} />
       )}
     </div>
   );

--- a/packages/web/src/app/(dashboard)/individuals/page.tsx
+++ b/packages/web/src/app/(dashboard)/individuals/page.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { History, Brain, Sparkles, FileText, User, Heart, Zap } from 'lucide-react';
+import { History, Brain, Sparkles, FileText, User, Heart, Zap, Inbox } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { useApiQuery } from '@/lib/api';
@@ -210,6 +210,12 @@ function IdentityCard({ identity }: { identity: Identity }) {
           </div>
           <div className="flex items-center gap-2">
             <Badge variant="secondary">v{identity.version}</Badge>
+            <Button variant="outline" size="sm" asChild>
+              <Link href={`/individuals/${identity.agentId}/inbox`}>
+                <Inbox className="mr-1 h-4 w-4" />
+                Inbox
+              </Link>
+            </Button>
             <Button variant="outline" size="sm" asChild>
               <Link href={`/individuals/${identity.agentId}/memories`}>
                 <Brain className="mr-1 h-4 w-4" />

--- a/packages/web/src/components/ui/sheet.tsx
+++ b/packages/web/src/components/ui/sheet.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import * as React from 'react';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { X } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+const Sheet = DialogPrimitive.Root;
+
+const SheetTrigger = DialogPrimitive.Trigger;
+
+const SheetClose = DialogPrimitive.Close;
+
+const SheetPortal = DialogPrimitive.Portal;
+
+const SheetOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      'fixed inset-0 z-50 bg-black/50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 duration-300',
+      className
+    )}
+    {...props}
+  />
+));
+SheetOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const SheetContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
+    side?: 'right' | 'left';
+  }
+>(({ className, children, side = 'right', ...props }, ref) => (
+  <SheetPortal>
+    <SheetOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        'fixed z-50 flex flex-col bg-white shadow-lg transition ease-in-out duration-300',
+        'data-[state=open]:animate-in data-[state=closed]:animate-out',
+        side === 'right' &&
+          'inset-y-0 right-0 h-full w-full max-w-lg border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right',
+        side === 'left' &&
+          'inset-y-0 left-0 h-full w-full max-w-lg border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left',
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-white transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-gray-950 focus:ring-offset-2 disabled:pointer-events-none">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </SheetPortal>
+));
+SheetContent.displayName = 'SheetContent';
+
+const SheetHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('flex flex-col space-y-2 border-b px-6 py-4', className)} {...props} />
+);
+SheetHeader.displayName = 'SheetHeader';
+
+const SheetTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn('text-lg font-semibold text-gray-900', className)}
+    {...props}
+  />
+));
+SheetTitle.displayName = DialogPrimitive.Title.displayName;
+
+const SheetDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn('text-sm text-gray-500', className)}
+    {...props}
+  />
+));
+SheetDescription.displayName = DialogPrimitive.Description.displayName;
+
+export {
+  Sheet,
+  SheetPortal,
+  SheetOverlay,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+};


### PR DESCRIPTION
## Summary

- **Per-SB inbox viewer** accessible from Individuals page — Discord/Slack-style chat rendering with avatar initials, bold sender names, compact consecutive messages
- **Sent + received messages** — queries both directions so you see the full picture (not just what was sent *to* the SB)
- **1-1 thread separation** — threads grouped by `threadKey + counterpart` so `pr:50 · lumen` and `pr:50 · myra` are distinct conversations, not one confusing mixed thread
- **Two-pass thread query** — backfills cross-agent messages in shared threads for complete conversation context
- **Routing inspector** — hover info button on any message opens a Sheet with sender/recipient identity IDs, session link, thread key, metadata, and timestamps
- **shadcn Sheet component** — proper Radix Dialog-based slide-out with smooth bidirectional animations (enter + exit)
- **Aligned with Lumen's rename** — `relatedSessionId` → `recipientSessionId` throughout
- **Fixed crash-loop** — unescaped backtick in `send_to_inbox` tool description broke TS compilation, producing invalid JS that crashed PM2 with `server is not defined`

## Files changed

- `packages/api/src/routes/admin.ts` — `GET /api/admin/individuals/:agentId/inbox` endpoint with dual-query, two-pass thread backfill, 1-1 grouping, identity IDs
- `packages/web/src/app/(dashboard)/individuals/[agentId]/inbox/page.tsx` — Full inbox page with filters, thread list, chat messages, routing inspector Sheet
- `packages/web/src/components/ui/sheet.tsx` — New shadcn Sheet component wrapping Radix Dialog
- `packages/web/src/app/(dashboard)/individuals/page.tsx` — Added Inbox nav button per SB
- `packages/api/src/mcp/tools/index.ts` — Fixed unescaped backtick in template literal

## Design decisions

Per Lumen's feedback: threads are separated per 1-1 conversation pair (`threadKey + counterpart`), keeping backend messaging 1-1 without group-message schema. A future "topic timeline" view could aggregate all messages by threadKey for the full cross-agent picture.

## Test plan

- [ ] Navigate to Individuals → click Inbox on any SB
- [ ] Verify sent + received messages both appear (check Myra's inbox for outgoing messages)
- [ ] Verify `pr:50` splits into separate threads per counterpart (e.g., `pr:50 · lumen`, `pr:50 · myra`)
- [ ] Click a thread → Sheet slides in smoothly, slides out on close/Escape
- [ ] Hover a message → info icon appears → click opens routing detail Sheet
- [ ] Verify routing Sheet shows identity IDs, session link, metadata
- [ ] Verify filters (status, message type) work
- [ ] Verify pagination with Prev/Next

🤖 Generated with [Claude Code](https://claude.com/claude-code)