### PR TITLE
fix: fail fast in dev:direct when API is down (by Lumen)

### DIFF
--- a/scripts/dev-direct.sh
+++ b/scripts/dev-direct.sh
@@ -51,6 +51,32 @@ trap cleanup EXIT INT TERM
 ) &
 API_PID=$!
 
+# Ensure API actually boots before starting web (avoids silent ECONNREFUSED loops).
+wait_for_api() {
+  local health_url="${API_URL}/health"
+  local attempts=30
+
+  for ((i = 1; i <= attempts; i++)); do
+    if curl -fsS "${health_url}" >/dev/null 2>&1; then
+      echo "  API health check passed at ${health_url}"
+      return 0
+    fi
+
+    if ! kill -0 "${API_PID}" 2>/dev/null; then
+      echo "ERROR: API process exited before becoming healthy (pid=${API_PID})"
+      wait "${API_PID}" || true
+      return 1
+    fi
+
+    sleep 1
+  done
+
+  echo "ERROR: API did not become healthy within ${attempts}s (${health_url})"
+  return 1
+}
+
+wait_for_api
+
 (
   API_URL="${API_URL}" \
   yarn --cwd "${ROOT_DIR}" workspace @personal-context/web exec next dev -p "${WEB_PORT}"


### PR DESCRIPTION
## Summary
- add API health gating to `scripts/dev-direct.sh`
- wait for `${API_URL}/health` before launching web
- fail early with clear error if API process exits or never becomes healthy

## Why
`yarn dev:direct` could previously leave web running while API failed to start, causing confusing `ECONNREFUSED` errors (e.g. `/api/admin/*` provision/login requests).

## Validation
- `bash -n scripts/dev-direct.sh`
- manual verification of script flow and failure messaging