### PR TITLE
fix(cli): auth review fixes + sb studio cli

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -183,6 +183,9 @@ sb studio remove <name>         # Remove studio (keeps branch)
 sb studio clean <name>          # Remove studio + delete branch
 sb studio path <name>           # Print studio path
 eval $(sb studio cd <name>)     # cd to studio
+sb studio cli                   # Build + link CLI as sb-<agent>
+sb studio cli --name sb-dev     # Custom binary name
+sb studio cli --unlink          # Remove linked binary
 ```
 
 Backwards compatibility aliases still work:

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -91,6 +91,7 @@ function startCallbackServer(
         const desc = url.searchParams.get('error_description') || error;
         res.writeHead(200, { 'Content-Type': 'text/html' });
         res.end(ERROR_HTML(desc));
+        clearTimeout(timeout);
         rejectResult(new Error(desc));
         return;
       }
@@ -98,6 +99,7 @@ function startCallbackServer(
       if (!code || !state) {
         res.writeHead(400, { 'Content-Type': 'text/html' });
         res.end(ERROR_HTML('Missing code or state parameter'));
+        clearTimeout(timeout);
         rejectResult(new Error('Missing code or state in callback'));
         return;
       }
@@ -105,14 +107,21 @@ function startCallbackServer(
       if (state !== expectedState) {
         res.writeHead(400, { 'Content-Type': 'text/html' });
         res.end(ERROR_HTML('State mismatch — possible CSRF. Try again.'));
+        clearTimeout(timeout);
         rejectResult(new Error('State mismatch'));
         return;
       }
 
       res.writeHead(200, { 'Content-Type': 'text/html' });
       res.end(SUCCESS_HTML);
+      clearTimeout(timeout);
       resolveResult({ code, state });
     });
+
+    const timeout = setTimeout(() => {
+      rejectResult(new Error('Login timed out'));
+      server.close();
+    }, LOGIN_TIMEOUT_MS);
 
     server.listen(0, '127.0.0.1', () => {
       const addr = server.address();
@@ -120,15 +129,12 @@ function startCallbackServer(
       resolveServer({
         result,
         port,
-        close: () => server.close(),
+        close: () => {
+          clearTimeout(timeout);
+          server.close();
+        },
       });
     });
-
-    // Timeout
-    setTimeout(() => {
-      rejectResult(new Error('Login timed out'));
-      server.close();
-    }, LOGIN_TIMEOUT_MS);
   });
 }
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -83,6 +83,21 @@ function ensureMcpJson(cwd: string): InitStepResult {
       const existing = JSON.parse(readFileSync(mcpPath, 'utf-8')) as Record<string, unknown>;
       const servers = existing.mcpServers as Record<string, unknown> | undefined;
       if (servers?.pcp) {
+        // Migrate existing pcp entry to include auth header if missing
+        const pcpEntry = servers.pcp as Record<string, unknown>;
+        const headers = pcpEntry.headers as Record<string, string> | undefined;
+        if (!headers?.Authorization) {
+          const updatedPcp = {
+            ...pcpEntry,
+            headers: { ...headers, Authorization: 'Bearer ${PCP_ACCESS_TOKEN}' },
+          };
+          const updated = {
+            ...existing,
+            mcpServers: { ...servers, pcp: updatedPcp },
+          };
+          writeFileSync(mcpPath, JSON.stringify(updated, null, 2) + '\n');
+          return { label: '.mcp.json', status: 'updated', detail: 'added auth header to pcp entry' };
+        }
         return { label: '.mcp.json', status: 'exists', detail: 'pcp server configured' };
       }
       // Add pcp server to existing config

--- a/packages/cli/src/commands/workspace.ts
+++ b/packages/cli/src/commands/workspace.ts
@@ -30,9 +30,11 @@ import {
 import { join, dirname, basename } from 'path';
 import { homedir } from 'os';
 import { installHooks } from './hooks.js';
+import { loadAuth, decodeJwtPayload, isTokenExpired } from '../auth/tokens.js';
 
 interface WorkspaceIdentity {
   agentId: string;
+  identityId?: string;
   context: string;
   backend?: string;
   description: string;
@@ -445,9 +447,20 @@ async function createWorkspace(
     const pcpDir = join(wsPath, '.pcp');
     mkdirSync(pcpDir, { recursive: true });
 
+    // Resolve identityId from auth token if available
+    let identityId: string | undefined;
+    const auth = loadAuth();
+    if (auth && !isTokenExpired(auth)) {
+      const payload = decodeJwtPayload(auth.access_token);
+      if (payload?.identityId) {
+        identityId = payload.identityId;
+      }
+    }
+
     // Always write fresh identity.json (never copy from source)
     const identity: WorkspaceIdentity = {
       agentId,
+      ...(identityId ? { identityId } : {}),
       context: `workspace-${name}`,
       ...(options.backend ? { backend: options.backend } : {}),
       description: options.purpose || `Workspace: ${name}`,

--- a/packages/cli/src/commands/workspace.ts
+++ b/packages/cli/src/commands/workspace.ts
@@ -655,6 +655,116 @@ function cdCommand(name: string): void {
 }
 
 // ============================================================================
+// CLI Link
+// ============================================================================
+
+function resolveCliRoot(): string {
+  // Walk up from cwd to find packages/cli/package.json
+  const cwd = process.cwd();
+  const candidates = [
+    join(cwd, 'packages', 'cli'),
+    cwd,
+  ];
+  for (const candidate of candidates) {
+    const pkgPath = join(candidate, 'package.json');
+    if (existsSync(pkgPath)) {
+      try {
+        const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+        if (pkg.name === '@personal-context/cli') return candidate;
+      } catch {
+        // continue
+      }
+    }
+  }
+  throw new Error('Could not find @personal-context/cli package. Run from the repo root or packages/cli.');
+}
+
+function resolveDefaultCliName(): string {
+  const cwd = process.cwd();
+  const identityPath = join(cwd, '.pcp', 'identity.json');
+  if (existsSync(identityPath)) {
+    try {
+      const identity = JSON.parse(readFileSync(identityPath, 'utf-8'));
+      if (identity.agentId) return `sb-${identity.agentId}`;
+    } catch {
+      // fall through
+    }
+  }
+  // Fall back to directory-based name
+  const dirName = basename(cwd);
+  const match = dirName.match(/--(.+)$/);
+  if (match) return `sb-${match[1]}`;
+  return 'sb-dev';
+}
+
+async function cliLinkCommand(options: { name?: string; unlink?: boolean }): Promise<void> {
+  const binDir = join(homedir(), '.local', 'bin');
+  const name = options.name || resolveDefaultCliName();
+
+  if (options.unlink) {
+    const linkPath = join(binDir, name);
+    if (existsSync(linkPath)) {
+      const { unlinkSync } = await import('fs');
+      unlinkSync(linkPath);
+      console.log(chalk.green(`Unlinked: ${linkPath}`));
+    } else {
+      console.log(chalk.dim(`Not found: ${linkPath}`));
+    }
+    return;
+  }
+
+  let cliRoot: string;
+  try {
+    cliRoot = resolveCliRoot();
+  } catch (err) {
+    console.error(chalk.red(err instanceof Error ? err.message : String(err)));
+    process.exit(1);
+    return;
+  }
+
+  const spinner = ora(`Building CLI from ${cliRoot}`).start();
+
+  try {
+    // Build
+    execSync('npx tsc', { cwd: cliRoot, stdio: 'pipe' });
+
+    // Copy templates (matches the build script)
+    const templatesSource = join(cliRoot, 'src', 'templates');
+    const templatesDest = join(cliRoot, 'dist', 'templates');
+    if (existsSync(templatesSource)) {
+      cpSync(templatesSource, templatesDest, { recursive: true });
+    }
+
+    // Ensure executable
+    const cliJs = join(cliRoot, 'dist', 'cli.js');
+    if (!existsSync(cliJs)) {
+      spinner.fail('Build succeeded but dist/cli.js not found');
+      process.exit(1);
+    }
+    execSync(`chmod +x "${cliJs}"`, { stdio: 'pipe' });
+
+    // Create symlink
+    mkdirSync(binDir, { recursive: true });
+    const linkPath = join(binDir, name);
+    const { symlinkSync, unlinkSync } = await import('fs');
+
+    // Remove existing symlink if present
+    if (existsSync(linkPath)) {
+      unlinkSync(linkPath);
+    }
+    symlinkSync(cliJs, linkPath);
+
+    spinner.succeed(`Linked: ${linkPath} → ${cliJs}`);
+    console.log('');
+    console.log(chalk.dim(`  Test it: ${name} --help`));
+    console.log(chalk.dim(`  Remove:  sb studio cli --unlink${options.name ? ` --name ${name}` : ''}`));
+  } catch (error) {
+    spinner.fail(`Failed: ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(1);
+  }
+}
+
+// ============================================================================
 // Register Commands
 // ============================================================================
 
