### PR TITLE
feat: runtime generating session state + reminders endpoint fix (by Lumen)

### DIFF
--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -1303,7 +1303,7 @@ router.post('/heartbeat', async (_req: Request, res: Response) => {
 
 /**
  * GET /api/admin/reminders
- * List reminders for the active user + workspace (admin view)
+ * List reminders for the active user (admin view)
  */
 router.get('/reminders', async (req: Request, res: Response) => {
   try {
@@ -1314,7 +1314,6 @@ router.get('/reminders', async (req: Request, res: Response) => {
       .from('scheduled_reminders')
       .select('*, users(email, first_name)')
       .eq('user_id', authReq.pcpUserId)
-      .eq('workspace_id', authReq.pcpWorkspaceId)
       .order('next_run_at', { ascending: true })
       .limit(100);
 

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -2975,7 +2975,7 @@ router.get('/sessions', async (req: Request, res: Response) => {
         const identity = s.agent_id ? identitiesByAgentId.get(s.agent_id) : null;
         return {
           id: s.id,
-          backendSessionId: s.claude_session_id || null,
+          backendSessionId: s.backend_session_id || s.claude_session_id || null,
           agentId: s.agent_id,
           agentName: identity?.name || s.agent_id || 'Unknown',
           agentRole: identity?.role || null,

--- a/packages/cli/HOOKS.md
+++ b/packages/cli/HOOKS.md
@@ -7,13 +7,13 @@ PCP hooks bridge coding agents (Claude Code, Codex, Gemini) with PCP's session, 
 
 ## Backend Support
 
-| Hook | Claude Code | Codex | Gemini |
-|------|:-----------:|:-----:|:------:|
-| `on-session-start` | SessionStart | session_start | session_start |
-| `pre-compact` | PreCompact | - | - |
-| `post-compact` | SessionStart* | - | - |
-| `on-prompt` | UserPromptSubmit | - | - |
-| `on-stop` | Stop | session_end | session_end |
+| Hook               |   Claude Code    |     Codex     |    Gemini    |
+| ------------------ | :--------------: | :-----------: | :----------: |
+| `on-session-start` |   SessionStart   | session_start | SessionStart |
+| `pre-compact`      |    PreCompact    |       -       | PreCompress  |
+| `post-compact`     |  SessionStart\*  |       -       |      -       |
+| `on-prompt`        | UserPromptSubmit |  user_prompt  | BeforeAgent  |
+| `on-stop`          |       Stop       |  session_end  |  AfterAgent  |
 
 \* `post-compact` uses the SessionStart event with a "compact" matcher to distinguish from initial startup.
 
@@ -24,6 +24,7 @@ PCP hooks bridge coding agents (Claude Code, Codex, Gemini) with PCP's session, 
 **When:** Agent session begins (first startup).
 
 **What it does:**
+
 1. Reads workspace ID from `.pcp/identity.json`
 2. Calls `bootstrap` with agentId and workspaceId
 3. Calls `get_inbox` for unread messages
@@ -33,6 +34,7 @@ PCP hooks bridge coding agents (Claude Code, Codex, Gemini) with PCP's session, 
 7. Links backend session ID to PCP session via `update_session_phase(sessionId, backendSessionId)`
 
 **Output:**
+
 ```
 ## Session Context (PCP)
 
@@ -64,6 +66,7 @@ Workspace: {workspace name}
 **What it does:** Outputs a static reminder prompting the agent to save state before context is lost.
 
 **Output:**
+
 ```
 ## Pre-Compaction Reminder (PCP)
 
@@ -86,10 +89,12 @@ This context will be lost after compaction unless you save it now.
 **When:** After context compaction (Claude Code only). Fires on SessionStart with a "compact" matcher.
 
 **What it does:**
+
 1. Calls `bootstrap` to reload identity
 2. Calls `get_inbox` for unread messages
 
 **Output:**
+
 ```
 ## Post-Compaction Context (PCP)
 
@@ -107,14 +112,17 @@ Agent: {agentId}
 
 ### `on-prompt`
 
-**When:** Before each user prompt is submitted (Claude Code only).
+**When:** Before each user prompt is submitted (Claude Code: `UserPromptSubmit`, Codex: `user_prompt`, Gemini: `BeforeAgent`).
 
 **What it does:**
-1. Checks if inbox was polled within the last 5 minutes — if so, exits silently
-2. Calls `get_inbox` for unread messages
-3. Updates the `last-inbox-check` timestamp in `.pcp/runtime/`
+
+1. Marks runtime phase as `runtime:generating` via `update_session_phase(sessionId, phase)`
+2. Checks if inbox was polled within the last 5 minutes — if so, exits silently
+3. Calls `get_inbox` for unread messages
+4. Updates the `last-inbox-check` timestamp in `.pcp/runtime/`
 
 **Output (only if messages exist and inbox is stale):**
+
 ```
 <pcp-inbox count="{count}">
 - **{from}**: {content or subject}
@@ -126,14 +134,17 @@ Agent: {agentId}
 
 ### `on-stop`
 
-**When:** After each agent tool call / turn (Claude Code: Stop, Codex/Gemini: session_end).
+**When:** After each agent tool call / turn (Claude Code: Stop, Codex: session_end, Gemini: AfterAgent).
 
 **What it does:**
-1. Increments tool call counter in `.pcp/runtime/tool-count`
-2. Every 30 tool calls, outputs a nudge to log session progress
-3. If inbox is stale (>5 minutes), checks for new messages
+
+1. Marks runtime phase as `runtime:idle` via `update_session_phase(sessionId, phase)`
+2. Increments tool call counter in `.pcp/runtime/tool-count`
+3. Every 30 tool calls, outputs a nudge to log session progress
+4. If inbox is stale (>5 minutes), checks for new messages
 
 **Output (conditional):**
+
 ```
 <pcp-reminder>
 You have completed ~{count} tool calls this session. Consider using
@@ -150,13 +161,13 @@ You have completed ~{count} tool calls this session. Consider using
 
 Hooks store ephemeral state in `.pcp/runtime/` (gitignored):
 
-| File | Purpose |
-|------|---------|
-| `sessions.json` | Runtime session registry (list of PCP sessions + backend session IDs + current pointer) |
-| `pcp-session-id` | Current PCP session UUID (legacy convenience file) |
-| `session-id` | Backend session ID from on-session-start (legacy convenience file) |
-| `last-inbox-check` | ISO timestamp of last inbox poll |
-| `tool-count` | Cumulative tool call counter for on-stop nudges |
+| File               | Purpose                                                                                 |
+| ------------------ | --------------------------------------------------------------------------------------- |
+| `sessions.json`    | Runtime session registry (list of PCP sessions + backend session IDs + current pointer) |
+| `pcp-session-id`   | Current PCP session UUID (legacy convenience file)                                      |
+| `session-id`       | Backend session ID from on-session-start (legacy convenience file)                      |
+| `last-inbox-check` | ISO timestamp of last inbox poll                                                        |
+| `tool-count`       | Cumulative tool call counter for on-stop nudges                                         |
 
 ## Installation
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -35,6 +35,7 @@ cp .env.example .env.local
 ```
 
 Key variables:
+
 - `SUPABASE_URL` — your Supabase project URL
 - `SUPABASE_PUBLISHABLE_KEY` — the anon/public key
 - `SUPABASE_SECRET_KEY` — the service role key
@@ -69,6 +70,7 @@ sb init
 ```
 
 This does everything for a single worktree:
+
 - Creates `.pcp/` directory
 - Creates `.mcp.json` with PCP server entry (including auth header)
 - Installs lifecycle hooks for the detected backend (Claude Code, Codex, or Gemini)
@@ -173,12 +175,12 @@ echo "explain this" | sb        # Pipe input as prompt
 
 ### SB Options
 
-| Flag | Description | Default |
-|------|-------------|---------|
-| `-a, --agent <id>` | Agent identity | from `.pcp/identity.json` |
-| `-b, --backend <name>` | AI backend | from `.pcp/identity.json`, or `claude` |
-| `--no-session` | Disable session tracking | enabled |
-| `-v, --verbose` | Show debug output | off |
+| Flag                   | Description              | Default                                |
+| ---------------------- | ------------------------ | -------------------------------------- |
+| `-a, --agent <id>`     | Agent identity           | from `.pcp/identity.json`              |
+| `-b, --backend <name>` | AI backend               | from `.pcp/identity.json`, or `claude` |
+| `--no-session`         | Disable session tracking | enabled                                |
+| `-v, --verbose`        | Show debug output        | off                                    |
 
 Any flag not listed above is forwarded to the backend.
 
@@ -203,6 +205,7 @@ The agent ID is resolved in order:
 4. Error — run `sb init` or `sb awaken` to configure identity
 
 The backend is resolved similarly:
+
 1. `-b` / `--backend` flag
 2. `.pcp/identity.json` → `backend` field
 3. Default: `claude`
@@ -263,13 +266,13 @@ Hooks are installed to **local-only** config by default (e.g., `.claude/settings
 
 **Hook events:**
 
-| PCP Event          | What it does                   | Claude Code        | Codex              | Gemini          |
-| ------------------ | ------------------------------ | ------------------ | ------------------ | --------------- |
-| `on-session-start` | Bootstrap identity + inbox     | `SessionStart`     | `session_start`    | `SessionStart`  |
-| `pre-compact`      | Save context before compaction | `PreCompact`       | —                  | `PreCompress`   |
-| `post-compact`     | Re-bootstrap after compaction  | `SessionStart`     | —                  | —               |
-| `on-prompt`        | Periodic inbox check           | `UserPromptSubmit` | `user_prompt`      | —               |
-| `on-stop`          | Session nudge + inbox check    | `Stop`             | `session_end`      | `AfterAgent`    |
+| PCP Event          | What it does                   | Claude Code        | Codex           | Gemini         |
+| ------------------ | ------------------------------ | ------------------ | --------------- | -------------- |
+| `on-session-start` | Bootstrap identity + inbox     | `SessionStart`     | `session_start` | `SessionStart` |
+| `pre-compact`      | Save context before compaction | `PreCompact`       | —               | `PreCompress`  |
+| `post-compact`     | Re-bootstrap after compaction  | `SessionStart`     | —               | —              |
+| `on-prompt`        | Periodic inbox check           | `UserPromptSubmit` | `user_prompt`   | `BeforeAgent`  |
+| `on-stop`          | Session nudge + inbox check    | `Stop`             | `session_end`   | `AfterAgent`   |
 
 ### Sessions (`sb session`)
 
@@ -296,12 +299,14 @@ sb workspace members [ws]       # List workspace members
 ```
 
 Options for `create`:
+
 - `--type <type>` — Workspace type: `personal` or `team` (default: team)
 - `--description <desc>` — Workspace description
 - `--slug <slug>` — URL-friendly slug
 - `--use` — Select the created workspace immediately
 
 Options for `invite`:
+
 - `--role <role>` — Role: `owner`, `admin`, `member`, or `viewer` (default: member)
 
 ## Environment Variables

--- a/packages/cli/src/commands/hooks.test.ts
+++ b/packages/cli/src/commands/hooks.test.ts
@@ -194,9 +194,10 @@ describe('installHooks: Gemini', () => {
     expect(existsSync(configPath)).toBe(true);
 
     const config = JSON.parse(readFileSync(configPath, 'utf-8'));
-    expect(config.hooks.SessionStart[0].command).toContain('sb hooks on-session-start');
-    expect(config.hooks.AfterAgent[0].command).toContain('sb hooks on-stop');
-    expect(config.hooks.PreCompress[0].command).toContain('sb hooks pre-compact');
+    expect(config.hooks.SessionStart[0].hooks[0].command).toContain('sb hooks on-session-start');
+    expect(config.hooks.BeforeAgent[0].hooks[0].command).toContain('sb hooks on-prompt');
+    expect(config.hooks.AfterAgent[0].hooks[0].command).toContain('sb hooks on-stop');
+    expect(config.hooks.PreCompress[0].hooks[0].command).toContain('sb hooks pre-compact');
   });
 
   it('should preserve existing Gemini settings', () => {

--- a/packages/cli/src/commands/hooks.ts
+++ b/packages/cli/src/commands/hooks.ts
@@ -23,7 +23,11 @@ import { fileURLToPath } from 'url';
 import { execSync } from 'child_process';
 import { homedir } from 'os';
 import { resolveAgentId, readIdentityJson } from '../backends/identity.js';
-import { setCurrentRuntimeSession, upsertRuntimeSession } from '../session/runtime.js';
+import {
+  getCurrentRuntimeSession,
+  setCurrentRuntimeSession,
+  upsertRuntimeSession,
+} from '../session/runtime.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -85,11 +89,11 @@ const GEMINI: HookCapabilities = {
     sessionStart: 'SessionStart',
     preCompact: 'PreCompress',
     postCompact: null,
-    onPrompt: null,
+    onPrompt: 'BeforeAgent',
     onStop: 'AfterAgent',
   },
   supportsCompaction: true,
-  supportsPromptHook: false,
+  supportsPromptHook: true,
 };
 
 interface PcpConfig {
@@ -279,6 +283,48 @@ function readRuntimeFile(cwd: string, filename: string): string | null {
 function writeRuntimeFile(cwd: string, filename: string, content: string): void {
   const dir = ensureRuntimeDir(cwd);
   writeFileSync(join(dir, filename), content);
+}
+
+function normalizeSessionBackend(backendName: string): string {
+  // Hook backend names and session/backend adapter names differ for Claude:
+  // - hooks backend: "claude-code"
+  // - session/backend adapter: "claude"
+  return backendName === 'claude-code' ? 'claude' : backendName;
+}
+
+function resolveActivePcpSessionId(cwd: string): string | undefined {
+  const detectedBackend = detectBackend(cwd);
+  const sessionBackend = normalizeSessionBackend(detectedBackend.name);
+
+  const current = getCurrentRuntimeSession(cwd, sessionBackend);
+  if (current?.pcpSessionId) return current.pcpSessionId;
+
+  const fromLegacyFile = readRuntimeFile(cwd, 'pcp-session-id');
+  if (fromLegacyFile) return fromLegacyFile;
+
+  return undefined;
+}
+
+async function updateRuntimeGenerationState(
+  cwd: string,
+  config: PcpConfig | null,
+  agentId: string,
+  phase: string
+): Promise<void> {
+  const sessionId = resolveActivePcpSessionId(cwd);
+  if (!sessionId) return;
+
+  try {
+    await callPcpTool('update_session_phase', {
+      email: config?.email,
+      agentId,
+      sessionId,
+      phase,
+      status: 'active',
+    });
+  } catch {
+    // Non-fatal; hook execution should not fail due to transient session sync issues.
+  }
 }
 
 function extractBackendSessionId(stdin: Record<string, unknown>): string | undefined {
@@ -506,9 +552,40 @@ function installGemini(cwd: string, force: boolean): InstallResult {
 
   const sbPath = resolveSbBinaryPath(cwd);
   const pcpHooks: Record<string, unknown> = {
-    [GEMINI.events.sessionStart!]: [{ command: `${sbPath} hooks on-session-start` }],
-    [GEMINI.events.onStop!]: [{ command: `${sbPath} hooks on-stop` }],
-    [GEMINI.events.preCompact!]: [{ command: `${sbPath} hooks pre-compact` }],
+    [GEMINI.events.sessionStart!]: [
+      { hooks: [{ type: 'command', command: `${sbPath} hooks on-session-start` }] },
+    ],
+    [GEMINI.events.onPrompt!]: [
+      { hooks: [{ type: 'command', command: `${sbPath} hooks on-prompt` }] },
+    ],
+    [GEMINI.events.onStop!]: [{ hooks: [{ type: 'command', command: `${sbPath} hooks on-stop` }] }],
+    [GEMINI.events.preCompact!]: [
+      { hooks: [{ type: 'command', command: `${sbPath} hooks pre-compact` }] },
+    ],
+  };
+
+  const entryHasCommand = (entry: unknown, targetCommand: string): boolean => {
+    if (!entry || typeof entry !== 'object') return false;
+    const entryObj = entry as Record<string, unknown>;
+    if (typeof entryObj.command === 'string') {
+      return entryObj.command === targetCommand;
+    }
+    const hooks = entryObj.hooks as Array<Record<string, unknown>> | undefined;
+    if (!Array.isArray(hooks)) return false;
+    return hooks.some((h) => h && typeof h.command === 'string' && h.command === targetCommand);
+  };
+
+  const entryHasNonPcpCommand = (entry: unknown): boolean => {
+    if (!entry || typeof entry !== 'object') return false;
+    const entryObj = entry as Record<string, unknown>;
+    if (typeof entryObj.command === 'string') {
+      return !isPcpHookCommand(entryObj.command);
+    }
+    const hooks = entryObj.hooks as Array<Record<string, unknown>> | undefined;
+    if (!Array.isArray(hooks)) return false;
+    return hooks.some(
+      (h) => h && typeof h.command === 'string' && !isPcpHookCommand(h.command as string)
+    );
   };
 
   if (existing.hooks && !force) {
@@ -517,8 +594,13 @@ function installGemini(cwd: string, force: boolean): InstallResult {
     const allPresent = Object.entries(pcpHooks).every(([event, targetEntries]) => {
       const existingEntries = hooksObj[event];
       if (!Array.isArray(existingEntries)) return false;
-      const targetCmd = (targetEntries as any)[0].command;
-      return existingEntries.some((h: any) => h.command === targetCmd);
+      const targetCmd = (
+        (targetEntries as Array<Record<string, unknown>>)[0]?.hooks as
+          | Array<Record<string, unknown>>
+          | undefined
+      )?.[0]?.command as string | undefined;
+      if (!targetCmd) return false;
+      return existingEntries.some((entry) => entryHasCommand(entry, targetCmd));
     });
 
     if (allPresent) {
@@ -529,7 +611,7 @@ function installGemini(cwd: string, force: boolean): InstallResult {
     const hasConflict = Object.keys(pcpHooks).some((event) => {
       const entries = hooksObj[event];
       if (!Array.isArray(entries)) return false;
-      return entries.some((h: any) => !isPcpHookCommand(h.command));
+      return entries.some((entry) => entryHasNonPcpCommand(entry));
     });
 
     if (hasConflict) {
@@ -540,7 +622,7 @@ function installGemini(cwd: string, force: boolean): InstallResult {
   const merged = {
     ...existing,
     hooks: {
-      ...(existing.hooks as Record<string, unknown> || {}),
+      ...((existing.hooks as Record<string, unknown>) || {}),
       ...pcpHooks,
     },
   };
@@ -890,7 +972,8 @@ async function postCompactHandler(): Promise<void> {
     });
     identityBlock = buildIdentityBlock(bootstrap.identity);
   } catch {
-    identityBlock = '*FAILED: Could not reach PCP server for `bootstrap`. You should call the `bootstrap` MCP tool manually to reload your identity context.*';
+    identityBlock =
+      '*FAILED: Could not reach PCP server for `bootstrap`. You should call the `bootstrap` MCP tool manually to reload your identity context.*';
   }
 
   // Check inbox
@@ -902,7 +985,8 @@ async function postCompactHandler(): Promise<void> {
     inboxBlock = buildInboxBlock(inbox.messages as Array<Record<string, unknown>> | undefined);
     writeRuntimeFile(cwd, 'last-inbox-check', new Date().toISOString());
   } catch {
-    inboxBlock = '*FAILED: Could not reach PCP server for `get_inbox`. You should call the `get_inbox` MCP tool manually to check for messages.*';
+    inboxBlock =
+      '*FAILED: Could not reach PCP server for `get_inbox`. You should call the `get_inbox` MCP tool manually to check for messages.*';
   }
 
   const template = loadTemplate('hook-post-compact');
@@ -963,7 +1047,8 @@ async function onSessionStartHandler(): Promise<void> {
       bootstrap.activeSessions as Array<Record<string, unknown>> | undefined
     );
   } catch {
-    identityBlock = '*FAILED: Could not reach PCP server for `bootstrap`. You should call the `bootstrap` MCP tool manually to reload your identity context.*';
+    identityBlock =
+      '*FAILED: Could not reach PCP server for `bootstrap`. You should call the `bootstrap` MCP tool manually to reload your identity context.*';
   }
 
   // Check inbox
@@ -975,15 +1060,13 @@ async function onSessionStartHandler(): Promise<void> {
     inboxBlock = buildInboxBlock(inbox.messages as Array<Record<string, unknown>> | undefined);
     writeRuntimeFile(cwd, 'last-inbox-check', new Date().toISOString());
   } catch {
-    inboxBlock = '*FAILED: Could not reach PCP server for `get_inbox`. You should call the `get_inbox` MCP tool manually to check for messages.*';
+    inboxBlock =
+      '*FAILED: Could not reach PCP server for `get_inbox`. You should call the `get_inbox` MCP tool manually to check for messages.*';
   }
 
   // Register PCP session with detected backend
   const detectedBackend = detectBackend(cwd);
-  // Hook backend names and session backend names differ for Claude:
-  // - hooks backend: "claude-code"
-  // - session/backend adapter: "claude"
-  const sessionBackend = detectedBackend.name === 'claude-code' ? 'claude' : detectedBackend.name;
+  const sessionBackend = normalizeSessionBackend(detectedBackend.name);
   let pcpSessionId: string | undefined;
   let pcpThreadKey: string | undefined;
   const backendSessionId = extractBackendSessionId(stdin);
@@ -1040,16 +1123,19 @@ async function onSessionStartHandler(): Promise<void> {
     });
   }
 
-  // Link backend-specific session id to the PCP session for deterministic routing/resume.
-  if (pcpSessionId && backendSessionId) {
+  // Keep an explicit runtime phase for dashboard "generating vs idle" visualization.
+  // Startup phase should always settle to idle.
+  if (pcpSessionId) {
     try {
-      await callPcpTool('update_session_phase', {
+      const updateArgs: Record<string, unknown> = {
         email: config?.email,
         agentId,
         sessionId: pcpSessionId,
-        backendSessionId,
+        phase: 'runtime:idle',
         status: 'active',
-      });
+      };
+      if (backendSessionId) updateArgs.backendSessionId = backendSessionId;
+      await callPcpTool('update_session_phase', updateArgs);
     } catch {
       // Non-fatal; startup should continue even if linkage fails.
     }
@@ -1074,6 +1160,9 @@ async function onPromptHandler(): Promise<void> {
   const cwd = process.cwd();
   const config = getPcpConfig();
   const agentId = resolveAgentId() || 'unknown';
+
+  // Mark session as actively generating at prompt start.
+  await updateRuntimeGenerationState(cwd, config, agentId, 'runtime:generating');
 
   // Check if inbox check is stale (> 5 minutes)
   const lastCheck = readRuntimeFile(cwd, 'last-inbox-check');
@@ -1114,6 +1203,9 @@ async function onStopHandler(): Promise<void> {
   const config = getPcpConfig();
   const agentId = resolveAgentId() || 'unknown';
   const parts: string[] = [];
+
+  // Mark session as idle after each completed backend turn.
+  await updateRuntimeGenerationState(cwd, config, agentId, 'runtime:idle');
 
   // Increment tool call counter
   const countStr = readRuntimeFile(cwd, 'tool-count');

--- a/packages/web/src/app/(dashboard)/page.tsx
+++ b/packages/web/src/app/(dashboard)/page.tsx
@@ -67,6 +67,67 @@ function isBlocked(session: Session): boolean {
   return session.currentPhase?.startsWith('blocked') ?? false;
 }
 
+function isGenerating(session: Session): boolean {
+  return session.currentPhase === 'runtime:generating';
+}
+
+function isRuntimeIdle(session: Session): boolean {
+  return session.currentPhase === 'runtime:idle';
+}
+
+function getSessionStatusBadge(session: Session): {
+  label: string;
+  badgeClass: string;
+  cardClass: string;
+} {
+  if (isBlocked(session)) {
+    return {
+      label: 'Blocked',
+      badgeClass: 'bg-amber-100 text-amber-700',
+      cardClass: 'border-amber-300 bg-amber-50/50',
+    };
+  }
+  if (session.status === 'paused') {
+    return {
+      label: 'Paused',
+      badgeClass: 'bg-gray-100 text-gray-600',
+      cardClass: 'border-gray-200',
+    };
+  }
+  if (isGenerating(session)) {
+    return {
+      label: 'Generating',
+      badgeClass: 'bg-blue-100 text-blue-700',
+      cardClass: 'border-blue-200 bg-blue-50/50',
+    };
+  }
+  if (isRuntimeIdle(session)) {
+    return {
+      label: 'Idle',
+      badgeClass: 'bg-green-100 text-green-700',
+      cardClass: 'border-green-200 bg-green-50/50',
+    };
+  }
+  if (session.status === 'active') {
+    return {
+      label: 'Active',
+      badgeClass: 'bg-green-100 text-green-700',
+      cardClass: 'border-green-200 bg-green-50/50',
+    };
+  }
+  return {
+    label: session.status,
+    badgeClass: 'bg-gray-100 text-gray-600',
+    cardClass: 'border-gray-200',
+  };
+}
+
+function phasePreviewLabel(phase: string | null): string | null {
+  if (!phase) return null;
+  if (phase.startsWith('runtime:')) return phase.replace('runtime:', 'Runtime: ');
+  return phase;
+}
+
 const quickLinks = [
   {
     name: 'Sessions',
@@ -101,20 +162,25 @@ const quickLinks = [
 ];
 
 export default function DashboardPage() {
-  const { data, isLoading } = useApiQuery<SessionsResponse>(
-    ['sessions'],
-    '/api/admin/sessions',
-    { refetchInterval: 30000 }
-  );
+  const { data, isLoading } = useApiQuery<SessionsResponse>(['sessions'], '/api/admin/sessions', {
+    refetchInterval: 30000,
+  });
 
   const sessions = data?.sessions ?? [];
 
   // Sort: blocked first, then active, then paused — then by updatedAt
   const previewSessions = [...sessions]
     .sort((a, b) => {
-      const aBlocked = isBlocked(a) ? 0 : 1;
-      const bBlocked = isBlocked(b) ? 0 : 1;
-      if (aBlocked !== bBlocked) return aBlocked - bBlocked;
+      const sessionPriority = (session: Session): number => {
+        if (isBlocked(session)) return 0;
+        if (isGenerating(session)) return 1;
+        if (isRuntimeIdle(session)) return 2;
+        if (session.status === 'active') return 3;
+        if (session.status === 'paused') return 4;
+        return 5;
+      };
+      const priorityDiff = sessionPriority(a) - sessionPriority(b);
+      if (priorityDiff !== 0) return priorityDiff;
       return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
     })
     .slice(0, 4);
@@ -142,7 +208,10 @@ export default function DashboardPage() {
         {isLoading ? (
           <div className="grid gap-3 sm:grid-cols-2">
             {[1, 2].map((i) => (
-              <div key={i} className="h-20 rounded-lg border border-gray-200 bg-gray-50 animate-pulse" />
+              <div
+                key={i}
+                className="h-20 rounded-lg border border-gray-200 bg-gray-50 animate-pulse"
+              />
             ))}
           </div>
         ) : previewSessions.length === 0 ? (
@@ -155,17 +224,15 @@ export default function DashboardPage() {
         ) : (
           <div className="grid gap-3 sm:grid-cols-2">
             {previewSessions.map((session) => {
-              const blocked = isBlocked(session);
-              const active = session.status === 'active' && !blocked;
+              const badge = getSessionStatusBadge(session);
+              const phaseLabel = phasePreviewLabel(session.currentPhase);
 
               return (
                 <Link key={session.id} href="/sessions">
                   <div
                     className={clsx(
                       'rounded-lg border p-3 hover:shadow-md transition-shadow cursor-pointer',
-                      blocked && 'border-amber-300 bg-amber-50/50',
-                      active && 'border-green-200 bg-green-50/50',
-                      !blocked && !active && 'border-gray-200'
+                      badge.cardClass
                     )}
                   >
                     <div className="flex items-center justify-between">
@@ -173,30 +240,16 @@ export default function DashboardPage() {
                         <span className="font-medium text-gray-900 truncate">
                           {session.agentName}
                         </span>
-                        <Badge
-                          className={clsx(
-                            'text-xs shrink-0',
-                            blocked && 'bg-amber-100 text-amber-700',
-                            active && 'bg-green-100 text-green-700',
-                            !blocked && !active && 'bg-gray-100 text-gray-600'
-                          )}
-                        >
-                          {blocked ? 'Blocked' : session.status}
+                        <Badge className={clsx('text-xs shrink-0', badge.badgeClass)}>
+                          {badge.label}
                         </Badge>
                       </div>
                       <span className="text-xs text-gray-400 shrink-0 ml-2">
                         {formatRelativeTime(session.updatedAt)}
                       </span>
                     </div>
-                    {session.currentPhase && (
-                      <p
-                        className={clsx(
-                          'text-xs mt-1 truncate',
-                          blocked ? 'text-amber-600' : 'text-gray-500'
-                        )}
-                      >
-                        {session.currentPhase}
-                      </p>
+                    {phaseLabel && (
+                      <p className="text-xs mt-1 truncate text-gray-500">{phaseLabel}</p>
                     )}
                     {session.workspace?.branch && (
                       <div className="flex items-center gap-1 mt-1 text-xs text-gray-400">

--- a/packages/web/src/app/(dashboard)/sessions/[sessionId]/page.tsx
+++ b/packages/web/src/app/(dashboard)/sessions/[sessionId]/page.tsx
@@ -54,6 +54,36 @@ function formatDate(date: string): string {
   return new Date(date).toLocaleString();
 }
 
+function isGenerating(phase: string | null): boolean {
+  return phase === 'runtime:generating';
+}
+
+function isRuntimeIdle(phase: string | null): boolean {
+  return phase === 'runtime:idle';
+}
+
+function isBlocked(phase: string | null): boolean {
+  return phase?.startsWith('blocked') ?? false;
+}
+
+function sessionStatusBadge(
+  status: string,
+  phase: string | null
+): { label: string; className: string } {
+  if (isBlocked(phase)) return { label: 'Blocked', className: 'bg-amber-100 text-amber-700' };
+  if (status === 'paused') return { label: 'Paused', className: 'bg-gray-100 text-gray-600' };
+  if (isGenerating(phase)) return { label: 'Generating', className: 'bg-blue-100 text-blue-700' };
+  if (isRuntimeIdle(phase)) return { label: 'Idle', className: 'bg-green-100 text-green-700' };
+  if (status === 'active') return { label: 'Active', className: 'bg-green-100 text-green-700' };
+  return { label: status, className: 'bg-gray-100 text-gray-600' };
+}
+
+function formatPhaseLabel(phase: string | null): string | null {
+  if (!phase) return null;
+  if (!phase.startsWith('runtime:')) return phase;
+  return `Runtime: ${phase.replace('runtime:', '')}`;
+}
+
 function safeJsonParse(input: string): unknown | null {
   try {
     return JSON.parse(input);
@@ -182,6 +212,8 @@ export default function SessionLogsPage() {
   const logs = data?.logs || [];
   const pagination = data?.pagination;
   const session = data?.session;
+  const statusBadge = session ? sessionStatusBadge(session.status, session.currentPhase) : null;
+  const phaseLabel = formatPhaseLabel(session?.currentPhase || null);
 
   return (
     <div>
@@ -197,11 +229,25 @@ export default function SessionLogsPage() {
       <div className="mb-6">
         <h1 className="text-3xl font-bold text-gray-900">Session Log</h1>
         {session && (
-          <p className="mt-2 text-gray-600">
-            <span className="font-medium">{session.agentId}</span> ·{' '}
-            {session.backend || 'unknown backend'}
-            {session.backendSessionId ? ` · ${session.backendSessionId}` : ''}
-          </p>
+          <div className="mt-2 flex flex-wrap items-center gap-2 text-gray-600">
+            <span className="font-medium">{session.agentId}</span>
+            <span>·</span>
+            <span>{session.backend || 'unknown backend'}</span>
+            {statusBadge ? (
+              <Badge className={clsx('text-xs', statusBadge.className)}>{statusBadge.label}</Badge>
+            ) : null}
+            {phaseLabel ? (
+              <Badge variant="outline" className="text-xs">
+                {phaseLabel}
+              </Badge>
+            ) : null}
+            {session.backendSessionId ? (
+              <>
+                <span>·</span>
+                <code className="font-mono text-xs">{session.backendSessionId}</code>
+              </>
+            ) : null}
+          </div>
         )}
       </div>
 

--- a/packages/web/src/app/(dashboard)/sessions/page.tsx
+++ b/packages/web/src/app/(dashboard)/sessions/page.tsx
@@ -8,6 +8,7 @@ import {
   Activity,
   AlertTriangle,
   Pause,
+  CircleDot,
   Monitor,
   GitBranch,
   ChevronDown,
@@ -78,22 +79,87 @@ function isBlocked(session: Session): boolean {
   return session.currentPhase?.startsWith('blocked') ?? false;
 }
 
+function isGenerating(session: Session): boolean {
+  return session.currentPhase === 'runtime:generating';
+}
+
+function isRuntimeIdle(session: Session): boolean {
+  return session.currentPhase === 'runtime:idle';
+}
+
+function formatPhaseLabel(phase: string | null): string | null {
+  if (!phase) return null;
+  if (!phase.startsWith('runtime:')) return phase;
+  const runtimeState = phase.replace('runtime:', '');
+  return `Runtime: ${runtimeState}`;
+}
+
+function getSessionState(session: Session): {
+  label: string;
+  cardClass: string;
+  badgeClass: string;
+  phaseClass: string;
+} {
+  if (isBlocked(session)) {
+    return {
+      label: 'Blocked',
+      cardClass: 'border-amber-300 bg-amber-50/50',
+      badgeClass: 'bg-amber-100 text-amber-700',
+      phaseClass: 'font-medium text-amber-700',
+    };
+  }
+
+  if (session.status === 'paused') {
+    return {
+      label: 'Paused',
+      cardClass: 'border-gray-200',
+      badgeClass: 'bg-gray-100 text-gray-600',
+      phaseClass: 'text-gray-600',
+    };
+  }
+
+  if (isGenerating(session)) {
+    return {
+      label: 'Generating',
+      cardClass: 'border-blue-200 bg-blue-50/50',
+      badgeClass: 'bg-blue-100 text-blue-700',
+      phaseClass: 'font-medium text-blue-700',
+    };
+  }
+
+  if (isRuntimeIdle(session)) {
+    return {
+      label: 'Idle',
+      cardClass: 'border-green-200 bg-green-50/50',
+      badgeClass: 'bg-green-100 text-green-700',
+      phaseClass: 'text-green-700',
+    };
+  }
+
+  if (session.status === 'active') {
+    return {
+      label: 'Active',
+      cardClass: 'border-green-200 bg-green-50/50',
+      badgeClass: 'bg-green-100 text-green-700',
+      phaseClass: 'text-gray-600',
+    };
+  }
+
+  return {
+    label: session.status,
+    cardClass: 'border-gray-200',
+    badgeClass: 'bg-gray-100 text-gray-600',
+    phaseClass: 'text-gray-600',
+  };
+}
+
 function SessionCard({ session }: { session: Session }) {
   const [expanded, setExpanded] = useState(false);
-  const blocked = isBlocked(session);
-  const active = session.status === 'active' && !blocked;
-  const paused = session.status === 'paused';
+  const state = getSessionState(session);
+  const phaseLabel = formatPhaseLabel(session.currentPhase);
 
   return (
-    <div
-      className={clsx(
-        'rounded-lg border p-4',
-        blocked && 'border-amber-300 bg-amber-50/50',
-        active && 'border-green-200 bg-green-50/50',
-        paused && 'border-gray-200',
-        !blocked && !active && !paused && 'border-gray-200'
-      )}
-    >
+    <div className={clsx('rounded-lg border p-4', state.cardClass)}>
       <div className="flex items-start justify-between">
         <div className="flex-1">
           <div className="flex items-center gap-2 flex-wrap">
@@ -101,30 +167,11 @@ function SessionCard({ session }: { session: Session }) {
             <Badge variant="outline" className="text-xs font-mono">
               {session.agentId}
             </Badge>
-            <Badge
-              className={clsx(
-                'text-xs',
-                blocked && 'bg-amber-100 text-amber-700',
-                active && 'bg-green-100 text-green-700',
-                paused && 'bg-gray-100 text-gray-600',
-                !blocked && !active && !paused && 'bg-gray-100 text-gray-600'
-              )}
-            >
-              {blocked ? 'Blocked' : session.status}
-            </Badge>
+            <Badge className={clsx('text-xs', state.badgeClass)}>{state.label}</Badge>
           </div>
 
           {/* Phase - prominent for blocked sessions */}
-          {session.currentPhase && (
-            <p
-              className={clsx(
-                'text-sm mt-1',
-                blocked ? 'font-medium text-amber-700' : 'text-gray-600'
-              )}
-            >
-              {session.currentPhase}
-            </p>
-          )}
+          {phaseLabel && <p className={clsx('text-sm mt-1', state.phaseClass)}>{phaseLabel}</p>}
 
           {/* Context / Summary */}
           {session.context && (
@@ -189,9 +236,7 @@ function SessionCard({ session }: { session: Session }) {
         </div>
         <div className="text-right text-sm shrink-0 ml-4">
           <div className="text-xs text-gray-400">Updated</div>
-          <div className="font-medium text-gray-700">
-            {formatRelativeTime(session.updatedAt)}
-          </div>
+          <div className="font-medium text-gray-700">{formatRelativeTime(session.updatedAt)}</div>
           <div className="text-xs text-gray-400 mt-1">
             Started {formatRelativeTime(session.startedAt)}
           </div>
@@ -203,9 +248,7 @@ function SessionCard({ session }: { session: Session }) {
         onClick={() => setExpanded(!expanded)}
         className="flex items-center gap-1 mt-3 text-xs text-gray-400 hover:text-gray-600 transition-colors"
       >
-        <ChevronDown
-          className={clsx('h-3 w-3 transition-transform', expanded && 'rotate-180')}
-        />
+        <ChevronDown className={clsx('h-3 w-3 transition-transform', expanded && 'rotate-180')} />
         {expanded ? 'Hide details' : 'Show details'}
       </button>
 
@@ -301,6 +344,8 @@ export default function SessionsPage() {
 
   const stats = data?.stats ?? { active: 0, blocked: 0, paused: 0, total: 0 };
   const sessions = data?.sessions ?? [];
+  const generatingCount = sessions.filter((session) => isGenerating(session)).length;
+  const idleCount = sessions.filter((session) => isRuntimeIdle(session)).length;
 
   return (
     <div>
@@ -316,12 +361,19 @@ export default function SessionsPage() {
       {error && <div className="mt-4 rounded-md bg-red-50 p-4 text-red-800">{error.message}</div>}
 
       {/* Stats */}
-      <div className="grid grid-cols-4 gap-4 mt-6">
+      <div className="grid grid-cols-2 md:grid-cols-5 gap-4 mt-6">
         <Card>
           <CardContent className="p-4 text-center">
-            <Activity className="h-5 w-5 mx-auto text-green-600 mb-1" />
-            <div className="text-2xl font-bold text-green-600">{stats.active}</div>
-            <div className="text-xs text-gray-500">Active</div>
+            <Activity className="h-5 w-5 mx-auto text-blue-600 mb-1" />
+            <div className="text-2xl font-bold text-blue-600">{generatingCount}</div>
+            <div className="text-xs text-gray-500">Generating</div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-4 text-center">
+            <CircleDot className="h-5 w-5 mx-auto text-green-600 mb-1" />
+            <div className="text-2xl font-bold text-green-600">{idleCount}</div>
+            <div className="text-xs text-gray-500">Runtime Idle</div>
           </CardContent>
         </Card>
         <Card>


### PR DESCRIPTION
## Summary
- track runtime generation state by PCP `sessionId` in CLI hooks
  - `on-prompt` => `runtime:generating`
  - `on-stop` / session start => `runtime:idle`
- improve Gemini hook integration
  - use `BeforeAgent` for prompt hook
  - write schema-compliant nested `hooks` entries
  - handle both legacy + nested formats when detecting existing hooks
- fix admin sessions payload backend session mapping
  - `backendSessionId` now uses `backend_session_id || claude_session_id`
- surface generating vs idle in dashboard/session UI pages
- fix admin reminders 500
  - remove invalid `workspace_id` filter on `scheduled_reminders`

## Validation
- `yarn workspace @personal-context/cli test src/commands/hooks.test.ts`
- `yarn workspace @personal-context/cli build`
- `yarn workspace @personal-context/web type-check`

## Notes
- Wren reviewed as merge-ready with non-blocking follow-ups (TTL/staleness and minor hardening/documentation nits).