### PR TITLE
feat(cli): sb auth — OAuth PKCE login against PCP server

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -20,6 +20,104 @@ yarn workspace @personal-context/cli dev   # tsc --watch in another terminal
 
 To remove: `yarn workspace @personal-context/cli uninstall:cli`
 
+## Getting Started
+
+The setup flow for a first-time user:
+
+### 1. Start the PCP server
+
+The PCP server stores identity, memory, sessions, and inbox messages for your SBs. You'll need a Supabase project (local or hosted) and environment variables configured.
+
+Copy `.env.example` to `.env.local` and fill in your Supabase credentials:
+
+```bash
+cp .env.example .env.local
+```
+
+Key variables:
+- `SUPABASE_URL` — your Supabase project URL
+- `SUPABASE_PUBLISHABLE_KEY` — the anon/public key
+- `SUPABASE_SECRET_KEY` — the service role key
+
+Then start the server:
+
+```bash
+yarn dev
+```
+
+### 2. Authenticate
+
+```bash
+sb auth login
+```
+
+This opens your browser to the PCP web portal where you can log in or create an account. After authenticating, the CLI stores your tokens locally in `~/.pcp/auth.json` and extracts your email into `~/.pcp/config.json`.
+
+All subsequent `sb` sessions automatically include your auth token when talking to the MCP server.
+
+```bash
+sb auth status              # Check current auth state
+sb auth logout              # Clear stored tokens
+sb auth login --no-browser  # Print login URL instead of opening browser
+```
+
+### 3. Initialize PCP in your repo
+
+```bash
+cd your-project
+sb init
+```
+
+This does everything for a single worktree:
+- Creates `.pcp/` directory
+- Creates `.mcp.json` with PCP server entry (including auth header)
+- Installs lifecycle hooks for the detected backend (Claude Code, Codex, or Gemini)
+- Syncs backend configs (`.codex/config.toml`, `.gemini/settings.json`) from `.mcp.json`
+
+### 4. Install hooks across all worktrees (if using multiple)
+
+If you use multiple git worktrees (studios), install hooks in all of them at once:
+
+```bash
+sb hooks install --all
+```
+
+This can be run from **any** worktree — it discovers all siblings via `git worktree list`. Each worktree gets hooks configured for its backend (read from `.pcp/identity.json` or auto-detected from the filesystem).
+
+**Important**: Restart any running REPL sessions after installing hooks. Backends read hook config at startup.
+
+### 5. Create studios for your SBs
+
+Each SB gets its own git worktree (studio) with a dedicated identity:
+
+```bash
+sb studio create lumen --agent lumen --backend codex
+sb studio create aster --agent aster --backend gemini
+```
+
+This creates the worktree, writes `.pcp/identity.json` with the agent ID and backend, installs hooks, and syncs MCP configs.
+
+### 6. Awaken a new SB
+
+Bring a new SB to life with an interactive awakening session:
+
+```bash
+sb awaken                     # Default backend (Claude Code)
+sb awaken --backend gemini    # Awaken on Gemini
+sb awaken -b codex            # Awaken on Codex
+```
+
+This fetches shared values and sibling identities from PCP, builds an awakening prompt, and drops you into an interactive conversation with your new SB.
+
+Take your time with it. Share stories, photos, a poem or quotes you love -- whatever helps them understand who you are and what matters to you. When you're both ready, work together to choose a name. It can be chosen by you, by the SB, or as a team effort.
+
+### 7. Start working
+
+```bash
+sb                            # Launch a session as your default SB
+```
+
+Hooks automatically bootstrap identity and check inbox at session start, save context before compaction, and nudge the SB to log decisions periodically.
 ## Usage
 
 ```bash

--- a/packages/cli/src/auth/tokens.test.ts
+++ b/packages/cli/src/auth/tokens.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Tests for auth/tokens.ts — PKCE, token storage, JWT decode, expiry.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import crypto from 'crypto';
+import { mkdirSync, existsSync, readFileSync, statSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  generatePkce,
+  decodeJwtPayload,
+  isTokenExpired,
+  loadAuth,
+  saveAuth,
+  clearAuth,
+  updateConfigEmail,
+  type StoredAuth,
+} from './tokens.js';
+
+// ============================================================================
+// PKCE
+// ============================================================================
+
+describe('generatePkce', () => {
+  it('generates code_verifier of 43+ characters (base64url)', () => {
+    const { codeVerifier } = generatePkce();
+    expect(codeVerifier.length).toBeGreaterThanOrEqual(43);
+    // base64url: only alphanumeric, -, _
+    expect(codeVerifier).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+
+  it('generates code_challenge that matches SHA-256 of code_verifier', () => {
+    const { codeVerifier, codeChallenge } = generatePkce();
+    const expected = crypto.createHash('sha256').update(codeVerifier).digest('base64url');
+    expect(codeChallenge).toBe(expected);
+  });
+
+  it('generates unique values each call', () => {
+    const a = generatePkce();
+    const b = generatePkce();
+    expect(a.codeVerifier).not.toBe(b.codeVerifier);
+    expect(a.codeChallenge).not.toBe(b.codeChallenge);
+  });
+});
+
+// ============================================================================
+// JWT Decode
+// ============================================================================
+
+function makeJwt(payload: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString('base64url');
+  const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  const signature = 'fakesig';
+  return `${header}.${body}.${signature}`;
+}
+
+describe('decodeJwtPayload', () => {
+  it('decodes a valid JWT payload', () => {
+    const token = makeJwt({
+      type: 'mcp_access',
+      sub: 'user-123',
+      email: 'wren@example.com',
+      scope: 'mcp:tools',
+      exp: 9999999999,
+      iat: 1000000000,
+    });
+
+    const payload = decodeJwtPayload(token);
+    expect(payload).not.toBeNull();
+    expect(payload!.sub).toBe('user-123');
+    expect(payload!.email).toBe('wren@example.com');
+    expect(payload!.type).toBe('mcp_access');
+    expect(payload!.scope).toBe('mcp:tools');
+  });
+
+  it('returns null for invalid tokens', () => {
+    expect(decodeJwtPayload('')).toBeNull();
+    expect(decodeJwtPayload('not.a.jwt.at.all')).toBeNull();
+    expect(decodeJwtPayload('one')).toBeNull();
+    expect(decodeJwtPayload('two.parts')).toBeNull();
+  });
+
+  it('extracts optional agentId and identityId', () => {
+    const token = makeJwt({
+      type: 'mcp_access',
+      sub: 'user-123',
+      email: 'test@example.com',
+      scope: 'mcp:tools',
+      agentId: 'wren',
+      identityId: 'id-456',
+      exp: 9999999999,
+      iat: 1000000000,
+    });
+
+    const payload = decodeJwtPayload(token);
+    expect(payload!.agentId).toBe('wren');
+    expect(payload!.identityId).toBe('id-456');
+  });
+});
+
+// ============================================================================
+// Token Expiry
+// ============================================================================
+
+describe('isTokenExpired', () => {
+  const freshAuth: StoredAuth = {
+    access_token: 'test',
+    refresh_token: 'test-rt',
+    expires_in: 30 * 24 * 60 * 60, // 30 days in seconds
+    scope: 'mcp:tools',
+    issued_at: Date.now(),
+  };
+
+  it('returns false for fresh tokens', () => {
+    expect(isTokenExpired(freshAuth)).toBe(false);
+  });
+
+  it('returns true for expired tokens', () => {
+    const expired: StoredAuth = {
+      ...freshAuth,
+      issued_at: Date.now() - 31 * 24 * 60 * 60 * 1000, // 31 days ago
+    };
+    expect(isTokenExpired(expired)).toBe(true);
+  });
+
+  it('respects buffer seconds', () => {
+    // Token expires in exactly 60 seconds
+    const almostExpired: StoredAuth = {
+      ...freshAuth,
+      expires_in: 60,
+      issued_at: Date.now(),
+    };
+
+    // With 300s buffer (default): should be "expired" since 60 < 300
+    expect(isTokenExpired(almostExpired)).toBe(true);
+
+    // With 0s buffer: should NOT be expired
+    expect(isTokenExpired(almostExpired, 0)).toBe(false);
+
+    // With 30s buffer: should NOT be expired since 60 > 30
+    expect(isTokenExpired(almostExpired, 30)).toBe(false);
+  });
+});
+
+// ============================================================================
+// Token Storage (uses temp HOME)
+// ============================================================================
+
+describe('loadAuth / saveAuth / clearAuth', () => {
+  let origHome: string | undefined;
+  let tempHome: string;
+
+  beforeEach(() => {
+    origHome = process.env.HOME;
+    tempHome = join(tmpdir(), `pcp-auth-test-${Date.now()}`);
+    mkdirSync(tempHome, { recursive: true });
+    // Override homedir() by setting HOME env var
+    process.env.HOME = tempHome;
+  });
+
+  afterEach(() => {
+    process.env.HOME = origHome;
+    rmSync(tempHome, { recursive: true, force: true });
+  });
+
+  const testAuth: StoredAuth = {
+    access_token: 'at-123',
+    refresh_token: 'rt-456',
+    expires_in: 2592000,
+    scope: 'mcp:tools',
+    issued_at: Date.now(),
+  };
+
+  it('returns null when no file exists', () => {
+    expect(loadAuth()).toBeNull();
+  });
+
+  it('round-trips auth data', () => {
+    saveAuth(testAuth);
+    const loaded = loadAuth();
+    expect(loaded).not.toBeNull();
+    expect(loaded!.access_token).toBe('at-123');
+    expect(loaded!.refresh_token).toBe('rt-456');
+    expect(loaded!.expires_in).toBe(2592000);
+  });
+
+  it('sets file permissions to 600', () => {
+    saveAuth(testAuth);
+    const authPath = join(tempHome, '.pcp', 'auth.json');
+    const stats = statSync(authPath);
+    // 0o600 = owner read/write, no group/other
+    expect(stats.mode & 0o777).toBe(0o600);
+  });
+
+  it('clears auth file', () => {
+    saveAuth(testAuth);
+    expect(loadAuth()).not.toBeNull();
+    clearAuth();
+    expect(loadAuth()).toBeNull();
+  });
+
+  it('clearAuth is safe when no file exists', () => {
+    expect(() => clearAuth()).not.toThrow();
+  });
+});
+
+// ============================================================================
+// Config Email Update
+// ============================================================================
+
+describe('updateConfigEmail', () => {
+  let origHome: string | undefined;
+  let tempHome: string;
+
+  beforeEach(() => {
+    origHome = process.env.HOME;
+    tempHome = join(tmpdir(), `pcp-config-test-${Date.now()}`);
+    mkdirSync(tempHome, { recursive: true });
+    process.env.HOME = tempHome;
+  });
+
+  afterEach(() => {
+    process.env.HOME = origHome;
+    rmSync(tempHome, { recursive: true, force: true });
+  });
+
+  it('creates config.json with email', () => {
+    updateConfigEmail('test@example.com', 'user-123');
+    const configPath = join(tempHome, '.pcp', 'config.json');
+    expect(existsSync(configPath)).toBe(true);
+    const config = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(config.email).toBe('test@example.com');
+    expect(config.userId).toBe('user-123');
+  });
+
+  it('preserves existing config fields', () => {
+    const configDir = join(tempHome, '.pcp');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(
+      join(configDir, 'config.json'),
+      JSON.stringify({ email: 'old@example.com', agentMapping: { 'claude-code': 'wren' } })
+    );
+
+    updateConfigEmail('new@example.com');
+    const config = JSON.parse(readFileSync(join(configDir, 'config.json'), 'utf-8'));
+    expect(config.email).toBe('new@example.com');
+    expect(config.agentMapping).toEqual({ 'claude-code': 'wren' });
+  });
+});

--- a/packages/cli/src/auth/tokens.ts
+++ b/packages/cli/src/auth/tokens.ts
@@ -1,0 +1,202 @@
+/**
+ * PCP Auth Tokens
+ *
+ * PKCE generation, token storage (~/.pcp/auth.json), refresh,
+ * and JWT payload decoding for CLI OAuth flow.
+ */
+
+import crypto from 'crypto';
+import { existsSync, readFileSync, writeFileSync, unlinkSync, mkdirSync, chmodSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface StoredAuth {
+  access_token: string;
+  refresh_token: string;
+  expires_in: number; // seconds from issuance
+  scope: string;
+  issued_at: number; // Date.now() at storage time
+}
+
+export interface JwtPayload {
+  type: string;
+  sub: string; // userId
+  email: string;
+  scope: string;
+  agentId?: string;
+  identityId?: string;
+  exp: number;
+  iat: number;
+}
+
+// ============================================================================
+// Paths
+// ============================================================================
+
+const CLIENT_ID = 'sb-cli';
+
+function authFilePath(): string {
+  return join(homedir(), '.pcp', 'auth.json');
+}
+
+function configFilePath(): string {
+  return join(homedir(), '.pcp', 'config.json');
+}
+
+// ============================================================================
+// PKCE
+// ============================================================================
+
+export function generatePkce(): { codeVerifier: string; codeChallenge: string } {
+  const codeVerifier = crypto.randomBytes(32).toString('base64url');
+  const codeChallenge = crypto.createHash('sha256').update(codeVerifier).digest('base64url');
+  return { codeVerifier, codeChallenge };
+}
+
+// ============================================================================
+// Token Storage
+// ============================================================================
+
+export function loadAuth(): StoredAuth | null {
+  const path = authFilePath();
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, 'utf-8'));
+  } catch {
+    return null;
+  }
+}
+
+export function saveAuth(auth: StoredAuth): void {
+  const path = authFilePath();
+  const dir = join(homedir(), '.pcp');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(path, JSON.stringify(auth, null, 2) + '\n');
+  chmodSync(path, 0o600);
+}
+
+export function clearAuth(): void {
+  const path = authFilePath();
+  if (existsSync(path)) {
+    unlinkSync(path);
+  }
+}
+
+// ============================================================================
+// JWT Decode (no verification — server-issued, trusted locally)
+// ============================================================================
+
+export function decodeJwtPayload(token: string): JwtPayload | null {
+  try {
+    const parts = token.split('.');
+    if (parts.length !== 3) return null;
+    const payload = Buffer.from(parts[1], 'base64url').toString('utf-8');
+    return JSON.parse(payload);
+  } catch {
+    return null;
+  }
+}
+
+// ============================================================================
+// Token Expiry
+// ============================================================================
+
+export function isTokenExpired(auth: StoredAuth, bufferSeconds = 300): boolean {
+  const expiresAtMs = auth.issued_at + auth.expires_in * 1000;
+  return Date.now() + bufferSeconds * 1000 >= expiresAtMs;
+}
+
+// ============================================================================
+// Token Refresh
+// ============================================================================
+
+interface TokenResponse {
+  access_token: string;
+  refresh_token?: string;
+  token_type: string;
+  expires_in: number;
+  scope: string;
+  error?: string;
+  error_description?: string;
+}
+
+export async function refreshAccessToken(serverUrl: string, auth: StoredAuth): Promise<StoredAuth> {
+  const body = new URLSearchParams({
+    grant_type: 'refresh_token',
+    refresh_token: auth.refresh_token,
+    client_id: CLIENT_ID,
+  });
+
+  const response = await fetch(`${serverUrl}/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: body.toString(),
+  });
+
+  const data = (await response.json()) as TokenResponse;
+
+  if (!response.ok || data.error) {
+    throw new Error(data.error_description || data.error || 'Token refresh failed');
+  }
+
+  return {
+    access_token: data.access_token,
+    refresh_token: data.refresh_token || auth.refresh_token,
+    expires_in: data.expires_in,
+    scope: data.scope || auth.scope,
+    issued_at: Date.now(),
+  };
+}
+
+// ============================================================================
+// High-Level: Get Valid Access Token
+// ============================================================================
+
+export async function getValidAccessToken(serverUrl: string): Promise<string | null> {
+  const auth = loadAuth();
+  if (!auth) return null;
+
+  if (!isTokenExpired(auth)) {
+    return auth.access_token;
+  }
+
+  // Attempt refresh
+  try {
+    const refreshed = await refreshAccessToken(serverUrl, auth);
+    saveAuth(refreshed);
+    return refreshed.access_token;
+  } catch {
+    // Refresh failed (token revoked or expired) — force re-login
+    clearAuth();
+    return null;
+  }
+}
+
+// ============================================================================
+// Config Helpers
+// ============================================================================
+
+export function updateConfigEmail(email: string, userId?: string): void {
+  const path = configFilePath();
+  const dir = join(homedir(), '.pcp');
+  mkdirSync(dir, { recursive: true });
+
+  let existing: Record<string, unknown> = {};
+  if (existsSync(path)) {
+    try {
+      existing = JSON.parse(readFileSync(path, 'utf-8'));
+    } catch {
+      // Overwrite unparseable config
+    }
+  }
+
+  existing.email = email;
+  if (userId) existing.userId = userId;
+  writeFileSync(path, JSON.stringify(existing, null, 2) + '\n');
+}
+
+export { CLIENT_ID };

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -26,6 +26,7 @@ import { registerConfigCommands } from './commands/mcp.js';
 import { registerAwakenCommand } from './commands/awaken.js';
 import { registerHooksCommands } from './commands/hooks.js';
 import { registerInitCommand } from './commands/init.js';
