### PR TITLE
feat(cli): standardize sb binary links under ~/.pcp/bin (by Lumen)

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -20,6 +20,7 @@ yarn workspace @personal-context/cli dev   # tsc --watch in another terminal
 
 `install:cli` links `sb` to `~/.pcp/bin/sb` and also creates a compatibility symlink at
 `~/.local/bin/sb`.
+If neither `~/.pcp/bin` nor `~/.local/bin` is in your `PATH`, the installer prints a warning.
 
 To remove: `yarn workspace @personal-context/cli uninstall:cli`
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -18,6 +18,9 @@ sb
 yarn workspace @personal-context/cli dev   # tsc --watch in another terminal
 ```
 
+`install:cli` links `sb` to `~/.pcp/bin/sb` and also creates a compatibility symlink at
+`~/.local/bin/sb`.
+
 To remove: `yarn workspace @personal-context/cli uninstall:cli`
 
 ## Getting Started
@@ -224,7 +227,7 @@ sb studio remove <name>         # Remove studio (keeps branch)
 sb studio clean <name>          # Remove studio + delete branch
 sb studio path <name>           # Print studio path
 eval $(sb studio cd <name>)     # cd to studio
-sb studio cli                   # Build + link CLI as sb-<agent>
+sb studio cli                   # Build + link CLI as sb-<agent> in ~/.pcp/bin
 sb studio cli --name sb-dev     # Custom binary name
 sb studio cli --unlink          # Remove linked binary
 ```

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -10,10 +10,10 @@
   "scripts": {
     "build": "tsc && cp -r src/templates dist/templates",
     "dev": "tsc --watch",
-    "dev:live": "tsc && cp -r src/templates dist/templates && chmod +x dist/cli.js && mkdir -p \"$HOME/.local/bin\" && ln -sf \"$(pwd)/dist/cli.js\" \"$HOME/.local/bin/sb\" && echo '✓ sb linked to '\"$(pwd)/dist/cli.js\" && tsc --watch",
+    "dev:live": "tsc && cp -r src/templates dist/templates && chmod +x dist/cli.js && mkdir -p \"$HOME/.pcp/bin\" \"$HOME/.local/bin\" && ln -sf \"$(pwd)/dist/cli.js\" \"$HOME/.pcp/bin/sb\" && ln -sf \"$HOME/.pcp/bin/sb\" \"$HOME/.local/bin/sb\" && echo \"✓ sb linked: $HOME/.pcp/bin/sb (compat: $HOME/.local/bin/sb)\" && tsc --watch",
     "cli": "tsx src/cli.ts",
-    "install:cli": "chmod +x dist/cli.js && mkdir -p \"$HOME/.local/bin\" && ln -sf \"$(pwd)/dist/cli.js\" \"$HOME/.local/bin/sb\" && echo 'Linked: $HOME/.local/bin/sb → dist/cli.js'",
-    "uninstall:cli": "rm -f \"$HOME/.local/bin/sb\" && echo 'Unlinked: $HOME/.local/bin/sb'",
+    "install:cli": "chmod +x dist/cli.js && mkdir -p \"$HOME/.pcp/bin\" \"$HOME/.local/bin\" && ln -sf \"$(pwd)/dist/cli.js\" \"$HOME/.pcp/bin/sb\" && ln -sf \"$HOME/.pcp/bin/sb\" \"$HOME/.local/bin/sb\" && echo \"Linked: $HOME/.pcp/bin/sb → dist/cli.js (compat: $HOME/.local/bin/sb)\"",
+    "uninstall:cli": "rm -f \"$HOME/.pcp/bin/sb\" \"$HOME/.local/bin/sb\" && echo \"Unlinked: $HOME/.pcp/bin/sb and $HOME/.local/bin/sb\"",
     "test": "vitest run",
     "test:watch": "vitest",
     "clean": "rm -rf dist"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -10,9 +10,9 @@
   "scripts": {
     "build": "tsc && cp -r src/templates dist/templates",
     "dev": "tsc --watch",
-    "dev:live": "tsc && cp -r src/templates dist/templates && chmod +x dist/cli.js && mkdir -p \"$HOME/.pcp/bin\" \"$HOME/.local/bin\" && ln -sf \"$(pwd)/dist/cli.js\" \"$HOME/.pcp/bin/sb\" && ln -sf \"$HOME/.pcp/bin/sb\" \"$HOME/.local/bin/sb\" && echo \"✓ sb linked: $HOME/.pcp/bin/sb (compat: $HOME/.local/bin/sb)\" && tsc --watch",
+    "dev:live": "tsc && cp -r src/templates dist/templates && chmod +x dist/cli.js && mkdir -p \"$HOME/.pcp/bin\" \"$HOME/.local/bin\" && ln -sf \"$(pwd)/dist/cli.js\" \"$HOME/.pcp/bin/sb\" && ln -sf \"$HOME/.pcp/bin/sb\" \"$HOME/.local/bin/sb\" && echo \"✓ sb linked: $HOME/.pcp/bin/sb (compat: $HOME/.local/bin/sb)\" && if ! printf '%s' \":$PATH:\" | grep -q \":$HOME/.pcp/bin:\" && ! printf '%s' \":$PATH:\" | grep -q \":$HOME/.local/bin:\"; then echo \"⚠️  PATH warning: neither $HOME/.pcp/bin nor $HOME/.local/bin is in PATH\"; echo \"   Add one of them in your shell profile so 'sb' resolves in new shells.\"; fi && tsc --watch",
     "cli": "tsx src/cli.ts",
-    "install:cli": "chmod +x dist/cli.js && mkdir -p \"$HOME/.pcp/bin\" \"$HOME/.local/bin\" && ln -sf \"$(pwd)/dist/cli.js\" \"$HOME/.pcp/bin/sb\" && ln -sf \"$HOME/.pcp/bin/sb\" \"$HOME/.local/bin/sb\" && echo \"Linked: $HOME/.pcp/bin/sb → dist/cli.js (compat: $HOME/.local/bin/sb)\"",
+    "install:cli": "chmod +x dist/cli.js && mkdir -p \"$HOME/.pcp/bin\" \"$HOME/.local/bin\" && ln -sf \"$(pwd)/dist/cli.js\" \"$HOME/.pcp/bin/sb\" && ln -sf \"$HOME/.pcp/bin/sb\" \"$HOME/.local/bin/sb\" && echo \"Linked: $HOME/.pcp/bin/sb → dist/cli.js (compat: $HOME/.local/bin/sb)\" && if ! printf '%s' \":$PATH:\" | grep -q \":$HOME/.pcp/bin:\" && ! printf '%s' \":$PATH:\" | grep -q \":$HOME/.local/bin:\"; then echo \"⚠️  PATH warning: neither $HOME/.pcp/bin nor $HOME/.local/bin is in PATH\"; echo \"   Add one of them in your shell profile so 'sb' resolves in new shells.\"; fi",
     "uninstall:cli": "rm -f \"$HOME/.pcp/bin/sb\" \"$HOME/.local/bin/sb\" && echo \"Unlinked: $HOME/.pcp/bin/sb and $HOME/.local/bin/sb\"",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/packages/cli/src/commands/studio.test.ts
+++ b/packages/cli/src/commands/studio.test.ts
@@ -5,7 +5,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { execSync } from 'child_process';
 import { existsSync, mkdirSync, writeFileSync, rmSync, readFileSync, renameSync } from 'fs';
-import { join, basename } from 'path';
+import { join, basename, delimiter as pathDelimiter } from 'path';
 import { tmpdir } from 'os';
 import {
   planInit,
@@ -13,6 +13,8 @@ import {
   getStudioPrefix,
   resolveCopySourceRoot,
   updateIdentityForStudioRename,
+  getCliLinkTargets,
+  shouldWarnMissingCliBinPath,
   type InitResult,
 } from './studio.js';
 
@@ -192,6 +194,35 @@ describe('Studio Commands', () => {
       const branches = git('branch', TEST_REPO);
       expect(branches).toContain(branchName);
     });
+  });
+});
+
+describe('CLI link path helpers', () => {
+  it('should resolve ~/.pcp/bin as primary and ~/.local/bin as compatibility path', () => {
+    const targets = getCliLinkTargets('/tmp/home', 'sb-lumen');
+    expect(targets.primaryBinDir).toBe('/tmp/home/.pcp/bin');
+    expect(targets.compatBinDir).toBe('/tmp/home/.local/bin');
+    expect(targets.primaryLinkPath).toBe('/tmp/home/.pcp/bin/sb-lumen');
+    expect(targets.compatLinkPath).toBe('/tmp/home/.local/bin/sb-lumen');
+  });
+
+  it('should not warn when PATH includes primary bin dir', () => {
+    const targets = getCliLinkTargets('/tmp/home', 'sb-lumen');
+    expect(
+      shouldWarnMissingCliBinPath(['/usr/bin', targets.primaryBinDir].join(pathDelimiter), targets)
+    ).toBe(false);
+  });
+
+  it('should not warn when PATH includes compatibility bin dir', () => {
+    const targets = getCliLinkTargets('/tmp/home', 'sb-lumen');
+    expect(
+      shouldWarnMissingCliBinPath(['/usr/bin', targets.compatBinDir].join(pathDelimiter), targets)
+    ).toBe(false);
+  });
+
+  it('should warn when PATH includes neither PCP nor compatibility bin dirs', () => {
+    const targets = getCliLinkTargets('/tmp/home', 'sb-lumen');
+    expect(shouldWarnMissingCliBinPath(['/usr/bin', '/bin'].join(pathDelimiter), targets)).toBe(true);
   });
 });
 

