### PR TITLE
fix: attach CLI auth token to hook HTTP requests (by Wren)

### DIFF
--- a/packages/cli/src/commands/hooks.test.ts
+++ b/packages/cli/src/commands/hooks.test.ts
@@ -5,11 +5,11 @@
  * idempotency, conflict detection, and uninstall.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { existsSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { installHooks } from './hooks.js';
+import { installHooks, callPcpTool } from './hooks.js';
 
 const TEST_DIR = join(tmpdir(), 'pcp-hooks-test-' + Date.now());
 
@@ -348,5 +348,74 @@ describe('installHooks: detection priority', () => {
     mkdirSync(join(TEST_DIR, '.codex'), { recursive: true });
     const { backend } = installHooks(TEST_DIR);
     expect(backend.name).toBe('gemini');
+  });
+});
+
+// ============================================================================
+// callPcpTool auth header regression
+// ============================================================================
+
+vi.mock('../auth/tokens.js', () => ({
+  getValidAccessToken: vi.fn(),
+  loadAuth: vi.fn(),
+  isTokenExpired: vi.fn(),
+  decodeJwtPayload: vi.fn(),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import * as tokensMod from '../auth/tokens.js';
+const mockedGetValidAccessToken = vi.mocked(tokensMod.getValidAccessToken);
+
+describe('callPcpTool: auth header', () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        jsonrpc: '2.0',
+        result: { content: [{ text: '{"success":true}' }] },
+        id: 1,
+      }),
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('should send Authorization header when CLI token is available', async () => {
+    mockedGetValidAccessToken.mockResolvedValue('test-jwt-token');
+
+    await callPcpTool('bootstrap', { agentId: 'wren' });
+
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    const [, options] = fetchSpy.mock.calls[0];
+    expect(options.headers).toHaveProperty('Authorization', 'Bearer test-jwt-token');
+  });
+
+  it('should omit Authorization header when no token is available', async () => {
+    mockedGetValidAccessToken.mockResolvedValue(null);
+
+    await callPcpTool('bootstrap', { agentId: 'wren' });
+
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    const [, options] = fetchSpy.mock.calls[0];
+    expect(options.headers).not.toHaveProperty('Authorization');
+  });
+
+  it('should send correct JSON-RPC payload', async () => {
+    mockedGetValidAccessToken.mockResolvedValue('token');
+
+    await callPcpTool('get_inbox', { agentId: 'wren', status: 'unread' });
+
+    const [url, options] = fetchSpy.mock.calls[0];
+    expect(url).toContain('/mcp');
+    const body = JSON.parse(options.body);
+    expect(body.method).toBe('tools/call');
+    expect(body.params.name).toBe('get_inbox');
+    expect(body.params.arguments).toEqual({ agentId: 'wren', status: 'unread' });
   });
 });

--- a/packages/cli/src/commands/hooks.ts
+++ b/packages/cli/src/commands/hooks.ts
@@ -23,6 +23,7 @@ import { fileURLToPath } from 'url';
 import { execSync } from 'child_process';
 import { homedir } from 'os';
 import { resolveAgentId, readIdentityJson } from '../backends/identity.js';
+import { getValidAccessToken } from '../auth/tokens.js';
 import {
   getCurrentRuntimeSession,
   setCurrentRuntimeSession,
@@ -208,17 +209,27 @@ function getPcpServerUrl(): string {
 
 let jsonRpcId = 1;
 
-async function callPcpTool(
+export async function callPcpTool(
   tool: string,
   args: Record<string, unknown>
 ): Promise<Record<string, unknown>> {
-  const url = `${getPcpServerUrl()}/mcp`;
+  const serverUrl = getPcpServerUrl();
+  const url = `${serverUrl}/mcp`;
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    Accept: 'application/json',
+  };
+
+  // Attach CLI auth token so hooks pass OAuth checks on the MCP server
+  const token = await getValidAccessToken(serverUrl);
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+
   const response = await fetch(url, {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Accept: 'application/json',
-    },
+    headers,
     body: JSON.stringify({
       jsonrpc: '2.0',
       method: 'tools/call',


### PR DESCRIPTION
## Summary

- `callPcpTool()` in hooks.ts was making raw `fetch()` calls to the MCP server **without an Authorization header**
- The MCP server enforces OAuth by default (`MCP_REQUIRE_OAUTH=true`), so all hook calls silently failed with 401
- Now loads the JWT from `~/.pcp/auth.json` (same token `sb auth login` stores) via `getValidAccessToken()` and attaches it as a `Bearer` token
- Gracefully degrades when not logged in (no header sent, same behavior as before)

## Root cause

Claude Code's MCP SDK handles OAuth automatically (follows 401 → OAuth dance). But hooks run as shell commands (`sb hooks on-session-start`) and use raw `fetch()` — completely outside the MCP client. The CLI auth token existed in `~/.pcp/auth.json` but was never loaded or attached.

## Test plan

- [x] 3 new regression tests in `hooks.test.ts`:
  - Sends `Authorization: Bearer <token>` when CLI token is available
  - Omits Authorization header when no token available (graceful degradation)
  - Sends correct JSON-RPC payload structure
- [x] All 123 CLI tests pass
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)