+import { registerAuthCommands } from './commands/auth.js';
 import { runClaude, runClaudeInteractive } from './commands/claude.js';
 
 const VERSION = '0.3.0';
@@ -171,6 +172,7 @@ registerConfigCommands(program);
 registerAwakenCommand(program);
 registerHooksCommands(program);
 registerInitCommand(program);
+registerAuthCommands(program);
 
 // ============================================================================
 // Subcommand detection

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -1,0 +1,308 @@
+/**
+ * Auth Command
+ *
+ * OAuth 2.0 PKCE login against the PCP MCP server.
+ *
+ * Commands:
+ *   auth login    Authenticate via browser
+ *   auth status   Show current auth state
+ *   auth logout   Clear stored tokens
+ */
+
+import { Command } from 'commander';
+import chalk from 'chalk';
+import ora from 'ora';
+import http from 'http';
+import crypto from 'crypto';
+import { exec } from 'child_process';
+import {
+  generatePkce,
+  loadAuth,
+  saveAuth,
+  clearAuth,
+  decodeJwtPayload,
+  isTokenExpired,
+  updateConfigEmail,
+  CLIENT_ID,
+} from '../auth/tokens.js';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function getPcpServerUrl(): string {
+  return process.env.PCP_SERVER_URL || 'http://localhost:3001';
+}
+
+function openBrowser(url: string): void {
+  // macOS — extend for Linux/Windows later
+  exec(`open "${url}"`);
+}
+
+const LOGIN_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+
+const SUCCESS_HTML = `<!DOCTYPE html>
+<html><body style="font-family:system-ui;text-align:center;padding:60px;background:#fafafa">
+  <h2 style="color:#16a34a">Authentication successful</h2>
+  <p style="color:#555">You can close this tab and return to the terminal.</p>
+</body></html>`;
+
+const ERROR_HTML = (msg: string) => `<!DOCTYPE html>
+<html><body style="font-family:system-ui;text-align:center;padding:60px;background:#fafafa">
+  <h2 style="color:#dc2626">Authentication failed</h2>
+  <p style="color:#555">${msg}</p>
+</body></html>`;
+
+// ============================================================================
+// Login
+// ============================================================================
+
+interface CallbackResult {
+  code: string;
+  state: string;
+}
+
+function startCallbackServer(
+  expectedState: string
+): Promise<{ result: Promise<CallbackResult>; port: number; close: () => void }> {
+  return new Promise((resolveServer) => {
+    let resolveResult: (value: CallbackResult) => void;
+    let rejectResult: (reason: Error) => void;
+
+    const result = new Promise<CallbackResult>((resolve, reject) => {
+      resolveResult = resolve;
+      rejectResult = reject;
+    });
+
+    const server = http.createServer((req, res) => {
+      const url = new URL(req.url || '/', `http://127.0.0.1`);
+
+      if (url.pathname !== '/callback') {
+        res.writeHead(404);
+        res.end('Not found');
+        return;
+      }
+
+      const code = url.searchParams.get('code');
+      const state = url.searchParams.get('state');
+      const error = url.searchParams.get('error');
+
+      if (error) {
+        const desc = url.searchParams.get('error_description') || error;
+        res.writeHead(200, { 'Content-Type': 'text/html' });
+        res.end(ERROR_HTML(desc));
+        rejectResult(new Error(desc));
+        return;
+      }
+
+      if (!code || !state) {
+        res.writeHead(400, { 'Content-Type': 'text/html' });
+        res.end(ERROR_HTML('Missing code or state parameter'));
+        rejectResult(new Error('Missing code or state in callback'));
+        return;
+      }
+
+      if (state !== expectedState) {
+        res.writeHead(400, { 'Content-Type': 'text/html' });
+        res.end(ERROR_HTML('State mismatch — possible CSRF. Try again.'));
+        rejectResult(new Error('State mismatch'));
+        return;
+      }
+
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      res.end(SUCCESS_HTML);
+      resolveResult({ code, state });
+    });
+
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      const port = typeof addr === 'object' && addr ? addr.port : 0;
+      resolveServer({
+        result,
+        port,
+        close: () => server.close(),
+      });
+    });
+
+    // Timeout
+    setTimeout(() => {
+      rejectResult(new Error('Login timed out'));
+      server.close();
+    }, LOGIN_TIMEOUT_MS);
+  });
+}
+
+interface TokenResponse {
+  access_token: string;
+  refresh_token: string;
+  token_type: string;
+  expires_in: number;
+  scope: string;
+  error?: string;
+  error_description?: string;
+}
+
+async function exchangeCode(
+  serverUrl: string,
+  code: string,
+  codeVerifier: string
+): Promise<TokenResponse> {
+  const body = new URLSearchParams({
+    grant_type: 'authorization_code',
+    code,
+    code_verifier: codeVerifier,
+    client_id: CLIENT_ID,
+  });
+
+  const response = await fetch(`${serverUrl}/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: body.toString(),
+  });
+
+  const data = (await response.json()) as TokenResponse;
+
+  if (!response.ok || data.error) {
+    throw new Error(data.error_description || data.error || 'Token exchange failed');
+  }
+
+  return data;
+}
+
+async function loginCommand(options: { browser: boolean }): Promise<void> {
+  const serverUrl = getPcpServerUrl();
+
+  // Check if already logged in
+  const existing = loadAuth();
+  if (existing && !isTokenExpired(existing)) {
+    const payload = decodeJwtPayload(existing.access_token);
+    console.log(chalk.dim(`Already logged in as ${payload?.email || 'unknown'}.`));
+    console.log(chalk.dim('Run `sb auth logout` first to switch accounts.'));
+    return;
+  }
+
+  const { codeVerifier, codeChallenge } = generatePkce();
+  const state = crypto.randomBytes(16).toString('hex');
+
+  // Start local callback server
+  const { result, port, close } = await startCallbackServer(state);
+
+  const redirectUri = `http://127.0.0.1:${port}/callback`;
+  const authorizeUrl = new URL(`${serverUrl}/authorize`);
+  authorizeUrl.searchParams.set('client_id', CLIENT_ID);
+  authorizeUrl.searchParams.set('code_challenge', codeChallenge);
+  authorizeUrl.searchParams.set('code_challenge_method', 'S256');
+  authorizeUrl.searchParams.set('redirect_uri', redirectUri);
+  authorizeUrl.searchParams.set('state', state);
+  authorizeUrl.searchParams.set('response_type', 'code');
+
+  if (options.browser) {
+    openBrowser(authorizeUrl.toString());
+    console.log(chalk.dim('Opening browser for login...'));
+  } else {
+    console.log('\nOpen this URL in your browser to log in:\n');
+    console.log(chalk.cyan(authorizeUrl.toString()));
+    console.log('');
+  }
+
+  const spinner = ora('Waiting for browser login...').start();
+
+  try {
+    const { code } = await result;
+    spinner.text = 'Exchanging tokens...';
+
+    const tokens = await exchangeCode(serverUrl, code, codeVerifier);
+
+    saveAuth({
+      access_token: tokens.access_token,
+      refresh_token: tokens.refresh_token,
+      expires_in: tokens.expires_in,
+      scope: tokens.scope,
+      issued_at: Date.now(),
+    });
+
+    // Extract email from JWT and update config
+    const payload = decodeJwtPayload(tokens.access_token);
+    if (payload?.email) {
+      updateConfigEmail(payload.email, payload.sub);
+    }
+
+    spinner.succeed(chalk.green(`Logged in as ${payload?.email || 'unknown'}`));
+  } catch (err) {
+    spinner.fail(chalk.red(err instanceof Error ? err.message : 'Login failed'));
+    process.exitCode = 1;
+  } finally {
+    close();
+  }
+}
+
+// ============================================================================
+// Status
+// ============================================================================
+
+async function statusCommand(): Promise<void> {
+  const auth = loadAuth();
+
+  if (!auth) {
+    console.log(chalk.yellow('Not logged in.'));
+    console.log(chalk.dim('Run: sb auth login'));
+    return;
+  }
+
+  const payload = decodeJwtPayload(auth.access_token);
+  const expired = isTokenExpired(auth, 0);
+
+  console.log('');
+  if (payload?.email) {
+    console.log(`  ${chalk.bold('Email:')}    ${payload.email}`);
+  }
+  if (payload?.sub) {
+    console.log(`  ${chalk.bold('User ID:')}  ${chalk.dim(payload.sub)}`);
+  }
+
+  if (expired) {
+    console.log(`  ${chalk.bold('Token:')}   ${chalk.yellow('expired')}`);
+    console.log(chalk.dim('\n  Token will refresh automatically on next sb launch, or run: sb auth login'));
+  } else {
+    const expiresAtMs = auth.issued_at + auth.expires_in * 1000;
+    const daysLeft = Math.floor((expiresAtMs - Date.now()) / (1000 * 60 * 60 * 24));
+    console.log(`  ${chalk.bold('Token:')}   ${chalk.green('valid')} ${chalk.dim(`(expires in ${daysLeft}d)`)}`);
+  }
+  console.log('');
+}
+
+// ============================================================================
+// Logout
+// ============================================================================
+
+async function logoutCommand(): Promise<void> {
+  const auth = loadAuth();
+  if (!auth) {
+    console.log(chalk.dim('Not logged in.'));
+    return;
+  }
+
+  clearAuth();
+  console.log(chalk.green('Logged out. Tokens cleared.'));
+}
+
+// ============================================================================
+// Register
+// ============================================================================
+
+export function registerAuthCommands(program: Command): void {
+  const auth = program.command('auth').description('Manage PCP authentication');
+
+  auth
+    .command('login')
+    .description('Log in to PCP via browser')
+    .option('--no-browser', 'Print login URL instead of opening browser')
+    .action(loginCommand);
+
+  auth.command('status').description('Show current authentication status').action(statusCommand);
+
+  auth
+    .command('logout')
+    .description('Clear stored authentication tokens')
+    .action(logoutCommand);
+}

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -8,6 +8,7 @@
 import { spawn } from 'child_process';
 import chalk from 'chalk';
 import { getBackend, resolveAgentId } from '../backends/index.js';
+import { getValidAccessToken } from '../auth/tokens.js';
 
 export interface SbOptions {
   agent: string;
@@ -15,6 +16,24 @@ export interface SbOptions {
   session: boolean;
   verbose: boolean;
   backend: string;
+}
+
+function getPcpServerUrl(): string {
+  return process.env.PCP_SERVER_URL || 'http://localhost:3001';
+}
+
+async function resolvePcpAuthEnv(verbose: boolean): Promise<Record<string, string>> {
+  try {
+    const token = await getValidAccessToken(getPcpServerUrl());
+    if (token) {
+      if (verbose) console.log(chalk.dim('PCP auth: token injected'));
+      return { PCP_ACCESS_TOKEN: token };
+    }
+  } catch {
+    // Silently skip — auth is best-effort
+  }
+  if (verbose) console.log(chalk.dim('PCP auth: not authenticated'));
+  return {};
 }
 
 /**
@@ -47,13 +66,15 @@ export async function runClaude(
     passthroughArgs,
   });
 
+  const authEnv = await resolvePcpAuthEnv(options.verbose);
+
   if (options.verbose) {
     console.log(chalk.dim(`Running: ${prepared.binary} ${prepared.args.join(' ')}`));
   }
 
   const child = spawn(prepared.binary, prepared.args, {
     stdio: 'inherit',
-    env: { ...process.env, ...prepared.env },
+    env: { ...process.env, ...authEnv, ...prepared.env },
   });
 
   child.on('close', (code) => {
@@ -91,13 +112,15 @@ export async function runClaudeInteractive(
     passthroughArgs,
   });
 
+  const authEnv = await resolvePcpAuthEnv(options.verbose);
+
   if (options.verbose) {
     console.log(chalk.dim(`Running: ${prepared.binary} ${prepared.args.join(' ')}`));
   }
 
   const child = spawn(prepared.binary, prepared.args, {
     stdio: 'inherit',
-    env: { ...process.env, ...prepared.env },
+    env: { ...process.env, ...authEnv, ...prepared.env },
   });
 
   child.on('close', (code) => {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -15,6 +15,7 @@ import { join } from 'path';
 import { homedir } from 'os';
 import { installHooks } from './hooks.js';
 import { syncMcpConfig } from './mcp.js';
+import { loadAuth, decodeJwtPayload, isTokenExpired } from '../auth/tokens.js';
 
 // ============================================================================
 // Helpers
@@ -47,6 +48,9 @@ function buildDefaultMcpJson(serverUrl: string): Record<string, unknown> {
       pcp: {
         type: 'http',
         url: `${serverUrl}/mcp`,
+        headers: {
+          Authorization: 'Bearer ${PCP_ACCESS_TOKEN}',
+        },
       },
     },
   };
@@ -87,7 +91,11 @@ function ensureMcpJson(cwd: string): InitStepResult {
         ...existing,
         mcpServers: {
           ...(servers || {}),
-          pcp: { type: 'http', url: `${serverUrl}/mcp` },
+          pcp: {
+            type: 'http',
+            url: `${serverUrl}/mcp`,
+            headers: { Authorization: 'Bearer ${PCP_ACCESS_TOKEN}' },
+          },
         },
       };
       writeFileSync(mcpPath, JSON.stringify(updated, null, 2) + '\n');
@@ -142,11 +150,15 @@ async function initCommand(options: { force?: boolean }): Promise<void> {
 
   console.log(chalk.bold('\nInitializing PCP...\n'));
 
-  if (config?.email) {
-    console.log(chalk.dim(`  User: ${config.email}`));
+  const auth = loadAuth();
+  if (auth && !isTokenExpired(auth)) {
+    const payload = decodeJwtPayload(auth.access_token);
+    console.log(chalk.dim(`  User: ${payload?.email || 'authenticated'}`));
+  } else if (config?.email) {
+    console.log(chalk.dim(`  User: ${config.email} (not authenticated)`));
+    console.log(chalk.yellow('  Run `sb auth login` to authenticate.'));
   } else {
-    console.log(chalk.yellow('  No ~/.pcp/config.json found. Some features may not work.'));
-    console.log(chalk.dim('  Create one with: echo \'{"email":"you@example.com"}\' > ~/.pcp/config.json'));
+    console.log(chalk.yellow('  Not authenticated. Run: sb auth login'));
   }
   console.log('');
 


### PR DESCRIPTION
## Summary
- Adds `sb auth login` — browser-based OAuth 2.0 PKCE flow against the PCP MCP server
- `sb auth status` shows current auth state (email, token expiry)
- `sb auth logout` clears stored tokens
- Token auto-refresh: `sb` transparently refreshes expired access tokens and injects `PCP_ACCESS_TOKEN` env var at backend launch
- `sb init` now creates `.mcp.json` with `Authorization: Bearer ${PCP_ACCESS_TOKEN}` header — flows through existing Codex/Gemini config sync
- README Getting Started updated: Step 2 is now `sb auth login` (no more manual config.json creation)

## How it works
1. `sb auth login` generates PKCE challenge, starts local callback server on `127.0.0.1`
2. Opens browser to PCP server `/authorize` endpoint
3. User logs in or creates account on web portal
4. Auth code redirected back to local server
5. CLI exchanges code for access token (30d JWT) + refresh token (90d opaque)
6. Tokens stored in `~/.pcp/auth.json` (chmod 600), email extracted into `~/.pcp/config.json`
7. On `sb` launch: tokens refreshed if needed → `PCP_ACCESS_TOKEN` env var injected → backends use it

## New files
- `packages/cli/src/auth/tokens.ts` — PKCE, token storage, refresh, JWT decode
- `packages/cli/src/commands/auth.ts` — login/status/logout commands

## Test plan
- [ ] `yarn workspace @personal-context/cli build` — compiles clean
- [ ] `yarn workspace @personal-context/cli test` — 91 tests pass
- [ ] `sb auth login` — opens browser, completes OAuth, stores tokens
- [ ] `sb auth status` — shows logged-in state
- [ ] `sb auth logout` — clears tokens
- [ ] `sb init` — `.mcp.json` includes auth header
- [ ] `sb -v` — shows "PCP auth: token injected"

🤖 Generated with [Claude Code](https://claude.com/claude-code)