### PR TITLE
fix: absolute CLI paths in hooks + surface trigger failures (by Wren)

### DIFF
--- a/packages/api/src/mcp/tools/inbox-handlers.ts
+++ b/packages/api/src/mcp/tools/inbox-handlers.ts
@@ -240,35 +240,47 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
       studioHint: recipientStudioHint,
     };
 
-    // Fire-and-forget: don't await the trigger processing
-    // The message is already in the inbox - we just need to wake the agent
-    gateway
-      .processTrigger(payload)
-      .then((result) => {
-        logger.info('Inbox message trigger completed', {
-          messageId: message.id,
-          triggerId: result.triggerId,
-          processed: result.processed,
-          error: result.error,
-        });
-      })
-      .catch((error) => {
-        logger.error('Inbox message trigger failed', {
-          messageId: message.id,
-          error: error instanceof Error ? error.message : String(error),
-        });
-      });
-
-    triggerResult = {
-      triggered: true,
-      triggerId: 'async', // Trigger ID assigned asynchronously
-      processed: undefined, // Processing happens in background
-    };
-
-    logger.info('Inbox message trigger dispatched (async)', {
+    // Await trigger with timeout so the sender sees the real result
+    const TRIGGER_TIMEOUT_MS = 30_000;
+    logger.info('Inbox message trigger dispatched', {
       messageId: message.id,
       recipientAgentId,
     });
+
+    try {
+      const result = await Promise.race([
+        gateway.processTrigger(payload),
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error('Trigger timed out (30s)')), TRIGGER_TIMEOUT_MS)
+        ),
+      ]);
+
+      logger.info('Inbox message trigger completed', {
+        messageId: message.id,
+        triggerId: result.triggerId,
+        processed: result.processed,
+        error: result.error,
+      });
+
+      triggerResult = {
+        triggered: true,
+        triggerId: result.triggerId,
+        processed: result.processed,
+        error: result.error,
+      };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      logger.error('Inbox message trigger failed', {
+        messageId: message.id,
+        error: errorMessage,
+      });
+
+      triggerResult = {
+        triggered: true,
+        processed: false,
+        error: errorMessage,
+      };
+    }
   }
 
   return {

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -365,12 +365,18 @@ Do NOT just respond here — you MUST explicitly call send_response to reach ext
     let userId: string | undefined;
     let recipientIdentityId: string | undefined;
     if (payload.inboxMessageId) {
-      const { data: inboxMsg } = await dataComposer!
+      const { data: inboxMsg, error: inboxError } = await dataComposer!
         .getClient()
         .from('agent_inbox')
         .select('recipient_user_id, recipient_identity_id')
         .eq('id', payload.inboxMessageId)
         .single();
+      if (inboxError) {
+        logger.error('[Trigger] Failed to look up inbox message', {
+          inboxMessageId: payload.inboxMessageId,
+          error: inboxError.message,
+        });
+      }
       userId = inboxMsg?.recipient_user_id;
       recipientIdentityId = inboxMsg?.recipient_identity_id || undefined;
     }
@@ -427,7 +433,9 @@ Do NOT just respond here — you MUST explicitly call send_response to reach ext
 
       const { data: identityRows, error: identityError } = await identityQuery;
       if (identityError) {
-        throw new Error(`Failed to resolve target identity for ${targetAgentId}: ${identityError.message}`);
+        throw new Error(
+          `Failed to resolve target identity for ${targetAgentId}: ${identityError.message}`
+        );
       }
 
       if (!identityRows || identityRows.length === 0) {
@@ -471,7 +479,9 @@ If you need to message a user, use send_response with the appropriate channel an
       userId,
       agentId: targetAgentId,
       channel: 'agent',
-      conversationId: payload.threadKey ? `trigger:${targetAgentId}:${payload.threadKey}` : `trigger:${targetAgentId}`,
+      conversationId: payload.threadKey
+        ? `trigger:${targetAgentId}:${payload.threadKey}`
+        : `trigger:${targetAgentId}`,
       sender: { id: payload.fromAgentId, name: payload.fromAgentId },
       content: triggerMessage,
       metadata: {

--- a/packages/api/src/services/sessions/codex-runner.ts
+++ b/packages/api/src/services/sessions/codex-runner.ts
@@ -141,6 +141,7 @@ export class CodexRunner implements IClaudeRunner {
       });
 
       let stderr = '';
+      const nonJsonLines: string[] = [];
       const responses: ChannelResponse[] = [];
       const toolCalls: ToolCall[] = [];
       let usage: CodexUsageStats | undefined;
@@ -183,7 +184,8 @@ export class CodexRunner implements IClaudeRunner {
             responses.push(...extracted.responses);
             toolCalls.push(...extracted.toolCalls);
           } catch {
-            // ignore non-JSON lines
+            // Capture non-JSON lines as diagnostic context
+            if (line.trim()) nonJsonLines.push(line.trim());
           }
         }
       });
