### PR TITLE
feat: Slack integration + cross-channel mention routing

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.71.2",
     "@modelcontextprotocol/sdk": "^1.26.0",
+    "@slack/bolt": "^4.6.0",
     "@supabase/supabase-js": "^2.39.3",
     "@whiskeysockets/baileys": "^7.0.0-rc.9",
     "bcrypt": "^5.1.1",

--- a/packages/api/src/agent/types.ts
+++ b/packages/api/src/agent/types.ts
@@ -12,6 +12,7 @@ export type ChannelType =
   | 'terminal'
   | 'discord'
   | 'whatsapp'
+  | 'slack'
   | 'http'
   | 'api'
   | 'agent'

--- a/packages/api/src/channels/gateway.test.ts
+++ b/packages/api/src/channels/gateway.test.ts
@@ -412,6 +412,98 @@ describe('Gateway Status', () => {
   });
 });
 
+describe('isAgentMentioned', () => {
+  let gateway: ChannelGateway;
+
+  beforeEach(() => {
+    gateway = new ChannelGateway({
+      enableTelegram: false,
+      enableWhatsApp: false,
+    });
+  });
+
+  const isAgentMentioned = (
+    gw: ChannelGateway,
+    text: string,
+    mentions?: { users: string[]; botMentioned: boolean }
+  ) => (gw as any).isAgentMentioned(text, mentions);
+
+  it('returns true when botMentioned is true', () => {
+    expect(isAgentMentioned(gateway, 'hello', { users: [], botMentioned: true })).toBe(true);
+  });
+
+  it('returns false with no mentions and no known agent names', () => {
+    expect(isAgentMentioned(gateway, 'hello world', { users: [], botMentioned: false })).toBe(
+      false
+    );
+  });
+
+  it('returns false with no mentions argument', () => {
+    expect(isAgentMentioned(gateway, 'hello world')).toBe(false);
+  });
+
+  it('returns true when mentioned username matches a known agent name', () => {
+    gateway.setKnownAgentNames(['wren', 'myra', 'benson']);
+    expect(
+      isAgentMentioned(gateway, 'hello', { users: ['@wren'], botMentioned: false })
+    ).toBe(true);
+  });
+
+  it('matches mentioned usernames case-insensitively', () => {
+    gateway.setKnownAgentNames(['wren']);
+    expect(
+      isAgentMentioned(gateway, 'hello', { users: ['WREN'], botMentioned: false })
+    ).toBe(true);
+  });
+
+  it('strips @ prefix from mentioned usernames', () => {
+    gateway.setKnownAgentNames(['myra']);
+    expect(
+      isAgentMentioned(gateway, 'hello', { users: ['@myra'], botMentioned: false })
+    ).toBe(true);
+  });
+
+  it('returns true when agent name appears in message text', () => {
+    gateway.setKnownAgentNames(['wren', 'myra']);
+    expect(
+      isAgentMentioned(gateway, 'hey wren, can you help?', { users: [], botMentioned: false })
+    ).toBe(true);
+  });
+
+  it('uses word boundaries for text matching', () => {
+    gateway.setKnownAgentNames(['wren']);
+    // "wrench" should NOT match "wren"
+    expect(
+      isAgentMentioned(gateway, 'pass me the wrench', { users: [], botMentioned: false })
+    ).toBe(false);
+  });
+
+  it('skips text matching for very short agent names (< 3 chars)', () => {
+    gateway.setKnownAgentNames(['ab']);
+    // "ab" is too short for text matching (would cause false positives)
+    expect(
+      isAgentMentioned(gateway, 'the ab test worked', { users: [], botMentioned: false })
+    ).toBe(false);
+  });
+
+  it('returns false when mentioned username does not match any agent', () => {
+    gateway.setKnownAgentNames(['wren', 'myra']);
+    expect(
+      isAgentMentioned(gateway, 'hello', { users: ['someuser'], botMentioned: false })
+    ).toBe(false);
+  });
+
+  it('handles multiple mentioned usernames', () => {
+    gateway.setKnownAgentNames(['wren', 'myra']);
+    expect(
+      isAgentMentioned(gateway, 'hello', {
+        users: ['randomuser', 'myra'],
+        botMentioned: false,
+      })
+    ).toBe(true);
+  });
+});
+
 describe('Activity Stream Integration', () => {
   let gateway: ChannelGateway;
   let mockLogMessage: Mock;

--- a/packages/api/src/channels/gateway.test.ts
+++ b/packages/api/src/channels/gateway.test.ts
@@ -502,6 +502,21 @@ describe('isAgentMentioned', () => {
       })
     ).toBe(true);
   });
