### PR TITLE
feat(cli): reconcile backend/pcp session linkage from hook signals (by Lumen)

### DIFF
--- a/packages/cli/HOOKS.md
+++ b/packages/cli/HOOKS.md
@@ -169,6 +169,7 @@ Hooks store ephemeral state in `.pcp/runtime/` (gitignored):
 | `sessions.json`    | Runtime session registry (list of PCP sessions + backend session IDs/history + current pointer + runtimeLinkId correlation token) |
 | `pcp-session-id`   | Current PCP session UUID (legacy convenience file)                                      |
 | `session-id`       | Backend session ID from on-session-start (legacy convenience file)                      |
+| `runtime-link-id`  | Current run correlation token (`PCP_RUNTIME_LINK_ID`) for local reconciliation/debug    |
 | `last-inbox-check` | ISO timestamp of last inbox poll                                                        |
 | `tool-count`       | Cumulative tool call counter for on-stop nudges                                         |
 

--- a/packages/cli/HOOKS.md
+++ b/packages/cli/HOOKS.md
@@ -29,9 +29,10 @@ PCP hooks bridge coding agents (Claude Code, Codex, Gemini) with PCP's session, 
 2. Calls `bootstrap` with agentId and workspaceId
 3. Calls `get_inbox` for unread messages
 4. Resolves PCP session ID (`PCP_SESSION_ID` env from launcher, or `start_session` fallback)
-5. Stores runtime session state in `.pcp/runtime/sessions.json` (multi-session list + current pointer)
-6. Stores backend session ID in `.pcp/runtime/session-id` (legacy compatibility)
-7. Links backend session ID to PCP session via `update_session_phase(sessionId, backendSessionId)`
+5. Reconciles PCP/backend session linkage when backend session ID is available (prefers existing server-side backend-session match)
+6. Stores runtime session state in `.pcp/runtime/sessions.json` (multi-session list + current pointer + correlation link)
+7. Stores backend session ID in `.pcp/runtime/session-id` (legacy compatibility)
+8. Links backend session ID to PCP session via `update_session_phase(sessionId, backendSessionId)`
 
 **Output:**
 
@@ -117,9 +118,10 @@ Agent: {agentId}
 **What it does:**
 
 1. Marks runtime phase as `runtime:generating` via `update_session_phase(sessionId, phase)`
-2. Checks if inbox was polled within the last 5 minutes — if so, exits silently
-3. Calls `get_inbox` for unread messages
-4. Updates the `last-inbox-check` timestamp in `.pcp/runtime/`
+2. Reconciles backend session ID linkage if the hook payload includes a session ID
+3. Checks if inbox was polled within the last 5 minutes — if so, exits silently
+4. Calls `get_inbox` for unread messages
+5. Updates the `last-inbox-check` timestamp in `.pcp/runtime/`
 
 **Output (only if messages exist and inbox is stale):**
 
@@ -139,9 +141,10 @@ Agent: {agentId}
 **What it does:**
 
 1. Marks runtime phase as `runtime:idle` via `update_session_phase(sessionId, phase)`
-2. Increments tool call counter in `.pcp/runtime/tool-count`
-3. Every 30 tool calls, outputs a nudge to log session progress
-4. If inbox is stale (>5 minutes), checks for new messages
+2. Reconciles backend session ID linkage if the hook payload includes a session ID
+3. Increments tool call counter in `.pcp/runtime/tool-count`
+4. Every 30 tool calls, outputs a nudge to log session progress
+5. If inbox is stale (>5 minutes), checks for new messages
 
 **Output (conditional):**
 
@@ -163,7 +166,7 @@ Hooks store ephemeral state in `.pcp/runtime/` (gitignored):
 
 | File               | Purpose                                                                                 |
 | ------------------ | --------------------------------------------------------------------------------------- |
-| `sessions.json`    | Runtime session registry (list of PCP sessions + backend session IDs + current pointer) |
+| `sessions.json`    | Runtime session registry (list of PCP sessions + backend session IDs/history + current pointer + runtimeLinkId correlation token) |
 | `pcp-session-id`   | Current PCP session UUID (legacy convenience file)                                      |
 | `session-id`       | Backend session ID from on-session-start (legacy convenience file)                      |
 | `last-inbox-check` | ISO timestamp of last inbox poll                                                        |

--- a/packages/cli/HOOKS.md
+++ b/packages/cli/HOOKS.md
@@ -119,6 +119,7 @@ Agent: {agentId}
 
 1. Marks runtime phase as `runtime:generating` via `update_session_phase(sessionId, phase)`
 2. Reconciles backend session ID linkage if the hook payload includes a session ID
+   - short-circuits on local `sessions.json` if linkage is already known
 3. Checks if inbox was polled within the last 5 minutes — if so, exits silently
 4. Calls `get_inbox` for unread messages
 5. Updates the `last-inbox-check` timestamp in `.pcp/runtime/`
@@ -142,6 +143,7 @@ Agent: {agentId}
 
 1. Marks runtime phase as `runtime:idle` via `update_session_phase(sessionId, phase)`
 2. Reconciles backend session ID linkage if the hook payload includes a session ID
+   - short-circuits on local `sessions.json` if linkage is already known
 3. Increments tool call counter in `.pcp/runtime/tool-count`
 4. Every 30 tool calls, outputs a nudge to log session progress
 5. If inbox is stale (>5 minutes), checks for new messages

