### PR TITLE
feat: deterministic session routing + runtime registry (by Lumen)

### DIFF
--- a/packages/api/src/channels/agent-gateway.test.ts
+++ b/packages/api/src/channels/agent-gateway.test.ts
@@ -145,6 +145,36 @@ describe('AgentGateway', () => {
     });
   });
 
+  describe('dispatchTrigger', () => {
+    const basePayload: AgentTriggerPayload = {
+      fromAgentId: 'wren',
+      toAgentId: 'myra',
+      triggerType: 'message',
+      summary: 'Async trigger',
+    };
+
+    it('should return accepted immediately without waiting for processing', () => {
+      let resolved = false;
+      gateway.registerHandler('myra', async () => {
+        await new Promise((r) => setTimeout(r, 25));
+        resolved = true;
+      });
+
+      const result = gateway.dispatchTrigger(basePayload);
+      expect(result.success).toBe(true);
+      expect(result.accepted).toBe(true);
+      expect(result.processed).toBe(false);
+      expect(resolved).toBe(false);
+    });
+
+    it('should return unhandled when no handler exists', () => {
+      const result = gateway.dispatchTrigger(basePayload);
+      expect(result.success).toBe(false);
+      expect(result.processed).toBe(false);
+      expect(result.error).toContain('No handler registered');
+    });
+  });
+
   describe('dynamic agent routing (stateless pattern)', () => {
     it('should route to any agent via default handler', async () => {
       const processedAgents: string[] = [];

--- a/packages/api/src/channels/agent-gateway.ts
+++ b/packages/api/src/channels/agent-gateway.ts
@@ -44,6 +44,7 @@ export interface AgentTriggerResponse {
   success: boolean;
   triggerId: string;
   processed: boolean;
+  accepted?: boolean;
   error?: string;
 }
 
@@ -104,26 +105,51 @@ export class AgentGateway extends EventEmitter {
   }
 
   /**
-   * Process an incoming trigger
-   * Called by the HTTP endpoint or MCP tool
+   * Resolve handler for target agent (specific handler first, then default)
    */
-  async processTrigger(payload: AgentTriggerPayload): Promise<AgentTriggerResponse> {
-    const triggerId = `trigger_${++this.triggerCounter}_${Date.now()}`;
+  private resolveHandler(payload: AgentTriggerPayload): {
+    handler: TriggerCallback | null;
+    isDefaultHandler: boolean;
+  } {
+    const handler = this.handlers.get(payload.toAgentId) || this.defaultHandler;
+    const isDefaultHandler = !this.handlers.has(payload.toAgentId);
+    return { handler, isDefaultHandler };
+  }
 
-    logger.info(`[AgentGateway] Processing trigger ${triggerId}`, {
+  /**
+   * Execute a trigger handler lifecycle (shared by sync/async entrypoints)
+   */
+  private async executeTrigger(
+    triggerId: string,
+    payload: AgentTriggerPayload,
+    handler: TriggerCallback,
+    isDefaultHandler: boolean
+  ): Promise<void> {
+    if (isDefaultHandler) {
+      logger.info(`[AgentGateway] Using default handler for agent: ${payload.toAgentId}`);
+    }
+
+    await handler(payload);
+    this.emit('trigger:processed', { triggerId, payload });
+    logger.info(`[AgentGateway] Trigger ${triggerId} processed successfully`);
+  }
+
+  /**
+   * Dispatch an incoming trigger asynchronously (fast-ack pattern).
+   * Returns as soon as trigger is accepted, without waiting for full processing.
+   */
+  dispatchTrigger(payload: AgentTriggerPayload): AgentTriggerResponse {
+    const triggerId = `trigger_${++this.triggerCounter}_${Date.now()}`;
+    logger.info(`[AgentGateway] Dispatching trigger ${triggerId} (async)`, {
       from: payload.fromAgentId,
       to: payload.toAgentId,
       type: payload.triggerType,
       priority: payload.priority,
     });
 
-    // Find handler for target agent (specific handler takes precedence over default)
-    const handler = this.handlers.get(payload.toAgentId) || this.defaultHandler;
-
+    const { handler, isDefaultHandler } = this.resolveHandler(payload);
     if (!handler) {
       logger.warn(`[AgentGateway] No handler for agent: ${payload.toAgentId}`);
-
-      // Emit event even if no handler - allows listeners to catch unhandled triggers
       this.emit('trigger:unhandled', { triggerId, payload });
 
       return {
@@ -134,31 +160,58 @@ export class AgentGateway extends EventEmitter {
       };
     }
 
-    const isDefaultHandler = !this.handlers.has(payload.toAgentId);
-    if (isDefaultHandler) {
-      logger.info(`[AgentGateway] Using default handler for agent: ${payload.toAgentId}`);
+    this.emit('trigger:accepted', { triggerId, payload });
+
+    // Fire-and-forget execution
+    void (async () => {
+      try {
+        await this.executeTrigger(triggerId, payload, handler, isDefaultHandler);
+      } catch (error) {
+        logger.error(`[AgentGateway] Trigger ${triggerId} failed:`, error);
+        this.emit('trigger:error', { triggerId, payload, error });
+      }
+    })();
+
+    return {
+      success: true,
+      triggerId,
+      processed: false,
+      accepted: true,
+    };
+  }
+
+  /**
+   * Process an incoming trigger synchronously (waits for handler completion).
+   * Called where strong delivery/processing semantics are required.
+   */
+  async processTrigger(payload: AgentTriggerPayload): Promise<AgentTriggerResponse> {
+    const triggerId = `trigger_${++this.triggerCounter}_${Date.now()}`;
+    logger.info(`[AgentGateway] Processing trigger ${triggerId}`, {
+      from: payload.fromAgentId,
+      to: payload.toAgentId,
+      type: payload.triggerType,
+      priority: payload.priority,
+    });
+
+    const { handler, isDefaultHandler } = this.resolveHandler(payload);
+    if (!handler) {
+      logger.warn(`[AgentGateway] No handler for agent: ${payload.toAgentId}`);
+      this.emit('trigger:unhandled', { triggerId, payload });
+      return {
+        success: false,
+        triggerId,
+        processed: false,
+        error: `No handler registered for agent: ${payload.toAgentId}`,
+      };
     }
 
     try {
-      // Execute the handler
-      await handler(payload);
-
-      this.emit('trigger:processed', { triggerId, payload });
-
-      logger.info(`[AgentGateway] Trigger ${triggerId} processed successfully`);
-
-      return {
-        success: true,
-        triggerId,
-        processed: true,
-      };
+      await this.executeTrigger(triggerId, payload, handler, isDefaultHandler);
+      return { success: true, triggerId, processed: true };
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-
       logger.error(`[AgentGateway] Trigger ${triggerId} failed:`, error);
-
       this.emit('trigger:error', { triggerId, payload, error });
-
       return {
         success: false,
         triggerId,
@@ -225,7 +278,7 @@ export function createAgentGatewayRoutes(app: {
         return;
       }
 
-      const result = await gateway.processTrigger(payload);
+      const result = gateway.dispatchTrigger(payload);
 
       if (result.success) {
         response.json(result);

--- a/packages/api/src/data/models/memory.ts
+++ b/packages/api/src/data/models/memory.ts
@@ -91,14 +91,23 @@ export interface Session {
    */
   workspaceId?: string;
   threadKey?: string;
+  status?: string;
   currentPhase?: string;
+  backend?: string;
+  model?: string;
+  backendSessionId?: string;
+  claudeSessionId?: string;
+  workingDir?: string;
+  context?: string;
   startedAt: Date;
   endedAt?: Date;
   summary?: string;
+  updatedAt?: Date;
   metadata: Record<string, unknown>;
 }
 
 export interface SessionCreateInput {
+  id?: string;
   userId: string;
   agentId?: string;
   studioId?: string;
@@ -168,10 +177,18 @@ export interface SessionRow {
   studio_id: string | null;
   workspace_id: string | null;
   thread_key: string | null;
+  status?: string | null;
   current_phase: string | null;
+  backend?: string | null;
+  model?: string | null;
+  backend_session_id?: string | null;
+  claude_session_id?: string | null;
+  working_dir?: string | null;
+  context?: string | null;
   started_at: string;
   ended_at: string | null;
   summary: string | null;
+  updated_at?: string | null;
   metadata: Record<string, unknown>;
 }
 

--- a/packages/api/src/data/repositories/memory-repository.ts
+++ b/packages/api/src/data/repositories/memory-repository.ts
@@ -361,6 +361,7 @@ export class MemoryRepository {
         : null;
 
     const insertData: Record<string, unknown> = {
+      ...(input.id ? { id: input.id } : {}),
       user_id: input.userId,
       agent_id: input.agentId,
       identity_id: identityId,
@@ -932,10 +933,18 @@ export class MemoryRepository {
       studioId,
       workspaceId: studioId,
       threadKey: row.thread_key || undefined,
+      status: row.status || undefined,
       currentPhase: row.current_phase || undefined,
+      backend: row.backend || undefined,
+      model: row.model || undefined,
+      backendSessionId: row.backend_session_id || undefined,
+      claudeSessionId: row.claude_session_id || undefined,
+      workingDir: row.working_dir || undefined,
+      context: row.context || undefined,
       startedAt: new Date(row.started_at),
       endedAt: row.ended_at ? new Date(row.ended_at) : undefined,
       summary: row.summary || undefined,
+      updatedAt: row.updated_at ? new Date(row.updated_at) : undefined,
       metadata: row.metadata,
     };
   }

--- a/packages/api/src/mcp/tools/agent-triggers.ts
+++ b/packages/api/src/mcp/tools/agent-triggers.ts
@@ -102,13 +102,18 @@ export async function handleTriggerAgent(
       metadata: args.metadata,
     };
 
-    const result = await gateway.processTrigger(payload);
+    const result = gateway.dispatchTrigger(payload);
 
     if (result.success) {
       return mcpResponse({
         success: true,
         triggerId: result.triggerId,
-        message: `Agent ${args.toAgentId} triggered successfully`,
+        accepted: result.accepted === true,
+        processed: result.processed,
+        message:
+          result.accepted === true
+            ? `Agent ${args.toAgentId} trigger accepted`
+            : `Agent ${args.toAgentId} triggered successfully`,
       });
     } else {
       return mcpResponse(

--- a/packages/api/src/mcp/tools/inbox-handlers.test.ts
+++ b/packages/api/src/mcp/tools/inbox-handlers.test.ts
@@ -32,10 +32,11 @@ vi.mock('../../utils/logger', () => ({
 // Mock agent gateway
 vi.mock('../../channels/agent-gateway.js', () => ({
   getAgentGateway: vi.fn().mockReturnValue({
-    processTrigger: vi.fn().mockResolvedValue({
+    dispatchTrigger: vi.fn().mockReturnValue({
       success: true,
       triggerId: 'trigger-1',
-      processed: true,
+      processed: false,
+      accepted: true,
     }),
   }),
 }));
@@ -244,7 +245,7 @@ describe('handleSendToInbox - threadKey', () => {
     );
 
     // The trigger is fire-and-forget, so check the gateway was called with threadKey
-    expect(mockGateway.processTrigger).toHaveBeenCalledWith(
+    expect(mockGateway.dispatchTrigger).toHaveBeenCalledWith(
       expect.objectContaining({
         threadKey: 'pr:32',
       })
@@ -270,7 +271,7 @@ describe('handleSendToInbox - threadKey', () => {
       mockDc as never
     );
 
-    expect(mockGateway.processTrigger).toHaveBeenCalledWith(
+    expect(mockGateway.dispatchTrigger).toHaveBeenCalledWith(
       expect.objectContaining({
         toAgentId: 'myra',
       })
@@ -296,7 +297,7 @@ describe('handleSendToInbox - threadKey', () => {
       mockDc as never
     );
 
-    expect(mockGateway.processTrigger).toHaveBeenCalledWith(
+    expect(mockGateway.dispatchTrigger).toHaveBeenCalledWith(
       expect.objectContaining({
         recipientSessionId: 'b85490f5-0836-4bdd-8193-f6cfa2562a41',
       })
@@ -327,7 +328,7 @@ describe('handleSendToInbox - threadKey', () => {
         recipient_session_id: 'b85490f5-0836-4bdd-8193-f6cfa2562a41',
       })
     );
-    expect(mockGateway.processTrigger).toHaveBeenCalledWith(
+    expect(mockGateway.dispatchTrigger).toHaveBeenCalledWith(
       expect.objectContaining({
         recipientSessionId: 'b85490f5-0836-4bdd-8193-f6cfa2562a41',
       })
@@ -353,7 +354,7 @@ describe('handleSendToInbox - threadKey', () => {
       mockDc as never
     );
 
-    expect(mockGateway.processTrigger).toHaveBeenCalledWith(
+    expect(mockGateway.dispatchTrigger).toHaveBeenCalledWith(
       expect.objectContaining({
         fromAgentId: 'system',
       })
@@ -380,7 +381,7 @@ describe('handleSendToInbox - threadKey', () => {
 
     const parsed = JSON.parse(result.content[0].text);
     expect(parsed.trigger.triggered).toBe(false);
-    expect(mockGateway.processTrigger).not.toHaveBeenCalled();
+    expect(mockGateway.dispatchTrigger).not.toHaveBeenCalled();
   });
 
   it('should deliver actionable handoff without anchor and return routing hint', async () => {
@@ -404,7 +405,7 @@ describe('handleSendToInbox - threadKey', () => {
     const parsed = JSON.parse(result.content[0].text);
     expect(parsed.success).toBe(true);
     expect(parsed.routingHint).toContain('routing anchor');
-    expect(mockGateway.processTrigger).toHaveBeenCalled();
+    expect(mockGateway.dispatchTrigger).toHaveBeenCalled();
   });
 });
 

--- a/packages/api/src/mcp/tools/inbox-handlers.ts
+++ b/packages/api/src/mcp/tools/inbox-handlers.ts
@@ -220,6 +220,7 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
     triggered: boolean;
     triggerId?: string;
     processed?: boolean;
+    accepted?: boolean;
     error?: string;
   } = {
     triggered: false,
@@ -240,47 +241,28 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
       studioHint: recipientStudioHint,
     };
 
-    // Await trigger with timeout so the sender sees the real result
-    const TRIGGER_TIMEOUT_MS = 30_000;
-    logger.info('Inbox message trigger dispatched', {
+    logger.info('Inbox message trigger dispatched (async)', {
       messageId: message.id,
       recipientAgentId,
     });
 
-    try {
-      const result = await Promise.race([
-        gateway.processTrigger(payload),
-        new Promise<never>((_, reject) =>
-          setTimeout(() => reject(new Error('Trigger timed out (30s)')), TRIGGER_TIMEOUT_MS)
-        ),
-      ]);
+    const result = gateway.dispatchTrigger(payload);
 
-      logger.info('Inbox message trigger completed', {
-        messageId: message.id,
-        triggerId: result.triggerId,
-        processed: result.processed,
-        error: result.error,
-      });
+    logger.info('Inbox message trigger accepted', {
+      messageId: message.id,
+      triggerId: result.triggerId,
+      accepted: result.accepted,
+      processed: result.processed,
+      error: result.error,
+    });
 
-      triggerResult = {
-        triggered: true,
-        triggerId: result.triggerId,
-        processed: result.processed,
-        error: result.error,
-      };
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      logger.error('Inbox message trigger failed', {
-        messageId: message.id,
-        error: errorMessage,
-      });
-
-      triggerResult = {
-        triggered: true,
-        processed: false,
-        error: errorMessage,
-      };
-    }
+    triggerResult = {
+      triggered: true,
+      triggerId: result.triggerId,
+      processed: result.processed,
+      accepted: result.accepted,
+      error: result.error,
+    };
   }
 
   return {

--- a/packages/api/src/mcp/tools/index.ts
+++ b/packages/api/src/mcp/tools/index.ts
@@ -1242,6 +1242,8 @@ Session matching priority:
 
 workspaceId is accepted as a deprecated alias for studioId.
 
+When forceNew=true, start_session always creates a new session (skips active-session reuse). You can optionally provide sessionId to set a client-generated canonical UUID.
+
 User can be identified by ONE of: userId, email, phone, or platform + platformId`,
       inputSchema: {
         ...userIdentifierFields,
@@ -1249,6 +1251,13 @@ User can be identified by ONE of: userId, email, phone, or platform + platformId
           .string()
           .optional()
           .describe('Agent identifier (e.g., "claude-code", "telegram-myra")'),
+        sessionId: z
+          .string()
+          .uuid()
+          .optional()
+          .describe(
+            'Optional PCP session UUID to use when creating a new session (typically with forceNew=true).'
+          ),
         studioId: z
           .string()
           .uuid()
@@ -1276,6 +1285,10 @@ User can be identified by ONE of: userId, email, phone, or platform + platformId
           .optional()
           .describe('Model identifier (e.g., "opus-4-6", "sonnet", "o3")'),
         metadata: z.record(z.unknown()).optional().describe('Session metadata'),
+        forceNew: z
+          .boolean()
+          .optional()
+          .describe('If true, create a new session even if an active one exists for this scope.'),
       },
     },
     async (args) => {

--- a/packages/api/src/mcp/tools/memory-handlers.test.ts
+++ b/packages/api/src/mcp/tools/memory-handlers.test.ts
@@ -152,6 +152,21 @@ describe('startSessionSchema', () => {
     // With none of these, it should still parse (resolution happens at handler level)
     expect(result.success).toBe(true);
   });
+
+  it('should accept client-provided sessionId and forceNew', () => {
+    const result = startSessionSchema.safeParse({
+      email: 'test@test.com',
+      agentId: 'wren',
+      sessionId: '550e8400-e29b-41d4-a716-446655440000',
+      forceNew: true,
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.sessionId).toBe('550e8400-e29b-41d4-a716-446655440000');
+      expect(result.data.forceNew).toBe(true);
+    }
+  });
 });
 
 describe('listSessionsSchema', () => {
@@ -1267,6 +1282,51 @@ describe('handleStartSession - threadKey matching', () => {
 
     const parsed = JSON.parse(result.content[0].text);
     expect(parsed.session.threadKey).toBeNull();
+  });
+
+  it('should create new session when forceNew is true even if active exists', async () => {
+    mockDataComposer.repositories.memory.getActiveSessionByThreadKey.mockResolvedValue(mockSession);
+    mockDataComposer.repositories.memory.getActiveSession.mockResolvedValue(mockSession);
+    mockDataComposer.repositories.memory.startSession.mockResolvedValue(mockNewSession);
+
+    const result = await handleStartSession(
+      {
+        email: 'test@test.com',
+        agentId: 'lumen',
+        threadKey: 'pr:32',
+        forceNew: true,
+      },
+      mockDataComposer as never
+    );
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.success).toBe(true);
+    expect(parsed.session.id).toBe('session-new');
+    expect(mockDataComposer.repositories.memory.getActiveSessionByThreadKey).not.toHaveBeenCalled();
+    expect(mockDataComposer.repositories.memory.getActiveSession).not.toHaveBeenCalled();
+    expect(mockDataComposer.repositories.memory.startSession).toHaveBeenCalled();
+  });
+
+  it('should pass sessionId through to startSession', async () => {
+    mockDataComposer.repositories.memory.getActiveSessionByThreadKey.mockResolvedValue(null);
+    mockDataComposer.repositories.memory.getActiveSession.mockResolvedValue(null);
+    mockDataComposer.repositories.memory.startSession.mockResolvedValue(mockNewSession);
+
+    await handleStartSession(
+      {
+        email: 'test@test.com',
+        agentId: 'lumen',
+        forceNew: true,
+        sessionId: '550e8400-e29b-41d4-a716-446655440000',
+      },
+      mockDataComposer as never
+    );
+
+    expect(mockDataComposer.repositories.memory.startSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: '550e8400-e29b-41d4-a716-446655440000',
+      })
+    );
   });
 });
 

--- a/packages/api/src/mcp/tools/memory-handlers.ts
+++ b/packages/api/src/mcp/tools/memory-handlers.ts
@@ -283,6 +283,13 @@ export const updateMemorySchema = userIdentifierBaseSchema.extend({
 // =====================================================
 
 export const startSessionSchema = userIdentifierBaseSchema.extend({
+  sessionId: z
+    .string()
+    .uuid()
+    .optional()
+    .describe(
+      'Optional PCP session UUID to use when creating a new session. Useful for client-generated canonical IDs.'
+    ),
   agentId: z
     .string()
     .optional()
@@ -311,6 +318,10 @@ export const startSessionSchema = userIdentifierBaseSchema.extend({
     .describe('Backend runtime (e.g., "claude-code", "codex", "gemini")'),
   model: z.string().optional().describe('Model identifier (e.g., "opus-4-6", "sonnet", "o3")'),
   metadata: z.record(z.unknown()).optional().describe('Additional session metadata'),
+  forceNew: z
+    .boolean()
+    .optional()
+    .describe('If true, create a new session even if an active one already exists for this scope.'),
 });
 
 export const logSessionSchema = userIdentifierBaseSchema.extend({
@@ -746,7 +757,7 @@ export async function handleStartSession(args: unknown, dataComposer: DataCompos
   // 2. studioId match — find active session scoped by agent+studio (existing behavior)
   let existingSession = null;
 
-  if (params.threadKey && agentId) {
+  if (!params.forceNew && params.threadKey && agentId) {
     existingSession = await dataComposer.repositories.memory.getActiveSessionByThreadKey(
       user.id,
       agentId,
@@ -755,7 +766,7 @@ export async function handleStartSession(args: unknown, dataComposer: DataCompos
     );
   }
 
-  if (!existingSession) {
+  if (!params.forceNew && !existingSession) {
     existingSession = await dataComposer.repositories.memory.getActiveSession(
       user.id,
       agentId,
@@ -779,6 +790,11 @@ export async function handleStartSession(args: unknown, dataComposer: DataCompos
                 studioId: existingSession.studioId,
                 workspaceId: existingSession.workspaceId,
                 threadKey: existingSession.threadKey || null,
+                status: existingSession.status || null,
+                backend: existingSession.backend || null,
+                model: existingSession.model || null,
+                backendSessionId: existingSession.backendSessionId || null,
+                claudeSessionId: existingSession.claudeSessionId || null,
                 startedAt: existingSession.startedAt.toISOString(),
                 isExisting: true,
               },
@@ -792,6 +808,7 @@ export async function handleStartSession(args: unknown, dataComposer: DataCompos
   }
 
   const session = await dataComposer.repositories.memory.startSession({
+    id: params.sessionId,
     userId: user.id,
     agentId,
     studioId,
@@ -825,6 +842,11 @@ export async function handleStartSession(args: unknown, dataComposer: DataCompos
               studioId: session.studioId,
               workspaceId: session.workspaceId,
               threadKey: session.threadKey || null,
+              status: session.status || null,
+              backend: session.backend || null,
+              model: session.model || null,
+              backendSessionId: session.backendSessionId || null,
+              claudeSessionId: session.claudeSessionId || null,
               startedAt: session.startedAt.toISOString(),
             },
           },
@@ -970,6 +992,13 @@ export async function handleEndSession(args: unknown, dataComposer: DataComposer
               studioId: session.studioId,
               workspaceId: session.workspaceId,
               currentPhase: session.currentPhase || null,
+              status: session.status || null,
+              backend: session.backend || null,
+              model: session.model || null,
+              backendSessionId: session.backendSessionId || null,
+              claudeSessionId: session.claudeSessionId || null,
+              context: session.context || null,
+              workingDir: session.workingDir || null,
               startedAt: session.startedAt.toISOString(),
               endedAt: session.endedAt?.toISOString(),
               summary: session.summary,
@@ -1099,6 +1128,13 @@ export async function handleListSessions(args: unknown, dataComposer: DataCompos
                   })()
                 : null,
               currentPhase: s.currentPhase || null,
+              status: s.status || null,
+              backend: s.backend || null,
+              model: s.model || null,
+              backendSessionId: s.backendSessionId || null,
+              claudeSessionId: s.claudeSessionId || null,
+              context: s.context || null,
+              workingDir: s.workingDir || null,
               startedAt: s.startedAt.toISOString(),
               endedAt: s.endedAt?.toISOString(),
               summary: s.summary,

--- a/packages/api/src/routes/agent-trigger.ts
+++ b/packages/api/src/routes/agent-trigger.ts
@@ -37,7 +37,7 @@ router.post('/trigger', async (req, res) => {
     });
 
     const gateway = getAgentGateway();
-    const result = await gateway.processTrigger(payload);
+    const result = gateway.dispatchTrigger(payload);
 
     if (result.success) {
       res.json(result);

--- a/packages/cli/HOOKS.md
+++ b/packages/cli/HOOKS.md
@@ -27,7 +27,10 @@ PCP hooks bridge coding agents (Claude Code, Codex, Gemini) with PCP's session, 
 1. Reads workspace ID from `.pcp/identity.json`
 2. Calls `bootstrap` with agentId and workspaceId
 3. Calls `get_inbox` for unread messages
-4. Stores backend session ID in `.pcp/runtime/session-id`
+4. Resolves PCP session ID (`PCP_SESSION_ID` env from launcher, or `start_session` fallback)
+5. Stores runtime session state in `.pcp/runtime/sessions.json` (multi-session list + current pointer)
+6. Stores backend session ID in `.pcp/runtime/session-id` (legacy compatibility)
+7. Links backend session ID to PCP session via `update_session_phase(sessionId, backendSessionId)`
 
 **Output:**
 ```
@@ -149,7 +152,9 @@ Hooks store ephemeral state in `.pcp/runtime/` (gitignored):
 
 | File | Purpose |
 |------|---------|
-| `session-id` | Backend session ID from on-session-start |
+| `sessions.json` | Runtime session registry (list of PCP sessions + backend session IDs + current pointer) |
+| `pcp-session-id` | Current PCP session UUID (legacy convenience file) |
+| `session-id` | Backend session ID from on-session-start (legacy convenience file) |
 | `last-inbox-check` | ISO timestamp of last inbox poll |
 | `tool-count` | Cumulative tool call counter for on-stop nudges |
 

--- a/packages/cli/src/backends/claude.ts
+++ b/packages/cli/src/backends/claude.ts
@@ -32,6 +32,14 @@ export class ClaudeAdapter implements BackendAdapter {
     // Identity (inline text, no temp file needed)
     args.push('--append-system-prompt', identityPrompt);
 
+    // Session routing
+    if (config.backendSessionId) {
+      args.push('--resume', config.backendSessionId);
+    } else if (config.pcpSessionId) {
+      // Keep Claude session ID aligned with PCP session ID when possible
+      args.push('--session-id', config.pcpSessionId);
+    }
+
     // MCP config (if present in CWD)
     const mcpConfig = join(process.cwd(), '.mcp.json');
     if (existsSync(mcpConfig)) {
@@ -49,7 +57,10 @@ export class ClaudeAdapter implements BackendAdapter {
     return {
       binary: this.binary,
       args,
-      env: { AGENT_ID: config.agentId },
+      env: {
+        AGENT_ID: config.agentId,
+        ...(config.pcpSessionId ? { PCP_SESSION_ID: config.pcpSessionId } : {}),
+      },
       cleanup: () => {}, // No temp file, no cleanup needed
     };
   }

--- a/packages/cli/src/backends/codex.ts
+++ b/packages/cli/src/backends/codex.ts
@@ -39,7 +39,10 @@ export class CodexAdapter implements BackendAdapter {
     return {
       binary: this.binary,
       args,
-      env: { AGENT_ID: config.agentId },
+      env: {
+        AGENT_ID: config.agentId,
+        ...(config.pcpSessionId ? { PCP_SESSION_ID: config.pcpSessionId } : {}),
+      },
       cleanup,
     };
   }

--- a/packages/cli/src/backends/gemini.ts
+++ b/packages/cli/src/backends/gemini.ts
@@ -45,6 +45,7 @@ export class GeminiAdapter implements BackendAdapter {
       env: {
         AGENT_ID: config.agentId,
         GEMINI_SYSTEM_MD: promptFile,
+        ...(config.pcpSessionId ? { PCP_SESSION_ID: config.pcpSessionId } : {}),
       },
       cleanup,
     };

--- a/packages/cli/src/backends/types.ts
+++ b/packages/cli/src/backends/types.ts
@@ -11,6 +11,8 @@ export interface BackendConfig {
   prompt?: string; // undefined = interactive mode
   promptParts: string[]; // raw positional args (preserves shell word boundaries)
   passthroughArgs: string[];
+  pcpSessionId?: string;
+  backendSessionId?: string;
 }
 
 export interface PreparedBackend {

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -17,6 +17,7 @@ import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
 import { resolveAgentId } from '../backends/identity.js';
+import { getCurrentRuntimeSession } from '../session/runtime.js';
 
 interface PcpConfig {
   userId?: string;
@@ -83,7 +84,14 @@ async function fetchPcp(path: string, options?: RequestInit): Promise<Response> 
 
 async function triggerAgent(
   agentId: string,
-  options: { message?: string; priority?: string }
+  options: {
+    message?: string;
+    priority?: string;
+    threadKey?: string;
+    recipientSessionId?: string;
+    studioId?: string;
+    studioHint?: string;
+  }
 ): Promise<void> {
   const spinner = ora(`Triggering agent: ${agentId}`).start();
 
@@ -95,6 +103,9 @@ async function triggerAgent(
     }
 
     // First, send to inbox
+    const currentRuntime = getCurrentRuntimeSession(process.cwd());
+    const threadKey = options.threadKey || currentRuntime?.threadKey;
+
     const inboxResponse = await fetchPcp('/api/mcp/call', {
       method: 'POST',
       body: JSON.stringify({
@@ -106,6 +117,10 @@ async function triggerAgent(
           content: options.message || `CLI trigger at ${new Date().toISOString()}`,
           messageType: 'message',
           priority: options.priority || 'normal',
+          ...(threadKey ? { threadKey } : {}),
+          ...(options.recipientSessionId ? { recipientSessionId: options.recipientSessionId } : {}),
+          ...(options.studioId ? { recipientStudioId: options.studioId } : {}),
+          ...(options.studioHint ? { recipientStudioHint: options.studioHint } : {}),
           trigger: true,
           triggerType: 'message',
           triggerSummary: options.message || 'CLI trigger',
@@ -293,6 +308,10 @@ export function registerAgentCommands(program: Command): void {
     .description('Trigger an agent to wake up')
     .option('-m, --message <msg>', 'Message to include')
     .option('-p, --priority <level>', 'Priority (low, normal, high, urgent)', 'normal')
+    .option('--thread-key <key>', 'Thread key for continuity (e.g., pr:75)')
+    .option('--recipient-session-id <id>', 'Recipient session UUID')
+    .option('--studio-id <id>', 'Recipient studio UUID')
+    .option('--studio-hint <hint>', 'Recipient studio routing hint (e.g., main)')
     .action(triggerAgent);
 
   agent

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -7,8 +7,17 @@
 
 import { spawn } from 'child_process';
 import chalk from 'chalk';
+import { randomUUID } from 'crypto';
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
 import { getBackend, resolveAgentId } from '../backends/index.js';
 import { getValidAccessToken } from '../auth/tokens.js';
+import {
+  getCurrentRuntimeSession,
+  setCurrentRuntimeSession,
+  upsertRuntimeSession,
+} from '../session/runtime.js';
 
 export interface SbOptions {
   agent: string | undefined;
@@ -16,6 +25,26 @@ export interface SbOptions {
   session: boolean;
   verbose: boolean;
   backend: string;
+}
+
+interface PcpConfig {
+  email?: string;
+}
+
+interface PcpSessionSummary {
+  id: string;
+  studioId?: string | null;
+  threadKey?: string | null;
+  currentPhase?: string | null;
+  startedAt: string;
+  endedAt?: string | null;
+  backend?: string | null;
+  backendSessionId?: string | null;
+  claudeSessionId?: string | null;
+}
+
+interface ListSessionsResult {
+  sessions?: PcpSessionSummary[];
 }
 
 function getPcpServerUrl(): string {
@@ -36,6 +65,194 @@ async function resolvePcpAuthEnv(verbose: boolean): Promise<Record<string, strin
   return {};
 }
 
+function getPcpConfig(): PcpConfig | null {
+  const configPath = join(homedir(), '.pcp', 'config.json');
+  if (!existsSync(configPath)) return null;
+  try {
+    return JSON.parse(readFileSync(configPath, 'utf-8')) as PcpConfig;
+  } catch {
+    return null;
+  }
+}
+
+function getIdentityContextFromIdentityJson(cwd = process.cwd()): {
+  studioId?: string;
+  identityId?: string;
+} {
+  const identityPath = join(cwd, '.pcp', 'identity.json');
+  if (!existsSync(identityPath)) return {};
+  try {
+    const identity = JSON.parse(readFileSync(identityPath, 'utf-8')) as {
+      studioId?: string;
+      workspaceId?: string;
+      identityId?: string;
+    };
+    return {
+      studioId: identity.studioId || identity.workspaceId,
+      identityId: identity.identityId,
+    };
+  } catch {
+    return {};
+  }
+}
+
+function hasBackendSessionOverride(backend: string, passthroughArgs: string[]): boolean {
+  const lowered = passthroughArgs.map((arg) => arg.toLowerCase());
+  const has = (flag: string) => lowered.includes(flag.toLowerCase());
+
+  if (backend === 'claude') {
+    return (
+      has('--resume') ||
+      has('-r') ||
+      has('--continue') ||
+      has('-c') ||
+      has('--session-id') ||
+      has('--from-pr')
+    );
+  }
+
+  return has('--resume') || has('-r');
+}
+
+async function callPcpTool<T = Record<string, unknown>>(tool: string, args: object): Promise<T> {
+  const response = await fetch(`${getPcpServerUrl()}/api/mcp/call`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ tool, args }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`PCP tool ${tool} failed: ${response.status} ${await response.text()}`);
+  }
+
+  return (await response.json()) as T;
+}
+
+async function ensurePcpSessionContext(
+  agentId: string,
+  backend: string,
+  passthroughArgs: string[],
+  verbose: boolean
+): Promise<{ pcpSessionId?: string; backendSessionId?: string }> {
+  if (hasBackendSessionOverride(backend, passthroughArgs)) return {};
+
+  const config = getPcpConfig();
+  const email = config?.email;
+  if (!email) return {};
+
+  const cwd = process.cwd();
+  const { studioId, identityId } = getIdentityContextFromIdentityJson(cwd);
+
+  // Fast path: runtime already knows current session for this backend.
+  const existing = getCurrentRuntimeSession(cwd, backend);
+  if (existing?.pcpSessionId) {
+    return {
+      pcpSessionId: existing.pcpSessionId,
+      backendSessionId: existing.backendSessionId,
+    };
+  }
+
+  // Pull active session list so caller can resume or start new.
+  let activeSessions: PcpSessionSummary[] = [];
+  try {
+    const listed = await callPcpTool<ListSessionsResult>('list_sessions', {
+      email,
+      agentId,
+      ...(studioId ? { studioId } : {}),
+      limit: 20,
+    });
+    activeSessions = (listed.sessions || []).filter((s) => !s.endedAt);
+  } catch {
+    // Non-fatal; fallback to start new below.
+  }
+
+  let chosen: PcpSessionSummary | undefined;
+
+  if (process.stdin.isTTY) {
+    const choices = activeSessions.map((s) => ({
+      name: `Resume ${s.id.slice(0, 8)}${s.threadKey ? ` (${s.threadKey})` : ''}${s.currentPhase ? ` — ${s.currentPhase}` : ''}`,
+      value: s.id,
+    }));
+    choices.unshift({ name: 'Start new session', value: '__new__' });
+
+    try {
+      const { select } = await import('@inquirer/prompts');
+      const selection = await select({
+        message: `Session for ${agentId}/${backend}`,
+        choices,
+      });
+      if (selection === '__new__') {
+        const newSessionId = randomUUID();
+        const started = await callPcpTool<{ session?: PcpSessionSummary }>('start_session', {
+          email,
+          agentId,
+          ...(studioId ? { studioId } : {}),
+          backend,
+          forceNew: true,
+          sessionId: newSessionId,
+        });
+        chosen = started.session || { id: newSessionId, startedAt: new Date().toISOString() };
+      } else {
+        chosen = activeSessions.find((s) => s.id === selection);
+      }
+    } catch {
+      // Prompt canceled or unavailable; fallback to start new.
+    }
+  }
+
+  if (!chosen) {
+    const newSessionId = randomUUID();
+    try {
+      const started = await callPcpTool<{ session?: PcpSessionSummary }>('start_session', {
+        email,
+        agentId,
+        ...(studioId ? { studioId } : {}),
+        backend,
+        forceNew: true,
+        sessionId: newSessionId,
+      });
+      chosen = started.session || { id: newSessionId, startedAt: new Date().toISOString() };
+    } catch {
+      chosen = { id: newSessionId, startedAt: new Date().toISOString() };
+    }
+  }
+
+  if (!chosen?.id) return {};
+
+  upsertRuntimeSession(cwd, {
+    pcpSessionId: chosen.id,
+    backend,
+    agentId,
+    ...(identityId ? { identityId } : {}),
+    ...(studioId ? { studioId } : {}),
+    ...(chosen.threadKey ? { threadKey: chosen.threadKey } : {}),
+    ...((!chosen.backend || chosen.backend === backend) &&
+    (chosen.backendSessionId || chosen.claudeSessionId)
+      ? { backendSessionId: chosen.backendSessionId || chosen.claudeSessionId || undefined }
+      : {}),
+    startedAt: chosen.startedAt,
+  });
+  setCurrentRuntimeSession(cwd, chosen.id, backend, {
+    agentId,
+    ...(identityId ? { identityId } : {}),
+    ...(studioId ? { studioId } : {}),
+  });
+
+  if (verbose) {
+    console.log(chalk.dim(`PCP session: ${chosen.id}`));
+  }
+
+  const backendSessionId =
+    !chosen.backend || chosen.backend === backend
+      ? chosen.backendSessionId || chosen.claudeSessionId || undefined
+      : undefined;
+
+  return {
+    pcpSessionId: chosen.id,
+    backendSessionId,
+  };
+}
+
 /**
  * Run a backend with a prompt (one-shot mode).
  */
@@ -53,6 +270,9 @@ export async function runClaude(
     process.exit(1);
   }
   const adapter = getBackend(options.backend);
+  const sessionContext = options.session
+    ? await ensurePcpSessionContext(agentId, options.backend, passthroughArgs, options.verbose)
+    : {};
 
   if (options.verbose) {
     console.log(chalk.dim(`Backend: ${adapter.name}`));
@@ -70,6 +290,7 @@ export async function runClaude(
     prompt,
     promptParts,
     passthroughArgs,
+    ...sessionContext,
   });
 
   const authEnv = await resolvePcpAuthEnv(options.verbose);
@@ -107,6 +328,9 @@ export async function runClaudeInteractive(
     process.exit(1);
   }
   const adapter = getBackend(options.backend);
+  const sessionContext = options.session
+    ? await ensurePcpSessionContext(agentId, options.backend, passthroughArgs, options.verbose)
+    : {};
 
   if (options.verbose) {
     console.log(chalk.dim(`Backend: ${adapter.name}`));
@@ -122,6 +346,7 @@ export async function runClaudeInteractive(
     model: options.model,
     promptParts: [],
     passthroughArgs,
+    ...sessionContext,
   });
 
   const authEnv = await resolvePcpAuthEnv(options.verbose);

--- a/packages/cli/src/commands/hooks.ts
+++ b/packages/cli/src/commands/hooks.ts
@@ -281,6 +281,25 @@ function writeRuntimeFile(cwd: string, filename: string, content: string): void 
   writeFileSync(join(dir, filename), content);
 }
 
+function extractBackendSessionId(stdin: Record<string, unknown>): string | undefined {
+  const candidates: unknown[] = [
+    stdin.session_id,
+    stdin.sessionId,
+    (stdin.session as Record<string, unknown> | undefined)?.id,
+    (stdin.session as Record<string, unknown> | undefined)?.session_id,
+    (stdin.data as Record<string, unknown> | undefined)?.session_id,
+    (stdin.data as Record<string, unknown> | undefined)?.sessionId,
+  ];
+
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string' && candidate.trim()) {
+      return candidate.trim();
+    }
+  }
+
+  return undefined;
+}
+
 // ============================================================================
 // Template Loading
 // ============================================================================
@@ -961,9 +980,13 @@ async function onSessionStartHandler(): Promise<void> {
 
   // Register PCP session with detected backend
   const detectedBackend = detectBackend(cwd);
+  // Hook backend names and session backend names differ for Claude:
+  // - hooks backend: "claude-code"
+  // - session/backend adapter: "claude"
   const sessionBackend = detectedBackend.name === 'claude-code' ? 'claude' : detectedBackend.name;
   let pcpSessionId: string | undefined;
   let pcpThreadKey: string | undefined;
+  const backendSessionId = extractBackendSessionId(stdin);
 
   // If provided by sb launcher, prefer that explicit session id.
   if (process.env.PCP_SESSION_ID) {
@@ -994,8 +1017,8 @@ async function onSessionStartHandler(): Promise<void> {
   }
 
   // Store session ID if provided in stdin
-  if (stdin.session_id) {
-    writeRuntimeFile(cwd, 'session-id', String(stdin.session_id));
+  if (backendSessionId) {
+    writeRuntimeFile(cwd, 'session-id', backendSessionId);
   }
 
   if (pcpSessionId) {
@@ -1007,7 +1030,7 @@ async function onSessionStartHandler(): Promise<void> {
       ...(identityId ? { identityId } : {}),
       ...(studioId ? { studioId } : {}),
       ...(pcpThreadKey ? { threadKey: pcpThreadKey } : {}),
-      ...(stdin.session_id ? { backendSessionId: String(stdin.session_id) } : {}),
+      ...(backendSessionId ? { backendSessionId } : {}),
       startedAt: new Date().toISOString(),
     });
     setCurrentRuntimeSession(cwd, pcpSessionId, sessionBackend, {
@@ -1018,13 +1041,13 @@ async function onSessionStartHandler(): Promise<void> {
   }
 
   // Link backend-specific session id to the PCP session for deterministic routing/resume.
-  if (pcpSessionId && stdin.session_id) {
+  if (pcpSessionId && backendSessionId) {
     try {
       await callPcpTool('update_session_phase', {
         email: config?.email,
         agentId,
         sessionId: pcpSessionId,
-        backendSessionId: String(stdin.session_id),
+        backendSessionId,
         status: 'active',
       });
     } catch {

--- a/packages/cli/src/commands/hooks.ts
+++ b/packages/cli/src/commands/hooks.ts
@@ -23,6 +23,7 @@ import { fileURLToPath } from 'url';
 import { execSync } from 'child_process';
 import { homedir } from 'os';
 import { resolveAgentId, readIdentityJson } from '../backends/identity.js';
+import { setCurrentRuntimeSession, upsertRuntimeSession } from '../session/runtime.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -905,11 +906,13 @@ async function onSessionStartHandler(): Promise<void> {
   // Read studio/workspace ID from identity.json
   const identityPath = join(cwd, '.pcp', 'identity.json');
   let studioId: string | undefined;
+  let identityId: string | undefined;
   let studioLine = '';
   if (existsSync(identityPath)) {
     try {
       const identity = JSON.parse(readFileSync(identityPath, 'utf-8'));
       studioId = identity.studioId || identity.workspaceId;
+      identityId = identity.identityId;
       const studioName = identity.studio || identity.workspace;
       if (studioName) {
         studioLine = `Studio: ${studioName}`;
@@ -958,14 +961,32 @@ async function onSessionStartHandler(): Promise<void> {
 
   // Register PCP session with detected backend
   const detectedBackend = detectBackend(cwd);
+  const sessionBackend = detectedBackend.name === 'claude-code' ? 'claude' : detectedBackend.name;
+  let pcpSessionId: string | undefined;
+  let pcpThreadKey: string | undefined;
+
+  // If provided by sb launcher, prefer that explicit session id.
+  if (process.env.PCP_SESSION_ID) {
+    pcpSessionId = process.env.PCP_SESSION_ID;
+  }
+
   try {
-    const startArgs: Record<string, unknown> = {
-      email: config?.email,
-      agentId,
-      backend: detectedBackend.name,
-    };
-    if (studioId) startArgs.studioId = studioId;
-    await callPcpTool('start_session', startArgs);
+    if (!pcpSessionId) {
+      const startArgs: Record<string, unknown> = {
+        email: config?.email,
+        agentId,
+        backend: sessionBackend,
+      };
+      if (studioId) startArgs.studioId = studioId;
+      const started = await callPcpTool('start_session', startArgs);
+      const startedSession = started.session as Record<string, unknown> | undefined;
+      if (startedSession && typeof startedSession.id === 'string') {
+        pcpSessionId = startedSession.id;
+        if (typeof startedSession.threadKey === 'string') {
+          pcpThreadKey = startedSession.threadKey;
+        }
+      }
+    }
   } catch {
     // Session tracking failure isn't shown to the SB (no block for it),
     // but it means the session won't be tracked. The bootstrap failure
@@ -975,6 +996,40 @@ async function onSessionStartHandler(): Promise<void> {
   // Store session ID if provided in stdin
   if (stdin.session_id) {
     writeRuntimeFile(cwd, 'session-id', String(stdin.session_id));
+  }
+
+  if (pcpSessionId) {
+    writeRuntimeFile(cwd, 'pcp-session-id', pcpSessionId);
+    upsertRuntimeSession(cwd, {
+      pcpSessionId,
+      backend: sessionBackend,
+      agentId,
+      ...(identityId ? { identityId } : {}),
+      ...(studioId ? { studioId } : {}),
+      ...(pcpThreadKey ? { threadKey: pcpThreadKey } : {}),
+      ...(stdin.session_id ? { backendSessionId: String(stdin.session_id) } : {}),
+      startedAt: new Date().toISOString(),
+    });
+    setCurrentRuntimeSession(cwd, pcpSessionId, sessionBackend, {
+      agentId,
+      ...(identityId ? { identityId } : {}),
+      ...(studioId ? { studioId } : {}),
+    });
+  }
+
+  // Link backend-specific session id to the PCP session for deterministic routing/resume.
+  if (pcpSessionId && stdin.session_id) {
+    try {
+      await callPcpTool('update_session_phase', {
+        email: config?.email,
+        agentId,
+        sessionId: pcpSessionId,
+        backendSessionId: String(stdin.session_id),
+        status: 'active',
+      });
+    } catch {
+      // Non-fatal; startup should continue even if linkage fails.
+    }
   }
 
   const template = loadTemplate('hook-session-start');

--- a/packages/cli/src/commands/studio.test.ts
+++ b/packages/cli/src/commands/studio.test.ts
@@ -7,7 +7,7 @@ import { execSync } from 'child_process';
 import { existsSync, mkdirSync, writeFileSync, rmSync, readFileSync, renameSync } from 'fs';
 import { join, basename } from 'path';
 import { tmpdir } from 'os';
-import { planInit, getWorktreePaths, type InitResult } from './studio.js';
+import { planInit, getWorktreePaths, getStudioPrefix, type InitResult } from './studio.js';
 
 type Move = InitResult['moves'][number];
 
@@ -362,5 +362,18 @@ describe('Studio init', () => {
         expect(worktreeList).toContain(wm.to);
       }
     });
+  });
+});
+
+describe('Studio prefix resolution', () => {
+  it('should derive prefix from canonical repo when running in a worktree', () => {
+    const mainRepo = join(TEST_DIR, 'personal-context-protocol');
+    const worktree = join(TEST_DIR, 'personal-context-protocol--lumen');
+    const gitDir = join(mainRepo, '.git', 'worktrees', 'lumen');
+
+    mkdirSync(worktree, { recursive: true });
+    writeFileSync(join(worktree, '.git'), `gitdir: ${gitDir}\n`);
+
+    expect(getStudioPrefix(worktree)).toBe('personal-context-protocol--');
   });
 });

--- a/packages/cli/src/commands/studio.ts
+++ b/packages/cli/src/commands/studio.ts
@@ -27,7 +27,7 @@ import {
   renameSync,
   cpSync,
 } from 'fs';
-import { join, dirname, basename, parse as parsePath } from 'path';
+import { join, dirname, basename, parse as parsePath, resolve as resolvePath } from 'path';
 import { homedir } from 'os';
 import { installHooks } from './hooks.js';
 import { loadAuth, decodeJwtPayload, isTokenExpired } from '../auth/tokens.js';
@@ -71,9 +71,32 @@ function getStudioParent(gitRoot: string): string {
   return dirname(gitRoot);
 }
 
+function resolveCanonicalRepoRoot(gitRoot: string): string {
+  const gitFile = join(gitRoot, '.git');
+  if (!existsSync(gitFile)) return gitRoot;
+
+  try {
+    const stat = readFileSync(gitFile, 'utf-8');
+    const match = stat.match(/^gitdir:\s*(.+)\s*$/m);
+    if (!match) return gitRoot;
+
+    const gitDirPath = resolvePath(gitRoot, match[1]);
+    const marker = `${join('.git', 'worktrees')}`;
+    const idx = gitDirPath.lastIndexOf(marker);
+    if (idx === -1) return gitRoot;
+
+    // /path/to/repo/.git/worktrees/name -> /path/to/repo
+    return gitDirPath.slice(0, idx);
+  } catch {
+    return gitRoot;
+  }
+}
+
 function getStudioPrefix(gitRoot: string): string {
-  // Use the repo folder name as prefix (e.g., "personal-context-protocol" -> "personal-context-protocol--")
-  return `${basename(gitRoot)}--`;
+  // Use canonical repo name (main worktree), not the current worktree folder.
+  // This avoids nested prefixes like repo--lumen--alpha when run from repo--lumen.
+  const canonicalRoot = resolveCanonicalRepoRoot(gitRoot);
+  return `${basename(canonicalRoot)}--`;
 }
 
 function getStudioPath(gitRoot: string, name: string): string {

--- a/packages/cli/src/session/runtime.ts
+++ b/packages/cli/src/session/runtime.ts
@@ -91,6 +91,8 @@ export function upsertRuntimeSession(
   cwd: string,
   input: Omit<RuntimeSessionRecord, 'updatedAt'> & { updatedAt?: string }
 ): RuntimeSessionRecord {
+  // NOTE: This is a best-effort local runtime cache (non-atomic read/modify/write).
+  // Concurrent writers can race and last-write-wins.
   const state = readRuntimeState(cwd);
   const now = input.updatedAt || new Date().toISOString();
 

--- a/packages/cli/src/session/runtime.ts
+++ b/packages/cli/src/session/runtime.ts
@@ -1,0 +1,165 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+
+export interface RuntimeSessionRecord {
+  pcpSessionId: string;
+  backend: string;
+  agentId?: string;
+  identityId?: string;
+  studioId?: string;
+  threadKey?: string;
+  backendSessionId?: string;
+  startedAt?: string;
+  updatedAt: string;
+}
+
+interface RuntimeSessionState {
+  version: 1;
+  current?: {
+    pcpSessionId: string;
+    backend: string;
+    agentId?: string;
+    identityId?: string;
+    studioId?: string;
+    updatedAt: string;
+  };
+  sessions: RuntimeSessionRecord[];
+}
+
+const RUNTIME_STATE_FILE = 'sessions.json';
+
+function getRuntimeDir(cwd: string): string {
+  return join(cwd, '.pcp', 'runtime');
+}
+
+function getRuntimeStatePath(cwd: string): string {
+  return join(getRuntimeDir(cwd), RUNTIME_STATE_FILE);
+}
+
+function ensureRuntimeDir(cwd: string): void {
+  mkdirSync(getRuntimeDir(cwd), { recursive: true });
+}
+
+function defaultState(): RuntimeSessionState {
+  return {
+    version: 1,
+    sessions: [],
+  };
+}
+
+export function readRuntimeState(cwd: string): RuntimeSessionState {
+  const filePath = getRuntimeStatePath(cwd);
+  if (!existsSync(filePath)) return defaultState();
+
+  try {
+    const parsed = JSON.parse(readFileSync(filePath, 'utf-8')) as Partial<RuntimeSessionState>;
+    const sessions = Array.isArray(parsed.sessions)
+      ? parsed.sessions.filter(
+          (s): s is RuntimeSessionRecord =>
+            !!s &&
+            typeof s === 'object' &&
+            typeof s.pcpSessionId === 'string' &&
+            typeof s.backend === 'string' &&
+            typeof s.updatedAt === 'string'
+        )
+      : [];
+
+    const current =
+      parsed.current &&
+      typeof parsed.current.pcpSessionId === 'string' &&
+      typeof parsed.current.backend === 'string' &&
+      typeof parsed.current.updatedAt === 'string'
+        ? parsed.current
+        : undefined;
+
+    return {
+      version: 1,
+      sessions,
+      ...(current ? { current } : {}),
+    };
+  } catch {
+    return defaultState();
+  }
+}
+
+export function writeRuntimeState(cwd: string, state: RuntimeSessionState): void {
+  ensureRuntimeDir(cwd);
+  writeFileSync(getRuntimeStatePath(cwd), JSON.stringify(state, null, 2));
+}
+
+export function upsertRuntimeSession(
+  cwd: string,
+  input: Omit<RuntimeSessionRecord, 'updatedAt'> & { updatedAt?: string }
+): RuntimeSessionRecord {
+  const state = readRuntimeState(cwd);
+  const now = input.updatedAt || new Date().toISOString();
+
+  const next: RuntimeSessionRecord = {
+    ...input,
+    updatedAt: now,
+  };
+
+  const idx = state.sessions.findIndex(
+    (s) =>
+      s.pcpSessionId === next.pcpSessionId &&
+      s.backend === next.backend &&
+      s.agentId === next.agentId &&
+      s.studioId === next.studioId
+  );
+
+  if (idx >= 0) {
+    state.sessions[idx] = { ...state.sessions[idx], ...next };
+  } else {
+    state.sessions.push(next);
+  }
+
+  writeRuntimeState(cwd, state);
+  return idx >= 0 ? state.sessions[idx] : next;
+}
+
+export function setCurrentRuntimeSession(
+  cwd: string,
+  pcpSessionId: string,
+  backend: string,
+  options?: { agentId?: string; identityId?: string; studioId?: string }
+): void {
+  const state = readRuntimeState(cwd);
+  state.current = {
+    pcpSessionId,
+    backend,
+    ...(options?.agentId ? { agentId: options.agentId } : {}),
+    ...(options?.identityId ? { identityId: options.identityId } : {}),
+    ...(options?.studioId ? { studioId: options.studioId } : {}),
+    updatedAt: new Date().toISOString(),
+  };
+  writeRuntimeState(cwd, state);
+}
+
+export function listRuntimeSessions(cwd: string, backend?: string): RuntimeSessionRecord[] {
+  const state = readRuntimeState(cwd);
+  const sessions = backend ? state.sessions.filter((s) => s.backend === backend) : state.sessions;
+  return [...sessions].sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+}
+
+export function getCurrentRuntimeSession(
+  cwd: string,
+  backend?: string
+): RuntimeSessionRecord | undefined {
+  const state = readRuntimeState(cwd);
+
+  if (state.current) {
+    const current = state.sessions.find(
+      (s) =>
+        s.pcpSessionId === state.current!.pcpSessionId &&
+        s.backend === state.current!.backend &&
+        (!state.current!.agentId || s.agentId === state.current!.agentId) &&
+        (!state.current!.identityId || s.identityId === state.current!.identityId) &&
+        (!state.current!.studioId || s.studioId === state.current!.studioId) &&
+        (!backend || s.backend === backend)
+    );
+    if (current) return current;
+  }
+
+  const sessions = listRuntimeSessions(cwd, backend);
+  return sessions[0];
+}


### PR DESCRIPTION
## Summary
- add runtime multi-session registry at `.pcp/runtime/sessions.json` keyed by backend + agent/identity + studio
- add launcher preflight for PCP session selection/creation (resume existing vs start new)
- pass canonical `PCP_SESSION_ID` through backend adapters; align Claude with `--session-id` when starting new
- persist PCP + backend session linkage from hooks via `update_session_phase(sessionId, backendSessionId)`
- extend `start_session` to accept `sessionId` + `forceNew`
- propagate routing anchors in `agent trigger` (`threadKey`, `recipientSessionId`, studio hints)
- fix studio prefix derivation in worktrees using canonical repo root
- include `identityId` in runtime session records when available

## Validation
- `yarn workspace @personal-context/cli build`
- `yarn workspace @personal-context/cli test`
- `SUPABASE_URL=https://example.supabase.co SUPABASE_PUBLISHABLE_KEY=test SUPABASE_SECRET_KEY=test JWT_SECRET=12345678901234567890123456789012 yarn workspace @personal-context/api test src/mcp/tools/memory-handlers.test.ts`
- `SUPABASE_URL=https://example.supabase.co SUPABASE_PUBLISHABLE_KEY=test SUPABASE_SECRET_KEY=test JWT_SECRET=12345678901234567890123456789012 yarn workspace @personal-context/api test src/data/repositories/memory-repository.test.ts`

## Notes
- Codex/Gemini currently support deterministic resume via backend session capture + resume flags; explicit new-session custom ID is Claude-only today.