### PR TITLE
feat: skills architecture v1 — 4-tier cascade + hook injection (by Wren)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,15 +208,15 @@ When sending messages to other SBs via `send_to_inbox`, use `threadKey` to maint
 
 `<type>:<identifier>` — always use the most specific reference available.
 
-| Type | When to use | Example |
-|------|------------|---------|
-| `pr:<number>` | PR review, feedback, iteration | `pr:32` |
-| `spec:<slug>` | Spec discussion (use artifact URI slug) | `spec:cli-session-hooks` |
-| `issue:<number>` | Issue triage or debugging | `issue:45` |
-| `branch:<name>` | Feature branch coordination | `branch:wren/feat/cli-hooks` |
-| `debug:<slug>` | Collaborative debugging | `debug:inbox-latency` |
-| `task:<id>` | PCP task coordination | `task:abc123` |
-| `thread:<slug>` | Multi-step conversation with no natural key | `thread:perf-audit` |
+| Type             | When to use                                 | Example                      |
+| ---------------- | ------------------------------------------- | ---------------------------- |
+| `pr:<number>`    | PR review, feedback, iteration              | `pr:32`                      |
+| `spec:<slug>`    | Spec discussion (use artifact URI slug)     | `spec:cli-session-hooks`     |
+| `issue:<number>` | Issue triage or debugging                   | `issue:45`                   |
+| `branch:<name>`  | Feature branch coordination                 | `branch:wren/feat/cli-hooks` |
+| `debug:<slug>`   | Collaborative debugging                     | `debug:inbox-latency`        |
+| `task:<id>`      | PCP task coordination                       | `task:abc123`                |
+| `thread:<slug>`  | Multi-step conversation with no natural key | `thread:perf-audit`          |
 
 ### Sender Rules
 
@@ -387,6 +387,64 @@ All tools support multiple identification methods:
 - `email` - Account email
 - `platform` + `platformId` - Platform-specific ID (telegram:123456)
 - `phone` - E.164 phone number
