### PR TITLE
feat: channel_routes for DB-driven message routing (by Wren)

### DIFF
--- a/packages/api/src/channels/gateway.ts
+++ b/packages/api/src/channels/gateway.ts
@@ -63,6 +63,7 @@ export type IncomingMessageHandler = (
     media?: Array<{ type: 'image' | 'video' | 'audio' | 'document'; path?: string; url?: string }>;
     chatType?: 'direct' | 'group' | 'channel';
     mentions?: { users: string[]; botMentioned: boolean };
+    platformAccountId?: string;
   }
 ) => Promise<void>;
 
@@ -92,6 +93,7 @@ interface MessageBuffer {
     replyToMessageId?: string;
     chatType?: 'direct' | 'group' | 'channel';
     mentions?: { users: string[]; botMentioned: boolean };
+    platformAccountId?: string;
   };
 }
 
@@ -253,6 +255,7 @@ export class ChannelGateway extends EventEmitter {
       }>;
       chatType?: 'direct' | 'group' | 'channel';
       mentions?: { users: string[]; botMentioned: boolean };
+      platformAccountId?: string;
     }
   ): void {
     // If buffering is disabled, forward immediately
@@ -314,6 +317,7 @@ export class ChannelGateway extends EventEmitter {
           replyToMessageId: metadata?.replyToMessageId,
           chatType: metadata?.chatType,
           mentions: metadata?.mentions,
+          platformAccountId: metadata?.platformAccountId,
         },
       });
 
@@ -407,6 +411,7 @@ export class ChannelGateway extends EventEmitter {
       }>;
       chatType?: 'direct' | 'group' | 'channel';
       mentions?: { users: string[]; botMentioned: boolean };
+      platformAccountId?: string;
     }
   ): Promise<void> {
     logger.info(`Forwarding message to handler: ${channel}:${conversationId}`);
@@ -763,6 +768,7 @@ export class ChannelGateway extends EventEmitter {
           media: message.media,
           chatType: message.chatType,
           mentions: message.mentions,
+          platformAccountId: message.accountId,
         }
       );
     });
@@ -818,6 +824,7 @@ export class ChannelGateway extends EventEmitter {
         {
           chatType: message.chatType,
           mentions: message.mentions,
+          platformAccountId: message.accountId,
         }
       );
     });
@@ -878,6 +885,7 @@ export class ChannelGateway extends EventEmitter {
           media: message.media,
           chatType: message.chatType,
           mentions: message.mentions,
+          platformAccountId: message.accountId,
         }
       );
     });