@@ -206,7 +208,8 @@ export class CodexRunner implements IClaudeRunner {
         settled = true;
 
         if (code !== 0 && !finalTextResponse && responses.length === 0) {
-          reject(new Error(`Codex exited with code ${code}: ${stderr}`));
+          const diagnostic = stderr || nonJsonLines.join('\n') || '(no output)';
+          reject(new Error(`Codex exited with code ${code}: ${diagnostic}`));
           return;
         }
 

--- a/packages/cli/src/commands/hooks.test.ts
+++ b/packages/cli/src/commands/hooks.test.ts
@@ -61,26 +61,29 @@ describe('installHooks: Claude Code', () => {
     const configPath = join(TEST_DIR, '.claude', 'settings.local.json');
     const config = JSON.parse(readFileSync(configPath, 'utf-8'));
 
+    // Commands may be absolute paths (e.g., /path/to/node_modules/.bin/sb hooks ...)
+    // or bare `sb hooks ...` depending on whether node_modules/.bin/sb exists
+
     // PreCompact
-    expect(config.hooks.PreCompact[0].hooks[0].command).toBe('sb hooks pre-compact');
+    expect(config.hooks.PreCompact[0].hooks[0].command).toContain('sb hooks pre-compact');
 
     // SessionStart — compact matcher
     const compactEntry = config.hooks.SessionStart.find(
       (e: Record<string, unknown>) => e.matcher === 'compact'
     );
-    expect(compactEntry.hooks[0].command).toBe('sb hooks post-compact');
+    expect(compactEntry.hooks[0].command).toContain('sb hooks post-compact');
 
     // SessionStart — startup matcher
     const startupEntry = config.hooks.SessionStart.find(
       (e: Record<string, unknown>) => e.matcher === 'startup'
     );
-    expect(startupEntry.hooks[0].command).toBe('sb hooks on-session-start');
+    expect(startupEntry.hooks[0].command).toContain('sb hooks on-session-start');
 
     // UserPromptSubmit
-    expect(config.hooks.UserPromptSubmit[0].hooks[0].command).toBe('sb hooks on-prompt');
+    expect(config.hooks.UserPromptSubmit[0].hooks[0].command).toContain('sb hooks on-prompt');
 
     // Stop
-    expect(config.hooks.Stop[0].hooks[0].command).toBe('sb hooks on-stop');
+    expect(config.hooks.Stop[0].hooks[0].command).toContain('sb hooks on-stop');
   });
 
   it('should preserve existing non-hooks settings', () => {
@@ -93,9 +96,7 @@ describe('installHooks: Claude Code', () => {
 
     installHooks(TEST_DIR);
 
-    const config = JSON.parse(
-      readFileSync(join(configDir, 'settings.local.json'), 'utf-8')
-    );
+    const config = JSON.parse(readFileSync(join(configDir, 'settings.local.json'), 'utf-8'));
     expect(config.permissions.allow).toContain('Bash(git:*)');
     expect(config.hooks).toBeDefined();
   });
@@ -149,11 +150,9 @@ describe('installHooks: Claude Code', () => {
     const { result } = installHooks(TEST_DIR, { force: true });
     expect(result).toBe('installed');
 
-    const config = JSON.parse(
-      readFileSync(join(configDir, 'settings.local.json'), 'utf-8')
-    );
+    const config = JSON.parse(readFileSync(join(configDir, 'settings.local.json'), 'utf-8'));
     // Should now have PCP hooks, not the custom one
-    expect(config.hooks.Stop[0].hooks[0].command).toBe('sb hooks on-stop');
+    expect(config.hooks.Stop[0].hooks[0].command).toContain('sb hooks on-stop');
   });
 
   it('should allow re-install over existing PCP hooks without force', () => {
@@ -195,8 +194,8 @@ describe('installHooks: Gemini', () => {
     expect(existsSync(configPath)).toBe(true);
 
     const config = JSON.parse(readFileSync(configPath, 'utf-8'));
-    expect(config.hooks.session_start[0].command).toBe('sb hooks on-session-start');
-    expect(config.hooks.session_end[0].command).toBe('sb hooks on-stop');
+    expect(config.hooks.session_start[0].command).toContain('sb hooks on-session-start');
+    expect(config.hooks.session_end[0].command).toContain('sb hooks on-stop');
   });
 
   it('should preserve existing Gemini settings', () => {
@@ -209,9 +208,7 @@ describe('installHooks: Gemini', () => {
 
     installHooks(TEST_DIR, { backend: 'gemini' });
 
-    const config = JSON.parse(
-      readFileSync(join(configDir, 'settings.json'), 'utf-8')
-    );
+    const config = JSON.parse(readFileSync(join(configDir, 'settings.json'), 'utf-8'));
     expect(config.mcpServers.pcp.url).toBe('http://localhost:3001/mcp');
     expect(config.hooks).toBeDefined();
   });
@@ -257,8 +254,8 @@ describe('installHooks: Codex', () => {
     const content = readFileSync(configPath, 'utf-8');
     expect(content).toContain('# pcp-managed');
     expect(content).toContain('[hooks]');
-    expect(content).toContain('session_start = "sb hooks on-session-start"');
-    expect(content).toContain('session_end = "sb hooks on-stop"');
+    expect(content).toMatch(/session_start = ".*sb hooks on-session-start"/);
+    expect(content).toMatch(/session_end = ".*sb hooks on-stop"/);
     expect(content).toContain('# end pcp-managed');
   });
 
@@ -271,10 +268,7 @@ describe('installHooks: Codex', () => {
   it('should return conflict when non-PCP [hooks] exists', () => {
     const configDir = join(TEST_DIR, '.codex');
     mkdirSync(configDir, { recursive: true });
-    writeFileSync(
-      join(configDir, 'config.toml'),
-      '[hooks]\nsession_start = "other-tool start"\n'
-    );
+    writeFileSync(join(configDir, 'config.toml'), '[hooks]\nsession_start = "other-tool start"\n');
 
     const { result } = installHooks(TEST_DIR, { backend: 'codex' });
     expect(result).toBe('conflict');
@@ -308,7 +302,7 @@ describe('installHooks: Codex', () => {
     const endMarkers = content.match(/# end pcp-managed/g);
     expect(startMarkers).toHaveLength(1);
     expect(endMarkers).toHaveLength(1);
-    expect(content).toContain('session_start = "sb hooks on-session-start"');
+    expect(content).toMatch(/session_start = ".*sb hooks on-session-start"/);
   });
 });
 

--- a/packages/cli/src/commands/hooks.ts
+++ b/packages/cli/src/commands/hooks.ts
@@ -203,13 +203,16 @@ function getPcpServerUrl(): string {
 
 let jsonRpcId = 1;
 
-async function callPcpTool(tool: string, args: Record<string, unknown>): Promise<Record<string, unknown>> {
+async function callPcpTool(
+  tool: string,
+  args: Record<string, unknown>
+): Promise<Record<string, unknown>> {
   const url = `${getPcpServerUrl()}/mcp`;
   const response = await fetch(url, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      'Accept': 'application/json',
+      Accept: 'application/json',
     },
     body: JSON.stringify({
       jsonrpc: '2.0',
@@ -343,7 +346,9 @@ function buildSessionsBlock(sessions: Array<Record<string, unknown>> | undefined
   if (!sessions || sessions.length === 0) return '';
   const lines = ['### Active Sessions'];
   for (const s of sessions) {
-    lines.push(`- ${(s.id as string)?.substring(0, 8) || 'unknown'}: ${s.summary || s.status || 'active'}`);
+    lines.push(
+      `- ${(s.id as string)?.substring(0, 8) || 'unknown'}: ${s.summary || s.status || 'active'}`
+    );
   }
   return lines.join('\n');
 }
@@ -355,34 +360,55 @@ function buildSessionsBlock(sessions: Array<Record<string, unknown>> | undefined
 /** Marker used to identify PCP-managed hook entries */
 const PCP_MARKER = 'pcp-managed';
 
+/**
+ * Resolve absolute path to the `sb` CLI binary from the main worktree's
+ * node_modules/.bin/sb. This ensures hooks work from PM2 and other
+ * environments where ~/.local/bin may not be in PATH.
+ */
+function resolveSbBinaryPath(cwd: string): string {
+  const worktrees = listWorktreePaths(cwd);
+  const mainWorktree = worktrees[0] || cwd;
+  const binPath = join(mainWorktree, 'node_modules', '.bin', 'sb');
+  if (existsSync(binPath)) return binPath;
+  // Fallback: bare `sb` (relies on PATH)
+  return 'sb';
+}
+
+/** Check if a hook command is PCP-managed (handles both bare `sb` and absolute paths) */
+function isPcpHookCommand(cmd: string | undefined): boolean {
+  if (!cmd) return false;
+  // Match bare `sb hooks ...` or `/abs/path/to/sb hooks ...`
+  return /\bsb hooks /.test(cmd);
+}
+
 type InstallResult = 'installed' | 'already-installed' | 'conflict';
 
-function buildClaudeCodeHooks(): Record<string, unknown> {
+function buildClaudeCodeHooks(sbPath: string): Record<string, unknown> {
   return {
     hooks: {
       PreCompact: [
         {
-          hooks: [{ type: 'command', command: 'sb hooks pre-compact' }],
+          hooks: [{ type: 'command', command: `${sbPath} hooks pre-compact` }],
         },
       ],
       SessionStart: [
         {
           matcher: 'compact',
-          hooks: [{ type: 'command', command: 'sb hooks post-compact' }],
+          hooks: [{ type: 'command', command: `${sbPath} hooks post-compact` }],
         },
         {
           matcher: 'startup',
-          hooks: [{ type: 'command', command: 'sb hooks on-session-start' }],
+          hooks: [{ type: 'command', command: `${sbPath} hooks on-session-start` }],
         },
       ],
       UserPromptSubmit: [
         {
-          hooks: [{ type: 'command', command: 'sb hooks on-prompt' }],
+          hooks: [{ type: 'command', command: `${sbPath} hooks on-prompt` }],
         },
       ],
       Stop: [
         {
-          hooks: [{ type: 'command', command: 'sb hooks on-stop' }],
+          hooks: [{ type: 'command', command: `${sbPath} hooks on-stop` }],
         },
       ],
     },
@@ -390,8 +416,9 @@ function buildClaudeCodeHooks(): Record<string, unknown> {
 }
 
 /** Check if existing Claude Code hooks already match the PCP hooks we'd write */
-function claudeCodeHooksMatch(existing: Record<string, unknown>): boolean {
-  const target = buildClaudeCodeHooks();
+function claudeCodeHooksMatch(existing: Record<string, unknown>, cwd: string): boolean {
+  const sbPath = resolveSbBinaryPath(cwd);
+  const target = buildClaudeCodeHooks(sbPath);
   const existingHooksStr = JSON.stringify(existing.hooks);
   const targetHooksStr = JSON.stringify(target.hooks);
   return existingHooksStr === targetHooksStr;
@@ -415,7 +442,7 @@ function installClaudeCode(cwd: string, force: boolean): InstallResult {
   const existingHooks = existing.hooks as Record<string, unknown> | undefined;
   if (existingHooks && !force) {
     // Check if PCP hooks already match exactly
-    if (claudeCodeHooksMatch(existing)) {
+    if (claudeCodeHooksMatch(existing, cwd)) {
       return 'already-installed';
     }
 
@@ -425,10 +452,7 @@ function installClaudeCode(cwd: string, force: boolean): InstallResult {
       return entries.some((entry: Record<string, unknown>) => {
         const hooks = entry.hooks as Array<Record<string, unknown>> | undefined;
         if (!hooks) return false;
-        return hooks.some((h) => {
-          const cmd = h.command as string | undefined;
-          return cmd && !cmd.startsWith('sb hooks ');
-        });
+        return hooks.some((h) => !isPcpHookCommand(h.command as string | undefined));
       });
     });
 
@@ -437,7 +461,8 @@ function installClaudeCode(cwd: string, force: boolean): InstallResult {
     }
   }
 
-  const pcpHooks = buildClaudeCodeHooks();
+  const sbPath = resolveSbBinaryPath(cwd);
+  const pcpHooks = buildClaudeCodeHooks(sbPath);
 
   // Merge: keep existing non-hooks settings, replace hooks
   const merged = { ...existing, ...pcpHooks };
@@ -462,13 +487,15 @@ function installGemini(cwd: string, force: boolean): InstallResult {
   if (existing.hooks && !force) {
     // Check if our hooks are already there
     const hooksObj = existing.hooks as Record<string, unknown>;
-    const hasSessionStart = Array.isArray(hooksObj.session_start) &&
-      (hooksObj.session_start as Array<Record<string, unknown>>).some(
-        (h) => h.command === 'sb hooks on-session-start'
+    const hasSessionStart =
+      Array.isArray(hooksObj.session_start) &&
+      (hooksObj.session_start as Array<Record<string, unknown>>).some((h) =>
+        isPcpHookCommand(h.command as string | undefined)
       );
-    const hasSessionEnd = Array.isArray(hooksObj.session_end) &&
-      (hooksObj.session_end as Array<Record<string, unknown>>).some(
-        (h) => h.command === 'sb hooks on-stop'
+    const hasSessionEnd =
+      Array.isArray(hooksObj.session_end) &&
+      (hooksObj.session_end as Array<Record<string, unknown>>).some((h) =>
+        isPcpHookCommand(h.command as string | undefined)
       );
     if (hasSessionStart && hasSessionEnd) {
       return 'already-installed';
@@ -477,11 +504,12 @@ function installGemini(cwd: string, force: boolean): InstallResult {
     return 'conflict';
   }
 
+  const sbPath = resolveSbBinaryPath(cwd);
   const merged = {
     ...existing,
     hooks: {
-      session_start: [{ command: 'sb hooks on-session-start' }],
-      session_end: [{ command: 'sb hooks on-stop' }],
+      session_start: [{ command: `${sbPath} hooks on-session-start` }],
+      session_end: [{ command: `${sbPath} hooks on-stop` }],
     },
   };
 
@@ -510,12 +538,13 @@ function installCodex(cwd: string, force: boolean): InstallResult {
   // Remove existing PCP-managed hooks section if present
   const cleaned = removePcpTomlSection(existingContent);
 
+  const sbPath = resolveSbBinaryPath(cwd);
   const pcpSection = [
     '',
     `# ${PCP_MARKER}`,
     '[hooks]',
-    'session_start = "sb hooks on-session-start"',
-    'session_end = "sb hooks on-stop"',
+    `session_start = "${sbPath} hooks on-session-start"`,
+    `session_end = "${sbPath} hooks on-stop"`,
     `# end ${PCP_MARKER}`,
     '',
   ].join('\n');
@@ -750,14 +779,12 @@ async function statusCommand(options: { backend?: string }): Promise<void> {
                 for (const h of hookList) {
                   const cmd = h.command as string;
                   const matcherSuffix = matcher ? ` (${matcher})` : '';
-                  const isPcp = cmd?.startsWith('sb hooks ');
-                  const icon = isPcp ? chalk.green('●') : chalk.dim('○');
+                  const icon = isPcpHookCommand(cmd) ? chalk.green('●') : chalk.dim('○');
                   console.log(`    ${icon} ${event}${matcherSuffix} → ${cmd}`);
                 }
               } else if (command) {
                 // Gemini/simpler format
-                const isPcp = command.startsWith('sb hooks ');
-                const icon = isPcp ? chalk.green('●') : chalk.dim('○');
+                const icon = isPcpHookCommand(command) ? chalk.green('●') : chalk.dim('○');
                 console.log(`    ${icon} ${event} → ${command}`);
               }
             }
@@ -790,7 +817,9 @@ async function statusCommand(options: { backend?: string }): Promise<void> {
   // Show capabilities
   console.log(chalk.dim('\n  Capabilities:'));
   console.log(
-    chalk.dim(`    Compaction: ${backend.supportsCompaction ? chalk.green('yes') : chalk.yellow('no')}`)
+    chalk.dim(
+      `    Compaction: ${backend.supportsCompaction ? chalk.green('yes') : chalk.yellow('no')}`
+    )
   );
   console.log(
     chalk.dim(
@@ -892,8 +921,12 @@ async function onSessionStartHandler(): Promise<void> {
 
     const bootstrap = await callPcpTool('bootstrap', bootstrapArgs);
     identityBlock = buildIdentityBlock(bootstrap.identity);
-    memoriesBlock = buildMemoriesBlock(bootstrap.recentMemories as Array<Record<string, unknown>> | undefined);
-    sessionsBlock = buildSessionsBlock(bootstrap.activeSessions as Array<Record<string, unknown>> | undefined);
+    memoriesBlock = buildMemoriesBlock(
+      bootstrap.recentMemories as Array<Record<string, unknown>> | undefined
+    );
+    sessionsBlock = buildSessionsBlock(
+      bootstrap.activeSessions as Array<Record<string, unknown>> | undefined
+    );
   } catch {
     identityBlock = '*Could not reach PCP server for bootstrap.*';
   }


### PR DESCRIPTION
## Summary

- **Hooks now use absolute paths** to `node_modules/.bin/sb` from the main worktree, resolved via `git worktree list`. Fixes silent failures when Codex is spawned from PM2 where `~/.local/bin` isn't in PATH.
- **Trigger pipeline no longer fire-and-forget** — `send_to_inbox` now awaits the trigger result (with 30s timeout) and returns the real success/failure/error to the sender SB. Previously returned `triggered: true` even when the trigger crashed.
- **Codex runner captures non-JSON stdout** as diagnostic context instead of silently discarding it. Exit code 1 errors now include the actual output for debugging.
- **Trigger handler logs `.single()` errors** instead of silently producing undefined.

## Context

Investigation of why Lumen's PR review triggers were silently failing revealed:
1. Codex exits code 1 with empty stderr when spawned from PM2
2. The fire-and-forget pattern masked the failure completely
3. Non-JSON stdout (potential error messages) was discarded by the JSON parser

## Test plan

- [x] `npx vitest run packages/cli/src/commands/hooks.test.ts` — 25/25 pass
- [x] `yarn workspace @personal-context/cli build` — clean
- [ ] Run `sb hooks install --all --force` from main worktree — verify absolute paths
- [ ] Send test `send_to_inbox` to lumen — verify trigger error surfaces in response

🤖 Generated with [Claude Code](https://claude.com/claude-code)