### PR TITLE
fix(cli): resolveCliRoot walk-up + workspace→studio naming migration

### DIFF
--- a/packages/cli/src/backends/identity.ts
+++ b/packages/cli/src/backends/identity.ts
@@ -17,9 +17,14 @@ interface PcpConfig {
 
 export interface IdentityJson {
   agentId: string;
+  identityId?: string;
   context?: string;
   backend?: string;
+  studioId?: string;
+  studio?: string;
+  /** @deprecated Use studioId */
   workspaceId?: string;
+  /** @deprecated Use studio */
   workspace?: string;
 }
 

--- a/packages/cli/src/commands/hooks.ts
+++ b/packages/cli/src/commands/hooks.ts
@@ -860,16 +860,17 @@ async function onSessionStartHandler(): Promise<void> {
   const config = getPcpConfig();
   const agentId = resolveAgentId();
 
-  // Read workspace ID from identity.json
+  // Read studio/workspace ID from identity.json
   const identityPath = join(cwd, '.pcp', 'identity.json');
-  let workspaceId: string | undefined;
-  let workspaceLine = '';
+  let studioId: string | undefined;
+  let studioLine = '';
   if (existsSync(identityPath)) {
     try {
       const identity = JSON.parse(readFileSync(identityPath, 'utf-8'));
-      workspaceId = identity.workspaceId;
-      if (identity.workspace) {
-        workspaceLine = `Workspace: ${identity.workspace}`;
+      studioId = identity.studioId || identity.workspaceId;
+      const studioName = identity.studio || identity.workspace;
+      if (studioName) {
+        studioLine = `Studio: ${studioName}`;
       }
     } catch {
       // ignore
@@ -887,7 +888,7 @@ async function onSessionStartHandler(): Promise<void> {
       email: config?.email,
       agentId,
     };
-    if (workspaceId) bootstrapArgs.workspaceId = workspaceId;
+    if (studioId) bootstrapArgs.studioId = studioId;
 
     const bootstrap = await callPcpTool('bootstrap', bootstrapArgs);
     identityBlock = buildIdentityBlock(bootstrap.identity);
@@ -917,7 +918,7 @@ async function onSessionStartHandler(): Promise<void> {
   const template = loadTemplate('hook-session-start');
   const output = renderTemplate(template, {
     AGENT_ID: agentId,
-    WORKSPACE_LINE: workspaceLine,
+    WORKSPACE_LINE: studioLine,
     IDENTITY_BLOCK: identityBlock,
     MEMORIES_BLOCK: memoriesBlock,
     SESSIONS_BLOCK: sessionsBlock,

--- a/packages/cli/src/commands/workspace.ts
+++ b/packages/cli/src/commands/workspace.ts
@@ -27,7 +27,7 @@ import {
   renameSync,
   cpSync,
 } from 'fs';
-import { join, dirname, basename } from 'path';
+import { join, dirname, basename, parse as parsePath } from 'path';
 import { homedir } from 'os';
 import { installHooks } from './hooks.js';
 import { loadAuth, decodeJwtPayload, isTokenExpired } from '../auth/tokens.js';
@@ -672,24 +672,25 @@ function cdCommand(name: string): void {
 // ============================================================================
 
 function resolveCliRoot(): string {
-  // Walk up from cwd to find packages/cli/package.json
-  const cwd = process.cwd();
-  const candidates = [
-    join(cwd, 'packages', 'cli'),
-    cwd,
-  ];
-  for (const candidate of candidates) {
-    const pkgPath = join(candidate, 'package.json');
-    if (existsSync(pkgPath)) {
-      try {
-        const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
-        if (pkg.name === '@personal-context/cli') return candidate;
-      } catch {
-        // continue
+  // Walk up from cwd checking each directory and its packages/cli subdir
+  let dir = process.cwd();
+  const { root } = parsePath(dir);
+  while (true) {
+    for (const candidate of [join(dir, 'packages', 'cli'), dir]) {
+      const pkgPath = join(candidate, 'package.json');
+      if (existsSync(pkgPath)) {
+        try {
+          const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+          if (pkg.name === '@personal-context/cli') return candidate;
+        } catch {
+          // continue
+        }
       }
     }
+    if (dir === root) break;
+    dir = dirname(dir);
   }
-  throw new Error('Could not find @personal-context/cli package. Run from the repo root or packages/cli.');
+  throw new Error('Could not find @personal-context/cli package. Run from within the repo.');
 }
 
 function resolveDefaultCliName(): string {

--- a/packages/cli/src/commands/workspace.ts
+++ b/packages/cli/src/commands/workspace.ts
@@ -37,8 +37,9 @@ interface WorkspaceIdentity {
   identityId?: string;
   context: string;
   backend?: string;
+  studioId?: string;
+  studio: string;
   description: string;
-  workspace: string;
   branch: string;
   createdAt: string;
   createdBy?: string;
@@ -461,10 +462,10 @@ async function createWorkspace(
     const identity: WorkspaceIdentity = {
       agentId,
       ...(identityId ? { identityId } : {}),
-      context: `workspace-${name}`,
+      context: `studio-${name}`,
       ...(options.backend ? { backend: options.backend } : {}),
-      description: options.purpose || `Workspace: ${name}`,
-      workspace: name,
+      studio: name,
+      description: options.purpose || `Studio: ${name}`,
       branch,
       createdAt: new Date().toISOString(),
       createdBy: getCurrentUser(),

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -7,12 +7,16 @@
 
 export interface WorkspaceIdentity {
   agentId: string;
+  identityId?: string;
   context: string;
   description: string;
-  workspace: string;
+  studioId?: string;
+  studio: string;
   branch: string;
   createdAt: string;
   createdBy?: string;
+  /** @deprecated Use studio */
+  workspace?: string;
 }
 
 export interface WorkspaceInfo {
@@ -26,6 +30,8 @@ export interface PcpConfig {
   userId?: string;
   email?: string;
   agentMapping?: Record<string, string>;
+  studioId?: string;
+  /** @deprecated Use studioId */
   workspaceId?: string;
 }
 


### PR DESCRIPTION
## Summary\n\n### resolveCliRoot walks up parent directories\n- Previously only checked `cwd` and `cwd/packages/cli`, so `sb studio cli` failed from nested subdirectories\n- Now walks up the directory tree checking each level\n- Addresses Lumen's nit from PR #62\n\n### workspace → studio naming in identity.json\n- `sb studio create` now writes `studio` and `studioId` fields (not `workspace`/`workspaceId`)\n- `IdentityJson` interface adds `studioId`/`studio` with `@deprecated` annotations on old fields\n- Hooks read `studioId` with fallback to `workspaceId`, pass `studioId` to bootstrap\n- Exported types in `index.ts` updated with deprecated annotations\n- Existing identity.json files with old field names continue to work via fallback reads\n\n## Test plan\n- [x] All 107 CLI tests pass\n- [x] Build clean\n- [x] Old identity.json files (with `workspace`/`workspaceId`) still work\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)