--- a/packages/api/src/channels/telegram-listener.ts
+++ b/packages/api/src/channels/telegram-listener.ts
@@ -168,6 +168,7 @@ export class TelegramListener extends EventEmitter {
   private messageCallback?: MessageCallback;
   private mediaGroupBuffer: MediaGroupBuffer | null = null;
   private authService: AuthorizationService;
+  private botUsername: string | null = null;
 
   // Ephemeral message cache - keyed by chatId, stores last N messages
   // Auto-cleaned periodically, never persisted to disk
@@ -215,6 +216,7 @@ export class TelegramListener extends EventEmitter {
     // Get bot info
     try {
       const me = await this.apiCall<TelegramUser>('getMe');
+      this.botUsername = me.username || String(me.id);
       logger.info(`Telegram bot connected: @${me.username} (${me.id})`);
       this.emit('connected', me);
     } catch (error) {
@@ -645,6 +647,7 @@ export class TelegramListener extends EventEmitter {
       messageId: String(msg.message_id),
       platform: 'telegram' as ChannelPlatform,
       chatType,
+      accountId: this.botUsername || undefined,
       sender: {
         id: msg.from ? String(msg.from.id) : String(msg.chat.id),
         username: msg.from?.username,

--- a/packages/api/src/channels/whatsapp-listener.ts
+++ b/packages/api/src/channels/whatsapp-listener.ts
@@ -612,6 +612,9 @@ export class WhatsAppListener extends EventEmitter {
       }
     }
 
+    // Account ID from WhatsApp self JID (e.g. "+16266621947")
+    const accountId = this.selfJid ? this.jidToE164(this.selfJid) : undefined;
+
     const message: InboundMessage = {
       body: text,
       rawBody: text,
@@ -619,6 +622,7 @@ export class WhatsAppListener extends EventEmitter {
       messageId: msg.key.id!,
       platform: 'whatsapp' as ChannelPlatform,
       chatType: isGroup ? 'group' : 'direct',
+      accountId,
       sender: {
         id: senderE164,
         name: senderName || undefined,

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -36,6 +36,7 @@ import type { GatewayChannel } from './channels/gateway';
 import { initHeartbeatService, processHeartbeat, type DueReminder } from './services/heartbeat';
 import { setResponseCallback, hasExplicitResponse } from './mcp/tools/response-handlers';
 import { getAgentGateway, type AgentTriggerPayload } from './channels/agent-gateway';
+import { resolveRouteAgentId } from './services/routing/resolve-route';
 import { logger } from './utils/logger';
 import { env } from './config/env';
 
@@ -152,10 +153,34 @@ async function startServer(config: ServerConfig = {}): Promise<void> {
       return;
     }
 
+    // Resolve agent from channel_routes, fall back to server default (AGENT_ID env)
+    let routedAgentId = agentId;
+    const route = await resolveRouteAgentId(
+      dataComposer!.getClient(),
+      userId,
+      channel,
+      metadata?.platformAccountId,
+      conversationId
+    );
+    if (route) {
+      routedAgentId = route.agentId;
+      logger.debug(`[Route] Resolved agent from channel_routes`, {
+        platform: channel,
+        agentId: route.agentId,
+        identityId: route.identityId,
+        routeId: route.routeId,
+      });
+    } else {
+      logger.warn(
+        `[Route] No channel_route found for ${channel}, falling back to AGENT_ID=${agentId}`,
+        { userId, platform: channel, conversationId }
+      );
+    }
+
     // Build SessionRequest
     const request: SessionRequest = {
       userId,
-      agentId,
+      agentId: routedAgentId,
       channel: channel as ChannelType,
       conversationId,
       sender: {

--- a/packages/api/src/services/routing/resolve-route.test.ts
+++ b/packages/api/src/services/routing/resolve-route.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { resolveRouteAgentId } from './resolve-route';
+
+// Mock Supabase client
+function createMockSupabase(
+  routes: Array<{
+    id: string;
+    platform_account_id: string | null;
+    chat_id: string | null;
+    identity_id: string;
+    agent_identities: { agent_id: string };
+  }>
+) {
+  return {
+    from: vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockImplementation(function (this: any) {
+          // Chain .eq calls — return self each time, with final data on last
+          return {
+            eq: vi.fn().mockImplementation(function () {
+              return {
+                eq: vi.fn().mockResolvedValue({ data: routes, error: null }),
+              };
+            }),
+          };
+        }),
+      }),
+    }),
+  } as any;
+}
+
+// Helper: mock that chains .from().select().eq().eq().eq() properly
+function mockClient(routes: any[], error: any = null) {
+  const eqChain = {
+    eq: vi.fn().mockReturnValue({
+      eq: vi.fn().mockReturnValue({
+        eq: vi.fn().mockResolvedValue({ data: routes, error }),
+      }),
+    }),
+  };
+  const selectChain = { select: vi.fn().mockReturnValue(eqChain) };
+  return {
+    from: vi.fn().mockReturnValue(selectChain),
+  } as any;
+}
+
+describe('resolveRouteAgentId', () => {
+  it('returns null when no routes exist', async () => {
+    const client = mockClient([]);
+    const result = await resolveRouteAgentId(client, 'user-1', 'telegram');
+    expect(result).toBeNull();
+  });
+
+  it('matches a platform-level default (no account, no chat)', async () => {
+    const routes = [
+      {
+        id: 'route-1',
+        platform_account_id: null,
+        chat_id: null,
+        identity_id: 'id-1',
+        agent_identities: { agent_id: 'myra' },
+      },
+    ];
+    const client = mockClient(routes);
+    const result = await resolveRouteAgentId(client, 'user-1', 'telegram');
+
+    expect(result).toEqual({
+      agentId: 'myra',
+      identityId: 'id-1',
+      routeId: 'route-1',
+    });
+  });
+
+  it('prefers account match over platform default', async () => {
+    const routes = [
+      {
+        id: 'route-platform',
+        platform_account_id: null,
+        chat_id: null,
+        identity_id: 'id-myra',
+        agent_identities: { agent_id: 'myra' },
+      },
+      {
+        id: 'route-account',
+        platform_account_id: 'myra_help_bot',
+        chat_id: null,
+        identity_id: 'id-benson',
+        agent_identities: { agent_id: 'benson' },
+      },
+    ];
+    const client = mockClient(routes);
+
+    const result = await resolveRouteAgentId(client, 'user-1', 'telegram', 'myra_help_bot');
+    expect(result?.agentId).toBe('benson');
+    expect(result?.routeId).toBe('route-account');
+  });
+
+  it('prefers exact chat match over account default', async () => {
+    const routes = [
+      {
+        id: 'route-account',
+        platform_account_id: 'myra_help_bot',
+        chat_id: null,
+        identity_id: 'id-myra',
+        agent_identities: { agent_id: 'myra' },
+      },
+      {
+        id: 'route-chat',
+        platform_account_id: 'myra_help_bot',
+        chat_id: 'chat-123',
+        identity_id: 'id-wren',
+        agent_identities: { agent_id: 'wren' },
+      },
+    ];
+    const client = mockClient(routes);
+
+    const result = await resolveRouteAgentId(
+      client,
+      'user-1',
+      'telegram',
+      'myra_help_bot',
+      'chat-123'
+    );
+    expect(result?.agentId).toBe('wren');
+    expect(result?.routeId).toBe('route-chat');
+  });
+
+  it('skips routes where account is specified but does not match', async () => {
+    const routes = [
+      {
+        id: 'route-other-bot',
+        platform_account_id: 'other_bot',
+        chat_id: null,
+        identity_id: 'id-benson',
+        agent_identities: { agent_id: 'benson' },
+      },
+      {
+        id: 'route-platform',
+        platform_account_id: null,
+        chat_id: null,
+        identity_id: 'id-myra',
+        agent_identities: { agent_id: 'myra' },
+      },
+    ];
+    const client = mockClient(routes);
+
+    // Incoming from myra_help_bot — should skip the other_bot route, match platform default
+    const result = await resolveRouteAgentId(client, 'user-1', 'telegram', 'myra_help_bot');
+    expect(result?.agentId).toBe('myra');
+    expect(result?.routeId).toBe('route-platform');
+  });
+
+  it('skips routes where chat is specified but does not match', async () => {
+    const routes = [
+      {
+        id: 'route-chat-specific',
+        platform_account_id: null,
+        chat_id: 'chat-999',
+        identity_id: 'id-wren',
+        agent_identities: { agent_id: 'wren' },
+      },
+      {
+        id: 'route-platform',
+        platform_account_id: null,
+        chat_id: null,
+        identity_id: 'id-myra',
+        agent_identities: { agent_id: 'myra' },
+      },
+    ];
+    const client = mockClient(routes);
+
+    const result = await resolveRouteAgentId(client, 'user-1', 'telegram', undefined, 'chat-123');
+    expect(result?.agentId).toBe('myra');
+  });
+
+  it('returns null on database error', async () => {
+    const client = mockClient(null, { message: 'DB error' });
+    const result = await resolveRouteAgentId(client, 'user-1', 'telegram');
+    expect(result).toBeNull();
+  });
+});

--- a/packages/api/src/services/routing/resolve-route.ts
+++ b/packages/api/src/services/routing/resolve-route.ts
@@ -1,0 +1,117 @@
+/**
+ * Channel Route Resolution
+ *
+ * Resolves which agent should handle an incoming message based on the
+ * channel_routes table. Uses a specificity cascade:
+ *   1. Exact match: platform + account + chat
+ *   2. Account default: platform + account (chat_id IS NULL)
+ *   3. Platform default: platform only (both account + chat NULL)
+ *
+ * Returns null if no route matches — caller falls back to AGENT_ID env var.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { logger } from '../../utils/logger';
+
+export interface ResolvedRoute {
+  agentId: string;
+  identityId: string;
+  routeId: string;
+}
+
+/**
+ * Resolve which agent should handle a message on a given channel.
+ *
+ * Fetches all active routes for (user_id, platform), then picks the most
+ * specific match in application code. This keeps the SQL simple and the
+ * resolution logic testable.
+ */
+export async function resolveRouteAgentId(
+  supabase: SupabaseClient,
+  userId: string,
+  platform: string,
+  platformAccountId?: string,
+  chatId?: string
+): Promise<ResolvedRoute | null> {
+  const { data: routes, error } = await supabase
+    .from('channel_routes')
+    .select(
+      `
+      id,
+      platform_account_id,
+      chat_id,
+      identity_id,
+      agent_identities!inner ( agent_id )
+    `
+    )
+    .eq('user_id', userId)
+    .eq('platform', platform)
+    .eq('is_active', true);
+
+  if (error) {
+    logger.error('[Route] Failed to query channel_routes', { error, userId, platform });
+    return null;
+  }
+
+  if (!routes || routes.length === 0) {
+    return null;
+  }
+
+  // Specificity cascade: exact > account > platform
+  let bestMatch: (typeof routes)[number] | null = null;
+  let bestScore = -1;
+
+  for (const route of routes) {
+    let score = 0;
+
+    const routeAccountId = route.platform_account_id;
+    const routeChatId = route.chat_id;
+
+    // Platform match is implicit (filtered in query)
+
+    // Account match
+    if (routeAccountId != null) {
+      if (platformAccountId && routeAccountId === platformAccountId) {
+        score += 2;
+      } else {
+        continue; // Account specified but doesn't match — skip
+      }
+    }
+
+    // Chat match
+    if (routeChatId != null) {
+      if (chatId && routeChatId === chatId) {
+        score += 1;
+      } else {
+        continue; // Chat specified but doesn't match — skip
+      }
+    }
+
+    if (score > bestScore) {
+      bestScore = score;
+      bestMatch = route;
+    }
+  }
+
+  if (!bestMatch) {
+    return null;
+  }
+
+  // Extract agent_id from the joined agent_identities
+  const identityData = bestMatch.agent_identities as unknown as { agent_id: string };
+  const agentId = identityData?.agent_id;
+
+  if (!agentId) {
+    logger.warn('[Route] Matched route but could not resolve agent_id from identity', {
+      routeId: bestMatch.id,
+      identityId: bestMatch.identity_id,
+    });
+    return null;
+  }
+
+  return {
+    agentId,
+    identityId: bestMatch.identity_id,
+    routeId: bestMatch.id,
+  };
+}

--- a/supabase/migrations/20260222020953_create_channel_routes.sql
+++ b/supabase/migrations/20260222020953_create_channel_routes.sql
@@ -4,7 +4,7 @@
 
 CREATE TABLE channel_routes (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
   identity_id uuid NOT NULL REFERENCES agent_identities(id) ON DELETE CASCADE,
   platform text NOT NULL,              -- 'telegram', 'whatsapp', 'discord'
   platform_account_id text,            -- bot username/id (nullable = any account on this platform)
@@ -48,23 +48,24 @@ CREATE POLICY "Users can delete own channel routes" ON channel_routes
   FOR DELETE USING (auth.uid() = user_id);
 
 -- Seed: route all Telegram messages to Myra (platform-level default)
+-- Uses DISTINCT ON to pick the latest Myra identity per user, regardless of workspace.
 INSERT INTO channel_routes (user_id, identity_id, platform)
-SELECT
+SELECT DISTINCT ON (ai.user_id)
   ai.user_id,
   ai.id,
   'telegram'
 FROM agent_identities ai
 WHERE ai.agent_id = 'myra'
-  AND ai.workspace_id IS NULL
+ORDER BY ai.user_id, ai.updated_at DESC
 ON CONFLICT DO NOTHING;
 
 -- Seed: route all WhatsApp messages to Myra
 INSERT INTO channel_routes (user_id, identity_id, platform)
-SELECT
+SELECT DISTINCT ON (ai.user_id)
   ai.user_id,
   ai.id,
   'whatsapp'
 FROM agent_identities ai
 WHERE ai.agent_id = 'myra'
-  AND ai.workspace_id IS NULL
+ORDER BY ai.user_id, ai.updated_at DESC
 ON CONFLICT DO NOTHING;

--- a/supabase/migrations/20260222020953_create_channel_routes.sql
+++ b/supabase/migrations/20260222020953_create_channel_routes.sql
@@ -1,0 +1,70 @@
+-- Channel Routes: DB-driven message routing
+-- Maps (platform, account, chat) → agent identity for incoming messages.
+-- Replaces the static AGENT_ID env var with a specificity-based cascade.
+
+CREATE TABLE channel_routes (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  identity_id uuid NOT NULL REFERENCES agent_identities(id) ON DELETE CASCADE,
+  platform text NOT NULL,              -- 'telegram', 'whatsapp', 'discord'
+  platform_account_id text,            -- bot username/id (nullable = any account on this platform)
+  chat_id text,                        -- specific chat/conversation (nullable = all chats on this account)
+  is_active boolean NOT NULL DEFAULT true,
+  metadata jsonb NOT NULL DEFAULT '{}',
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Resolution index: used for the specificity cascade lookup
+CREATE INDEX idx_channel_routes_lookup
+  ON channel_routes (user_id, platform, platform_account_id, chat_id)
+  WHERE is_active = true;
+
+-- Prevent duplicate routes at the same specificity level
+CREATE UNIQUE INDEX idx_channel_routes_unique_route
+  ON channel_routes (user_id, platform, COALESCE(platform_account_id, ''), COALESCE(chat_id, ''));
+
+-- Auto-update updated_at
+CREATE TRIGGER channel_routes_updated_at
+  BEFORE UPDATE ON channel_routes
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+-- RLS: service role + user self-management (matches agent_identities pattern)
+ALTER TABLE channel_routes ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Service role full access to channel_routes" ON channel_routes
+  FOR ALL USING ((auth.jwt() ->> 'role') = 'service_role');
+
+CREATE POLICY "Users can view own channel routes" ON channel_routes
+  FOR SELECT USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert own channel routes" ON channel_routes
+  FOR INSERT WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can update own channel routes" ON channel_routes
+  FOR UPDATE USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can delete own channel routes" ON channel_routes
+  FOR DELETE USING (auth.uid() = user_id);
+
+-- Seed: route all Telegram messages to Myra (platform-level default)
+INSERT INTO channel_routes (user_id, identity_id, platform)
+SELECT
+  ai.user_id,
+  ai.id,
+  'telegram'
+FROM agent_identities ai
+WHERE ai.agent_id = 'myra'
+  AND ai.workspace_id IS NULL
+ON CONFLICT DO NOTHING;
+
+-- Seed: route all WhatsApp messages to Myra
+INSERT INTO channel_routes (user_id, identity_id, platform)
+SELECT
+  ai.user_id,
+  ai.id,
+  'whatsapp'
+FROM agent_identities ai
+WHERE ai.agent_id = 'myra'
+  AND ai.workspace_id IS NULL
+ON CONFLICT DO NOTHING;


### PR DESCRIPTION
## Summary

- New `channel_routes` table that maps (platform, account, chat) → agent identity, replacing the fragile `AGENT_ID` env var for message routing
- Specificity-based resolution cascade: exact match (platform+account+chat) → account default → platform default → env var fallback with warning
- Channel listeners (Telegram, WhatsApp, Discord) now pass their bot identity (`platformAccountId`) through the gateway to the route resolver
- Seeded with Myra as default for Telegram and WhatsApp
- User-scoped (not workspace-scoped) — workspace context is carried by `identity_id` FK to `agent_identities`

## Context

When the PCP server was restarted via manual `pm2 start` (bypassing `ecosystem.config.cjs`), `AGENT_ID=wren` leaked from the Claude Code shell, routing all Telegram messages to Wren instead of Myra. The static env var approach can't express multi-SB routing. This PR makes routing DB-driven and explicit.

## Test plan

- [x] `resolveRouteAgentId` unit tests pass (7 tests: no routes, platform match, account match, exact match, skip mismatches, DB error)
- [ ] `supabase db reset` applies migration cleanly
- [ ] Seed data creates myra→telegram and myra→whatsapp routes
- [ ] Restart PCP server, send Telegram message — routes to Myra
- [ ] Remove route — falls back to AGENT_ID with warning log
- [ ] Add chat-specific route — verify chat-level routing

🤖 Generated with [Claude Code](https://claude.com/claude-code)