@@ -733,4 +843,10 @@ export function registerWorkspaceCommands(program: Command): void {
   ws.command('cd <name>')
     .description('Output cd command (use with: eval $(sb studio cd <name>))')
     .action(cdCommand);
+
+  ws.command('cli')
+    .description('Build CLI and link as a named binary (default: sb-<agent>)')
+    .option('-n, --name <name>', 'Binary name (default: sb-<agent> from .pcp/identity.json)')
+    .option('--unlink', 'Remove the linked binary instead of creating it')
+    .action(cliLinkCommand);
 }


### PR DESCRIPTION
## Summary\n\n### Auth review fixes (from Lumen's PR #61 review)\n\n- **Clear callback server timeout on success/error/close** — `sb auth login` was keeping the Node process alive up to 5 min after successful token exchange because the `setTimeout` handle was never cleared. Now cleared on every exit path.\n- **Migrate existing `.mcp.json` pcp entries** — `sb init` previously skipped pcp entries that already existed, even if they lacked the `Authorization` header. Now detects missing auth header and adds it in-place, preserving other user customizations.\n\n### `sb studio cli` — named CLI linking\n\nNew command to build the CLI from the current worktree and link it as a named binary in `~/.local/bin`:\n\n```bash\nsb studio cli                   # Build + link as sb-<agent> (from .pcp/identity.json)\nsb studio cli --name sb-dev     # Custom binary name\nsb studio cli --unlink          # Remove the linked binary\n```\n\nDefault name is `sb-<agent>` (e.g., `sb-wren`), derived from `.pcp/identity.json`. Useful for testing feature branches without overwriting the global `sb` install.\n\n## Test plan\n- [x] All 107 CLI tests pass\n- [x] Build clean\n- [x] `sb studio cli --help` shows correct options\n- [ ] `sb studio cli` builds and creates symlink\n- [ ] `sb auth login` exits promptly after success\n- [ ] `sb init` on repo with old `.mcp.json` upgrades the pcp entry\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)