+
+  it('safely handles agent names with regex metacharacters', () => {
+    gateway.setKnownAgentNames(['agent+1', 'bot.v2']);
+    // Should not throw, and should match literally
+    expect(
+      isAgentMentioned(gateway, 'hey agent+1!', { users: [], botMentioned: false })
+    ).toBe(true);
+    expect(
+      isAgentMentioned(gateway, 'ask bot.v2 about it', { users: [], botMentioned: false })
+    ).toBe(true);
+    // "+" unescaped would match "agent1" — escaped should NOT
+    expect(
+      isAgentMentioned(gateway, 'hey agent1 help', { users: [], botMentioned: false })
+    ).toBe(false);
+  });
 });
 
 describe('Activity Stream Integration', () => {

--- a/packages/api/src/channels/gateway.ts
+++ b/packages/api/src/channels/gateway.ts
@@ -16,6 +16,7 @@ import { EventEmitter } from 'events';
 import { createTelegramListener, TelegramListener } from './telegram-listener';
 import { createWhatsAppListener, WhatsAppListener } from './whatsapp-listener';
 import { createDiscordListener, DiscordListener } from './discord-listener';
+import { createSlackListener, SlackListener } from './slack-listener';
 import { setResponseCallback, type ResponseCallback } from '../mcp/tools/response-handlers';
 import type { AgentResponse } from '../agent/types';
 import type { DataComposer } from '../data/composer';
@@ -24,7 +25,7 @@ import { env } from '../config/env';
 import telegramifyMarkdown from 'telegramify-markdown';
 
 // Supported messaging channels
-export type GatewayChannel = 'telegram' | 'whatsapp' | 'discord';
+export type GatewayChannel = 'telegram' | 'whatsapp' | 'discord' | 'slack';
 
 // Activity stream - conversation to user mapping for outbound message logging
 const conversationUserMap = new Map<string, string>(); // conversationId -> userId
@@ -46,6 +47,8 @@ export interface ChannelGatewayConfig {
   onWhatsAppQr?: (qr: string) => void;
   /** Whether to enable Discord listener */
   enableDiscord?: boolean;
+  /** Whether to enable Slack listener */
+  enableSlack?: boolean;
   /** Message buffer delay in ms (default: 2000). Set to 0 to disable buffering. */
   messageBufferDelayMs?: number;
   /** Data composer for activity stream logging */
@@ -101,6 +104,7 @@ export class ChannelGateway extends EventEmitter {
   private telegramListener: TelegramListener | null = null;
   private whatsappListener: WhatsAppListener | null = null;
   private discordListener: DiscordListener | null = null;
+  private slackListener: SlackListener | null = null;
   private config: ChannelGatewayConfig;
   private messageHandler: IncomingMessageHandler | null = null;
   private dataComposer: DataComposer | null = null;
@@ -114,6 +118,9 @@ export class ChannelGateway extends EventEmitter {
   private processingConversations: Set<string> = new Set();
   private pendingBuffers: Map<string, MessageBuffer> = new Map();
 
+  // Known agent names for mention detection in group chats
+  private knownAgentNames: Set<string> = new Set();
+
   constructor(config: ChannelGatewayConfig = {}) {
     super();
     this.config = {
@@ -123,6 +130,7 @@ export class ChannelGateway extends EventEmitter {
       whatsappAccountId: config.whatsappAccountId ?? 'default',
       printWhatsAppQr: config.printWhatsAppQr ?? true,
       enableDiscord: config.enableDiscord ?? process.env.ENABLE_DISCORD === 'true',
+      enableSlack: config.enableSlack ?? process.env.ENABLE_SLACK === 'true',
       messageBufferDelayMs: config.messageBufferDelayMs ?? DEFAULT_BUFFER_DELAY_MS,
       ...config,
     };
@@ -135,6 +143,49 @@ export class ChannelGateway extends EventEmitter {
    */
   setMessageHandler(handler: IncomingMessageHandler): void {
     this.messageHandler = handler;
+  }
+
+  /**
+   * Set known agent names for dynamic mention detection in group chats.
+   * Called on startup after querying agent_identities from the DB.
+   */
+  setKnownAgentNames(names: string[]): void {
+    this.knownAgentNames = new Set(names.map((n) => n.toLowerCase()));
+    logger.info(`ChannelGateway: known agent names updated`, {
+      names: [...this.knownAgentNames],
+    });
+  }
+
+  /**
+   * Check if any known agent (or the platform bot itself) is mentioned.
+   * Used as the gate for processing group messages.
+   */
+  private isAgentMentioned(
+    text: string,
+    mentions?: { users: string[]; botMentioned: boolean }
+  ): boolean {
+    // Platform-native bot mention (e.g., @myra_help_bot in Telegram, <@UBOTID> in Slack)
+    if (mentions?.botMentioned) return true;
+
+    // Check mentioned usernames against known agent names
+    if (mentions?.users?.length) {
+      for (const mentioned of mentions.users) {
+        const mentionedLower = mentioned.toLowerCase().replace(/^@/, '');
+        if (this.knownAgentNames.has(mentionedLower)) return true;
+      }
+    }
+
+    // Check message text for agent names (word-boundary match)
+    if (this.knownAgentNames.size > 0) {
+      const textLower = text.toLowerCase();
+      for (const name of this.knownAgentNames) {
+        if (name.length >= 3 && new RegExp(`\\b${name}\\b`).test(textLower)) {
+          return true;
+        }
+      }
+    }
+
+    return false;
   }
 
   /**
@@ -173,11 +224,19 @@ export class ChannelGateway extends EventEmitter {
       logger.info('Discord listener disabled (set ENABLE_DISCORD=true to enable)');
     }
 
+    // Start Slack listener
+    if (this.config.enableSlack) {
+      await this.startSlack();
+    } else {
+      logger.info('Slack listener disabled (set ENABLE_SLACK=true to enable)');
+    }
+
     this.started = true;
     logger.info('ChannelGateway started', {
       telegram: !!this.telegramListener,
       whatsapp: !!this.whatsappListener,
       discord: !!this.discordListener,
+      slack: !!this.slackListener,
     });
   }
 
@@ -220,6 +279,11 @@ export class ChannelGateway extends EventEmitter {
     if (this.discordListener) {
       await this.discordListener.stop();
       this.discordListener = null;
+    }
+
+    if (this.slackListener) {
+      await this.slackListener.stop();
+      this.slackListener = null;
     }
 
     this.started = false;
@@ -426,7 +490,7 @@ export class ChannelGateway extends EventEmitter {
     if (!userId && this.dataComposer && sender.id) {
       try {
         const user = await this.dataComposer.repositories.users.findByPlatformId(
-          channel as 'telegram' | 'whatsapp' | 'discord',
+          channel as 'telegram' | 'whatsapp' | 'discord' | 'slack',
           sender.id
         );
         if (user) {
@@ -489,6 +553,11 @@ export class ChannelGateway extends EventEmitter {
           );
         } else if (channel === 'discord' && this.discordListener) {
           await this.discordListener.sendMessage(
+            conversationId,
+            'Sorry, I encountered an error processing your message. Please try again.'
+          );
+        } else if (channel === 'slack' && this.slackListener) {
+          await this.slackListener.sendMessage(
             conversationId,
             'Sorry, I encountered an error processing your message. Please try again.'
           );
@@ -580,6 +649,35 @@ export class ChannelGateway extends EventEmitter {
             } catch (activityError) {
               logger.warn(
                 'Failed to log outgoing Discord message to activity stream:',
+                activityError
+              );
+            }
+          }
+        }
+        break;
+
+      case 'slack':
+        if (!this.slackListener) {
+          throw new Error('Slack listener not available');
+        }
+        await this.slackListener.sendMessage(conversationId, content);
+        // Log outgoing Slack message to activity stream
+        {
+          const userId = conversationUserMap.get(conversationId);
+          if (this.dataComposer && userId) {
+            try {
+              await this.dataComposer.repositories.activityStream.logMessage({
+                userId,
+                agentId: 'slack', // Will be resolved by routing
+                direction: 'out',
+                content,
+                platform: 'slack',
+                platformChatId: conversationId,
+                isDm: true,
+              });
+            } catch (activityError) {
+              logger.warn(
+                'Failed to log outgoing Slack message to activity stream:',
                 activityError
               );
             }
@@ -746,11 +844,10 @@ export class ChannelGateway extends EventEmitter {
       const senderId = message.sender.id || 'unknown';
       const conversationId = message.conversationId || senderId;
       const isGroupChat = message.chatType === 'group';
-      const botMentioned = message.mentions?.botMentioned ?? false;
 
-      // In group chats, only respond if bot is mentioned
-      if (isGroupChat && !botMentioned) {
-        logger.debug('Skipping group message - bot not mentioned');
+      // In group chats, only respond if bot or any known agent is mentioned
+      if (isGroupChat && !this.isAgentMentioned(message.body, message.mentions)) {
+        logger.debug('Skipping group message - no agent mentioned');
         return;
       }
 
@@ -804,11 +901,10 @@ export class ChannelGateway extends EventEmitter {
       const senderId = message.sender.id || 'unknown';
       const conversationId = message.conversationId || senderId;
       const isGroupChat = message.chatType === 'group';
-      const botMentioned = message.mentions?.botMentioned ?? false;
 
-      // In group chats, only respond if bot is mentioned
-      if (isGroupChat && !botMentioned) {
-        logger.debug('Skipping WhatsApp group message - bot not mentioned');
+      // In group chats, only respond if bot or any known agent is mentioned
+      if (isGroupChat && !this.isAgentMentioned(message.body, message.mentions)) {
+        logger.debug('Skipping WhatsApp group message - no agent mentioned');
         return;
       }
 
@@ -906,6 +1002,66 @@ export class ChannelGateway extends EventEmitter {
   }
 
   /**
+   * Start Slack listener
+   */
+  private async startSlack(): Promise<void> {
+    if (!env.SLACK_BOT_TOKEN || !env.SLACK_APP_TOKEN) {
+      logger.warn('SLACK_BOT_TOKEN or SLACK_APP_TOKEN not set - Slack listener disabled');
+      return;
+    }
+
+    logger.info('Creating Slack listener...');
+    this.slackListener = createSlackListener({
+      botToken: env.SLACK_BOT_TOKEN,
+      appToken: env.SLACK_APP_TOKEN,
+    });
+
+    // Wire up message handling
+    this.slackListener.onMessage(async (message) => {
+      const senderId = message.sender.id || 'unknown';
+      const conversationId = message.conversationId || senderId;
+      const isGroupChat = message.chatType === 'group' || message.chatType === 'channel';
+
+      // In group chats, only respond if bot or any known agent is mentioned
+      if (isGroupChat && !this.isAgentMentioned(message.body, message.mentions)) {
+        logger.debug('Skipping Slack group message - no agent mentioned');
+        return;
+      }
+
+      // Start typing indicator (no-op for Slack, but keeps pattern consistent)
+      this.startTypingIndicator(conversationId, 'slack');
+
+      // Buffer the message
+      this.bufferMessage(
+        'slack',
+        conversationId,
+        { id: senderId, name: message.sender.name || message.sender.username },
+        message.body,
+        {
+          media: message.media,
+          chatType: message.chatType,
+          mentions: message.mentions,
+          platformAccountId: message.accountId,
+        }
+      );
+    });
+
+    // Forward events
+    this.slackListener.on('connected', (bot: { username: string; id: string }) => {
+      logger.info(`Slack bot connected: @${bot.username} (${bot.id})`);
+      this.emit('slack:connected', bot);
+    });
+
+    this.slackListener.on('error', (error: Error) => {
+      logger.error('Slack listener error:', error);
+      this.emit('slack:error', error);
+    });
+
+    await this.slackListener.start();
+    logger.info('Slack listener started');
+  }
+
+  /**
    * Start a typing indicator that refreshes every 4s
    */
   private startTypingIndicator(conversationId: string, channel: GatewayChannel): void {
@@ -918,6 +1074,8 @@ export class ChannelGateway extends EventEmitter {
         this.whatsappListener.sendTypingIndicator(conversationId);
       } else if (channel === 'discord' && this.discordListener) {
         this.discordListener.sendTypingIndicator(conversationId);
+      } else if (channel === 'slack' && this.slackListener) {
+        this.slackListener.sendTypingIndicator(conversationId);
       }
     };
 
@@ -974,6 +1132,10 @@ export class ChannelGateway extends EventEmitter {
     return this.discordListener;
   }
 
+  getSlackListener(): SlackListener | null {
+    return this.slackListener;
+  }
+
   isStarted(): boolean {
     return this.started;
   }
@@ -983,6 +1145,7 @@ export class ChannelGateway extends EventEmitter {
     telegram: { enabled: boolean; connected: boolean };
     whatsapp: { enabled: boolean; connected: boolean };
     discord: { enabled: boolean; connected: boolean };
+    slack: { enabled: boolean; connected: boolean };
   } {
     return {
       started: this.started,
@@ -997,6 +1160,10 @@ export class ChannelGateway extends EventEmitter {
       discord: {
         enabled: this.config.enableDiscord ?? false,
         connected: this.discordListener?.connected ?? false,
+      },
+      slack: {
+        enabled: this.config.enableSlack ?? false,
+        connected: this.slackListener?.connected ?? false,
       },
     };
   }

--- a/packages/api/src/channels/gateway.ts
+++ b/packages/api/src/channels/gateway.ts
@@ -179,7 +179,8 @@ export class ChannelGateway extends EventEmitter {
     if (this.knownAgentNames.size > 0) {
       const textLower = text.toLowerCase();
       for (const name of this.knownAgentNames) {
-        if (name.length >= 3 && new RegExp(`\\b${name}\\b`).test(textLower)) {
+        const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        if (name.length >= 3 && new RegExp(`\\b${escaped}\\b`).test(textLower)) {
           return true;
         }
       }

--- a/packages/api/src/channels/slack-listener.ts
+++ b/packages/api/src/channels/slack-listener.ts
@@ -1,0 +1,796 @@
+/**
+ * Slack Listener Service
+ *
+ * Listens for incoming Slack messages via Socket Mode (WebSocket)
+ * and routes them to the ChannelGateway for processing.
+ *
+ * Uses the same authorization model as Discord/Telegram:
+ * - DMs: Only from trusted users
+ * - Channels: Only authorized channels/workspaces, with @mention trigger
+ *
+ * Requires:
+ * - SLACK_BOT_TOKEN (xoxb-...) — Bot User OAuth Token
+ * - SLACK_APP_TOKEN (xapp-...) — App-Level Token with connections:write scope
+ */
+
+import { EventEmitter } from 'events';
+import { App } from '@slack/bolt';
+import type { InboundMessage, ChannelPlatform, MediaAttachment } from './types';
+
+/** Slack message event shape — subset of fields we use from the message callback */
+interface SlackMessageEvent {
+  type: string;
+  subtype?: string;
+  text?: string;
+  user: string;
+  bot_id?: string;
+  channel: string;
+  channel_type?: string;
+  ts: string;
+  thread_ts?: string;
+  files?: Array<{
+    url_private?: string;
+    name?: string;
+    mimetype?: string;
+  }>;
+}
+import { logger } from '../utils/logger';
+import { env } from '../config/env';
+import { getAuthorizationService, type AuthorizationService } from '../services/authorization';
+
+export interface SlackListenerConfig {
+  /** Bot User OAuth Token (defaults to env.SLACK_BOT_TOKEN) */
+  botToken?: string;
+  /** App-Level Token for Socket Mode (defaults to env.SLACK_APP_TOKEN) */
+  appToken?: string;
+}
+
+export type MessageCallback = (message: InboundMessage) => Promise<void>;
+
+// Slack has a 4000 character message limit for chat.postMessage
+const SLACK_MAX_MESSAGE_LENGTH = 4000;
+
+// Ephemeral message storage for context (not persisted to DB)
+interface EphemeralMessage {
+  messageId: string;
+  chatId: string;
+  from: string;
+  fromId: string;
+  text: string;
+  timestamp: Date;
+}
+
+export class SlackListener extends EventEmitter {
+  private botToken: string;
+  private appToken: string;
+  private app: App;
+  private authService: AuthorizationService;
+  private messageCallback?: MessageCallback;
+  private isRunning = false;
+  private botUserId: string | null = null;
+  private botUsername: string | null = null;
+
+  // User info cache to avoid repeated API calls
+  private userInfoCache = new Map<string, { name: string; username: string }>();
+  private readonly userInfoCacheTtlMs = 10 * 60 * 1000; // 10 minutes
+  private userInfoCacheTimestamps = new Map<string, number>();
+
+  // Ephemeral message cache - keyed by channelId, stores last N messages
+  private messageCache = new Map<string, EphemeralMessage[]>();
+  private readonly maxMessagesPerChat = 100;
+  private readonly messageTtlMs = 30 * 60 * 1000; // 30 minutes
+
+  constructor(config?: SlackListenerConfig) {
+    super();
+    const botToken = config?.botToken || env.SLACK_BOT_TOKEN;
+    const appToken = config?.appToken || env.SLACK_APP_TOKEN;
+
+    if (!botToken) {
+      throw new Error('SLACK_BOT_TOKEN is required');
+    }
+    if (!appToken) {
+      throw new Error('SLACK_APP_TOKEN is required for Socket Mode');
+    }
+
+    this.botToken = botToken;
+    this.appToken = appToken;
+
+    this.app = new App({
+      token: this.botToken,
+      appToken: this.appToken,
+      socketMode: true,
+    });
+
+    this.authService = getAuthorizationService();
+  }
+
+  /**
+   * Set the callback for incoming messages
+   */
+  onMessage(callback: MessageCallback): void {
+    this.messageCallback = callback;
+  }
+
+  /**
+   * Start listening for messages via Socket Mode
+   */
+  async start(): Promise<void> {
+    if (this.isRunning) {
+      logger.warn('SlackListener is already running');
+      return;
+    }
+
+    logger.info('Starting Slack listener (Socket Mode)...');
+
+    // Register message handler
+    this.app.message(async ({ message }) => {
+      await this.handleMessage(message as SlackMessageEvent);
+    });
+
+    // Handle errors
+    this.app.error(async (error) => {
+      logger.error('Slack app error:', error);
+      this.emit('error', error);
+    });
+
+    try {
+      await this.app.start();
+      this.isRunning = true;
+
+      // Get bot identity
+      const authResult = await this.app.client.auth.test({ token: this.botToken });
+      this.botUserId = (authResult.user_id as string) || null;
+      this.botUsername = (authResult.user as string) || null;
+
+      logger.info(`Slack bot connected: @${this.botUsername} (${this.botUserId})`);
+      this.emit('connected', { username: this.botUsername, id: this.botUserId });
+    } catch (error) {
+      logger.error('Failed to connect to Slack:', error);
+      this.isRunning = false;
+      throw error;
+    }
+  }
+
+  /**
+   * Stop listening for messages
+   */
+  async stop(): Promise<void> {
+    if (!this.isRunning) {
+      return;
+    }
+
+    logger.info('Stopping Slack listener...');
+    this.isRunning = false;
+
+    try {
+      await this.app.stop();
+    } catch (error) {
+      logger.error('Error stopping Slack app:', error);
+    }
+
+    this.emit('disconnected');
+  }
+
+  /**
+   * Handle incoming Slack messages
+   */
+  private async handleMessage(event: SlackMessageEvent): Promise<void> {
+    // Ignore bot messages, message_changed, etc.
+    if (event.subtype) return;
+    if (event.bot_id) return;
+    if (!event.user) return;
+    if (!event.text && !event.files) return;
+
+    const userId = event.user;
+    const channelId = event.channel;
+    const isDm = event.channel_type === 'im';
+
+    // ========== AUTHORIZATION CHECK ==========
+
+    if (!isDm) {
+      // Channel/group: check if workspace/channel is authorized
+      const isAuthorized = await this.authService.isGroupAuthorized('slack', channelId);
+
+      if (!isAuthorized) {
+        const text = (event.text || '').trim();
+        // Only respond to /authorize command
+        if (text.toLowerCase().startsWith('/authorize')) {
+          await this.handleAuthorizeCommand(channelId, userId, text);
+          return;
+        }
+
+        logger.debug(`Ignoring message from unauthorized Slack channel: ${channelId}`);
+        return;
+      }
+
+      // In authorized channels, only process if bot is mentioned
+      if (!this.isBotMentioned(event)) {
+        return;
+      }
+    } else {
+      // DM: check if user is trusted
+      const trustedUser = await this.authService.isUserTrusted('slack', userId);
+
+      if (!trustedUser) {
+        logger.debug(`Ignoring DM from untrusted Slack user: ${userId}`);
+        return;
+      }
+
+      // Handle DM commands for trusted users
+      if (await this.handleTrustedUserCommand(channelId, userId, event.text || '')) {
+        return;
+      }
+    }
+
+    // ========== NORMAL MESSAGE PROCESSING ==========
+
+    const message = await this.convertMessage(event);
+    await this.dispatchMessage(message);
+  }
+
+  /**
+   * Check if the bot is mentioned in a message
+   */
+  private isBotMentioned(event: SlackMessageEvent): boolean {
+    if (!this.botUserId) return false;
+
+    const text = event.text || '';
+    // Slack encodes mentions as <@UXXXXXX>
+    return text.includes(`<@${this.botUserId}>`);
+  }
+
+  /**
+   * Handle /authorize command in an unauthorized channel
+   */
+  private async handleAuthorizeCommand(
+    channelId: string,
+    _userId: string,
+    text: string
+  ): Promise<void> {
+    const parts = text.trim().split(/\s+/);
+    if (parts.length < 2) return;
+
+    const code = parts[1];
+
+    // Try to get channel name
+    let channelName: string | null = null;
+    try {
+      const info = await this.app.client.conversations.info({ channel: channelId });
+      channelName = (info.channel as { name?: string })?.name || null;
+    } catch {
+      // Non-critical
+    }
+
+    const result = await this.authService.authorizeGroupWithCode(
+      'slack',
+      channelId,
+      channelName,
+      code
+    );
+
+    if (result.success) {
+      await this.sendMessage(channelId, "Channel authorized! I'm now active here.");
+      logger.info('Slack channel authorized via challenge code', { channelId, channelName });
+    } else if (result.error === 'Invalid or expired code') {
+      await this.sendMessage(
+        channelId,
+        'Invalid or expired code. Please get a new code from a trusted user.'
+      );
+    }
+  }
+
+  /**
+   * Handle DM commands for trusted users
+   * Returns true if a command was handled
+   */
+  private async handleTrustedUserCommand(
+    channelId: string,
+    userId: string,
+    text: string
+  ): Promise<boolean> {
+    const command = text.trim().toLowerCase().split(/\s+/)[0];
+
+    switch (command) {
+      case '/generate-group-code':
+      case '/groupcode':
+        return this.handleGenerateCodeCommand(channelId, userId);
+
+      case '/list-groups':
+      case '/groups':
+        return this.handleListGroupsCommand(channelId);
+
+      case '/list-trusted':
+      case '/trusted':
+        return this.handleListTrustedCommand(channelId);
+
+      case '/add-trusted':
+        return this.handleAddTrustedCommand(channelId, userId, text);
+
+      case '/revoke-group':
+        return this.handleRevokeGroupCommand(channelId, userId, text);
+
+      default:
+        return false;
+    }
+  }
+
+  private async handleGenerateCodeCommand(channelId: string, userId: string): Promise<boolean> {
+    const code = await this.authService.generateChallengeCode('slack', userId);
+
+    if (code) {
+      await this.sendMessage(
+        channelId,
+        `Group authorization code: \`${code}\`\n\n` +
+          `This code expires in 24 hours.\n` +
+          `To authorize a channel, invite me and send:\n` +
+          `/authorize ${code}`
+      );
+    } else {
+      await this.sendMessage(
+        channelId,
+        'Unable to generate code. You may have reached the limit of 5 active codes.'
+      );
+    }
+    return true;
+  }
+
+  private async handleListGroupsCommand(channelId: string): Promise<boolean> {
+    const groups = await this.authService.listAuthorizedGroups('slack');
+
+    if (groups.length === 0) {
+      await this.sendMessage(channelId, 'No authorized Slack channels yet.');
+    } else {
+      const lines = groups.map(
+        (g) => `- ${g.groupName || g.platformGroupId} (${g.authorizationMethod})`
+      );
+      await this.sendMessage(channelId, `Authorized channels:\n${lines.join('\n')}`);
+    }
+    return true;
+  }
+
+  private async handleListTrustedCommand(channelId: string): Promise<boolean> {
+    const users = await this.authService.listTrustedUsers('slack');
+
+    if (users.length === 0) {
+      await this.sendMessage(channelId, 'No trusted users configured.');
+    } else {
+      const lines = users.map((u) => `- ${u.platformUserId} (${u.trustLevel})`);
+      await this.sendMessage(channelId, `Trusted users:\n${lines.join('\n')}`);
+    }
+    return true;
+  }
+
+  private async handleAddTrustedCommand(
+    channelId: string,
+    addedByUserId: string,
+    text: string
+  ): Promise<boolean> {
+    const parts = text.trim().split(/\s+/);
+
+    if (parts.length < 2) {
+      await this.sendMessage(
+        channelId,
+        'Usage: /add-trusted <slack_user_id> [admin|member]\nExample: /add-trusted U12345678 member'
+      );
+      return true;
+    }
+
+    const targetUserId = parts[1];
+    const trustLevel = (parts[2]?.toLowerCase() === 'admin' ? 'admin' : 'member') as
+      | 'admin'
+      | 'member';
+
+    const result = await this.authService.addTrustedUser(
+      'slack',
+      targetUserId,
+      trustLevel,
+      addedByUserId
+    );
+
+    if (result.success) {
+      await this.sendMessage(channelId, `Added ${targetUserId} as trusted ${trustLevel}.`);
+    } else {
+      await this.sendMessage(channelId, `Error: ${result.error}`);
+    }
+    return true;
+  }
+
+  private async handleRevokeGroupCommand(
+    channelId: string,
+    userId: string,
+    text: string
+  ): Promise<boolean> {
+    const parts = text.trim().split(/\s+/);
+
+    if (parts.length < 2) {
+      await this.sendMessage(
+        channelId,
+        'Usage: /revoke-group <channel_id>\nExample: /revoke-group C1234567890'
+      );
+      return true;
+    }
+
+    const groupId = parts[1];
+    const result = await this.authService.revokeGroup('slack', groupId, userId);
+
+    if (result.success) {
+      await this.sendMessage(channelId, `Revoked channel ${groupId}.`);
+    } else {
+      await this.sendMessage(channelId, `Error: ${result.error}`);
+    }
+    return true;
+  }
+
+  /**
+   * Convert Slack message event to InboundMessage format
+   */
+  private async convertMessage(event: SlackMessageEvent): Promise<InboundMessage> {
+    const isDm = event.channel_type === 'im';
+    const chatType = isDm ? 'direct' : 'group';
+
+    // Get sender info
+    const senderInfo = await this.getUserInfo(event.user);
+
+    // Strip bot @mention from content
+    let body = event.text || '';
+    if (this.botUserId) {
+      body = body.replace(new RegExp(`<@${this.botUserId}>`, 'g'), '').trim();
+    }
+
+    // Extract @mentions from text: <@UXXXXXX> patterns
+    const mentionRegex = /<@(U[A-Z0-9]+)>/g;
+    const mentionedUserIds: string[] = [];
+    const mentionedUsernames: string[] = [];
+    let match;
+    while ((match = mentionRegex.exec(event.text || '')) !== null) {
+      const mentionedUserId = match[1];
+      if (mentionedUserId !== this.botUserId) {
+        mentionedUserIds.push(mentionedUserId);
+        const info = await this.getUserInfo(mentionedUserId);
+        mentionedUsernames.push(info.username);
+      }
+    }
+
+    const botMentioned = this.botUserId
+      ? (event.text || '').includes(`<@${this.botUserId}>`)
+      : false;
+
+    // Get channel name for context
+    let conversationLabel: string | undefined;
+    let groupSubject: string | undefined;
+    if (!isDm) {
+      try {
+        const info = await this.app.client.conversations.info({ channel: event.channel });
+        const channelInfo = info.channel as { name?: string; topic?: { value?: string } };
+        conversationLabel = channelInfo?.name;
+        groupSubject = channelInfo?.topic?.value || channelInfo?.name;
+      } catch {
+        // Non-critical
+      }
+    } else {
+      conversationLabel = senderInfo.username;
+    }
+
+    const message: InboundMessage = {
+      body,
+      rawBody: event.text || '',
+      timestamp: event.ts ? Math.floor(parseFloat(event.ts) * 1000) : Date.now(),
+      messageId: event.ts,
+      platform: 'slack' as ChannelPlatform,
+      chatType,
+      sender: {
+        id: event.user,
+        username: senderInfo.username,
+        name: senderInfo.name,
+      },
+      conversationId: event.channel,
+      conversationLabel,
+      groupSubject,
+      mentions: {
+        users: mentionedUsernames,
+        botMentioned,
+      },
+    };
+
+    // Handle file attachments
+    if (event.files && event.files.length > 0) {
+      const mediaAttachments: MediaAttachment[] = [];
+      for (const file of event.files) {
+        const localPath = await this.downloadFile(file);
+        if (localPath) {
+          mediaAttachments.push({
+            type: this.getMediaType(file.mimetype || ''),
+            path: localPath,
+            filename: file.name || undefined,
+            contentType: file.mimetype || undefined,
+          });
+        }
+      }
+      if (mediaAttachments.length > 0) {
+        message.media = mediaAttachments;
+        if (!body) {
+          message.body = `[${mediaAttachments.length} file(s) attached]`;
+        }
+      }
+    }
+
+    // Handle thread replies
+    if (event.thread_ts && event.thread_ts !== event.ts) {
+      message.replyTo = {
+        id: event.thread_ts,
+      };
+    }
+
+    message.raw = event;
+    return message;
+  }
+
+  /**
+   * Look up user info from Slack API (with caching)
+   */
+  private async getUserInfo(userId: string): Promise<{ name: string; username: string }> {
+    const now = Date.now();
+    const cachedTs = this.userInfoCacheTimestamps.get(userId);
+
+    if (cachedTs && now - cachedTs < this.userInfoCacheTtlMs) {
+      const cached = this.userInfoCache.get(userId);
+      if (cached) return cached;
+    }
+
+    try {
+      const result = await this.app.client.users.info({ user: userId });
+      const user = result.user as {
+        real_name?: string;
+        name?: string;
+        profile?: { display_name?: string; real_name?: string };
+      };
+
+      const info = {
+        name: user?.real_name || user?.profile?.real_name || user?.name || userId,
+        username: user?.name || userId,
+      };
+
+      this.userInfoCache.set(userId, info);
+      this.userInfoCacheTimestamps.set(userId, now);
+      return info;
+    } catch {
+      return { name: userId, username: userId };
+    }
+  }
+
+  /**
+   * Determine media type from MIME type
+   */
+  private getMediaType(mimeType: string): 'image' | 'video' | 'audio' | 'document' {
+    if (mimeType.startsWith('image/')) return 'image';
+    if (mimeType.startsWith('video/')) return 'video';
+    if (mimeType.startsWith('audio/')) return 'audio';
+    return 'document';
+  }
+
+  /**
+   * Download a Slack file and save locally
+   * Files are saved to ~/.pcp/files/slack/
+   */
+  private async downloadFile(file: {
+    url_private?: string;
+    name?: string;
+    mimetype?: string;
+  }): Promise<string | null> {
+    if (!file.url_private) return null;
+
+    try {
+      const response = await fetch(file.url_private, {
+        headers: { Authorization: `Bearer ${this.botToken}` },
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed to download: ${response.status}`);
+      }
+
+      const buffer = await response.arrayBuffer();
+
+      const fs = await import('fs/promises');
+      const path = await import('path');
+      const os = await import('os');
+
+      const pcpFilesDir = path.join(os.homedir(), '.pcp', 'files', 'slack');
+      await fs.mkdir(pcpFilesDir, { recursive: true });
+
+      const safeName = (file.name || `attachment_${Date.now()}`).replace(/[^a-zA-Z0-9._-]/g, '_');
+      const filePath = path.join(pcpFilesDir, `${Date.now()}_${safeName}`);
+
+      await fs.writeFile(filePath, Buffer.from(buffer));
+
+      logger.info('Downloaded Slack file', { filePath, size: buffer.byteLength });
+      return filePath;
+    } catch (error) {
+      logger.error('Failed to download Slack file:', error);
+      return null;
+    }
+  }
+
+  /**
+   * Dispatch a converted InboundMessage: cache, emit, and call callback.
+   */
+  private async dispatchMessage(message: InboundMessage): Promise<void> {
+    const chatId = message.conversationId || '';
+
+    // Cache message for context retrieval
+    this.cacheMessage({
+      messageId: message.messageId || '',
+      chatId,
+      from: message.sender.name || message.sender.username || 'Unknown',
+      fromId: message.sender.id || chatId,
+      text: message.body,
+      timestamp: new Date(message.timestamp || Date.now()),
+    });
+
+    logger.info(`Received Slack message from @${message.sender.username || message.sender.id}`, {
+      chatId,
+      messageId: message.messageId,
+      body: message.body.substring(0, 50),
+      mediaCount: message.media?.length ?? 0,
+    });
+
+    this.emit('message', message);
+
+    if (this.messageCallback) {
+      try {
+        await this.messageCallback(message);
+      } catch (error) {
+        logger.error('Error in Slack message callback:', error);
+        this.emit('error', error);
+      }
+    }
+  }
+
+  /**
+   * Send a message to a Slack channel.
+   * Handles the 4000-char limit by splitting into chunks.
+   */
+  async sendMessage(conversationId: string, content: string): Promise<void> {
+    const channelId = conversationId.startsWith('slack:')
+      ? conversationId.replace('slack:', '')
+      : conversationId;
+
+    try {
+      if (content.length <= SLACK_MAX_MESSAGE_LENGTH) {
+        await this.app.client.chat.postMessage({
+          channel: channelId,
+          text: content,
+        });
+      } else {
+        const chunks = this.splitMessage(content);
+        for (const chunk of chunks) {
+          await this.app.client.chat.postMessage({
+            channel: channelId,
+            text: chunk,
+          });
+        }
+      }
+
+      logger.info(`Sent message to Slack channel ${channelId}`);
+    } catch (error) {
+      logger.error(`Failed to send message to Slack channel ${channelId}:`, error);
+      throw error;
+    }
+  }
+
+  /**
+   * Split a long message into chunks that fit Slack's 4000-char limit
+   */
+  private splitMessage(content: string): string[] {
+    const chunks: string[] = [];
+    let remaining = content;
+
+    while (remaining.length > 0) {
+      if (remaining.length <= SLACK_MAX_MESSAGE_LENGTH) {
+        chunks.push(remaining);
+        break;
+      }
+
+      let splitIndex = remaining.lastIndexOf('\n', SLACK_MAX_MESSAGE_LENGTH);
+      if (splitIndex <= 0 || splitIndex < SLACK_MAX_MESSAGE_LENGTH / 2) {
+        splitIndex = remaining.lastIndexOf(' ', SLACK_MAX_MESSAGE_LENGTH);
+      }
+      if (splitIndex <= 0) {
+        splitIndex = SLACK_MAX_MESSAGE_LENGTH;
+      }
+
+      chunks.push(remaining.substring(0, splitIndex));
+      remaining = remaining.substring(splitIndex).trimStart();
+    }
+
+    return chunks;
+  }
+
+  /**
+   * Send typing indicator — Slack bots can't show typing indicators
+   */
+  async sendTypingIndicator(_conversationId: string): Promise<void> {
+    // Slack's API doesn't support typing indicators for bots
+  }
+
+  /**
+   * Get the bot's Slack user ID (for mention detection in gateway)
+   */
+  get botId(): string | null {
+    return this.botUserId;
+  }
+
+  /**
+   * Check if listener is running
+   */
+  get running(): boolean {
+    return this.isRunning;
+  }
+
+  /**
+   * Whether the bot is connected
+   */
+  get connected(): boolean {
+    return this.isRunning;
+  }
+
+  // ============================================================================
+  // Ephemeral message cache (mirrors Discord/Telegram listeners)
+  // ============================================================================
+
+  private cacheMessage(message: EphemeralMessage): void {
+    const { chatId } = message;
+
+    if (!this.messageCache.has(chatId)) {
+      this.messageCache.set(chatId, []);
+    }
+
+    const cache = this.messageCache.get(chatId)!;
+    cache.push(message);
+
+    if (cache.length > this.maxMessagesPerChat) {
+      cache.shift();
+    }
+
+    this.cleanExpiredMessages(chatId);
+  }
+
+  private cleanExpiredMessages(chatId: string): void {
+    const cache = this.messageCache.get(chatId);
+    if (!cache) return;
+
+    const now = Date.now();
+    const filtered = cache.filter((msg) => now - msg.timestamp.getTime() < this.messageTtlMs);
+
+    if (filtered.length !== cache.length) {
+      this.messageCache.set(chatId, filtered);
+    }
+  }
+
+  getRecentMessages(chatId: string, limit = 50): EphemeralMessage[] {
+    this.cleanExpiredMessages(chatId);
+    const cache = this.messageCache.get(chatId) || [];
+    return cache.slice(-limit);
+  }
+
+  clearMessageCache(chatId: string): void {
+    this.messageCache.delete(chatId);
+  }
+
+  getCacheStats(): { chatCount: number; totalMessages: number } {
+    let totalMessages = 0;
+    for (const messages of this.messageCache.values()) {
+      totalMessages += messages.length;
+    }
+    return {
+      chatCount: this.messageCache.size,
+      totalMessages,
+    };
+  }
+}
+
+/**
+ * Create a Slack listener instance
+ */
+export function createSlackListener(config?: SlackListenerConfig): SlackListener {
+  return new SlackListener(config);
+}

--- a/packages/api/src/channels/telegram-listener.ts
+++ b/packages/api/src/channels/telegram-listener.ts
@@ -755,17 +755,14 @@ export class TelegramListener extends EventEmitter {
         // Extract the @username from the text
         const mentionText = textContent.substring(entity.offset, entity.offset + entity.length);
         mentionedUsers.push(mentionText);
-        // Check if it's our bot
-        if (mentionText.toLowerCase() === '@myra_help_bot') {
+        // Check if it's our bot (dynamic — uses bot's actual username)
+        if (
+          this.botUsername &&
+          mentionText.toLowerCase() === `@${this.botUsername.toLowerCase()}`
+        ) {
           botMentioned = true;
         }
       }
-    }
-
-    // Also check for name mentions (case-insensitive)
-    const lowerText = textContent.toLowerCase();
-    if (lowerText.includes('myra')) {
-      botMentioned = true;
     }
 
     message.mentions = {

--- a/packages/api/src/channels/whatsapp-listener.ts
+++ b/packages/api/src/channels/whatsapp-listener.ts
@@ -269,11 +269,8 @@ export class WhatsAppListener extends EventEmitter {
         return;
       }
 
-      // Check for mention/trigger in group
-      if (!this.shouldRespondInGroup(text)) {
-        logger.debug(`Ignoring non-triggered message in WhatsApp group: ${chatId}`);
-        return;
-      }
+      // Group mention filtering is handled by the ChannelGateway's isAgentMentioned()
+      // which uses dynamic agent names. The listener passes all authorized group messages through.
     } else {
       // DM: Check if user is trusted
       const trustedUser = await this.authService.isUserTrusted('whatsapp', senderE164);
@@ -358,18 +355,6 @@ export class WhatsAppListener extends EventEmitter {
     // JID format: 1234567890@s.whatsapp.net or 1234567890:123@s.whatsapp.net
     const match = jid.match(/^(\d+)/);
     return match ? `+${match[1]}` : jid;
-  }
-
-  /**
-   * Check if message should trigger bot in group
-   */
-  private shouldRespondInGroup(text: string): boolean {
-    const lowerText = text.toLowerCase();
-
-    // Check for @mention (WhatsApp uses @phone for mentions)
-    // Also check for name mentions
-    const triggers = ['myra', '@myra', 'hey myra', 'hi myra'];
-    return triggers.some((t) => lowerText.includes(t));
   }
 
   /**
@@ -632,11 +617,11 @@ export class WhatsAppListener extends EventEmitter {
       groupSubject,
     };
 
-    // Check for mentions
-    const lowerText = text.toLowerCase();
+    // WhatsApp doesn't have native bot @mentions.
+    // Agent name matching is handled by ChannelGateway.isAgentMentioned().
     message.mentions = {
       users: [],
-      botMentioned: lowerText.includes('myra'),
+      botMentioned: false,
     };
 
     // Handle quoted/reply message

--- a/packages/api/src/config/env.ts
+++ b/packages/api/src/config/env.ts
@@ -87,6 +87,10 @@ const envSchema = z.object({
   DISCORD_BOT_TOKEN: optionalString,
   DISCORD_APPLICATION_ID: optionalString,
 
+  // Slack Bot
+  SLACK_BOT_TOKEN: optionalString,
+  SLACK_APP_TOKEN: optionalString,
+
   // Identity enforcement
   ENFORCE_IDENTITY_PINNING: z.enum(['true', 'false']).default('true'),
 

--- a/packages/api/src/data/repositories/users.repository.ts
+++ b/packages/api/src/data/repositories/users.repository.ts
@@ -94,8 +94,23 @@ export class UsersRepository extends BaseRepository {
     }
   }
 
+  async findBySlackId(slackId: string): Promise<User | null> {
+    try {
+      const { data, error } = await this.client
+        .from('users')
+        .select('*')
+        .eq('slack_id', slackId)
+        .single();
+
+      if (error && error.code !== 'PGRST116') throw error;
+      return data;
+    } catch (error) {
+      this.handleError(error, 'findBySlackId');
+    }
+  }
+
   async findByPlatformId(
-    platform: 'telegram' | 'whatsapp' | 'discord',
+    platform: 'telegram' | 'whatsapp' | 'discord' | 'slack',
     platformId: string | number
   ): Promise<User | null> {
     switch (platform) {
@@ -107,6 +122,8 @@ export class UsersRepository extends BaseRepository {
         return this.findByWhatsAppId(String(platformId));
       case 'discord':
         return this.findByDiscordId(String(platformId));
+      case 'slack':
+        return this.findBySlackId(String(platformId));
       default:
         return null;
     }

--- a/packages/api/src/data/supabase/types.ts
+++ b/packages/api/src/data/supabase/types.ts
@@ -2689,6 +2689,7 @@ export type Database = {
           last_name: string | null;
           phone_number: string | null;
           preferences: Json | null;
+          slack_id: string | null;
           telegram_id: number | null;
           telegram_username: string | null;
           timezone: string | null;
@@ -2706,6 +2707,7 @@ export type Database = {
           last_name?: string | null;
           phone_number?: string | null;
           preferences?: Json | null;
+          slack_id?: string | null;
           telegram_id?: number | null;
           telegram_username?: string | null;
           timezone?: string | null;
@@ -2723,6 +2725,7 @@ export type Database = {
           last_name?: string | null;
           phone_number?: string | null;
           preferences?: Json | null;
+          slack_id?: string | null;
           telegram_id?: number | null;
           telegram_username?: string | null;
           timezone?: string | null;

--- a/packages/api/src/mcp/server.ts
+++ b/packages/api/src/mcp/server.ts
@@ -602,6 +602,14 @@ export class MCPServer {
       }
     });
 
+    this.channelGateway.on('slack:connected', () => {
+      const listener = this.channelGateway?.getSlackListener();
+      if (listener) {
+        registerChannelListener('slack', listener);
+        logger.info('Slack listener registered with MCP tools');
+      }
+    });
+
     await this.channelGateway.start();
 
     const telegramListener = this.channelGateway.getTelegramListener();
@@ -617,6 +625,11 @@ export class MCPServer {
     const discordListener = this.channelGateway.getDiscordListener();
     if (discordListener) {
       registerChannelListener('discord', discordListener);
+    }
+
+    const slackListener = this.channelGateway.getSlackListener();
+    if (slackListener) {
+      registerChannelListener('slack', slackListener);
     }
 
     logger.info('ChannelGateway started', this.channelGateway.getStatus());

--- a/packages/api/src/mcp/tools/response-handlers.ts
+++ b/packages/api/src/mcp/tools/response-handlers.ts
@@ -77,7 +77,7 @@ function markExplicitResponse(channel: string, conversationId: string): void {
 
 export const sendResponseSchema = z.object({
   channel: z
-    .enum(['telegram', 'terminal', 'discord', 'whatsapp', 'http', 'api', 'agent'])
+    .enum(['telegram', 'terminal', 'discord', 'whatsapp', 'slack', 'http', 'api', 'agent'])
     .describe('Channel to send the response to'),
   conversationId: z.string().describe('Conversation ID to route the response to'),
   content: z.string().describe('The response content to send'),
@@ -133,7 +133,7 @@ export async function handleSendResponse(
       logger.info(`Response sent to ${args.channel}:${args.conversationId} via local callback`);
     } else {
       // Fallback: route through Myra's HTTP endpoint for external channels
-      if (args.channel === 'telegram' || args.channel === 'whatsapp') {
+      if (args.channel === 'telegram' || args.channel === 'whatsapp' || args.channel === 'slack') {
         logger.info(`Routing ${args.channel} message through Myra's HTTP endpoint`);
         const httpResponse = await fetch(MYRA_SEND_ENDPOINT, {
           method: 'POST',
@@ -187,7 +187,7 @@ export async function handleSendResponse(
 
 export const getPendingMessagesSchema = z.object({
   channel: z
-    .enum(['telegram', 'terminal', 'discord', 'whatsapp', 'http', 'api', 'all'])
+    .enum(['telegram', 'terminal', 'discord', 'whatsapp', 'slack', 'http', 'api', 'all'])
     .optional()
     .default('all')
     .describe('Filter by channel (default: all)'),

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -37,6 +37,7 @@ import { initHeartbeatService, processHeartbeat, type DueReminder } from './serv
 import { setResponseCallback, hasExplicitResponse } from './mcp/tools/response-handlers';
 import { getAgentGateway, type AgentTriggerPayload } from './channels/agent-gateway';
 import { resolveRouteAgentId } from './services/routing/resolve-route';
+import { resolveAgentFromMention } from './services/routing/resolve-mention';
 import { logger } from './utils/logger';
 import { env } from './config/env';
 
@@ -153,28 +154,51 @@ async function startServer(config: ServerConfig = {}): Promise<void> {
       return;
     }
 
-    // Resolve agent from channel_routes, fall back to server default (AGENT_ID env)
+    // Resolve agent: mention → channel_routes → AGENT_ID env fallback
     let routedAgentId = agentId;
-    const route = await resolveRouteAgentId(
-      dataComposer!.getClient(),
-      userId,
-      channel,
-      metadata?.platformAccountId,
-      conversationId
-    );
-    if (route) {
-      routedAgentId = route.agentId;
-      logger.debug(`[Route] Resolved agent from channel_routes`, {
-        platform: channel,
-        agentId: route.agentId,
-        identityId: route.identityId,
-        routeId: route.routeId,
-      });
-    } else {
-      logger.warn(
-        `[Route] No channel_route found for ${channel}, falling back to AGENT_ID=${agentId}`,
-        { userId, platform: channel, conversationId }
+    const isGroupChat = metadata?.chatType === 'group' || metadata?.chatType === 'channel';
+
+    // For group chats, try mention-based routing first
+    if (isGroupChat && metadata?.mentions?.users?.length) {
+      const mentionMatch = await resolveAgentFromMention(
+        dataComposer!.getClient(),
+        userId,
+        content,
+        metadata.mentions.users
       );
+      if (mentionMatch) {
+        routedAgentId = mentionMatch.agentId;
+        logger.debug(`[Route] Resolved agent from @mention`, {
+          platform: channel,
+          agentId: mentionMatch.agentId,
+          identityId: mentionMatch.identityId,
+        });
+      }
+    }
+
+    // If mention didn't match, try channel_routes specificity cascade
+    if (routedAgentId === agentId) {
+      const route = await resolveRouteAgentId(
+        dataComposer!.getClient(),
+        userId,
+        channel,
+        metadata?.platformAccountId,
+        conversationId
+      );
+      if (route) {
+        routedAgentId = route.agentId;
+        logger.debug(`[Route] Resolved agent from channel_routes`, {
+          platform: channel,
+          agentId: route.agentId,
+          identityId: route.identityId,
+          routeId: route.routeId,
+        });
+      } else {
+        logger.warn(
+          `[Route] No channel_route found for ${channel}, falling back to AGENT_ID=${agentId}`,
+          { userId, platform: channel, conversationId }
+        );
+      }
     }
 
     // Build SessionRequest
@@ -208,7 +232,7 @@ async function startServer(config: ServerConfig = {}): Promise<void> {
     // For external channels (telegram/whatsapp), ensure the conversation is released
     // and auto-route the text response if no explicit send_response was called
     const isExternalChannel =
-      channel === 'telegram' || channel === 'whatsapp' || channel === 'discord';
+      channel === 'telegram' || channel === 'whatsapp' || channel === 'discord' || channel === 'slack';
     if (isExternalChannel && channelGateway) {
       // Check if send_response was called via MCP (tracked in response-handlers)
       const hadExplicitResponse = hasExplicitResponse(channel, conversationId);
@@ -260,6 +284,7 @@ async function startServer(config: ServerConfig = {}): Promise<void> {
       whatsappAccountId: config.whatsappAccountId || 'default',
       printWhatsAppQr: true,
       enableDiscord: process.env.ENABLE_DISCORD === 'true',
+      enableSlack: process.env.ENABLE_SLACK === 'true',
     },
     messageHandler,
   });
@@ -275,6 +300,24 @@ async function startServer(config: ServerConfig = {}): Promise<void> {
   channelGateway = mcpServer.getChannelGateway();
   if (channelGateway) {
     logger.info('ChannelGateway ready', channelGateway.getStatus());
+
+    // Load known agent names for dynamic mention detection in group chats
+    try {
+      const { data: identities } = await dataComposer!
+        .getClient()
+        .from('agent_identities')
+        .select('agent_id, name');
+      if (identities && identities.length > 0) {
+        const names = new Set<string>();
+        for (const identity of identities) {
+          names.add(identity.agent_id);
+          if (identity.name) names.add(identity.name);
+        }
+        channelGateway.setKnownAgentNames([...names]);
+      }
+    } catch (err) {
+      logger.warn('Failed to load agent names for mention detection:', err);
+    }
 
     // Register the response callback so send_response MCP calls route through ChannelGateway
     setResponseCallback(async (response) => {
@@ -557,6 +600,7 @@ If you need to message a user, use send_response with the appropriate channel an
   if (status?.telegram.enabled) enabledChannels.push('Telegram');
   if (status?.whatsapp.enabled) enabledChannels.push('WhatsApp');
   if (status?.discord.enabled) enabledChannels.push('Discord');
+  if (status?.slack.enabled) enabledChannels.push('Slack');
 
   if (enabledChannels.length > 0) {
     logger.info(`Send a message via ${enabledChannels.join(' or ')} to start a conversation.`);
@@ -621,6 +665,19 @@ async function resolveUserId(
       }
 
       return user.id;
+    } else if (channel === 'slack') {
+      let user = await dataComposer.repositories.users.findBySlackId(senderId);
+
+      if (!user) {
+        user = await dataComposer.repositories.users.create({
+          slack_id: senderId,
+          first_name: senderName?.split(' ')[0],
+          last_name: senderName?.split(' ').slice(1).join(' ') || undefined,
+        });
+        logger.info(`Created new Slack user: ${user.id}`);
+      }
+
+      return user.id;
     }
   } catch (error) {
     logger.error('Failed to resolve user:', error);
@@ -651,6 +708,9 @@ function printStatus(): void {
     );
     logger.info(
       `  Discord: ${status.discord.enabled ? (status.discord.connected ? 'Connected' : 'Enabled') : 'Disabled'}`
+    );
+    logger.info(
+      `  Slack: ${status.slack.enabled ? (status.slack.connected ? 'Connected' : 'Enabled') : 'Disabled'}`
     );
   }
 

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -159,12 +159,14 @@ async function startServer(config: ServerConfig = {}): Promise<void> {
     const isGroupChat = metadata?.chatType === 'group' || metadata?.chatType === 'channel';
 
     // For group chats, try mention-based routing first
-    if (isGroupChat && metadata?.mentions?.users?.length) {
+    // Always call for group chats — text matching works even without platform mentions
+    // (e.g., WhatsApp has no native @mentions, Slack bot mention excluded from users array)
+    if (isGroupChat) {
       const mentionMatch = await resolveAgentFromMention(
         dataComposer!.getClient(),
         userId,
         content,
-        metadata.mentions.users
+        metadata?.mentions?.users ?? []
       );
       if (mentionMatch) {
         routedAgentId = mentionMatch.agentId;

--- a/packages/api/src/services/authorization.ts
+++ b/packages/api/src/services/authorization.ts
@@ -12,7 +12,7 @@ import { getRequestContext, getSessionContext } from '../utils/request-context';
 import crypto from 'crypto';
 
 export type TrustLevel = 'owner' | 'admin' | 'member';
-export type Platform = 'telegram' | 'whatsapp' | 'discord';
+export type Platform = 'telegram' | 'whatsapp' | 'discord' | 'slack';
 
 interface TrustedUser {
   id: string;

--- a/packages/api/src/services/routing/resolve-mention.integration.test.ts
+++ b/packages/api/src/services/routing/resolve-mention.integration.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Mention Resolver Integration Tests
+ *
+ * Tests resolveAgentFromMention against a real Supabase database.
+ * Uses the echo test agent identity (from migration 008) as a fixture.
+ * Uses unique names (Zephyr, Kira, Orion) to avoid collisions with real identities.
+ *
+ * Run via: yarn test:integration
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { getDataComposer, type DataComposer } from '../../data/composer';
+import { resolveAgentFromMention } from './resolve-mention';
+
+describe('resolveAgentFromMention (integration)', () => {
+  let dataComposer: DataComposer;
+  let testUserId: string;
+  const createdIdentityIds: string[] = [];
+
+  beforeAll(async () => {
+    dataComposer = await getDataComposer();
+
+    // Find the echo test agent's user
+    const { data: echoIdentity, error } = await dataComposer
+      .getClient()
+      .from('agent_identities')
+      .select('user_id')
+      .eq('agent_id', 'echo')
+      .single();
+
+    if (error || !echoIdentity) {
+      throw new Error(
+        'Echo test agent identity not found. Apply migration 008_add_echo_test_agent.sql first.'
+      );
+    }
+
+    testUserId = echoIdentity.user_id;
+
+    // Create test identities with unique names to avoid collisions with real identities
+    const testIdentities = [
+      { agent_id: 'test-zephyr', name: 'Zephyr', role: 'test agent', user_id: testUserId },
+      { agent_id: 'test-kira', name: 'Kira', role: 'test agent', user_id: testUserId },
+      { agent_id: 'test-orion', name: 'Orion Bot', role: 'test agent', user_id: testUserId },
+    ];
+
+    for (const identity of testIdentities) {
+      const { data, error: insertError } = await dataComposer
+        .getClient()
+        .from('agent_identities')
+        .insert(identity)
+        .select('id')
+        .single();
+
+      if (insertError) {
+        throw new Error(`Failed to create test identity: ${insertError.message}`);
+      }
+      createdIdentityIds.push(data.id);
+    }
+  });
+
+  afterAll(async () => {
+    // Clean up test identities
+    if (createdIdentityIds.length > 0) {
+      await dataComposer
+        .getClient()
+        .from('agent_identities')
+        .delete()
+        .in('id', createdIdentityIds);
+    }
+  });
+
+  it('resolves agent by mentioned username matching agent_id', async () => {
+    const result = await resolveAgentFromMention(
+      dataComposer.getClient(),
+      testUserId,
+      'hello',
+      ['test-zephyr']
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.agentId).toBe('test-zephyr');
+  });
+
+  it('resolves agent by mentioned username matching name (case-insensitive)', async () => {
+    const result = await resolveAgentFromMention(
+      dataComposer.getClient(),
+      testUserId,
+      'hello',
+      ['kira']
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.agentId).toBe('test-kira');
+  });
+
+  it('resolves agent by text mention with word boundary', async () => {
+    const result = await resolveAgentFromMention(
+      dataComposer.getClient(),
+      testUserId,
+      'hey test-zephyr, can you help?',
+      []
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.agentId).toBe('test-zephyr');
+  });
+
+  it('resolves agent by name in text (case-insensitive)', async () => {
+    const result = await resolveAgentFromMention(
+      dataComposer.getClient(),
+      testUserId,
+      'Hey ZEPHYR, check this out',
+      []
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.agentId).toBe('test-zephyr');
+  });
+
+  it('returns null when no agents are mentioned', async () => {
+    const result = await resolveAgentFromMention(
+      dataComposer.getClient(),
+      testUserId,
+      'just a normal message with no names',
+      ['randomuser']
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null for a different user who has no identities', async () => {
+    const result = await resolveAgentFromMention(
+      dataComposer.getClient(),
+      '00000000-0000-0000-0000-000000000000', // non-existent user
+      'hey zephyr',
+      ['zephyr']
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it('prioritizes mentioned username over text match', async () => {
+    // Username says "test-kira", text says "zephyr" — username should win
+    const result = await resolveAgentFromMention(
+      dataComposer.getClient(),
+      testUserId,
+      'zephyr should do this',
+      ['test-kira']
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.agentId).toBe('test-kira');
+  });
+
+  it('returns a valid identityId that exists in the database', async () => {
+    const result = await resolveAgentFromMention(
+      dataComposer.getClient(),
+      testUserId,
+      'hello',
+      ['test-zephyr']
+    );
+
+    expect(result).not.toBeNull();
+    expect(createdIdentityIds).toContain(result!.identityId);
+  });
+});

--- a/packages/api/src/services/routing/resolve-mention.test.ts
+++ b/packages/api/src/services/routing/resolve-mention.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { resolveAgentFromMention } from './resolve-mention';
+
+// Mock Supabase client
+function createMockSupabase(identities: Array<{ id: string; agent_id: string; name: string | null }>) {
+  return {
+    from: vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          data: identities,
+          error: null,
+        }),
+      }),
+    }),
+  } as any;
+}
+
+function createErrorSupabase() {
+  return {
+    from: vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          data: null,
+          error: { message: 'DB error' },
+        }),
+      }),
+    }),
+  } as any;
+}
+
+const TEST_IDENTITIES = [
+  { id: 'id-wren', agent_id: 'wren', name: 'Wren' },
+  { id: 'id-myra', agent_id: 'myra', name: 'Myra' },
+  { id: 'id-benson', agent_id: 'benson', name: 'Benson' },
+];
+
+describe('resolveAgentFromMention', () => {
+  it('matches by mentioned username against agent_id', async () => {
+    const supabase = createMockSupabase(TEST_IDENTITIES);
+    const result = await resolveAgentFromMention(supabase, 'user-1', 'hello', ['wren']);
+    expect(result).toEqual({ agentId: 'wren', identityId: 'id-wren' });
+  });
+
+  it('matches by mentioned username against name', async () => {
+    const supabase = createMockSupabase(TEST_IDENTITIES);
+    const result = await resolveAgentFromMention(supabase, 'user-1', 'hello', ['Myra']);
+    expect(result).toEqual({ agentId: 'myra', identityId: 'id-myra' });
+  });
+
+  it('matches case-insensitively', async () => {
+    const supabase = createMockSupabase(TEST_IDENTITIES);
+    const result = await resolveAgentFromMention(supabase, 'user-1', 'hello', ['BENSON']);
+    expect(result).toEqual({ agentId: 'benson', identityId: 'id-benson' });
+  });
+
+  it('matches by text mention when no username match', async () => {
+    const supabase = createMockSupabase(TEST_IDENTITIES);
+    const result = await resolveAgentFromMention(supabase, 'user-1', 'hey wren, can you help?', []);
+    expect(result).toEqual({ agentId: 'wren', identityId: 'id-wren' });
+  });
+
+  it('uses word boundaries for text matching', async () => {
+    const supabase = createMockSupabase(TEST_IDENTITIES);
+    // "wrench" should NOT match "wren"
+    const result = await resolveAgentFromMention(supabase, 'user-1', 'pass me the wrench', []);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when no mention matches', async () => {
+    const supabase = createMockSupabase(TEST_IDENTITIES);
+    const result = await resolveAgentFromMention(supabase, 'user-1', 'hello world', ['someuser']);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when no identities exist', async () => {
+    const supabase = createMockSupabase([]);
+    const result = await resolveAgentFromMention(supabase, 'user-1', 'hey wren', ['wren']);
+    expect(result).toBeNull();
+  });
+
+  it('returns null on DB error', async () => {
+    const supabase = createErrorSupabase();
+    const result = await resolveAgentFromMention(supabase, 'user-1', 'hey wren', ['wren']);
+    expect(result).toBeNull();
+  });
+
+  it('prioritizes mentioned username over text match', async () => {
+    const supabase = createMockSupabase(TEST_IDENTITIES);
+    // Mentions say "myra" but text says "wren" — mention should win
+    const result = await resolveAgentFromMention(supabase, 'user-1', 'wren should help', ['myra']);
+    expect(result).toEqual({ agentId: 'myra', identityId: 'id-myra' });
+  });
+
+  it('matches text with agent name (identity name, not agent_id)', async () => {
+    const supabase = createMockSupabase([
+      { id: 'id-custom', agent_id: 'custom-agent', name: 'Nova' },
+    ]);
+    const result = await resolveAgentFromMention(supabase, 'user-1', 'hey Nova!', []);
+    expect(result).toEqual({ agentId: 'custom-agent', identityId: 'id-custom' });
+  });
+});

--- a/packages/api/src/services/routing/resolve-mention.ts
+++ b/packages/api/src/services/routing/resolve-mention.ts
@@ -1,0 +1,110 @@
+/**
+ * Mention-Based Agent Resolution
+ *
+ * For group chats where multiple SBs may be present, resolves which agent
+ * is being @mentioned. This runs BEFORE the channel_routes specificity
+ * cascade, allowing per-message routing in shared channels.
+ *
+ * Resolution order:
+ *   1. Check mentionedUsernames against agent identity names (case-insensitive)
+ *   2. Check message text for agent name mentions (e.g., "hey wren, ...")
+ *   3. Return null if no mention match — caller falls through to channel_routes
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { logger } from '../../utils/logger';
+
+export interface MentionResolvedAgent {
+  agentId: string;
+  identityId: string;
+}
+
+/**
+ * Resolve which agent is being @mentioned in a group message.
+ *
+ * @param supabase - Supabase client
+ * @param userId - The user who owns the agent identities
+ * @param messageText - Raw message text (for text-based name matching)
+ * @param mentionedUsernames - Platform-native @mentioned usernames (already resolved by listener)
+ * @returns The matched agent, or null if no mention detected
+ */
+export async function resolveAgentFromMention(
+  supabase: SupabaseClient,
+  userId: string,
+  messageText: string,
+  mentionedUsernames: string[]
+): Promise<MentionResolvedAgent | null> {
+  // Fetch all agent identities for this user
+  const { data: identities, error } = await supabase
+    .from('agent_identities')
+    .select('id, agent_id, name')
+    .eq('user_id', userId);
+
+  if (error) {
+    logger.error('[Mention] Failed to query agent_identities', { error, userId });
+    return null;
+  }
+
+  if (!identities || identities.length === 0) {
+    return null;
+  }
+
+  // Normalize mentioned usernames to lowercase for comparison
+  const mentionedLower = mentionedUsernames.map((u) => u.toLowerCase());
+
+  // 1. Check mentionedUsernames against identity agent_id and name
+  for (const identity of identities) {
+    const agentIdLower = identity.agent_id.toLowerCase();
+    const nameLower = identity.name?.toLowerCase();
+
+    if (mentionedLower.includes(agentIdLower)) {
+      logger.debug('[Mention] Matched by mentioned username → agent_id', {
+        agentId: identity.agent_id,
+        identityId: identity.id,
+      });
+      return { agentId: identity.agent_id, identityId: identity.id };
+    }
+
+    if (nameLower && mentionedLower.includes(nameLower)) {
+      logger.debug('[Mention] Matched by mentioned username → name', {
+        agentId: identity.agent_id,
+        name: identity.name,
+        identityId: identity.id,
+      });
+      return { agentId: identity.agent_id, identityId: identity.id };
+    }
+  }
+
+  // 2. Check message text for agent names (word-boundary match)
+  const textLower = messageText.toLowerCase();
+  for (const identity of identities) {
+    const agentId = identity.agent_id;
+    const name = identity.name;
+
+    // Match agent_id as a word boundary (e.g., "wren" but not "wrench")
+    if (new RegExp(`\\b${escapeRegex(agentId)}\\b`, 'i').test(textLower)) {
+      logger.debug('[Mention] Matched by text mention → agent_id', {
+        agentId: identity.agent_id,
+        identityId: identity.id,
+      });
+      return { agentId: identity.agent_id, identityId: identity.id };
+    }
+
+    // Match identity name as word boundary
+    if (name && new RegExp(`\\b${escapeRegex(name)}\\b`, 'i').test(textLower)) {
+      logger.debug('[Mention] Matched by text mention → name', {
+        agentId: identity.agent_id,
+        name,
+        identityId: identity.id,
+      });
+      return { agentId: identity.agent_id, identityId: identity.id };
+    }
+  }
+
+  return null;
+}
+
+/** Escape special regex characters in a string */
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/packages/api/src/services/sessions/types.ts
+++ b/packages/api/src/services/sessions/types.ts
@@ -12,6 +12,7 @@ export type ChannelType =
   | 'terminal'
   | 'discord'
   | 'whatsapp'
+  | 'slack'
   | 'http'
   | 'api'
   | 'agent'

--- a/supabase/migrations/20260223000000_add_slack_id_to_users.sql
+++ b/supabase/migrations/20260223000000_add_slack_id_to_users.sql
@@ -1,0 +1,3 @@
+-- Add slack_id to users table for Slack channel integration
+ALTER TABLE users ADD COLUMN slack_id varchar(255);
+CREATE UNIQUE INDEX users_slack_id_key ON users (slack_id) WHERE slack_id IS NOT NULL;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2028,6 +2028,7 @@ __metadata:
   dependencies:
     "@anthropic-ai/sdk": "npm:^0.71.2"
     "@modelcontextprotocol/sdk": "npm:^1.26.0"
+    "@slack/bolt": "npm:^4.6.0"
     "@supabase/supabase-js": "npm:^2.39.3"
     "@types/bcrypt": "npm:^5.0.2"
     "@types/compression": "npm:^1.7.5"
@@ -2945,6 +2946,89 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@slack/bolt@npm:^4.6.0":
+  version: 4.6.0
+  resolution: "@slack/bolt@npm:4.6.0"
+  dependencies:
+    "@slack/logger": "npm:^4.0.0"
+    "@slack/oauth": "npm:^3.0.4"
+    "@slack/socket-mode": "npm:^2.0.5"
+    "@slack/types": "npm:^2.18.0"
+    "@slack/web-api": "npm:^7.12.0"
+    axios: "npm:^1.12.0"
+    express: "npm:^5.0.0"
+    path-to-regexp: "npm:^8.1.0"
+    raw-body: "npm:^3"
+    tsscmp: "npm:^1.0.6"
+  peerDependencies:
+    "@types/express": ^5.0.0
+  checksum: 10/12180346ececdfe78873226151d470a40f813db0b5b60507161f2bcb1a934487101bacd4ea26dae3a8062597e0877cf06809b248d77fc34c141f2dd38aa08921
+  languageName: node
+  linkType: hard
+
+"@slack/logger@npm:^4, @slack/logger@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "@slack/logger@npm:4.0.0"
+  dependencies:
+    "@types/node": "npm:>=18.0.0"
+  checksum: 10/dc79e9d2032c4bf9ce01d96cc72882f003dd376d036f172d4169662cfc2c9b384a80d5546b06021578dd473e7059f064303f0ba851eeb153387f2081a1e3062e
+  languageName: node
+  linkType: hard
+
+"@slack/oauth@npm:^3.0.4":
+  version: 3.0.4
+  resolution: "@slack/oauth@npm:3.0.4"
+  dependencies:
+    "@slack/logger": "npm:^4"
+    "@slack/web-api": "npm:^7.10.0"
+    "@types/jsonwebtoken": "npm:^9"
+    "@types/node": "npm:>=18"
+    jsonwebtoken: "npm:^9"
+  checksum: 10/99328c76774c2cd3fcfaa701c78fa4a1b75f1ba69928e280730955f33ca4ffc8db43c3e3157af804739a08cda224ec33798d07e222aa5e862b25ee95290a11a0
+  languageName: node
+  linkType: hard
+
+"@slack/socket-mode@npm:^2.0.5":
+  version: 2.0.5
+  resolution: "@slack/socket-mode@npm:2.0.5"
+  dependencies:
+    "@slack/logger": "npm:^4"
+    "@slack/web-api": "npm:^7.10.0"
+    "@types/node": "npm:>=18"
+    "@types/ws": "npm:^8"
+    eventemitter3: "npm:^5"
+    ws: "npm:^8"
+  checksum: 10/9c103bc97f0e09d075e8a9d62ede7f6c4d3c68be7d18a5591a65e3484cf8124c76b8879304d58931808c5da7f19a2b32ccaf001c2d3d0a49792a5be360b4c686
+  languageName: node
+  linkType: hard
+
+"@slack/types@npm:^2.18.0, @slack/types@npm:^2.20.0":
+  version: 2.20.0
+  resolution: "@slack/types@npm:2.20.0"
+  checksum: 10/c97c12c7de0ea37fdb0f47fefbe58f1ff0a4b1d993cc29a8a3bb7a370a41b6422abfe32a786ddf743cc6b17e464a0e5e1dc26dc2b05bb647a4febca51130444f
+  languageName: node
+  linkType: hard
+
+"@slack/web-api@npm:^7.10.0, @slack/web-api@npm:^7.12.0":
+  version: 7.14.1
+  resolution: "@slack/web-api@npm:7.14.1"
+  dependencies:
+    "@slack/logger": "npm:^4.0.0"
+    "@slack/types": "npm:^2.20.0"
+    "@types/node": "npm:>=18.0.0"
+    "@types/retry": "npm:0.12.0"
+    axios: "npm:^1.13.5"
+    eventemitter3: "npm:^5.0.1"
+    form-data: "npm:^4.0.4"
+    is-electron: "npm:2.2.2"
+    is-stream: "npm:^2"
+    p-queue: "npm:^6"
+    p-retry: "npm:^4"
+    retry: "npm:^0.13.1"
+  checksum: 10/50c61ff38dda7960eed9212f4754019bbbfab7396e49e9d75a336f5d953087ba9ba46fde133bf16d70516eadaffa7bc5c6b8d878752d30e1a8b124278e7560aa
+  languageName: node
+  linkType: hard
+
 "@so-ric/colorspace@npm:^1.1.6":
   version: 1.1.6
   resolution: "@so-ric/colorspace@npm:1.1.6"
@@ -3710,7 +3794,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/jsonwebtoken@npm:^9.0.5":
+"@types/jsonwebtoken@npm:^9, @types/jsonwebtoken@npm:^9.0.5":
   version: 9.0.10
   resolution: "@types/jsonwebtoken@npm:9.0.10"
   dependencies:
@@ -3823,6 +3907,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/node@npm:>=18, @types/node@npm:>=18.0.0":
+  version: 25.3.0
+  resolution: "@types/node@npm:25.3.0"
+  dependencies:
+    undici-types: "npm:~7.18.0"
+  checksum: 10/061b00c8de070a606a052afaa4c45dca5f8d6a8e7e39c0c3e196bb650ee37e986bbb161991ea39076a05aada102f36b13c974528448a09efd8d36bdfee75de4b
+  languageName: node
+  linkType: hard
+
 "@types/node@npm:^10.1.0":
   version: 10.17.60
   resolution: "@types/node@npm:10.17.60"
@@ -3884,6 +3977,13 @@ __metadata:
   dependencies:
     csstype: "npm:^3.2.2"
   checksum: 10/0e34a0e42db02f4b3f4bed446128c555446c2854b833d71d597e6c8b08800dd90519a03a226ad250cccc4a0c9e51bd3f9c54cdcb79ee1219f4d5b318fb3a3813
+  languageName: node
+  linkType: hard
+
+"@types/retry@npm:0.12.0":
+  version: 0.12.0
+  resolution: "@types/retry@npm:0.12.0"
+  checksum: 10/bbd0b88f4b3eba7b7acfc55ed09c65ef6f2e1bcb4ec9b4dca82c66566934351534317d294a770a7cc6c0468d5573c5350abab6e37c65f8ef254443e1b028e44d
   languageName: node
   linkType: hard
 
@@ -3969,7 +4069,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/ws@npm:^8.18.1, @types/ws@npm:^8.5.10":
+"@types/ws@npm:^8, @types/ws@npm:^8.18.1, @types/ws@npm:^8.5.10":
   version: 8.18.1
   resolution: "@types/ws@npm:8.18.1"
   dependencies:
@@ -4655,6 +4755,17 @@ __metadata:
   bin:
     autoprefixer: bin/autoprefixer
   checksum: 10/153033db6f137712383ddf3f1f267b1d5900695d135f7794cbfaaec832fdbf4e34efd85418dec6f78c418062afdf3f0a07313e32a83764c119bfb5b2f01648b6
+  languageName: node
+  linkType: hard
+
+"axios@npm:^1.12.0, axios@npm:^1.13.5":
+  version: 1.13.5
+  resolution: "axios@npm:1.13.5"
+  dependencies:
+    follow-redirects: "npm:^1.15.11"
+    form-data: "npm:^4.0.5"
+    proxy-from-env: "npm:^1.1.0"
+  checksum: 10/db726d09902565ef9a0632893530028310e2ec2b95b727114eca1b101450b00014133dfc3871cffc87983fb922bca7e4874d7e2826d1550a377a157cdf3f05b6
   languageName: node
   linkType: hard
 
@@ -6496,7 +6607,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eventemitter3@npm:^5.0.1":
+"eventemitter3@npm:^4.0.4":
+  version: 4.0.7
+  resolution: "eventemitter3@npm:4.0.7"
+  checksum: 10/8030029382404942c01d0037079f1b1bc8fed524b5849c237b80549b01e2fc49709e1d0c557fa65ca4498fc9e24cff1475ef7b855121fcc15f9d61f93e282346
+  languageName: node
+  linkType: hard
+
+"eventemitter3@npm:^5, eventemitter3@npm:^5.0.1":
   version: 5.0.4
   resolution: "eventemitter3@npm:5.0.4"
   checksum: 10/54f5c8c543650d65f92d03dbef1bb73a682a920490c44699ad8f863a6b19bbca42fb7409aa09ca09cb98a44149d9a7bc1dffd55ca88a740bd928c7be0ad666a0
@@ -6629,7 +6747,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"express@npm:^5.2.1":
+"express@npm:^5.0.0, express@npm:^5.2.1":
   version: 5.2.1
   resolution: "express@npm:5.2.1"
   dependencies:
@@ -6894,7 +7012,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.14.0, follow-redirects@npm:^1.15.6":
+"follow-redirects@npm:^1.14.0, follow-redirects@npm:^1.15.11, follow-redirects@npm:^1.15.6":
   version: 1.15.11
   resolution: "follow-redirects@npm:1.15.11"
   peerDependenciesMeta:
@@ -6914,7 +7032,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"form-data@npm:^4.0.4":
+"form-data@npm:^4.0.4, form-data@npm:^4.0.5":
   version: 4.0.5
   resolution: "form-data@npm:4.0.5"
   dependencies:
@@ -7754,6 +7872,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-electron@npm:2.2.2":
+  version: 2.2.2
+  resolution: "is-electron@npm:2.2.2"
+  checksum: 10/de5aa8bd8d72c96675b8d0f93fab4cc21f62be5440f65bc05c61338ca27bd851a64200f31f1bf9facbaa01b3dbfed7997b2186741d84b93b63e0aff1db6a9494
+  languageName: node
+  linkType: hard
+
 "is-extglob@npm:^2.1.1":
   version: 2.1.1
   resolution: "is-extglob@npm:2.1.1"
@@ -7849,7 +7974,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-stream@npm:^2.0.0":
+"is-stream@npm:^2, is-stream@npm:^2.0.0":
   version: 2.0.1
   resolution: "is-stream@npm:2.0.1"
   checksum: 10/b8e05ccdf96ac330ea83c12450304d4a591f9958c11fd17bed240af8d5ffe08aedafa4c0f4cfccd4d28dc9d4d129daca1023633d5c11601a6cbc77521f6fae66
@@ -8552,7 +8677,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsonwebtoken@npm:^9.0.2":
+"jsonwebtoken@npm:^9, jsonwebtoken@npm:^9.0.2":
   version: 9.0.3
   resolution: "jsonwebtoken@npm:9.0.3"
   dependencies:
@@ -10522,6 +10647,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"p-finally@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "p-finally@npm:1.0.0"
+  checksum: 10/93a654c53dc805dd5b5891bab16eb0ea46db8f66c4bfd99336ae929323b1af2b70a8b0654f8f1eae924b2b73d037031366d645f1fd18b3d30cbd15950cc4b1d4
+  languageName: node
+  linkType: hard
+
 "p-limit@npm:^2.2.0":
   version: 2.3.0
   resolution: "p-limit@npm:2.3.0"
@@ -10565,6 +10697,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"p-queue@npm:^6":
+  version: 6.6.2
+  resolution: "p-queue@npm:6.6.2"
+  dependencies:
+    eventemitter3: "npm:^4.0.4"
+    p-timeout: "npm:^3.2.0"
+  checksum: 10/60fe227ffce59fbc5b1b081305b61a2f283ff145005853702b7d4d3f99a0176bd21bb126c99a962e51fe1e01cb8aa10f0488b7bbe73b5dc2e84b5cc650b8ffd2
+  languageName: node
+  linkType: hard
+
 "p-queue@npm:^9.0.0":
   version: 9.1.0
   resolution: "p-queue@npm:9.1.0"
@@ -10572,6 +10714,25 @@ __metadata:
     eventemitter3: "npm:^5.0.1"
     p-timeout: "npm:^7.0.0"
   checksum: 10/7221f58c20852fe1d9283fdcfb2c62628384daf4ccd7a936ba826637d41e1e66f606bc2eaa6d1705513daccb47c21eb890400fc0a91f8566c83d176e63fd3664
+  languageName: node
+  linkType: hard
+
+"p-retry@npm:^4":
+  version: 4.6.2
+  resolution: "p-retry@npm:4.6.2"
+  dependencies:
+    "@types/retry": "npm:0.12.0"
+    retry: "npm:^0.13.1"
+  checksum: 10/45c270bfddaffb4a895cea16cb760dcc72bdecb6cb45fef1971fa6ea2e91ddeafddefe01e444ac73e33b1b3d5d29fb0dd18a7effb294262437221ddc03ce0f2e
+  languageName: node
+  linkType: hard
+
+"p-timeout@npm:^3.2.0":
+  version: 3.2.0
+  resolution: "p-timeout@npm:3.2.0"
+  dependencies:
+    p-finally: "npm:^1.0.0"
+  checksum: 10/3dd0eaa048780a6f23e5855df3dd45c7beacff1f820476c1d0d1bcd6648e3298752ba2c877aa1c92f6453c7dd23faaf13d9f5149fc14c0598a142e2c5e8d649c
   languageName: node
   linkType: hard
 
@@ -10760,7 +10921,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-to-regexp@npm:^8.0.0":
+"path-to-regexp@npm:^8.0.0, path-to-regexp@npm:^8.1.0":
   version: 8.3.0
   resolution: "path-to-regexp@npm:8.3.0"
   checksum: 10/568f148fc64f5fd1ecebf44d531383b28df924214eabf5f2570dce9587a228e36c37882805ff02d71c6209b080ea3ee6a4d2b712b5df09741b67f1f3cf91e55a
@@ -11571,7 +11732,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"raw-body@npm:^3.0.0, raw-body@npm:^3.0.1":
+"raw-body@npm:^3, raw-body@npm:^3.0.0, raw-body@npm:^3.0.1":
   version: 3.0.2
   resolution: "raw-body@npm:3.0.2"
   dependencies:
@@ -11972,6 +12133,13 @@ __metadata:
   version: 0.12.0
   resolution: "retry@npm:0.12.0"
   checksum: 10/1f914879f97e7ee931ad05fe3afa629bd55270fc6cf1c1e589b6a99fab96d15daad0fa1a52a00c729ec0078045fe3e399bd4fd0c93bcc906957bdc17f89cb8e6
+  languageName: node
+  linkType: hard
+
+"retry@npm:^0.13.1":
+  version: 0.13.1
+  resolution: "retry@npm:0.13.1"
+  checksum: 10/6125ec2e06d6e47e9201539c887defba4e47f63471db304c59e4b82fc63c8e89ca06a77e9d34939a9a42a76f00774b2f46c0d4a4cbb3e287268bd018ed69426d
   languageName: node
   linkType: hard
 
@@ -13228,6 +13396,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tsscmp@npm:^1.0.6":
+  version: 1.0.6
+  resolution: "tsscmp@npm:1.0.6"
+  checksum: 10/850405080ea3ecb158e9e01bc4e87c9edb94a829d8ad8747f30ba103fcc41a287d7949ab84d7b27c36294036a2c9878f050db15b73a1a1961abfb7688b82ac53
+  languageName: node
+  linkType: hard
+
 "tsx@npm:^4.7.0":
   version: 4.21.0
   resolution: "tsx@npm:4.21.0"
@@ -13372,6 +13547,13 @@ __metadata:
   version: 7.16.0
   resolution: "undici-types@npm:7.16.0"
   checksum: 10/db43439f69c2d94cc29f75cbfe9de86df87061d6b0c577ebe9bb3255f49b22c50162a7d7eb413b0458b6510b8ca299ac7cff38c3a29fbd31af9f504bcf7fbc0d
+  languageName: node
+  linkType: hard
+
+"undici-types@npm:~7.18.0":
+  version: 7.18.2
+  resolution: "undici-types@npm:7.18.2"
+  checksum: 10/e61a5918f624d68420c3ca9d301e9f15b61cba6e97be39fe2ce266dd6151e4afe424d679372638826cb506be33952774e0424141200111a9857e464216c009af
   languageName: node
   linkType: hard
 
@@ -14065,7 +14247,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:^8.13.0, ws@npm:^8.17.0, ws@npm:^8.18.2":
+"ws@npm:^8, ws@npm:^8.13.0, ws@npm:^8.17.0, ws@npm:^8.18.2":
   version: 8.19.0
   resolution: "ws@npm:8.19.0"
   peerDependencies:


### PR DESCRIPTION
## Summary

- **Slack listener** using Socket Mode (`@slack/bolt`) — follows the existing Discord/Telegram/WhatsApp listener patterns with message chunking, ephemeral cache, and authorization
- **Cross-channel mention routing** via `resolveAgentFromMention()` — any SB can now be @mentioned in group chats across all platforms, replacing hardcoded "myra" trigger words
- **Dynamic agent name detection** — gateway loads agent names from `agent_identities` on startup, used for group message filtering across all channels
- **Migration**: `slack_id` column on users table for Slack user resolution

## What changed

| Area | Detail |
|------|--------|
| New: `slack-listener.ts` | Socket Mode listener with `@slack/bolt`, message handling, file attachments, auth commands |
| New: `resolve-mention.ts` | Cross-channel mention resolver — matches mentioned usernames and message text against agent identities |
| Modified: `gateway.ts` | Added Slack channel, `isAgentMentioned()` replaces per-listener hardcoded checks, `setKnownAgentNames()` |
| Modified: `server.ts` | Mention routing before channel_routes, Slack user resolution, agent name loading on startup |
| Modified: `telegram-listener.ts` | Removed hardcoded "@myra_help_bot" / "myra" — uses dynamic bot username |
| Modified: `whatsapp-listener.ts` | Removed `shouldRespondInGroup()` with hardcoded trigger words |
| Types | Added `'slack'` to ChannelType, Platform, GatewayChannel, response schemas |
| Migration | `slack_id` on users table with unique partial index |

## Test plan

- [x] 10 unit tests for `resolveAgentFromMention` (name matching, case insensitivity, word boundaries, priority)
- [x] 12 unit tests for gateway `isAgentMentioned` (bot mentions, username matching, text matching, edge cases)
- [x] 8 integration tests for mention resolver against real Supabase
- [x] All 829 existing unit tests pass (1 pre-existing failure in session-service.test.ts)
- [x] TypeScript compiles clean
- [ ] Manual: Slack DM routes to default agent
- [ ] Manual: @mention in Slack group routes to correct SB
- [ ] Manual: Telegram/WhatsApp mention routing still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)