--- a/packages/cli/src/backends/identity.test.ts
+++ b/packages/cli/src/backends/identity.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { resolveAgentId } from './identity.js';
+
+describe('resolveAgentId', () => {
+  let originalHome: string | undefined;
+  let originalAgentEnv: string | undefined;
+  let originalBackendEnv: string | undefined;
+  let originalCwd: string;
+  let rootDir: string;
+  let workDir: string;
+
+  beforeEach(() => {
+    originalHome = process.env.HOME;
+    originalAgentEnv = process.env.AGENT_ID;
+    originalBackendEnv = process.env.SB_BACKEND;
+    originalCwd = process.cwd();
+
+    rootDir = mkdtempSync(join(tmpdir(), 'pcp-identity-'));
+    workDir = join(rootDir, 'work');
+    mkdirSync(workDir, { recursive: true });
+    process.chdir(workDir);
+
+    process.env.HOME = rootDir;
+    delete process.env.AGENT_ID;
+    delete process.env.SB_BACKEND;
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    if (originalAgentEnv === undefined) delete process.env.AGENT_ID;
+    else process.env.AGENT_ID = originalAgentEnv;
+    if (originalBackendEnv === undefined) delete process.env.SB_BACKEND;
+    else process.env.SB_BACKEND = originalBackendEnv;
+    rmSync(rootDir, { recursive: true, force: true });
+  });
+
+  it('prefers explicit CLI agent over env/config', () => {
+    process.env.AGENT_ID = 'env-agent';
+    expect(resolveAgentId('cli-agent', 'codex')).toBe('cli-agent');
+  });
+
+  it('uses AGENT_ID env when present', () => {
+    process.env.AGENT_ID = 'lumen';
+    expect(resolveAgentId(undefined, 'claude')).toBe('lumen');
+  });
+
+  it('uses local .pcp/identity.json when env is not set', () => {
+    mkdirSync(join(workDir, '.pcp'), { recursive: true });
+    writeFileSync(join(workDir, '.pcp', 'identity.json'), JSON.stringify({ agentId: 'aster' }));
+    expect(resolveAgentId(undefined, 'gemini')).toBe('aster');
+  });
+
+  it('uses backend-specific agentMapping fallback', () => {
+    mkdirSync(join(rootDir, '.pcp'), { recursive: true });
+    writeFileSync(
+      join(rootDir, '.pcp', 'config.json'),
+      JSON.stringify({
+        agentMapping: {
+          'claude-code': 'wren',
+          codex: 'lumen',
+          gemini: 'aster',
+        },
+      })
+    );
+
+    expect(resolveAgentId(undefined, 'codex')).toBe('lumen');
+    expect(resolveAgentId(undefined, 'gemini')).toBe('aster');
+    expect(resolveAgentId(undefined, 'claude')).toBe('wren');
+  });
+});
+