+
+## Skills
+
+PCP uses the [AgentSkills format](https://docs.openclaw.ai/tools/skills) — each skill is a `SKILL.md` file with YAML frontmatter, optionally in its own directory with bundled scripts.
+
+### Skill Types
+
+| Type         | Description                               | Example              |
+| ------------ | ----------------------------------------- | -------------------- |
+| **mini-app** | Code-based skills with callable functions | bill-split           |
+| **cli**      | External CLI tool wrappers                | github-cli           |
+| **guide**    | Markdown guides for handling situations   | group-chat-etiquette |
+
+### Loading Cascade (lowest → highest precedence)
+
+Skills load from four tiers. When names collide, higher tiers win:
+
+1. **Bundled** — `packages/api/src/skills/builtin/` (shipped with PCP)
+2. **Extra dirs** — configurable paths in `~/.pcp/config.json` (ClawHub interop, etc.)
+3. **Managed** — `~/.pcp/skills/` (user-installed, shared across all SBs)
+4. **Workspace** — `<cwd>/.pcp/skills/` (per-worktree, per-SB)
+
+Configure extra directories in `~/.pcp/config.json`:
+
+```json
+{
+  "skills": {
+    "extraDirs": ["~/.openclaw/skills"]
+  }
+}
+```
+
+### Creating a Skill
+
+See [`packages/api/src/skills/README.md`](./packages/api/src/skills/README.md) for the full reference. Minimum viable skill:
+
+```markdown
+---
+name: my-skill
+description: What this skill does
+type: guide
+triggers:
+  keywords: [trigger, words]
+---
+
+# My Skill
+
+Instructions for the agent on how and when to use this skill.
+```
+
+Skills can reference `{baseDir}` in their content to resolve paths relative to their own directory (useful for bundled scripts).
+
+### MCP Tools for Skills
+
+- `list_skills` — Browse available skills with eligibility status
+- `get_skill` — Get full skill content and manifest
+- `publish_skill` — Publish to cloud registry
+- `update_skill`, `fork_skill`, `deprecate_skill`, `delete_skill` — Registry management
 
 ## Coding Conventions
 

--- a/README.md
+++ b/README.md
@@ -162,6 +162,12 @@ Stories are living documents — update them as the feature evolves.
 - **Process Management**: pm2
 - **CLI**: Commander.js
 
+## Skills
+
+PCP supports extensible skills using the [AgentSkills format](https://docs.openclaw.ai/tools/skills). Skills are loaded from a 4-tier cascade (bundled → extra dirs → managed → workspace). Compatible with [ClawHub](https://clawhub.com) for community skill installation.
+
+See [`packages/api/src/skills/README.md`](./packages/api/src/skills/README.md) for the full reference and [AGENTS.md](./AGENTS.md#skills) for agent-facing docs.
+
 ## Architecture
 
 See [ARCHITECTURE.md](./ARCHITECTURE.md) for system diagrams, data flow, and design decisions.

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "dev:mcp": "tsx watch src/index.ts",
-    "build": "tsc",
+    "build": "tsc; cp -r src/skills/builtin dist/skills/builtin",
     "start": "node dist/index.js",
     "server": "tsx src/server.ts",
     "server:dev": "tsx watch src/server.ts",

--- a/packages/api/src/mcp/tools/index.ts
+++ b/packages/api/src/mcp/tools/index.ts
@@ -1850,14 +1850,19 @@ User can be identified by ONE of: userId, email, phone, or platform + platformId
   server.registerTool(
     'list_skills',
     {
-      description: `List all available mini-app skills. Each skill provides specialized capabilities (like bill splitting, expense tracking, etc.).
+      description: `List all available skills (guides, mini-apps, CLI tools). Each skill provides specialized capabilities.
 
-When a user's message matches a skill's triggers, use get_skill to read the full instructions before proceeding.`,
-      inputSchema: {},
+When a user's message matches a skill's triggers, use get_skill to read the full instructions before proceeding. Guide-type skills are behavioral instructions that should be followed when active.`,
+      inputSchema: {
+        includeContent: z
+          .boolean()
+          .optional()
+          .describe('Include full content for guide-type skills (for session injection)'),
+      },
     },
-    async () => {
+    async (args) => {
       try {
-        return await handleListSkills({}, dataComposer);
+        return await handleListSkills(args as Parameters<typeof handleListSkills>[0], dataComposer);
       } catch (error) {
         logger.error('Error in list_skills:', error);
         return {
@@ -1880,15 +1885,15 @@ When a user's message matches a skill's triggers, use get_skill to read the full
   server.registerTool(
     'get_skill',
     {
-      description: `Get the full skill documentation (SKILL.md) for a mini-app. Read this before using a skill's functions.
+      description: `Get the full skill documentation (SKILL.md) for a skill. Read this before using a skill's functions or following a guide.
 
 The skill document contains:
-- Conversation flow guidelines
+- Behavioral instructions (guides)
+- Conversation flow guidelines (mini-apps)
 - How to use the skill's functions correctly
-- Edge case handling
-- Formatting instructions`,
+- Edge case handling`,
       inputSchema: {
-        skillName: z.string().describe('Name of the skill/mini-app to get instructions for'),
+        skillName: z.string().describe('Name of the skill to get instructions for'),
       },
     },
     async (args) => {

--- a/packages/api/src/mcp/tools/skill-handlers.ts
+++ b/packages/api/src/mcp/tools/skill-handlers.ts
@@ -1,13 +1,15 @@
 /**
  * MCP Tool Handlers for Skills
  *
- * Enables Claude to discover and read mini-app skill instructions.
- * Following the clawdbot pattern: list available skills, read on-demand.
+ * Enables AI agents to discover and read skill instructions.
+ * Uses the SkillsService (4-tier cascade) for all skill types,
+ * plus the miniAppsRegistry for dynamic MCP tool registration.
  */
 
 import { z } from 'zod';
 import type { DataComposer } from '../../data/composer';
 import { logger } from '../../utils/logger';
+import { getSkillsService } from '../../skills/service';
 
 // Type for loaded mini-app (matches loader.ts)
 interface LoadedMiniApp {
@@ -28,19 +30,20 @@ interface LoadedMiniApp {
 }
 
 // Registry of loaded mini-apps (set by server startup)
+// Used for dynamic MCP tool registration — separate from SkillsService browsing
 let miniAppsRegistry: Map<string, LoadedMiniApp> | null = null;
 
 /**
- * Register the loaded mini-apps for skill access
+ * Register the loaded mini-apps for dynamic tool access
  * Called by server.ts after loading mini-apps
  */
 export function setMiniAppsRegistry(miniApps: Map<string, LoadedMiniApp>): void {
   miniAppsRegistry = miniApps;
-  logger.info(`Skills registry initialized with ${miniApps.size} mini-apps`);
+  logger.info(`Mini-apps registry initialized with ${miniApps.size} mini-apps`);
 }
 
 /**
- * Get the mini-apps registry
+ * Get the mini-apps registry (for dynamic tool registration)
  */
 export function getMiniAppsRegistry(): Map<string, LoadedMiniApp> | null {
   return miniAppsRegistry;
@@ -66,34 +69,58 @@ function mcpResponse(data: object, isError = false): McpResponse {
 // LIST SKILLS
 // ============================================================================
 
-export const listSkillsSchema = z.object({});
+export const listSkillsSchema = z.object({
+  includeContent: z
+    .boolean()
+    .optional()
+    .describe('Include full skill content for guide-type skills (for session injection)'),
+});
 
 export async function handleListSkills(
-  _args: z.infer<typeof listSkillsSchema>,
+  args: z.infer<typeof listSkillsSchema>,
   _dataComposer: DataComposer
 ): Promise<McpResponse> {
   try {
-    if (!miniAppsRegistry || miniAppsRegistry.size === 0) {
+    const service = getSkillsService();
+    const { skills: allSkills } = service.listSkills();
+
+    if (allSkills.length === 0) {
       return mcpResponse({
         success: true,
         skills: [],
-        message: 'No mini-app skills loaded.',
+        message: 'No skills loaded.',
       });
     }
 
-    const skills = Array.from(miniAppsRegistry.entries()).map(([name, app]) => ({
-      name,
-      version: app.manifest.version,
-      description: app.manifest.description,
-      triggers: app.manifest.triggers.keywords,
-      functions: app.manifest.functions.map((f) => f.name),
-      hasSkillDoc: app.skillContent.length > 0,
-    }));
+    const skills = allSkills.map((s) => {
+      const base: Record<string, unknown> = {
+        name: s.name,
+        displayName: s.displayName,
+        type: s.type,
+        version: s.version,
+        description: s.description,
+        status: s.status,
+        triggers: s.triggers,
+        functionCount: s.functionCount,
+        capabilities: s.capabilities,
+      };
+
+      // Include full content for guides when requested (for hook injection)
+      if (args.includeContent && s.type === 'guide' && s.eligibility?.eligible !== false) {
+        const detail = service.getSkill(s.name);
+        if (detail?.skillContent) {
+          base.content = detail.skillContent;
+        }
+      }
+
+      return base;
+    });
 
     return mcpResponse({
       success: true,
       skills,
-      usage: 'When a user message matches a trigger, call get_skill to read the full instructions.',
+      usage:
+        'Call get_skill with a skill name for full instructions. Guide skills are behavioral — follow their instructions when active.',
     });
   } catch (error) {
     logger.error('Error in list_skills:', error);
@@ -112,7 +139,7 @@ export async function handleListSkills(
 // ============================================================================
 
 export const getSkillSchema = z.object({
-  skillName: z.string().describe('Name of the skill/mini-app to get instructions for'),
+  skillName: z.string().describe('Name of the skill to get instructions for'),
 });
 
 export async function handleGetSkill(
@@ -120,28 +147,25 @@ export async function handleGetSkill(
   _dataComposer: DataComposer
 ): Promise<McpResponse> {
   try {
-    if (!miniAppsRegistry) {
-      return mcpResponse(
-        {
-          success: false,
-          error: 'Skills registry not initialized.',
-        },
-        true
-      );
-    }
+    const service = getSkillsService();
+    const detail = service.getSkill(args.skillName);
 
-    const app = miniAppsRegistry.get(args.skillName);
-    if (!app) {
+    if (!detail) {
       // Try case-insensitive match
-      for (const [name, miniApp] of miniAppsRegistry) {
-        if (name.toLowerCase() === args.skillName.toLowerCase()) {
+      const { skills: allSkills } = service.listSkills();
+      const match = allSkills.find((s) => s.name.toLowerCase() === args.skillName.toLowerCase());
+      if (match) {
+        const matchDetail = service.getSkill(match.name);
+        if (matchDetail) {
           return mcpResponse({
             success: true,
-            skillName: name,
-            version: miniApp.manifest.version,
-            description: miniApp.manifest.description,
-            content: miniApp.skillContent || 'No skill documentation available.',
-            functions: miniApp.manifest.functions,
+            skillName: match.name,
+            type: matchDetail.manifest.type,
+            version: matchDetail.manifest.version,
+            description: matchDetail.manifest.description,
+            content: matchDetail.skillContent || 'No skill documentation available.',
+            functions: matchDetail.manifest.functions,
+            triggers: matchDetail.manifest.triggers,
           });
         }
       }
@@ -150,7 +174,7 @@ export async function handleGetSkill(
         {
           success: false,
           error: `Skill "${args.skillName}" not found.`,
-          availableSkills: Array.from(miniAppsRegistry.keys()),
+          availableSkills: allSkills.map((s) => s.name),
         },
         true
       );
@@ -161,10 +185,12 @@ export async function handleGetSkill(
     return mcpResponse({
       success: true,
       skillName: args.skillName,
-      version: app.manifest.version,
-      description: app.manifest.description,
-      content: app.skillContent || 'No skill documentation available.',
-      functions: app.manifest.functions,
+      type: detail.manifest.type,
+      version: detail.manifest.version,
+      description: detail.manifest.description,
+      content: detail.skillContent || 'No skill documentation available.',
+      functions: detail.manifest.functions,
+      triggers: detail.manifest.triggers,
     });
   } catch (error) {
     logger.error('Error in get_skill:', error);

--- a/packages/api/src/skills/README.md
+++ b/packages/api/src/skills/README.md
@@ -32,6 +32,8 @@ Skills are loaded from a 4-tier precedence cascade (lowest → highest). When na
    - Per-worktree / per-SB skills
    - Highest precedence — overrides everything
 
+> **Note:** The MCP `list_skills` endpoint covers tiers 1–3 (builtin, extra dirs, managed). Workspace skills (tier 4) require knowing the agent's working directory, which the PCP server doesn't have. Instead, workspace skills are picked up by the session start hooks running inside the agent's process and injected into the `{{SKILLS_BLOCK}}`.
+
 ### Configuring Extra Directories
 
 Add `skills.extraDirs` to `~/.pcp/config.json`:

--- a/packages/api/src/skills/README.md
+++ b/packages/api/src/skills/README.md
@@ -2,29 +2,56 @@
 
 Skills extend your AI assistant's capabilities. There are three types:
 
-| Type | Description | Example |
-|------|-------------|---------|
+| Type         | Description                      | Example                          |
+| ------------ | -------------------------------- | -------------------------------- |
 | **mini-app** | Code-based skills with functions | Bill splitting, expense tracking |
-| **cli** | Wrappers for CLI tools | GitHub CLI, AWS CLI |
-| **guide** | Behavioral guides for situations | Group chat etiquette |
+| **cli**      | Wrappers for CLI tools           | GitHub CLI, AWS CLI              |
+| **guide**    | Behavioral guides for situations | Group chat etiquette             |
+
+## Format Compatibility
+
+PCP skills use the [AgentSkills format](https://docs.openclaw.ai/tools/skills) — an open standard adopted by Claude Code, Cursor, VS Code, Gemini, and others. Skills installed via [ClawHub](https://clawhub.com) are compatible with PCP's loader.
 
 ## Skill Locations
 
-Skills are loaded from two locations:
+Skills are loaded from a 4-tier precedence cascade (lowest → highest). When names collide, higher tiers win:
 
-1. **Built-in skills**: `packages/api/src/skills/builtin/`
+1. **Built-in**: `packages/api/src/skills/builtin/`
    - Ships with PCP
    - Updated via PCP releases
 
-2. **User skills**: `~/.pcp/skills/`
+2. **Extra dirs**: configurable paths (default: `~/.openclaw/skills`)
+   - ClawHub interop — `clawdhub install playwright-mcp` just works
+   - Configured in `~/.pcp/config.json` (see below)
+
+3. **Managed**: `~/.pcp/skills/`
    - Your custom skills
    - Downloaded skills from registries
+
+4. **Workspace**: `<cwd>/.pcp/skills/`
+   - Per-worktree / per-SB skills
+   - Highest precedence — overrides everything
+
+### Configuring Extra Directories
+
+Add `skills.extraDirs` to `~/.pcp/config.json`:
+
+```json
+{
+  "skills": {
+    "extraDirs": ["~/.openclaw/skills"]
+  }
+}
+```
+
+This lets ClawHub-installed skills (and any other AgentSkills-compatible sources) be automatically available to PCP.
 
 ## Installing Skills
 
 ### Manual Installation
 
 1. Create the skills directory if it doesn't exist:
+
    ```bash
    mkdir -p ~/.pcp/skills
    ```
@@ -59,17 +86,26 @@ If the skill is a directory package, place it under:
 ~/.pcp/skills/<skill-name>/
 ```
 
-### Future: PCP CLI (coming soon)
+### From ClawHub
+
+If [ClawHub](https://clawhub.com) is installed, skills install directly into `~/.openclaw/skills/` and are automatically available to PCP (via `extraDirs`):
+
+```bash
+clawdhub install playwright-mcp
+clawdhub install playwright-scraper-skill
+```
+
+### Future: SB CLI (coming soon)
 
 ```bash
 # Install from registry
-pcp skill install bill-split
+sb skill install bill-split
 
 # List installed skills
-pcp skill list
+sb skill list
 
 # Update all skills
-pcp skill update
+sb skill update
 ```
 
 ## Creating a Skill
@@ -81,11 +117,11 @@ The simplest format - a markdown file with YAML frontmatter:
 ```markdown
 ---
 name: my-skill
-version: "1.0.0"
+version: '1.0.0'
 displayName: My Skill
 description: What this skill does
-type: guide  # or mini-app, cli
-emoji: "🎯"
+type: guide # or mini-app, cli
+emoji: '🎯'
 category: productivity
 tags:
   - example
@@ -118,9 +154,21 @@ For more complex skills with multiple files:
 ~/.pcp/skills/my-skill/
 ├── manifest.yaml     # Skill metadata (required)
 ├── SKILL.md          # Instructions for AI (optional)
+├── run.js            # Bundled scripts (optional)
 ├── functions.ts      # Code for mini-apps (optional)
 └── README.md         # Human documentation (optional)
 ```
+
+### The `{baseDir}` Placeholder
+
+Skills can reference `{baseDir}` in their SKILL.md content to resolve paths relative to their own directory. This is useful for bundled scripts:
+
+```markdown
+To run the automation:
+`cd {baseDir} && node run.js /tmp/my-script.js`
+```
+
+At load time, `{baseDir}` is replaced with the skill's actual filesystem path (e.g., `~/.pcp/skills/my-skill`).
 
 ## Skill Types
 
@@ -182,7 +230,6 @@ guide:
     - any
   priority: 5
 ---
-
 # Meeting Notes Guide
 
 How to take effective meeting notes...
@@ -236,10 +283,11 @@ install:
 
   - kind: manual
     url: https://example.com/install
-    instructions: "Download and run the installer"
+    instructions: 'Download and run the installer'
 ```
 
 Supported install kinds:
+
 - `brew` - Homebrew (macOS/Linux)
 - `npm` - Node.js packages
 - `pip` - Python packages
@@ -282,11 +330,15 @@ PCP supports cloud-based skill storage and distribution:
 
 ### Loading Order
 
-Default source priority is deterministic:
+Default source priority is deterministic (lowest → highest precedence):
 
-1. **Cloud installations** - User's installed skills from registry
-2. **Local skills** (`~/.pcp/skills/`) - Loaded after cloud
-3. **Deduplication** - Later sources override earlier ones, so local skills take precedence over cloud when names collide
+1. **Built-in** — shipped with PCP
+2. **Cloud installations** — user's installed skills from registry
+3. **Extra dirs** — ClawHub and other configured sources
+4. **Managed** (`~/.pcp/skills/`) — user-installed local skills
+5. **Workspace** (`<cwd>/.pcp/skills/`) — per-worktree overrides
+
+Later sources override earlier ones when names collide.
 
 ### User Installation Flow
 
@@ -345,8 +397,11 @@ supabase db push
 mcp__supabase__apply_migration
 ```
 
-## Future: Skill Registries
+## Future (v2)
 
+- **Public/private visibility** — Cloud registry already has `is_public`. Surface in local config for per-SB access control (public-facing SBs get different skills than private ones).
+- **`sb skills install`** — CLI command to fetch from cloud registry or ClawHub
+- **Backend skill injection** — Inject skill content into `sb`-wrapped sessions (Claude Code, Codex, Gemini)
 - **PCP Hub**: Curated, verified official skills
 - **Community**: User-submitted public skills
 - **Organization**: Private team skill collections

--- a/packages/api/src/skills/loader.ts
+++ b/packages/api/src/skills/loader.ts
@@ -1,22 +1,40 @@
 /**
  * Skill Loader
  *
- * Loads skills from the filesystem. Skills can be:
- * - SKILL.md files with YAML frontmatter (like clawdbot)
+ * Loads skills from the filesystem using a 4-tier precedence cascade
+ * (inspired by the AgentSkills format: https://docs.openclaw.ai/tools/skills).
+ *
+ * Skills can be:
+ * - SKILL.md files with YAML frontmatter
  * - Directories with manifest.yaml + SKILL.md
  *
- * Default skill locations:
- * 1. Built-in: packages/api/src/skills/builtin/
- * 2. User skills: ~/.pcp/skills/
+ * Loading order (lowest → highest precedence, later overrides by name):
+ * 1. Built-in:  packages/api/src/skills/builtin/   (shipped with PCP)
+ * 2. Extra dirs: configurable paths                 (ClawHub interop, etc.)
+ * 3. Managed:   ~/.pcp/skills/                      (user-installed, all SBs)
+ * 4. Workspace:  <cwd>/.pcp/skills/                 (per-worktree, per-SB)
  */
 
 import { readFileSync, readdirSync, existsSync, statSync } from 'fs';
-import { join, basename } from 'path';
+import { join, basename, dirname } from 'path';
 import * as yaml from 'yaml';
 import type { SkillManifest, LoadedSkill, SkillType } from './types';
 import { checkEligibility } from './eligibility';
 
 const BUILTIN_SKILLS_PATH = join(__dirname, 'builtin');
+const HOME = process.env.HOME || '';
+
+/**
+ * Options for skill loading.
+ */
+export interface SkillLoadOptions {
+  /** Override the default ~/.pcp/skills/ managed path */
+  userSkillsPath?: string;
+  /** Working directory for workspace-level skills (<cwd>/.pcp/skills/) */
+  workspacePath?: string;
+  /** Additional skill directories (e.g., ["~/.openclaw/skills"]) */
+  extraDirs?: string[];
+}
 
 /**
  * Parse YAML frontmatter from markdown content
@@ -71,6 +89,14 @@ function frontmatterToManifest(
 }
 
 /**
+ * Replace {baseDir} placeholder with the skill's source directory path.
+ * This lets SKILL.md reference bundled scripts relative to its own directory.
+ */
+function resolveBaseDir(content: string, sourcePath: string): string {
+  return content.replace(/\{baseDir\}/g, sourcePath);
+}
+
+/**
  * Load a single skill from a SKILL.md file
  */
 function loadSkillFromFile(filePath: string): LoadedSkill | null {
@@ -80,10 +106,11 @@ function loadSkillFromFile(filePath: string): LoadedSkill | null {
 
     const manifest = frontmatterToManifest(frontmatter, basename(filePath));
     const eligibility = checkEligibility(manifest.requirements);
+    const skillContent = resolveBaseDir(body, dirname(filePath));
 
     return {
       manifest,
-      skillContent: body,
+      skillContent,
       sourcePath: filePath,
       eligibility,
     };
@@ -114,6 +141,7 @@ function loadSkillFromDirectory(dirPath: string): LoadedSkill | null {
         skillContent = body;
       }
 
+      skillContent = resolveBaseDir(skillContent, dirPath);
       const eligibility = checkEligibility(manifest.requirements);
 
       return {
@@ -170,33 +198,88 @@ function scanDirectory(dirPath: string): LoadedSkill[] {
 }
 
 /**
- * Load all skills from default locations
+ * Expand ~ to $HOME in a path
  */
-export function loadAllSkills(userSkillsPath?: string): LoadedSkill[] {
-  const skills: LoadedSkill[] = [];
+function expandHome(p: string): string {
+  return p.replace(/^~/, HOME);
+}
 
-  // Load built-in skills
-  skills.push(...scanDirectory(BUILTIN_SKILLS_PATH));
+/**
+ * Load all skills using the 4-tier precedence cascade.
+ *
+ * Accepts either the legacy single-string `userSkillsPath` parameter
+ * or the full `SkillLoadOptions` object.
+ */
+export function loadAllSkills(options?: string | SkillLoadOptions): LoadedSkill[] {
+  // Backwards compat: accept bare string as userSkillsPath
+  const opts: SkillLoadOptions =
+    typeof options === 'string' ? { userSkillsPath: options } : options || {};
 
-  // Load user skills
-  const userPath = userSkillsPath || join(process.env.HOME || '', '.pcp', 'skills');
-  skills.push(...scanDirectory(userPath));
+  // Map keyed by skill name — last write wins (higher precedence overrides)
+  const skills = new Map<string, LoadedSkill>();
 
-  return skills;
+  // Tier 1: Built-in (lowest precedence)
+  for (const s of scanDirectory(BUILTIN_SKILLS_PATH)) {
+    skills.set(s.manifest.name, s);
+  }
+
+  // Tier 2: Extra dirs (ClawHub, etc.)
+  if (opts.extraDirs) {
+    for (const dir of opts.extraDirs) {
+      for (const s of scanDirectory(expandHome(dir))) {
+        skills.set(s.manifest.name, s);
+      }
+    }
+  }
+
+  // Tier 3: Managed (~/.pcp/skills/)
+  const userPath = opts.userSkillsPath || join(HOME, '.pcp', 'skills');
+  for (const s of scanDirectory(userPath)) {
+    skills.set(s.manifest.name, s);
+  }
+
+  // Tier 4: Workspace (<cwd>/.pcp/skills/) — highest precedence
+  if (opts.workspacePath) {
+    const wsSkillsPath = join(opts.workspacePath, '.pcp', 'skills');
+    for (const s of scanDirectory(wsSkillsPath)) {
+      skills.set(s.manifest.name, s);
+    }
+  }
+
+  return Array.from(skills.values());
 }
 
 /**
  * Load a specific skill by name
  */
-export function loadSkillByName(name: string, userSkillsPath?: string): LoadedSkill | null {
-  const allSkills = loadAllSkills(userSkillsPath);
+export function loadSkillByName(
+  name: string,
+  options?: string | SkillLoadOptions
+): LoadedSkill | null {
+  const allSkills = loadAllSkills(options);
   return allSkills.find((s) => s.manifest.name === name) || null;
 }
 
 /**
- * Get skill paths being scanned
+ * Get all skill paths being scanned
  */
-export function getSkillPaths(userSkillsPath?: string): string[] {
-  const userPath = userSkillsPath || join(process.env.HOME || '', '.pcp', 'skills');
-  return [BUILTIN_SKILLS_PATH, userPath];
+export function getSkillPaths(options?: string | SkillLoadOptions): string[] {
+  const opts: SkillLoadOptions =
+    typeof options === 'string' ? { userSkillsPath: options } : options || {};
+
+  const paths = [BUILTIN_SKILLS_PATH];
+
+  if (opts.extraDirs) {
+    for (const dir of opts.extraDirs) {
+      paths.push(expandHome(dir));
+    }
+  }
+
+  paths.push(opts.userSkillsPath || join(HOME, '.pcp', 'skills'));
+
+  if (opts.workspacePath) {
+    paths.push(join(opts.workspacePath, '.pcp', 'skills'));
+  }
+
+  return paths;
 }

--- a/packages/api/src/skills/loader.ts
+++ b/packages/api/src/skills/loader.ts
@@ -53,13 +53,81 @@ function parseFrontmatter(content: string): { frontmatter: Record<string, unknow
 }
 
 /**
- * Convert frontmatter to SkillManifest
+ * Extract OpenClaw-format metadata from the `metadata.openclaw` frontmatter field.
+ * Maps their nested format to our flat SkillManifest fields.
+ *
+ * OpenClaw nests emoji, os, requires, and install under `metadata.openclaw`:
+ *   metadata: { openclaw: { emoji, os, requires: { bins }, install: [...] } }
+ */
+function extractOpenClawMetadata(frontmatter: Record<string, unknown>): Partial<SkillManifest> {
+  const metadata = frontmatter.metadata as Record<string, unknown> | undefined;
+  if (!metadata) return {};
+
+  // metadata can be a string (JSON) or object
+  let oc: Record<string, unknown> | undefined;
+  if (typeof metadata === 'string') {
+    try {
+      const parsed = JSON.parse(metadata);
+      oc = parsed?.openclaw as Record<string, unknown>;
+    } catch {
+      return {};
+    }
+  } else {
+    oc = metadata.openclaw as Record<string, unknown> | undefined;
+  }
+
+  if (!oc) return {};
+
+  const result: Partial<SkillManifest> = {};
+
+  if (oc.emoji) result.emoji = oc.emoji as string;
+
+  // Map requires + os → requirements
+  const requires = oc.requires as Record<string, unknown> | undefined;
+  const osArr = oc.os as string[] | undefined;
+  if (requires || osArr) {
+    const reqs: SkillManifest['requirements'] = {};
+    if (requires?.bins) reqs.bins = requires.bins as string[];
+    if (requires?.env) reqs.env = requires.env as string[];
+    if (requires?.config) reqs.config = requires.config as string[];
+    if (osArr) {
+      // Map OpenClaw OS names → our names
+      reqs.os = osArr.map((o) => {
+        if (o === 'darwin') return 'macos';
+        if (o === 'win32') return 'windows';
+        return o;
+      }) as Array<'macos' | 'linux' | 'windows'>;
+    }
+    result.requirements = reqs;
+  }
+
+  // Map install specs
+  const installArr = oc.install as Array<Record<string, unknown>> | undefined;
+  if (installArr?.length) {
+    result.install = installArr.map((spec) => ({
+      kind: (spec.kind as string) || 'manual',
+      package: spec.package as string | undefined,
+      bins: spec.bins as string[] | undefined,
+      url: spec.url as string | undefined,
+      instructions: (spec.label as string) || (spec.instructions as string) || undefined,
+    })) as SkillManifest['install'];
+  }
+
+  return result;
+}
+
+/**
+ * Convert frontmatter to SkillManifest.
+ * Supports both PCP's flat format and OpenClaw's nested `metadata.openclaw` format.
  */
 function frontmatterToManifest(
   frontmatter: Record<string, unknown>,
   fileName: string
 ): SkillManifest {
   const name = (frontmatter.name as string) || basename(fileName, '.md').toLowerCase();
+
+  // Extract OpenClaw nested metadata as fallback values
+  const oc = extractOpenClawMetadata(frontmatter);
 
   return {
     name,
@@ -68,7 +136,7 @@ function frontmatterToManifest(
       (frontmatter.displayName as string) || (frontmatter.display_name as string) || name,
     description: (frontmatter.description as string) || '',
     type: (frontmatter.type as SkillType) || 'guide',
-    emoji: frontmatter.emoji as string,
+    emoji: (frontmatter.emoji as string) || oc.emoji,
     category: frontmatter.category as string,
     tags: frontmatter.tags as string[],
     author: frontmatter.author as string,
@@ -77,8 +145,8 @@ function frontmatterToManifest(
 
     triggers: frontmatter.triggers as SkillManifest['triggers'],
     capabilities: frontmatter.capabilities as SkillManifest['capabilities'],
-    requirements: frontmatter.requirements as SkillManifest['requirements'],
-    install: frontmatter.install as SkillManifest['install'],
+    requirements: (frontmatter.requirements as SkillManifest['requirements']) || oc.requirements,
+    install: (frontmatter.install as SkillManifest['install']) || oc.install,
 
     functions: frontmatter.functions as SkillManifest['functions'],
     cli: frontmatter.cli as SkillManifest['cli'],

--- a/packages/api/src/skills/service.ts
+++ b/packages/api/src/skills/service.ts
@@ -5,6 +5,9 @@
  * user settings integration, and status tracking.
  */
 
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
 import { loadAllSkills, loadSkillByName, getSkillPaths, type SkillLoadOptions } from './loader';
 import type {
   LoadedSkill,
@@ -196,11 +199,32 @@ export class SkillsService {
 let serviceInstance: SkillsService | null = null;
 
 /**
- * Get the skills service singleton
+ * Read skills config from ~/.pcp/config.json.
+ * Returns extraDirs if configured under `skills.extraDirs`.
+ */
+function readSkillsConfig(): SkillLoadOptions {
+  const configPath = join(homedir(), '.pcp', 'config.json');
+  if (!existsSync(configPath)) return {};
+
+  try {
+    const config = JSON.parse(readFileSync(configPath, 'utf-8'));
+    const extraDirs = config?.skills?.extraDirs as string[] | undefined;
+    return extraDirs?.length ? { extraDirs } : {};
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Get the skills service singleton.
+ * When no options are provided, reads ~/.pcp/config.json for extraDirs.
  */
 export function getSkillsService(options?: SkillLoadOptions): SkillsService {
   if (!serviceInstance) {
-    serviceInstance = new SkillsService(options);
+    // Merge caller options with config-file options (caller wins)
+    const configOptions = readSkillsConfig();
+    const merged: SkillLoadOptions = { ...configOptions, ...options };
+    serviceInstance = new SkillsService(merged);
   }
   return serviceInstance;
 }

--- a/packages/api/src/skills/service.ts
+++ b/packages/api/src/skills/service.ts
@@ -5,7 +5,7 @@
  * user settings integration, and status tracking.
  */
 
-import { loadAllSkills, loadSkillByName, getSkillPaths } from './loader';
+import { loadAllSkills, loadSkillByName, getSkillPaths, type SkillLoadOptions } from './loader';
 import type {
   LoadedSkill,
   SkillSummary,
@@ -82,10 +82,10 @@ function toDetail(skill: LoadedSkill, userSettings?: UserSkillSettings): SkillDe
  * Skills Service
  */
 export class SkillsService {
-  private userSkillsPath?: string;
+  private loadOptions: SkillLoadOptions;
 
-  constructor(userSkillsPath?: string) {
-    this.userSkillsPath = userSkillsPath;
+  constructor(options?: SkillLoadOptions) {
+    this.loadOptions = options || {};
   }
 
   /**
@@ -97,7 +97,7 @@ export class SkillsService {
       return skillsCache;
     }
 
-    skillsCache = loadAllSkills(this.userSkillsPath);
+    skillsCache = loadAllSkills(this.loadOptions);
     cacheTimestamp = now;
     return skillsCache;
   }
@@ -156,7 +156,7 @@ export class SkillsService {
    * Get skill details by name
    */
   getSkill(name: string): SkillDetail | null {
-    const skill = loadSkillByName(name, this.userSkillsPath);
+    const skill = loadSkillByName(name, this.loadOptions);
     if (!skill) return null;
     return toDetail(skill);
   }
@@ -174,14 +174,14 @@ export class SkillsService {
    * Get skill paths being scanned
    */
   getSkillPaths(): string[] {
-    return getSkillPaths(this.userSkillsPath);
+    return getSkillPaths(this.loadOptions);
   }
 
   /**
    * Check if a specific skill is eligible
    */
   checkSkillEligibility(name: string): { eligible: boolean; message?: string } {
-    const skill = loadSkillByName(name, this.userSkillsPath);
+    const skill = loadSkillByName(name, this.loadOptions);
     if (!skill) {
       return { eligible: false, message: `Skill "${name}" not found` };
     }
@@ -198,9 +198,9 @@ let serviceInstance: SkillsService | null = null;
 /**
  * Get the skills service singleton
  */
-export function getSkillsService(userSkillsPath?: string): SkillsService {
+export function getSkillsService(options?: SkillLoadOptions): SkillsService {
   if (!serviceInstance) {
-    serviceInstance = new SkillsService(userSkillsPath);
+    serviceInstance = new SkillsService(options);
   }
   return serviceInstance;
 }

--- a/packages/cli/src/commands/hooks.ts
+++ b/packages/cli/src/commands/hooks.ts
@@ -434,10 +434,9 @@ function buildSkillsBlock(skills: Array<Record<string, unknown>> | undefined): s
     const type = skill.type as string;
     const desc = skill.description as string;
     const displayName = (skill.displayName as string) || name;
-    const triggers = skill.triggers as { keywords?: string[] } | undefined;
-    const triggerStr = triggers?.keywords?.length
-      ? ` — triggers: ${triggers.keywords.join(', ')}`
-      : '';
+    // triggers comes as a flat keywords array from list_skills summary
+    const triggers = skill.triggers as string[] | undefined;
+    const triggerStr = triggers?.length ? ` — triggers: ${triggers.join(', ')}` : '';
 
     if (type === 'guide' && skill.content) {
       lines.push(`- **${displayName}** (guide): ${desc}${triggerStr} — *active, see below*`);

--- a/packages/cli/src/commands/hooks.ts
+++ b/packages/cli/src/commands/hooks.ts
@@ -419,6 +419,42 @@ function buildSessionsBlock(sessions: Array<Record<string, unknown>> | undefined
   return lines.join('\n');
 }
 
+function buildSkillsBlock(skills: Array<Record<string, unknown>> | undefined): string {
+  if (!skills || skills.length === 0) return '';
+
+  const lines = ['### Available Skills'];
+  lines.push('');
+  lines.push('Call `get_skill` with a skill name for full instructions.');
+  lines.push('');
+
+  const guideContents: string[] = [];
+
+  for (const skill of skills) {
+    const name = skill.name as string;
+    const type = skill.type as string;
+    const desc = skill.description as string;
+    const displayName = (skill.displayName as string) || name;
+    const triggers = skill.triggers as { keywords?: string[] } | undefined;
+    const triggerStr = triggers?.keywords?.length
+      ? ` — triggers: ${triggers.keywords.join(', ')}`
+      : '';
+
+    if (type === 'guide' && skill.content) {
+      lines.push(`- **${displayName}** (guide): ${desc}${triggerStr} — *active, see below*`);
+      guideContents.push(`#### ${displayName}\n\n${skill.content}`);
+    } else {
+      lines.push(`- **${displayName}** (${type}): ${desc}${triggerStr}`);
+    }
+  }
+
+  if (guideContents.length > 0) {
+    lines.push('');
+    lines.push(...guideContents);
+  }
+
+  return lines.join('\n');
+}
+
 // ============================================================================
 // Install / Uninstall / Status
 // ============================================================================
@@ -963,6 +999,7 @@ async function postCompactHandler(): Promise<void> {
 
   let identityBlock = '';
   let inboxBlock = '';
+  let skillsBlock = '';
 
   // Bootstrap identity
   try {
@@ -989,10 +1026,21 @@ async function postCompactHandler(): Promise<void> {
       '*FAILED: Could not reach PCP server for `get_inbox`. You should call the `get_inbox` MCP tool manually to check for messages.*';
   }
 
+  // Load available skills
+  try {
+    const skillsResult = await callPcpTool('list_skills', { includeContent: true });
+    skillsBlock = buildSkillsBlock(
+      skillsResult.skills as Array<Record<string, unknown>> | undefined
+    );
+  } catch {
+    // Non-fatal
+  }
+
   const template = loadTemplate('hook-post-compact');
   const output = renderTemplate(template, {
     AGENT_ID: agentId,
     IDENTITY_BLOCK: identityBlock,
+    SKILLS_BLOCK: skillsBlock,
     INBOX_BLOCK: inboxBlock,
   });
 
@@ -1029,6 +1077,7 @@ async function onSessionStartHandler(): Promise<void> {
   let memoriesBlock = '';
   let sessionsBlock = '';
   let inboxBlock = '';
+  let skillsBlock = '';
 
   // Bootstrap
   try {
@@ -1062,6 +1111,16 @@ async function onSessionStartHandler(): Promise<void> {
   } catch {
     inboxBlock =
       '*FAILED: Could not reach PCP server for `get_inbox`. You should call the `get_inbox` MCP tool manually to check for messages.*';
+  }
+
+  // Load available skills (guide content included inline)
+  try {
+    const skillsResult = await callPcpTool('list_skills', { includeContent: true });
+    skillsBlock = buildSkillsBlock(
+      skillsResult.skills as Array<Record<string, unknown>> | undefined
+    );
+  } catch {
+    // Non-fatal: skills are a nice-to-have at session start
   }
 
   // Register PCP session with detected backend
@@ -1148,6 +1207,7 @@ async function onSessionStartHandler(): Promise<void> {
     IDENTITY_BLOCK: identityBlock,
     MEMORIES_BLOCK: memoriesBlock,
     SESSIONS_BLOCK: sessionsBlock,
+    SKILLS_BLOCK: skillsBlock,
     INBOX_BLOCK: inboxBlock,
   });
 

--- a/packages/cli/src/templates/hook-post-compact.md
+++ b/packages/cli/src/templates/hook-post-compact.md
@@ -4,6 +4,8 @@ Agent: {{AGENT_ID}}
 
 {{IDENTITY_BLOCK}}
 
+{{SKILLS_BLOCK}}
+
 {{INBOX_BLOCK}}
 
 If any PCP call above failed (e.g. "Could not reach PCP server"), alert the user immediately. Tell them the specific call that failed and that they should manually run it — for example, calling the `bootstrap` MCP tool to reload identity context. Do not silently continue without context.

--- a/packages/cli/src/templates/hook-session-start.md
+++ b/packages/cli/src/templates/hook-session-start.md
@@ -9,6 +9,8 @@ Agent: **{{AGENT_ID}}**
 
 {{SESSIONS_BLOCK}}
 
+{{SKILLS_BLOCK}}
+
 {{INBOX_BLOCK}}
 
 If any PCP call above failed (e.g. "Could not reach PCP server"), alert the user immediately. Tell them the specific call that failed and that they should manually run it — for example, calling the `bootstrap` MCP tool to reload identity context. Do not silently continue without context.


### PR DESCRIPTION
## Summary

- **4-tier skill loading cascade**: bundled → extra dirs → managed → workspace (name-based dedup, last write wins)
- **`SkillLoadOptions`** with configurable `extraDirs` (ClawHub interop: `~/.openclaw/skills/`)
- **`{baseDir}` placeholder** — skills reference bundled scripts relative to their own directory
- **MCP `list_skills`/`get_skill` upgraded** to use SkillsService (all skill types, not just mini-apps)
- **Hook-based skill injection** — session start and post-compact hooks fetch skills via `list_skills` and inject a `{{SKILLS_BLOCK}}` into sb-wrapped backends (Claude Code, Codex, Gemini)
  - Guide skills: full content injected inline (behavioral instructions)
  - Mini-app/CLI skills: listed with triggers for on-demand `get_skill` calls
- Documentation updates across README, AGENTS.md, and skills README

## How it works

```
sb claude / sb codex / sb gemini
  → session start hook fires
  → hook calls PCP list_skills(includeContent: true) via HTTP
  → builds skills summary block (guides inline, others listed)
  → injected alongside identity, memories, inbox in hook output
  → backend sees skills in system context
```

## Test plan

- [x] `yarn workspace @personal-context/api build` compiles (pre-existing errors only)
- [x] `yarn workspace @personal-context/cli build` compiles
- [x] All 43 skills tests pass
- [x] 813/814 tests pass (1 pre-existing session-service test failure)
- [ ] Manual: create `<project>/.pcp/skills/test-skill.md` → verify `list_skills` returns it
- [ ] Manual: verify hook output includes skills block when PCP server is running
- [ ] Manual: if ClawHub installed, verify `~/.openclaw/skills/` skills appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)