### PR TITLE
fix(api): improve Codex trigger-failure diagnostics (by Lumen)

### DIFF
--- a/packages/api/src/services/sessions/codex-runner.test.ts
+++ b/packages/api/src/services/sessions/codex-runner.test.ts
@@ -153,4 +153,46 @@ describe('CodexRunner', () => {
     ];
     expect(options.env?.PCP_ACCESS_TOKEN).toBe('test-pcp-token');
   });
+
+  it('includes parsed startup events in diagnostics when codex exits non-zero without stderr', async () => {
+    const mockProc = createMockProcess();
+    (spawn as Mock).mockReturnValue(mockProc);
+
+    const runner = new CodexRunner();
+    const runPromise = runner.run('hello', {
+      config: {
+        workingDirectory: process.cwd(),
+        mcpConfigPath: '',
+        model: 'gpt-5-codex',
+        appendSystemPrompt: 'identity override',
+      },
+    });
+
+    setTimeout(() => {
+      mockProc.stdout.emit(
+        'data',
+        Buffer.from(`${JSON.stringify({ type: 'thread.started', thread_id: 'thread-1' })}\n`)
+      );
+      mockProc.stdout.emit('data', Buffer.from(`${JSON.stringify({ type: 'turn.started' })}\n`));
+      mockProc.stdout.emit(
+        'data',
+        Buffer.from(
+          `${JSON.stringify({
+            type: 'error',
+            message: 'stream disconnected before completion',
+          })}\n`
+        )
+      );
+      mockProc.emit('close', 1, null);
+    }, 5);
+
+    const result = await runPromise;
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('exitCode=1');
+    expect(result.error).toContain('parsedEvents=3');
+    expect(result.error).toContain('thread.started');
+    expect(result.error).toContain('turn.started');
+    expect(result.error).toContain('parsedErrorMessages');
+    expect(result.error).toContain('stream disconnected before completion');
+  });
 });