--- a/packages/cli/src/backends/identity.ts
+++ b/packages/cli/src/backends/identity.ts
@@ -44,13 +44,19 @@ export function readIdentityJson(cwd: string): IdentityJson | null {
 /**
  * Resolve agent ID from multiple sources:
  * 1. CLI --agent flag (if provided)
- * 2. .pcp/identity.json in current directory
- * 3. ~/.pcp/config.json agentMapping
- * 4. null (no identity configured)
+ * 2. AGENT_ID env var (propagated by sb launcher into backend/hook subprocesses)
+ * 3. .pcp/identity.json in current directory
+ * 4. ~/.pcp/config.json agentMapping (backend-aware when possible)
+ * 5. null (no identity configured)
  */
-export function resolveAgentId(cliAgent?: string): string | null {
+export function resolveAgentId(cliAgent?: string, backendHint?: string): string | null {
   if (cliAgent) {
     return cliAgent;
+  }
+
+  const envAgent = process.env.AGENT_ID?.trim();
+  if (envAgent) {
+    return envAgent;
   }
 
   // process.cwd() throws ENOENT if the working directory has been deleted
@@ -81,7 +87,29 @@ export function resolveAgentId(cliAgent?: string): string | null {
   if (existsSync(configPath)) {
     try {
       const config: PcpConfig = JSON.parse(readFileSync(configPath, 'utf-8'));
-      if (config.agentMapping?.['claude-code']) return config.agentMapping['claude-code'];
+      const mapping = config.agentMapping || {};
+
+      const normalized = (backendHint || process.env.SB_BACKEND || process.env.PCP_BACKEND || '')
+        .toLowerCase()
+        .trim();
+      const backendKeyCandidates: string[] =
+        normalized === 'claude' || normalized === 'claude-code'
+          ? ['claude-code', 'claude']
+          : normalized === 'codex' || normalized === 'codex-cli'
+            ? ['codex-cli', 'codex']
+            : normalized === 'gemini' || normalized === 'gemini-cli'
+              ? ['gemini-cli', 'gemini']
+              : [];
+
+      for (const key of backendKeyCandidates) {
+        if (mapping[key]) return mapping[key];
+      }
+
+      // Back-compat fallback for legacy single-agent setups.
+      const fallbackKeys = ['claude-code', 'codex-cli', 'gemini-cli', 'claude', 'codex', 'gemini'];
+      for (const key of fallbackKeys) {
+        if (mapping[key]) return mapping[key];
+      }
     } catch {
       /* ignore */
     }

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -124,7 +124,7 @@ function hasBackendSessionOverride(backend: string, passthroughArgs: string[]): 
     );
   }
 
-  return has('--resume') || has('-r');
+  return has('--resume') || has('-r') || has('--session-id');
 }
 
 async function callPcpTool<T = Record<string, unknown>>(tool: string, args: object): Promise<T> {

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -290,6 +290,21 @@ export async function runClaude(
   const sessionContext = options.session
     ? await ensurePcpSessionContext(agentId, options.backend, passthroughArgs, options.verbose)
     : {};
+  const runtimeLinkId = options.session ? randomUUID() : undefined;
+  const { studioId, identityId } = getIdentityContextFromIdentityJson(process.cwd());
+
+  if (sessionContext.pcpSessionId && runtimeLinkId) {
+    upsertRuntimeSession(process.cwd(), {
+      pcpSessionId: sessionContext.pcpSessionId,
+      backend: options.backend,
+      agentId,
+      ...(identityId ? { identityId } : {}),
+      ...(studioId ? { studioId } : {}),
+      runtimeLinkId,
+      ...(sessionContext.backendSessionId ? { backendSessionId: sessionContext.backendSessionId } : {}),
+      updatedAt: new Date().toISOString(),
+    });
+  }
 
   if (options.verbose) {
     console.log(chalk.dim(`Backend: ${adapter.name}`));
@@ -318,7 +333,12 @@ export async function runClaude(
 
   const child = spawn(prepared.binary, prepared.args, {
     stdio: 'inherit',
-    env: { ...process.env, ...authEnv, ...prepared.env },
+    env: {
+      ...process.env,
+      ...authEnv,
+      ...prepared.env,
+      ...(runtimeLinkId ? { PCP_RUNTIME_LINK_ID: runtimeLinkId } : {}),
+    },
   });
 
   child.on('close', (code) => {
@@ -348,6 +368,21 @@ export async function runClaudeInteractive(
   const sessionContext = options.session
     ? await ensurePcpSessionContext(agentId, options.backend, passthroughArgs, options.verbose)
     : {};
+  const runtimeLinkId = options.session ? randomUUID() : undefined;
+  const { studioId, identityId } = getIdentityContextFromIdentityJson(process.cwd());
+
+  if (sessionContext.pcpSessionId && runtimeLinkId) {
+    upsertRuntimeSession(process.cwd(), {
+      pcpSessionId: sessionContext.pcpSessionId,
+      backend: options.backend,
+      agentId,
+      ...(identityId ? { identityId } : {}),
+      ...(studioId ? { studioId } : {}),
+      runtimeLinkId,
+      ...(sessionContext.backendSessionId ? { backendSessionId: sessionContext.backendSessionId } : {}),
+      updatedAt: new Date().toISOString(),
+    });
+  }
 
   if (options.verbose) {
     console.log(chalk.dim(`Backend: ${adapter.name}`));
@@ -374,7 +409,12 @@ export async function runClaudeInteractive(
 
   const child = spawn(prepared.binary, prepared.args, {
     stdio: 'inherit',
-    env: { ...process.env, ...authEnv, ...prepared.env },
+    env: {
+      ...process.env,
+      ...authEnv,
+      ...prepared.env,
+      ...(runtimeLinkId ? { PCP_RUNTIME_LINK_ID: runtimeLinkId } : {}),
+    },
   });
 
   child.on('close', (code) => {

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -353,7 +353,7 @@ export async function runClaude(
   options: SbOptions,
   passthroughArgs: string[] = []
 ): Promise<void> {
-  const agentId = resolveAgentId(options.agent);
+  const agentId = resolveAgentId(options.agent, options.backend);
   if (!agentId) {
     console.error(chalk.red('No agent identity configured.'));
     console.error(chalk.dim('Run `sb init` to set up PCP in this repo, or `sb awaken` to create a new SB.'));
@@ -470,7 +470,7 @@ export async function runClaudeInteractive(
   options: SbOptions,
   passthroughArgs: string[] = []
 ): Promise<void> {
-  const agentId = resolveAgentId(options.agent);
+  const agentId = resolveAgentId(options.agent, options.backend);
   if (!agentId) {
     console.error(chalk.red('No agent identity configured.'));
     console.error(chalk.dim('Run `sb init` to set up PCP in this repo, or `sb awaken` to create a new SB.'));

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -141,6 +141,80 @@ async function callPcpTool<T = Record<string, unknown>>(tool: string, args: obje
   return (await response.json()) as T;
 }
 
+function extractBackendSessionIdFromEvent(event: Record<string, unknown>): string | undefined {
+  const queue: unknown[] = [event];
+  const sessionKeys = new Set([
+    'session_id',
+    'sessionId',
+    'conversation_id',
+    'conversationId',
+    'thread_id',
+    'threadId',
+  ]);
+
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (!current || typeof current !== 'object') continue;
+    const obj = current as Record<string, unknown>;
+
+    for (const [key, value] of Object.entries(obj)) {
+      if (typeof value === 'string' && sessionKeys.has(key) && value.trim()) {
+        return value.trim();
+      }
+      if (value && typeof value === 'object') queue.push(value);
+    }
+  }
+
+  return undefined;
+}
+
+function parseSessionIdFromJsonLine(line: string): string | undefined {
+  try {
+    const parsed = JSON.parse(line) as Record<string, unknown>;
+    return extractBackendSessionIdFromEvent(parsed);
+  } catch {
+    return undefined;
+  }
+}
+
+async function persistBackendSessionLink(
+  options: {
+    pcpSessionId?: string;
+    backendSessionId?: string;
+    backend: string;
+    agentId: string;
+    runtimeLinkId?: string;
+    studioId?: string;
+    identityId?: string;
+    email?: string;
+  }
+): Promise<void> {
+  if (!options.pcpSessionId || !options.backendSessionId) return;
+
+  upsertRuntimeSession(process.cwd(), {
+    pcpSessionId: options.pcpSessionId,
+    backend: options.backend,
+    agentId: options.agentId,
+    ...(options.identityId ? { identityId: options.identityId } : {}),
+    ...(options.studioId ? { studioId: options.studioId } : {}),
+    ...(options.runtimeLinkId ? { runtimeLinkId: options.runtimeLinkId } : {}),
+    backendSessionId: options.backendSessionId,
+    updatedAt: new Date().toISOString(),
+  });
+
+  try {
+    await callPcpTool('update_session_phase', {
+      email: options.email,
+      agentId: options.agentId,
+      sessionId: options.pcpSessionId,
+      backendSessionId: options.backendSessionId,
+      status: 'active',
+    });
+  } catch {
+    // Best-effort linkage update only.
+  }
+}
+
 async function ensurePcpSessionContext(
   agentId: string,
   backend: string,
@@ -331,8 +405,22 @@ export async function runClaude(
     console.log(chalk.dim(`Running: ${prepared.binary} ${prepared.args.join(' ')}`));
   }
 
+  const pcpConfig = getPcpConfig();
+  let capturedBackendSessionId = sessionContext.backendSessionId;
+  let stdoutLineBuffer = '';
+  const consumeOutputChunk = (chunkText: string): void => {
+    stdoutLineBuffer += chunkText;
+    const lines = stdoutLineBuffer.split('\n');
+    stdoutLineBuffer = lines.pop() || '';
+
+    for (const line of lines) {
+      const parsedSessionId = parseSessionIdFromJsonLine(line.trim());
+      if (parsedSessionId) capturedBackendSessionId = parsedSessionId;
+    }
+  };
+
   const child = spawn(prepared.binary, prepared.args, {
-    stdio: 'inherit',
+    stdio: ['inherit', 'pipe', 'pipe'],
     env: {
       ...process.env,
       ...authEnv,
@@ -341,8 +429,33 @@ export async function runClaude(
     },
   });
 
-  child.on('close', (code) => {
+  child.stdout?.on('data', (chunk) => {
+    process.stdout.write(chunk);
+    consumeOutputChunk(chunk.toString());
+  });
+
+  child.stderr?.on('data', (chunk) => {
+    process.stderr.write(chunk);
+  });
+
+  child.on('close', async (code) => {
     prepared.cleanup();
+    if (stdoutLineBuffer.trim()) {
+      const parsedSessionId = parseSessionIdFromJsonLine(stdoutLineBuffer.trim());
+      if (parsedSessionId) capturedBackendSessionId = parsedSessionId;
+    }
+
+    await persistBackendSessionLink({
+      pcpSessionId: sessionContext.pcpSessionId,
+      backendSessionId: capturedBackendSessionId,
+      backend: options.backend,
+      agentId,
+      runtimeLinkId,
+      studioId,
+      identityId,
+      email: pcpConfig?.email,
+    });
+
     if (code !== 0) process.exit(code || 1);
   });
 

--- a/packages/cli/src/commands/hooks.ts
+++ b/packages/cli/src/commands/hooks.ts
@@ -26,6 +26,7 @@ import { randomUUID } from 'crypto';
 import { resolveAgentId, readIdentityJson } from '../backends/identity.js';
 import { getValidAccessToken } from '../auth/tokens.js';
 import {
+  findRuntimeSessionByLinkId,
   getCurrentRuntimeSession,
   setCurrentRuntimeSession,
   upsertRuntimeSession,
@@ -307,9 +308,21 @@ function normalizeSessionBackend(backendName: string): string {
 function resolveActivePcpSessionId(cwd: string): string | undefined {
   const detectedBackend = detectBackend(cwd);
   const sessionBackend = normalizeSessionBackend(detectedBackend.name);
+  const { studioId } = getIdentitySessionContext(cwd);
+  const agentId = resolveAgentId() || 'unknown';
 
   const current = getCurrentRuntimeSession(cwd, sessionBackend);
   if (current?.pcpSessionId) return current.pcpSessionId;
+
+  const runtimeLinkId = process.env.PCP_RUNTIME_LINK_ID;
+  if (runtimeLinkId) {
+    const linked = findRuntimeSessionByLinkId(cwd, runtimeLinkId, {
+      backend: sessionBackend,
+      agentId,
+      ...(studioId ? { studioId } : {}),
+    });
+    if (linked?.pcpSessionId) return linked.pcpSessionId;
+  }
 
   const fromLegacyFile = readRuntimeFile(cwd, 'pcp-session-id');
   if (fromLegacyFile) return fromLegacyFile;
@@ -401,10 +414,23 @@ async function reconcileBackendSignal(
   const sessionBackend = normalizeSessionBackend(detectedBackend.name);
   const backendSessionId = extractBackendSessionId(stdin);
   const runtimeLinkId = getRuntimeLinkId();
+  writeRuntimeFile(cwd, 'runtime-link-id', runtimeLinkId);
   const { studioId, identityId } = getIdentitySessionContext(cwd);
 
   let pcpSessionId = options?.initialPcpSessionId || resolveActivePcpSessionId(cwd);
   let threadKey = options?.initialThreadKey;
+
+  if (!pcpSessionId) {
+    const linked = findRuntimeSessionByLinkId(cwd, runtimeLinkId, {
+      backend: sessionBackend,
+      agentId,
+      ...(studioId ? { studioId } : {}),
+    });
+    if (linked?.pcpSessionId) {
+      pcpSessionId = linked.pcpSessionId;
+      if (linked.threadKey) threadKey = linked.threadKey;
+    }
+  }
 
   if (backendSessionId) {
     // Reconcile mismatched pcpSessionId/backendSessionId by checking existing server-side links first.

--- a/packages/cli/src/commands/hooks.ts
+++ b/packages/cli/src/commands/hooks.ts
@@ -22,6 +22,7 @@ import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { execSync } from 'child_process';
 import { homedir } from 'os';
+import { randomUUID } from 'crypto';
 import { resolveAgentId, readIdentityJson } from '../backends/identity.js';
 import { getValidAccessToken } from '../auth/tokens.js';
 import {
@@ -314,6 +315,147 @@ function resolveActivePcpSessionId(cwd: string): string | undefined {
   if (fromLegacyFile) return fromLegacyFile;
 
   return undefined;
+}
+
+function getIdentitySessionContext(cwd: string): {
+  studioId?: string;
+  identityId?: string;
+  studioName?: string;
+} {
+  const identityPath = join(cwd, '.pcp', 'identity.json');
+  if (!existsSync(identityPath)) return {};
+
+  try {
+    const identity = JSON.parse(readFileSync(identityPath, 'utf-8')) as {
+      studioId?: string;
+      workspaceId?: string;
+      identityId?: string;
+      studio?: string;
+      workspace?: string;
+    };
+    return {
+      studioId: identity.studioId || identity.workspaceId,
+      identityId: identity.identityId,
+      studioName: identity.studio || identity.workspace,
+    };
+  } catch {
+    return {};
+  }
+}
+
+function getRuntimeLinkId(): string {
+  const candidate = process.env.PCP_RUNTIME_LINK_ID;
+  if (typeof candidate === 'string' && candidate.trim()) return candidate.trim();
+  return randomUUID();
+}
+
+async function findPcpSessionByBackendSessionId(
+  config: PcpConfig | null,
+  agentId: string,
+  sessionBackend: string,
+  backendSessionId: string,
+  studioId?: string
+): Promise<{ pcpSessionId?: string; threadKey?: string }> {
+  try {
+    const listArgs: Record<string, unknown> = {
+      email: config?.email,
+      agentId,
+      limit: 50,
+      ...(studioId ? { studioId } : {}),
+    };
+    const listed = await callPcpTool('list_sessions', listArgs);
+    const sessions = Array.isArray(listed.sessions)
+      ? (listed.sessions as Array<Record<string, unknown>>)
+      : [];
+
+    const matched = sessions.find((session) => {
+      if (session.endedAt) return false;
+      if (typeof session.backend === 'string' && session.backend && session.backend !== sessionBackend) {
+        return false;
+      }
+      const backendCandidate =
+        (typeof session.backendSessionId === 'string' ? session.backendSessionId : undefined) ||
+        (typeof session.claudeSessionId === 'string' ? session.claudeSessionId : undefined);
+      return backendCandidate === backendSessionId;
+    });
+
+    if (!matched || typeof matched.id !== 'string') return {};
+
+    return {
+      pcpSessionId: matched.id,
+      ...(typeof matched.threadKey === 'string' ? { threadKey: matched.threadKey } : {}),
+    };
+  } catch {
+    return {};
+  }
+}
+
+async function reconcileBackendSignal(
+  cwd: string,
+  config: PcpConfig | null,
+  agentId: string,
+  stdin: Record<string, unknown>,
+  options?: { initialPcpSessionId?: string; initialThreadKey?: string }
+): Promise<{ pcpSessionId?: string; threadKey?: string; backendSessionId?: string }> {
+  const detectedBackend = detectBackend(cwd);
+  const sessionBackend = normalizeSessionBackend(detectedBackend.name);
+  const backendSessionId = extractBackendSessionId(stdin);
+  const runtimeLinkId = getRuntimeLinkId();
+  const { studioId, identityId } = getIdentitySessionContext(cwd);
+
+  let pcpSessionId = options?.initialPcpSessionId || resolveActivePcpSessionId(cwd);
+  let threadKey = options?.initialThreadKey;
+
+  if (backendSessionId) {
+    // Reconcile mismatched pcpSessionId/backendSessionId by checking existing server-side links first.
+    const matched = await findPcpSessionByBackendSessionId(
+      config,
+      agentId,
+      sessionBackend,
+      backendSessionId,
+      studioId
+    );
+
+    if (matched.pcpSessionId) {
+      pcpSessionId = matched.pcpSessionId;
+      threadKey = matched.threadKey || threadKey;
+    }
+  }
+
+  if (backendSessionId) {
+    writeRuntimeFile(cwd, 'session-id', backendSessionId);
+  }
+
+  if (!pcpSessionId) {
+    return {
+      ...(backendSessionId ? { backendSessionId } : {}),
+      ...(threadKey ? { threadKey } : {}),
+    };
+  }
+
+  writeRuntimeFile(cwd, 'pcp-session-id', pcpSessionId);
+  upsertRuntimeSession(cwd, {
+    pcpSessionId,
+    backend: sessionBackend,
+    agentId,
+    ...(identityId ? { identityId } : {}),
+    ...(studioId ? { studioId } : {}),
+    ...(threadKey ? { threadKey } : {}),
+    runtimeLinkId,
+    ...(backendSessionId ? { backendSessionId } : {}),
+    updatedAt: new Date().toISOString(),
+  });
+  setCurrentRuntimeSession(cwd, pcpSessionId, sessionBackend, {
+    agentId,
+    ...(identityId ? { identityId } : {}),
+    ...(studioId ? { studioId } : {}),
+  });
+
+  return {
+    pcpSessionId,
+    ...(threadKey ? { threadKey } : {}),
+    ...(backendSessionId ? { backendSessionId } : {}),
+  };
 }
 
 async function updateRuntimeGenerationState(
@@ -1064,24 +1206,8 @@ async function onSessionStartHandler(): Promise<void> {
   const config = getPcpConfig();
   const agentId = resolveAgentId() || 'unknown';
 
-  // Read studio/workspace ID from identity.json
-  const identityPath = join(cwd, '.pcp', 'identity.json');
-  let studioId: string | undefined;
-  let identityId: string | undefined;
-  let studioLine = '';
-  if (existsSync(identityPath)) {
-    try {
-      const identity = JSON.parse(readFileSync(identityPath, 'utf-8'));
-      studioId = identity.studioId || identity.workspaceId;
-      identityId = identity.identityId;
-      const studioName = identity.studio || identity.workspace;
-      if (studioName) {
-        studioLine = `Studio: ${studioName}`;
-      }
-    } catch {
-      // ignore
-    }
-  }
+  const { studioId, studioName } = getIdentitySessionContext(cwd);
+  const studioLine = studioName ? `Studio: ${studioName}` : '';
 
   let identityBlock = '';
   let memoriesBlock = '';
@@ -1138,8 +1264,6 @@ async function onSessionStartHandler(): Promise<void> {
   const sessionBackend = normalizeSessionBackend(detectedBackend.name);
   let pcpSessionId: string | undefined;
   let pcpThreadKey: string | undefined;
-  const backendSessionId = extractBackendSessionId(stdin);
-
   // If provided by sb launcher, prefer that explicit session id.
   if (process.env.PCP_SESSION_ID) {
     pcpSessionId = process.env.PCP_SESSION_ID;
@@ -1168,27 +1292,22 @@ async function onSessionStartHandler(): Promise<void> {
     // message above will already alert about server connectivity.
   }
 
-  // Store session ID if provided in stdin
-  if (backendSessionId) {
-    writeRuntimeFile(cwd, 'session-id', backendSessionId);
-  }
+  const reconciled = await reconcileBackendSignal(cwd, config, agentId, stdin, {
+    initialPcpSessionId: pcpSessionId,
+    initialThreadKey: pcpThreadKey,
+  });
+  pcpSessionId = reconciled.pcpSessionId || pcpSessionId;
+  pcpThreadKey = reconciled.threadKey || pcpThreadKey;
+  const backendSessionId = reconciled.backendSessionId;
 
   if (pcpSessionId) {
-    writeRuntimeFile(cwd, 'pcp-session-id', pcpSessionId);
     upsertRuntimeSession(cwd, {
       pcpSessionId,
       backend: sessionBackend,
       agentId,
-      ...(identityId ? { identityId } : {}),
-      ...(studioId ? { studioId } : {}),
       ...(pcpThreadKey ? { threadKey: pcpThreadKey } : {}),
-      ...(backendSessionId ? { backendSessionId } : {}),
       startedAt: new Date().toISOString(),
-    });
-    setCurrentRuntimeSession(cwd, pcpSessionId, sessionBackend, {
-      agentId,
-      ...(identityId ? { identityId } : {}),
-      ...(studioId ? { studioId } : {}),
+      updatedAt: new Date().toISOString(),
     });
   }
 
@@ -1225,11 +1344,12 @@ async function onSessionStartHandler(): Promise<void> {
 }
 
 async function onPromptHandler(): Promise<void> {
-  await readStdin();
+  const stdin = await readStdin();
 
   const cwd = process.cwd();
   const config = getPcpConfig();
   const agentId = resolveAgentId() || 'unknown';
+  await reconcileBackendSignal(cwd, config, agentId, stdin);
 
   // Mark session as actively generating at prompt start.
   await updateRuntimeGenerationState(cwd, config, agentId, 'runtime:generating');
@@ -1267,12 +1387,13 @@ async function onPromptHandler(): Promise<void> {
 }
 
 async function onStopHandler(): Promise<void> {
-  await readStdin();
+  const stdin = await readStdin();
 
   const cwd = process.cwd();
   const config = getPcpConfig();
   const agentId = resolveAgentId() || 'unknown';
   const parts: string[] = [];
+  await reconcileBackendSignal(cwd, config, agentId, stdin);
 
   // Mark session as idle after each completed backend turn.
   await updateRuntimeGenerationState(cwd, config, agentId, 'runtime:idle');

--- a/packages/cli/src/commands/hooks.ts
+++ b/packages/cli/src/commands/hooks.ts
@@ -22,12 +22,12 @@ import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { execSync } from 'child_process';
 import { homedir } from 'os';
-import { randomUUID } from 'crypto';
 import { resolveAgentId, readIdentityJson } from '../backends/identity.js';
 import { getValidAccessToken } from '../auth/tokens.js';
 import {
   findRuntimeSessionByLinkId,
   getCurrentRuntimeSession,
+  listRuntimeSessions,
   setCurrentRuntimeSession,
   upsertRuntimeSession,
 } from '../session/runtime.js';
@@ -356,10 +356,10 @@ function getIdentitySessionContext(cwd: string): {
   }
 }
 
-function getRuntimeLinkId(): string {
+function getRuntimeLinkId(): string | undefined {
   const candidate = process.env.PCP_RUNTIME_LINK_ID;
   if (typeof candidate === 'string' && candidate.trim()) return candidate.trim();
-  return randomUUID();
+  return undefined;
 }
 
 async function findPcpSessionByBackendSessionId(
@@ -408,19 +408,21 @@ async function reconcileBackendSignal(
   config: PcpConfig | null,
   agentId: string,
   stdin: Record<string, unknown>,
-  options?: { initialPcpSessionId?: string; initialThreadKey?: string }
+  options?: { initialPcpSessionId?: string; initialThreadKey?: string; startedAt?: string }
 ): Promise<{ pcpSessionId?: string; threadKey?: string; backendSessionId?: string }> {
   const detectedBackend = detectBackend(cwd);
   const sessionBackend = normalizeSessionBackend(detectedBackend.name);
   const backendSessionId = extractBackendSessionId(stdin);
   const runtimeLinkId = getRuntimeLinkId();
-  writeRuntimeFile(cwd, 'runtime-link-id', runtimeLinkId);
+  if (runtimeLinkId) {
+    writeRuntimeFile(cwd, 'runtime-link-id', runtimeLinkId);
+  }
   const { studioId, identityId } = getIdentitySessionContext(cwd);
 
   let pcpSessionId = options?.initialPcpSessionId || resolveActivePcpSessionId(cwd);
   let threadKey = options?.initialThreadKey;
 
-  if (!pcpSessionId) {
+  if (!pcpSessionId && runtimeLinkId) {
     const linked = findRuntimeSessionByLinkId(cwd, runtimeLinkId, {
       backend: sessionBackend,
       agentId,
@@ -432,7 +434,36 @@ async function reconcileBackendSignal(
     }
   }
 
-  if (backendSessionId) {
+  if (!pcpSessionId && backendSessionId) {
+    const linkedByBackendSessionId = listRuntimeSessions(cwd, sessionBackend).find(
+      (session) =>
+        session.agentId === agentId &&
+        (!studioId || session.studioId === studioId) &&
+        (session.backendSessionId === backendSessionId ||
+          session.backendSessionIds?.includes(backendSessionId))
+    );
+    if (linkedByBackendSessionId?.pcpSessionId) {
+      pcpSessionId = linkedByBackendSessionId.pcpSessionId;
+      if (linkedByBackendSessionId.threadKey) threadKey = linkedByBackendSessionId.threadKey;
+    }
+  }
+
+  let hasLocalBackendLink = false;
+  if (backendSessionId && pcpSessionId) {
+    const local = listRuntimeSessions(cwd, sessionBackend).find(
+      (session) =>
+        session.pcpSessionId === pcpSessionId &&
+        session.agentId === agentId &&
+        (!studioId || session.studioId === studioId)
+    );
+    hasLocalBackendLink = !!(
+      local &&
+      (local.backendSessionId === backendSessionId ||
+        local.backendSessionIds?.includes(backendSessionId))
+    );
+  }
+
+  if (backendSessionId && !hasLocalBackendLink) {
     // Reconcile mismatched pcpSessionId/backendSessionId by checking existing server-side links first.
     const matched = await findPcpSessionByBackendSessionId(
       config,
@@ -467,8 +498,9 @@ async function reconcileBackendSignal(
     ...(identityId ? { identityId } : {}),
     ...(studioId ? { studioId } : {}),
     ...(threadKey ? { threadKey } : {}),
-    runtimeLinkId,
+    ...(runtimeLinkId ? { runtimeLinkId } : {}),
     ...(backendSessionId ? { backendSessionId } : {}),
+    ...(options?.startedAt ? { startedAt: options.startedAt } : {}),
     updatedAt: new Date().toISOString(),
   });
   setCurrentRuntimeSession(cwd, pcpSessionId, sessionBackend, {
@@ -1318,24 +1350,15 @@ async function onSessionStartHandler(): Promise<void> {
     // message above will already alert about server connectivity.
   }
 
+  const startedAt = new Date().toISOString();
   const reconciled = await reconcileBackendSignal(cwd, config, agentId, stdin, {
     initialPcpSessionId: pcpSessionId,
     initialThreadKey: pcpThreadKey,
+    startedAt,
   });
   pcpSessionId = reconciled.pcpSessionId || pcpSessionId;
   pcpThreadKey = reconciled.threadKey || pcpThreadKey;
   const backendSessionId = reconciled.backendSessionId;
-
-  if (pcpSessionId) {
-    upsertRuntimeSession(cwd, {
-      pcpSessionId,
-      backend: sessionBackend,
-      agentId,
-      ...(pcpThreadKey ? { threadKey: pcpThreadKey } : {}),
-      startedAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    });
-  }
 
   // Keep an explicit runtime phase for dashboard "generating vs idle" visualization.
   // Startup phase should always settle to idle.

--- a/packages/cli/src/session/runtime.test.ts
+++ b/packages/cli/src/session/runtime.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { mkdtempSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { readRuntimeState, upsertRuntimeSession } from './runtime.js';
+import { findRuntimeSessionByLinkId, readRuntimeState, upsertRuntimeSession } from './runtime.js';
 
 describe('runtime session linkage', () => {
   let cwd: string;
@@ -63,5 +63,34 @@ describe('runtime session linkage', () => {
     expect(state.sessions).toHaveLength(1);
     expect(state.sessions[0].backendSessionIds).toEqual(['sess-1']);
   });
-});
 
+  it('finds sessions by runtimeLinkId with optional filters', () => {
+    upsertRuntimeSession(cwd, {
+      pcpSessionId: 'pcp-1',
+      backend: 'codex',
+      agentId: 'lumen',
+      studioId: 'studio-a',
+      runtimeLinkId: 'link-shared',
+    });
+    upsertRuntimeSession(cwd, {
+      pcpSessionId: 'pcp-2',
+      backend: 'gemini',
+      agentId: 'aster',
+      studioId: 'studio-b',
+      runtimeLinkId: 'link-shared',
+    });
+
+    const codex = findRuntimeSessionByLinkId(cwd, 'link-shared', {
+      backend: 'codex',
+      agentId: 'lumen',
+      studioId: 'studio-a',
+    });
+    expect(codex?.pcpSessionId).toBe('pcp-1');
+
+    const gemini = findRuntimeSessionByLinkId(cwd, 'link-shared', {
+      backend: 'gemini',
+      agentId: 'aster',
+    });
+    expect(gemini?.pcpSessionId).toBe('pcp-2');
+  });
+});

--- a/packages/cli/src/session/runtime.test.ts
+++ b/packages/cli/src/session/runtime.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { readRuntimeState, upsertRuntimeSession } from './runtime.js';
+
+describe('runtime session linkage', () => {
+  let cwd: string;
+
+  beforeEach(() => {
+    cwd = mkdtempSync(join(tmpdir(), 'pcp-runtime-'));
+  });
+
+  afterEach(() => {
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it('preserves runtimeLinkId and accumulates backend session ids', () => {
+    upsertRuntimeSession(cwd, {
+      pcpSessionId: 'pcp-1',
+      backend: 'codex',
+      agentId: 'lumen',
+      runtimeLinkId: 'link-1',
+    });
+
+    upsertRuntimeSession(cwd, {
+      pcpSessionId: 'pcp-1',
+      backend: 'codex',
+      agentId: 'lumen',
+      backendSessionId: 'backend-a',
+    });
+
+    upsertRuntimeSession(cwd, {
+      pcpSessionId: 'pcp-1',
+      backend: 'codex',
+      agentId: 'lumen',
+      backendSessionId: 'backend-b',
+    });
+
+    const state = readRuntimeState(cwd);
+    expect(state.sessions).toHaveLength(1);
+    expect(state.sessions[0].runtimeLinkId).toBe('link-1');
+    expect(state.sessions[0].backendSessionId).toBe('backend-b');
+    expect(state.sessions[0].backendSessionIds).toEqual(['backend-a', 'backend-b']);
+  });
+
+  it('de-duplicates backend session ids when the same id is seen multiple times', () => {
+    upsertRuntimeSession(cwd, {
+      pcpSessionId: 'pcp-1',
+      backend: 'claude',
+      agentId: 'lumen',
+      backendSessionId: 'sess-1',
+    });
+    upsertRuntimeSession(cwd, {
+      pcpSessionId: 'pcp-1',
+      backend: 'claude',
+      agentId: 'lumen',
+      backendSessionId: 'sess-1',
+      backendSessionIds: ['sess-1'],
+    });
+
+    const state = readRuntimeState(cwd);
+    expect(state.sessions).toHaveLength(1);
+    expect(state.sessions[0].backendSessionIds).toEqual(['sess-1']);
+  });
+});
+

--- a/packages/cli/src/session/runtime.ts
+++ b/packages/cli/src/session/runtime.ts
@@ -177,6 +177,22 @@ export function listRuntimeSessions(cwd: string, backend?: string): RuntimeSessi
   return [...sessions].sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
 }
 
+export function findRuntimeSessionByLinkId(
+  cwd: string,
+  runtimeLinkId: string,
+  options?: { backend?: string; agentId?: string; studioId?: string }
+): RuntimeSessionRecord | undefined {
+  if (!runtimeLinkId.trim()) return undefined;
+
+  const sessions = listRuntimeSessions(cwd, options?.backend);
+  return sessions.find(
+    (session) =>
+      session.runtimeLinkId === runtimeLinkId &&
+      (!options?.agentId || session.agentId === options.agentId) &&
+      (!options?.studioId || session.studioId === options.studioId)
+  );
+}
+
 export function getCurrentRuntimeSession(
   cwd: string,
   backend?: string

--- a/packages/cli/src/session/runtime.ts
+++ b/packages/cli/src/session/runtime.ts
@@ -8,7 +8,9 @@ export interface RuntimeSessionRecord {
   identityId?: string;
   studioId?: string;
   threadKey?: string;
+  runtimeLinkId?: string;
   backendSessionId?: string;
+  backendSessionIds?: string[];
   startedAt?: string;
   updatedAt: string;
 }
@@ -109,9 +111,41 @@ export function upsertRuntimeSession(
       s.studioId === next.studioId
   );
 
+  const mergeSessionIds = (existing?: RuntimeSessionRecord, incoming?: RuntimeSessionRecord): string[] => {
+    const ids = new Set<string>();
+
+    const add = (value: unknown): void => {
+      if (typeof value === 'string' && value.trim()) ids.add(value.trim());
+    };
+
+    for (const id of existing?.backendSessionIds || []) add(id);
+    add(existing?.backendSessionId);
+
+    for (const id of incoming?.backendSessionIds || []) add(id);
+    add(incoming?.backendSessionId);
+
+    return [...ids];
+  };
+
   if (idx >= 0) {
-    state.sessions[idx] = { ...state.sessions[idx], ...next };
+    const existing = state.sessions[idx];
+    const merged = { ...existing, ...next };
+    const backendSessionIds = mergeSessionIds(existing, next);
+    if (backendSessionIds.length > 0) {
+      merged.backendSessionIds = backendSessionIds;
+      if (!merged.backendSessionId) {
+        merged.backendSessionId = backendSessionIds[backendSessionIds.length - 1];
+      }
+    }
+    state.sessions[idx] = merged;
   } else {
+    const backendSessionIds = mergeSessionIds(undefined, next);
+    if (backendSessionIds.length > 0) {
+      next.backendSessionIds = backendSessionIds;
+      if (!next.backendSessionId) {
+        next.backendSessionId = backendSessionIds[backendSessionIds.length - 1];
+      }
+    }
     state.sessions.push(next);
   }
 


### PR DESCRIPTION
## Summary
- add runtime correlation token (`PCP_RUNTIME_LINK_ID`) from sb launcher into backend runs
- reconcile backend session IDs in hooks (`on-session-start`, `on-prompt`, `on-stop`) and prefer existing server-side backend-session matches when available
- persist richer runtime linkage state in `.pcp/runtime/sessions.json` (including backend session history)
- add runtime session linkage tests for id accumulation/deduplication
- document updated hook behavior and runtime state in `packages/cli/HOOKS.md`

## Why
Session continuity can drift when `pcpSessionId` and `backendSessionId` are observed at different times or from different sources. This introduces a correlation + reconciliation pass to reduce mismatches and improve deterministic linkage in interactive flows.

## Validation
- `npx vitest run packages/cli/src/session/runtime.test.ts packages/cli/src/commands/hooks.test.ts packages/cli/src/commands/mcp.test.ts`
- `yarn workspace @personal-context/cli build`

## Notes
- This is the first reconciliation slice; next iteration can add explicit server-side linkage tables/audit trail if needed.

— Lumen