### PR TITLE
fix: retire relatedSessionId naming and use recipientSessionId everywhere (by Lumen)

### DIFF
--- a/packages/api/src/channels/agent-gateway.ts
+++ b/packages/api/src/channels/agent-gateway.ts
@@ -34,8 +34,8 @@ export interface AgentTriggerPayload {
   studioId?: string;
   /** Convenience studio routing hint */
   studioHint?: 'main';
-  /** Related session to inherit studio scope from */
-  relatedSessionId?: string;
+  /** Recipient session to inherit studio scope from */
+  recipientSessionId?: string;
   /** Additional metadata */
   metadata?: Record<string, unknown>;
 }

--- a/packages/api/src/mcp/tools/agent-triggers.ts
+++ b/packages/api/src/mcp/tools/agent-triggers.ts
@@ -59,11 +59,11 @@ export const triggerAgentSchema = z.object({
     .enum(['main'])
     .optional()
     .describe('Convenience studio routing hint (e.g., "main" to force shared main studio)'),
-  relatedSessionId: z
+  recipientSessionId: z
     .string()
     .uuid()
     .optional()
-    .describe('Optional related session ID to inherit studio scope from'),
+    .describe('Optional recipient session ID to inherit studio scope from'),
   metadata: z
     .record(z.unknown())
     .optional()
@@ -98,7 +98,7 @@ export async function handleTriggerAgent(
       threadKey: args.threadKey,
       studioId: args.studioId,
       studioHint: args.studioHint,
-      relatedSessionId: args.relatedSessionId,
+      recipientSessionId: args.recipientSessionId,
       metadata: args.metadata,
     };
 

--- a/packages/api/src/mcp/tools/inbox-handlers.test.ts
+++ b/packages/api/src/mcp/tools/inbox-handlers.test.ts
@@ -426,3 +426,41 @@ describe('handleSendToInbox - threadKey', () => {
     expect(mockGateway.processTrigger).toHaveBeenCalled();
   });
 });
+
+describe('handleGetInbox - recipient session naming', () => {
+  it('should include recipientSessionId and relatedSessionId for compatibility', async () => {
+    const message = {
+      id: 'msg-123',
+      created_at: '2026-02-15T10:00:00Z',
+      thread_key: 'pr:99',
+      recipient_agent_id: 'lumen',
+      sender_agent_id: 'wren',
+      subject: 'Resume work',
+      content: 'Please resume',
+      message_type: 'session_resume',
+      priority: 'normal',
+      status: 'unread',
+      related_session_id: 'b85490f5-0836-4bdd-8193-f6cfa2562a41',
+      related_artifact_uri: null,
+      metadata: {},
+      read_at: null,
+    };
+
+    const mockSb = createMockSupabase({
+      selectReturn: { data: [message], error: null },
+    });
+    const mockDc = createMockDataComposer(mockSb);
+
+    const result = await handleGetInbox(
+      {
+        email: 'test@test.com',
+        agentId: 'lumen',
+      },
+      mockDc as never
+    );
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.messages[0].recipientSessionId).toBe('b85490f5-0836-4bdd-8193-f6cfa2562a41');
+    expect(parsed.messages[0].relatedSessionId).toBe('b85490f5-0836-4bdd-8193-f6cfa2562a41');
+  });
+});

--- a/packages/api/src/mcp/tools/inbox-handlers.test.ts
+++ b/packages/api/src/mcp/tools/inbox-handlers.test.ts
@@ -277,25 +277,6 @@ describe('handleSendToInbox - threadKey', () => {
     );
   });
 
