### PR TITLE
fix: auto-logout only on invalid admin token failures (by Lumen)

### DIFF
--- a/packages/web/src/app/api/auth/logout/route.test.ts
+++ b/packages/web/src/app/api/auth/logout/route.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockSignOut = vi.fn();
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn().mockResolvedValue({
+    auth: {
+      signOut: () => mockSignOut(),
+    },
+  }),
+}));
+
+import { POST } from './route';
+
+describe('POST /api/auth/logout', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('signs out supabase and clears PCP auth cookies', async () => {
+    mockSignOut.mockResolvedValue({});
+
+    const response = await POST();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ success: true });
+    expect(mockSignOut).toHaveBeenCalledTimes(1);
+
+    const cookies = response.cookies.getAll();
+    const pcpAccessCookie = cookies.find((cookie) => cookie.name === 'pcp-admin-token');
+    const pcpRefreshCookie = cookies.find((cookie) => cookie.name === 'pcp-admin-refresh');
+
+    expect(pcpAccessCookie?.value).toBe('');
+    expect(pcpRefreshCookie?.value).toBe('');
+  });
+});

--- a/packages/web/src/app/api/auth/logout/route.ts
+++ b/packages/web/src/app/api/auth/logout/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+
+export async function POST() {
+  const supabase = await createClient();
+  await supabase.auth.signOut();
+
+  const response = NextResponse.json({ success: true });
+  response.cookies.delete({ name: 'pcp-admin-token', path: '/api/admin' });
+  response.cookies.delete({ name: 'pcp-admin-refresh', path: '/api/admin' });
+  return response;
+}

--- a/packages/web/src/lib/api/client.ts
+++ b/packages/web/src/lib/api/client.ts
@@ -17,6 +17,34 @@ const apiClient = axios.create({
   },
 });
 
+let invalidTokenRecoveryInFlight = false;
+
+function isInvalidTokenAuthFailure(error: AxiosError<{ error?: string }>): boolean {
+  const status = error.response?.status;
+  const serverMessage = error.response?.data?.error?.trim().toLowerCase();
+  const requestUrl = error.config?.url || '';
+
+  return (
+    status === 401 &&
+    serverMessage === 'invalid token' &&
+    requestUrl.startsWith('/api/admin/') &&
+    !requestUrl.startsWith('/api/admin/auth/logout')
+  );
+}
+
+async function handleInvalidTokenLogout(): Promise<void> {
+  if (invalidTokenRecoveryInFlight || typeof window === 'undefined') return;
+  invalidTokenRecoveryInFlight = true;
+
+  try {
+    await fetch('/api/auth/logout', { method: 'POST', credentials: 'include' });
+  } catch {
+    // Best-effort cleanup only.
+  } finally {
+    window.location.assign('/login?reason=session-expired');
+  }
+}
+
 // Request interceptor - inject workspace scope header when selected.
 apiClient.interceptors.request.use(async (config) => {
   const workspaceId = getSelectedWorkspaceId();
@@ -30,6 +58,10 @@ apiClient.interceptors.request.use(async (config) => {
 apiClient.interceptors.response.use(
   (response: AxiosResponse) => response,
   (error: AxiosError<{ error?: string }>) => {
+    if (isInvalidTokenAuthFailure(error)) {
+      void handleInvalidTokenLogout();
+    }
+
     const apiError = new Error(
       error.response?.data?.error || error.message || 'Request failed'
     ) as ApiError;


### PR DESCRIPTION
## Summary
- detect only this scenario in web API client interceptor:
  - `401` + backend error exactly `Invalid token`
  - request path under `/api/admin/*`
- when it happens, trigger best-effort cleanup and redirect:
  - POST `/api/auth/logout` (new route)
  - clear Supabase session server-side
  - clear PCP admin cookies (`pcp-admin-token`, `pcp-admin-refresh`)
  - redirect to `/login?reason=session-expired`

## Why
Prevents users from getting stuck in stale cookie/token states while avoiding aggressive logout behavior for other failures (`403`, network, `5xx`, etc.).

## Added
- `packages/web/src/app/api/auth/logout/route.ts`
- `packages/web/src/app/api/auth/logout/route.test.ts`

## Validation
- `yarn workspace @personal-context/web test src/app/api/auth/logout/route.test.ts src/app/api/auth/me/route.test.ts`
- `yarn workspace @personal-context/web type-check`