--- a/packages/api/src/services/sessions/codex-runner.ts
+++ b/packages/api/src/services/sessions/codex-runner.ts
@@ -191,6 +191,9 @@ export class CodexRunner implements IClaudeRunner {
             parsedEventCount += 1;
             if (typeof parsed.type === 'string') {
               parsedEventTypes.push(parsed.type);
+              if (parsedEventTypes.length > DIAGNOSTIC_MAX_LINES) {
+                parsedEventTypes.shift();
+              }
             }
             if (parsed.type === 'error' && typeof parsed.message === 'string') {
               parsedErrorMessages.push(parsed.message);
@@ -247,6 +250,9 @@ export class CodexRunner implements IClaudeRunner {
             parsedEventCount += 1;
             if (typeof parsed.type === 'string') {
               parsedEventTypes.push(parsed.type);
+              if (parsedEventTypes.length > DIAGNOSTIC_MAX_LINES) {
+                parsedEventTypes.shift();
+              }
             }
             if (parsed.type === 'error' && typeof parsed.message === 'string') {
               parsedErrorMessages.push(parsed.message);

--- a/packages/api/src/services/sessions/codex-runner.ts
+++ b/packages/api/src/services/sessions/codex-runner.ts
@@ -23,6 +23,8 @@ import { formatInjectedContext } from './context-builder.js';
 import { logger } from '../../utils/logger.js';
 
 const PROCESS_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
+const DIAGNOSTIC_MAX_CHARS = 4000;
+const DIAGNOSTIC_MAX_LINES = 20;
 
 interface CodexUsageStats {
   contextTokens: number;
@@ -148,6 +150,12 @@ export class CodexRunner implements IClaudeRunner {
 
       let stderr = '';
       const nonJsonLines: string[] = [];
+      let stdoutRemainder = '';
+      let stdoutBytes = 0;
+      let stderrBytes = 0;
+      const parsedEventTypes: string[] = [];
+      const parsedErrorMessages: string[] = [];
+      let parsedEventCount = 0;
       const responses: ChannelResponse[] = [];
       const toolCalls: ToolCall[] = [];
       let usage: CodexUsageStats | undefined;
@@ -170,12 +178,26 @@ export class CodexRunner implements IClaudeRunner {
       }, PROCESS_TIMEOUT_MS);
 
       proc.stdout.on('data', (data) => {
+        stdoutBytes += data.length;
         const chunk = data.toString();
-        const lines = chunk.split('\n').filter((line: string) => line.trim());
+        const combined = `${stdoutRemainder}${chunk}`;
+        const lines = combined.split('\n');
+        stdoutRemainder = lines.pop() ?? '';
 
         for (const line of lines) {
+          if (!line.trim()) continue;
           try {
             const parsed = JSON.parse(line) as Record<string, unknown>;
+            parsedEventCount += 1;
+            if (typeof parsed.type === 'string') {
+              parsedEventTypes.push(parsed.type);
+            }
+            if (parsed.type === 'error' && typeof parsed.message === 'string') {
+              parsedErrorMessages.push(parsed.message);
+              if (parsedErrorMessages.length > DIAGNOSTIC_MAX_LINES) {
+                parsedErrorMessages.shift();
+              }
+            }
 
             const maybeSessionId = this.extractSessionId(parsed);
             if (maybeSessionId) resolvedSessionId = maybeSessionId;
@@ -191,12 +213,18 @@ export class CodexRunner implements IClaudeRunner {
             toolCalls.push(...extracted.toolCalls);
           } catch {
             // Capture non-JSON lines as diagnostic context
-            if (line.trim()) nonJsonLines.push(line.trim());
+            if (line.trim()) {
+              nonJsonLines.push(line.trim());
+              if (nonJsonLines.length > DIAGNOSTIC_MAX_LINES) {
+                nonJsonLines.shift();
+              }
+            }
           }
         }
       });
 
       proc.stderr.on('data', (data) => {
+        stderrBytes += data.length;
         stderr += data.toString();
       });
 
@@ -208,13 +236,74 @@ export class CodexRunner implements IClaudeRunner {
         }
       });
 
-      proc.on('close', (code) => {
+      proc.on('close', (code, signal) => {
         clearTimeout(timeout);
         if (settled) return;
         settled = true;
 
+        if (stdoutRemainder.trim()) {
+          try {
+            const parsed = JSON.parse(stdoutRemainder) as Record<string, unknown>;
+            parsedEventCount += 1;
+            if (typeof parsed.type === 'string') {
+              parsedEventTypes.push(parsed.type);
+            }
+            if (parsed.type === 'error' && typeof parsed.message === 'string') {
+              parsedErrorMessages.push(parsed.message);
+              if (parsedErrorMessages.length > DIAGNOSTIC_MAX_LINES) {
+                parsedErrorMessages.shift();
+              }
+            }
+            const maybeSessionId = this.extractSessionId(parsed);
+            if (maybeSessionId) resolvedSessionId = maybeSessionId;
+            const maybeUsage = this.extractUsage(parsed);
+            if (maybeUsage) usage = maybeUsage;
+            const maybeText = this.extractFinalText(parsed);
+            if (maybeText) finalTextResponse = maybeText;
+            const extracted = this.extractToolData(parsed);
+            responses.push(...extracted.responses);
+            toolCalls.push(...extracted.toolCalls);
+          } catch {
+            nonJsonLines.push(stdoutRemainder.trim());
+            if (nonJsonLines.length > DIAGNOSTIC_MAX_LINES) {
+              nonJsonLines.shift();
+            }
+          }
+        }
+
         if (code !== 0 && !finalTextResponse && responses.length === 0) {
-          const diagnostic = stderr || nonJsonLines.join('\n') || '(no output)';
+          const stderrTrimmed = stderr.trim();
+          const nonJsonText = nonJsonLines.join('\n').trim();
+          const startupOnlyEvents =
+            parsedEventTypes.length > 0 &&
+            parsedEventTypes.every((type) => type === 'thread.started' || type === 'turn.started');
+
+          const diagnostics: string[] = [];
+          diagnostics.push(
+            `exitCode=${code ?? 'null'} signal=${signal ?? 'none'} stdoutBytes=${stdoutBytes} stderrBytes=${stderrBytes}`
+          );
+          if (parsedEventCount > 0) {
+            const uniqueTypes = Array.from(new Set(parsedEventTypes));
+            diagnostics.push(
+              `parsedEvents=${parsedEventCount} types=${uniqueTypes.join(',') || '(none)'}`
+            );
+          }
+          if (parsedErrorMessages.length > 0) {
+            diagnostics.push(`parsedErrorMessages:\n${parsedErrorMessages.join('\n')}`);
+          }
+          if (stderrTrimmed) {
+            diagnostics.push(`stderr:\n${stderrTrimmed}`);
+          } else if (nonJsonText) {
+            diagnostics.push(`stdout(non-json):\n${nonJsonText}`);
+          } else if (startupOnlyEvents) {
+            diagnostics.push(
+              'Codex emitted startup events only (thread.started/turn.started) then exited before completion.'
+            );
+          } else {
+            diagnostics.push('No stderr and no non-JSON stdout captured.');
+          }
+
+          const diagnostic = diagnostics.join('\n\n').slice(0, DIAGNOSTIC_MAX_CHARS);
           reject(new Error(`Codex exited with code ${code}: ${diagnostic}`));
           return;
         }


### PR DESCRIPTION
## Summary
- improve `CodexRunner` non-zero exit diagnostics to avoid opaque `(no output)` failures
- include exit metadata in errors: `exitCode`, `signal`, stdout/stderr byte counts
- include parsed JSON event context (`type`s + parsed `error.message`s)
- preserve/flush trailing stdout fragment (`stdoutRemainder`) to avoid losing final JSON line
- keep bounded diagnostic buffers to avoid log spam

## Why
Trigger-driven Codex runs were failing with `Codex exited with code 1: (no output)` even when Codex emitted startup/error JSON events. This made root-cause analysis difficult.

## Validation
- `yarn workspace @personal-context/api test src/services/sessions/codex-runner.test.ts`

## Notes
This PR is focused on observability/hardening only (no behavior change to trigger routing itself).

— Lumen