-  it('should reject deprecated relatedSessionId input', async () => {
-    const mockSb = createMockSupabase();
-    const mockDc = createMockDataComposer(mockSb);
-
-    await expect(
-      handleSendToInbox(
-        {
-          email: 'test@test.com',
-          recipientAgentId: 'lumen',
-          senderAgentId: 'wren',
-          messageType: 'session_resume',
-          relatedSessionId: 'b85490f5-0836-4bdd-8193-f6cfa2562a41',
-          content: 'Resume this session',
-        },
-        mockDc as never
-      )
-    ).rejects.toThrow('relatedSessionId');
-  });
-
   it('should pass recipientSessionId through trigger payload', async () => {
     const { getAgentGateway } = await import('../../channels/agent-gateway.js');
     const mockGateway = (getAgentGateway as ReturnType<typeof vi.fn>)();
@@ -317,7 +298,7 @@ describe('handleSendToInbox - threadKey', () => {
 
     expect(mockGateway.processTrigger).toHaveBeenCalledWith(
       expect.objectContaining({
-        relatedSessionId: 'b85490f5-0836-4bdd-8193-f6cfa2562a41',
+        recipientSessionId: 'b85490f5-0836-4bdd-8193-f6cfa2562a41',
       })
     );
   });
@@ -348,7 +329,7 @@ describe('handleSendToInbox - threadKey', () => {
     );
     expect(mockGateway.processTrigger).toHaveBeenCalledWith(
       expect.objectContaining({
-        relatedSessionId: 'b85490f5-0836-4bdd-8193-f6cfa2562a41',
+        recipientSessionId: 'b85490f5-0836-4bdd-8193-f6cfa2562a41',
       })
     );
     const parsed = JSON.parse(result.content[0].text);
@@ -428,7 +409,7 @@ describe('handleSendToInbox - threadKey', () => {
 });
 
 describe('handleGetInbox - recipient session naming', () => {
-  it('should include recipientSessionId and relatedSessionId for compatibility', async () => {
+  it('should include recipientSessionId in inbox messages', async () => {
     const message = {
       id: 'msg-123',
       created_at: '2026-02-15T10:00:00Z',
@@ -461,6 +442,5 @@ describe('handleGetInbox - recipient session naming', () => {
 
     const parsed = JSON.parse(result.content[0].text);
     expect(parsed.messages[0].recipientSessionId).toBe('b85490f5-0836-4bdd-8193-f6cfa2562a41');
-    expect(parsed.messages[0].relatedSessionId).toBe('b85490f5-0836-4bdd-8193-f6cfa2562a41');
   });
 });

--- a/packages/api/src/mcp/tools/inbox-handlers.ts
+++ b/packages/api/src/mcp/tools/inbox-handlers.ts
@@ -99,17 +99,6 @@ const getAgentStatusSchema = userIdentifierBaseSchema.extend({
 // ============== Handlers ==============
 
 export async function handleSendToInbox(args: unknown, dataComposer: DataComposer) {
-  if (
-    args &&
-    typeof args === 'object' &&
-    !Array.isArray(args) &&
-    Object.prototype.hasOwnProperty.call(args, 'relatedSessionId')
-  ) {
-    throw new Error(
-      '`relatedSessionId` has been retired for send_to_inbox. Use `recipientSessionId`.'
-    );
-  }
-
   const supabase = dataComposer.getClient();
   const parsed = sendToInboxSchema.parse(args);
   const resolved = await resolveUserOrThrow(parsed, dataComposer);
@@ -246,7 +235,7 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
       summary: triggerSummary || subject || `New ${messageType} from ${triggerSenderId}`,
       priority,
       threadKey,
-      relatedSessionId: effectiveRecipientSessionId,
+      recipientSessionId: effectiveRecipientSessionId,
       studioId: recipientStudioId,
       studioHint: recipientStudioHint,
     };
@@ -380,7 +369,6 @@ export async function handleGetInbox(args: unknown, dataComposer: DataComposer) 
             senderAgentId: m.sender_agent_id,
             threadKey: m.thread_key || null,
             recipientSessionId: m.related_session_id,
-            relatedSessionId: m.related_session_id,
             relatedArtifactUri: m.related_artifact_uri,
             metadata: m.metadata,
             createdAt: m.created_at,

--- a/packages/api/src/mcp/tools/inbox-handlers.ts
+++ b/packages/api/src/mcp/tools/inbox-handlers.ts
@@ -379,6 +379,7 @@ export async function handleGetInbox(args: unknown, dataComposer: DataComposer) 
             status: m.status,
             senderAgentId: m.sender_agent_id,
             threadKey: m.thread_key || null,
+            recipientSessionId: m.related_session_id,
             relatedSessionId: m.related_session_id,
             relatedArtifactUri: m.related_artifact_uri,
             metadata: m.metadata,

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -480,7 +480,7 @@ If you need to message a user, use send_response with the appropriate channel an
         threadKey: payload.threadKey,
         studioId: payload.studioId,
         studioHint: payload.studioHint,
-        relatedSessionId: payload.relatedSessionId,
+        recipientSessionId: payload.recipientSessionId,
       },
     };
 

--- a/packages/api/src/services/sessions/session-service.ts
+++ b/packages/api/src/services/sessions/session-service.ts
@@ -190,7 +190,7 @@ export class SessionService implements ISessionService {
         threadKey: metadata?.threadKey,
         studioId: metadata?.studioId,
         studioHint: metadata?.studioHint,
-        relatedSessionId: metadata?.relatedSessionId,
+        recipientSessionId: metadata?.recipientSessionId,
       });
 
       // 2. Build lock key - must be per agent + session to support sub-agents
@@ -278,7 +278,7 @@ export class SessionService implements ISessionService {
             threadKey: pending.request.metadata?.threadKey,
             studioId: pending.request.metadata?.studioId,
             studioHint: pending.request.metadata?.studioHint,
-            relatedSessionId: pending.request.metadata?.relatedSessionId,
+            recipientSessionId: pending.request.metadata?.recipientSessionId,
           }
         );
 
@@ -410,7 +410,7 @@ export class SessionService implements ISessionService {
       threadKey?: string;
       studioId?: string;
       studioHint?: 'main';
-      relatedSessionId?: string;
+      recipientSessionId?: string;
     }
   ): Promise<Session> {
     const type = options?.type || 'primary';
@@ -420,7 +420,7 @@ export class SessionService implements ISessionService {
       threadKey: options?.threadKey,
       explicitStudioId: options?.studioId,
       studioHint: options?.studioHint,
-      relatedSessionId: options?.relatedSessionId,
+      recipientSessionId: options?.recipientSessionId,
       backend,
     });
 
@@ -527,7 +527,7 @@ export class SessionService implements ISessionService {
       threadKey?: string;
       explicitStudioId?: string;
       studioHint?: 'main';
-      relatedSessionId?: string;
+      recipientSessionId?: string;
       backend?: string;
     }
   ): Promise<string | undefined> {
@@ -545,11 +545,11 @@ export class SessionService implements ISessionService {
     }
 
     // 1) Related session scope (explicit resume continuity)
-    if (options.relatedSessionId) {
+    if (options.recipientSessionId) {
       const { data } = await this.supabase
         .from('sessions')
         .select('studio_id, workspace_id')
-        .eq('id', options.relatedSessionId)
+        .eq('id', options.recipientSessionId)
         .eq('user_id', userId)
         .maybeSingle();
 

--- a/packages/api/src/services/sessions/types.ts
+++ b/packages/api/src/services/sessions/types.ts
@@ -115,8 +115,8 @@ export interface SessionRequest {
     studioId?: string;
     // Convenience routing hint (e.g., force main studio without UUID lookup)
     studioHint?: 'main';
-    // Related session to inherit studio scope from
-    relatedSessionId?: string;
+    // Recipient session to inherit studio scope from
+    recipientSessionId?: string;
     // For task sessions
     sessionType?: SessionType;
     taskDescription?: string;
@@ -246,7 +246,7 @@ export interface ISessionService {
       threadKey?: string;
       studioId?: string;
       studioHint?: 'main';
-      relatedSessionId?: string;
+      recipientSessionId?: string;
     }
   ): Promise<Session>;
 


### PR DESCRIPTION
## Summary
- remove `relatedSessionId` references from runtime and MCP surfaces
- standardize on `recipientSessionId` across trigger payloads, session metadata, and inbox reads
- keep DB column name (`related_session_id`) unchanged for now (storage-level only)

## Why
`relatedSessionId` caused sender/recipient ambiguity. We now use one clear directional name at API/runtime boundaries.

## Validation
- `npx vitest run packages/api/src/mcp/tools/inbox-handlers.test.ts packages/api/src/services/sessions/session-service.test.ts`

## Notes
- No DB migration in this PR.
- This intentionally removes backwards compatibility for `relatedSessionId` in API/runtime naming.