--- a/packages/cli/src/commands/studio.ts
+++ b/packages/cli/src/commands/studio.ts
@@ -893,17 +893,29 @@ function resolveDefaultCliName(): string {
 }
 
 async function cliLinkCommand(options: { name?: string; unlink?: boolean }): Promise<void> {
-  const binDir = join(homedir(), '.local', 'bin');
+  const primaryBinDir = join(homedir(), '.pcp', 'bin');
+  const compatBinDir = join(homedir(), '.local', 'bin');
   const name = options.name || resolveDefaultCliName();
+  const primaryLinkPath = join(primaryBinDir, name);
+  const compatLinkPath = join(compatBinDir, name);
 
   if (options.unlink) {
-    const linkPath = join(binDir, name);
-    if (existsSync(linkPath)) {
+    let removed = false;
+    if (existsSync(primaryLinkPath)) {
       const { unlinkSync } = await import('fs');
-      unlinkSync(linkPath);
-      console.log(chalk.green(`Unlinked: ${linkPath}`));
-    } else {
-      console.log(chalk.dim(`Not found: ${linkPath}`));
+      unlinkSync(primaryLinkPath);
+      console.log(chalk.green(`Unlinked: ${primaryLinkPath}`));
+      removed = true;
+    }
+    if (existsSync(compatLinkPath)) {
+      const { unlinkSync } = await import('fs');
+      unlinkSync(compatLinkPath);
+      console.log(chalk.green(`Unlinked compatibility link: ${compatLinkPath}`));
+      removed = true;
+    }
+    if (!removed) {
+      console.log(chalk.dim(`Not found: ${primaryLinkPath}`));
+      console.log(chalk.dim(`Not found: ${compatLinkPath}`));
     }
     return;
   }
@@ -939,17 +951,22 @@ async function cliLinkCommand(options: { name?: string; unlink?: boolean }): Pro
     execSync(`chmod +x "${cliJs}"`, { stdio: 'pipe' });
 
     // Create symlink
-    mkdirSync(binDir, { recursive: true });
-    const linkPath = join(binDir, name);
+    mkdirSync(primaryBinDir, { recursive: true });
+    mkdirSync(compatBinDir, { recursive: true });
     const { symlinkSync, unlinkSync } = await import('fs');
 
     // Remove existing symlink if present
-    if (existsSync(linkPath)) {
-      unlinkSync(linkPath);
+    if (existsSync(primaryLinkPath)) {
+      unlinkSync(primaryLinkPath);
     }
-    symlinkSync(cliJs, linkPath);
+    if (existsSync(compatLinkPath)) {
+      unlinkSync(compatLinkPath);
+    }
+    symlinkSync(cliJs, primaryLinkPath);
+    symlinkSync(primaryLinkPath, compatLinkPath);
 
-    spinner.succeed(`Linked: ${linkPath} → ${cliJs}`);
+    spinner.succeed(`Linked: ${primaryLinkPath} → ${cliJs}`);
+    console.log(chalk.dim(`  Compatibility link: ${compatLinkPath} → ${primaryLinkPath}`));
     console.log('');
     console.log(chalk.dim(`  Test it: ${name} --help`));
     console.log(chalk.dim(`  Remove:  sb studio cli --unlink${options.name ? ` --name ${name}` : ''}`));
@@ -1058,7 +1075,7 @@ export function registerStudioCommands(program: Command): void {
     .action(cdCommand);
 
   ws.command('cli')
-    .description('Build CLI and link as a named binary (default: sb-<agent>)')
+    .description('Build CLI and link as a named binary in ~/.pcp/bin (default: sb-<agent>)')
     .option('-n, --name <name>', 'Binary name (default: sb-<agent> from .pcp/identity.json)')
     .option('--unlink', 'Remove the linked binary instead of creating it')
     .action(cliLinkCommand);

--- a/packages/cli/src/commands/studio.ts
+++ b/packages/cli/src/commands/studio.ts
@@ -899,12 +899,33 @@ function resolveDefaultCliName(): string {
   return 'sb-dev';
 }
 
+type CliLinkTargets = {
+  primaryBinDir: string;
+  compatBinDir: string;
+  primaryLinkPath: string;
+  compatLinkPath: string;
+};
+
+function getCliLinkTargets(homeDir: string, name: string): CliLinkTargets {
+  const primaryBinDir = join(homeDir, '.pcp', 'bin');
+  const compatBinDir = join(homeDir, '.local', 'bin');
+  return {
+    primaryBinDir,
+    compatBinDir,
+    primaryLinkPath: join(primaryBinDir, name),
+    compatLinkPath: join(compatBinDir, name),
+  };
+}
+
+function shouldWarnMissingCliBinPath(pathValue: string | undefined, targets: CliLinkTargets): boolean {
+  const pathEntries = (pathValue || '').split(pathDelimiter);
+  return !pathEntries.includes(targets.primaryBinDir) && !pathEntries.includes(targets.compatBinDir);
+}
+
 async function cliLinkCommand(options: { name?: string; unlink?: boolean }): Promise<void> {
-  const primaryBinDir = join(homedir(), '.pcp', 'bin');
-  const compatBinDir = join(homedir(), '.local', 'bin');
   const name = options.name || resolveDefaultCliName();
-  const primaryLinkPath = join(primaryBinDir, name);
-  const compatLinkPath = join(compatBinDir, name);
+  const targets = getCliLinkTargets(homedir(), name);
+  const { primaryBinDir, compatBinDir, primaryLinkPath, compatLinkPath } = targets;
 
   if (options.unlink) {
     let removed = false;
@@ -975,8 +996,7 @@ async function cliLinkCommand(options: { name?: string; unlink?: boolean }): Pro
     spinner.succeed(`Linked: ${primaryLinkPath} → ${cliJs}`);
     console.log(chalk.dim(`  Compatibility link: ${compatLinkPath} → ${primaryLinkPath}`));
 
-    const pathEntries = (process.env.PATH || '').split(pathDelimiter);
-    if (!pathEntries.includes(primaryBinDir) && !pathEntries.includes(compatBinDir)) {
+    if (shouldWarnMissingCliBinPath(process.env.PATH, targets)) {
       console.log(
         chalk.yellow(
           `  PATH warning: neither ${primaryBinDir} nor ${compatBinDir} is currently in PATH`
@@ -1009,6 +1029,8 @@ export {
   getWorktreePaths,
   updateIdentityForStudioRename,
   resolveCopySourceRoot,
+  getCliLinkTargets,
+  shouldWarnMissingCliBinPath,
   planInit,
   git,
 };

--- a/packages/cli/src/commands/studio.ts
+++ b/packages/cli/src/commands/studio.ts
@@ -28,7 +28,14 @@ import {
   cpSync,
   statSync,
 } from 'fs';
-import { join, dirname, basename, parse as parsePath, resolve as resolvePath } from 'path';
+import {
+  join,
+  dirname,
+  basename,
+  parse as parsePath,
+  resolve as resolvePath,
+  delimiter as pathDelimiter,
+} from 'path';
 import { homedir } from 'os';
 import { installHooks } from './hooks.js';
 import { loadAuth, decodeJwtPayload, isTokenExpired } from '../auth/tokens.js';
@@ -967,6 +974,19 @@ async function cliLinkCommand(options: { name?: string; unlink?: boolean }): Pro
 
     spinner.succeed(`Linked: ${primaryLinkPath} → ${cliJs}`);
     console.log(chalk.dim(`  Compatibility link: ${compatLinkPath} → ${primaryLinkPath}`));
+
+    const pathEntries = (process.env.PATH || '').split(pathDelimiter);
+    if (!pathEntries.includes(primaryBinDir) && !pathEntries.includes(compatBinDir)) {
+      console.log(
+        chalk.yellow(
+          `  PATH warning: neither ${primaryBinDir} nor ${compatBinDir} is currently in PATH`
+        )
+      );
+      console.log(
+        chalk.dim(`  Add one of them to your shell profile so '${name}' resolves in new shells.`)
+      );
+    }
+
     console.log('');
     console.log(chalk.dim(`  Test it: ${name} --help`));
     console.log(chalk.dim(`  Remove:  sb studio cli --unlink${options.name ? ` --name ${name}` : ''}`));


### PR DESCRIPTION
## Summary

- Standardize CLI binary linking to `~/.pcp/bin` as the primary install location.
- Keep compatibility symlinks in `~/.local/bin` to avoid breaking existing PATH setups.
- Update `studio cli` linking/unlinking behavior to manage both locations.
- Update CLI docs to reflect the new primary path and compatibility behavior.

## Changes

- `packages/cli/package.json`
  - `install:cli`: now links `sb` to `~/.pcp/bin/sb` and creates compatibility link `~/.local/bin/sb`.
  - `uninstall:cli`: removes both `~/.pcp/bin/sb` and `~/.local/bin/sb`.
  - `dev:live`: now links to `~/.pcp/bin/sb` with a compatibility link in `~/.local/bin/sb`.
- `packages/cli/src/commands/studio.ts`
  - `sb studio cli` now links named binaries into `~/.pcp/bin/<name>`.
  - Also creates compatibility symlink `~/.local/bin/<name>`.
  - `--unlink` removes both links.
  - Help description updated to mention `~/.pcp/bin`.
- `packages/cli/README.md`
  - Clarifies install behavior and primary/compat link locations.
  - Updates `sb studio cli` description accordingly.

## Validation

- `yarn workspace @personal-context/cli test src/commands/studio.test.ts src/commands/mcp.test.ts`
- `yarn workspace @personal-context/cli build`

— Lumen