### PR TITLE
feat(api): auto-create daily check-in reminders on identity creation

### DIFF
--- a/packages/api/src/mcp/tools/identity-handlers.ts
+++ b/packages/api/src/mcp/tools/identity-handlers.ts
@@ -13,6 +13,7 @@ import type { Json, TablesInsert } from '../../data/supabase/types';
 import { logger } from '../../utils/logger';
 import { getEffectiveAgentId } from '../../auth/enforce-identity';
 import { userIdentifierBaseSchema, resolveUserOrThrow } from '../../services/user-resolver';
+import { ensureDefaultReminders } from '../../services/heartbeat';
 
 // =====================================================
 // SCHEMAS
@@ -255,6 +256,17 @@ export async function handleSaveIdentity(args: unknown, dataComposer: DataCompos
   }
 
   logger.info('Identity saved', { agentId, version: data.version });
+
+  // Seed default reminders on first creation only
+  if (data.version === 1) {
+    ensureDefaultReminders({
+      userId: user.id,
+      identityId: data.id,
+      agentId,
+      deliveryChannel: user.telegram_id ? 'telegram' : user.whatsapp_id ? 'whatsapp' : undefined,
+      deliveryTarget: user.telegram_id?.toString() ?? user.whatsapp_id ?? undefined,
+    }).catch(() => {});
+  }
 
   // Optionally sync to file system
   let filePath: string | undefined;
@@ -803,6 +815,15 @@ export async function handleChooseName(args: unknown, dataComposer: DataComposer
   }
 
   logger.info('New SB chose their name', { agentId, name: params.name, backend });
+
+  // Seed default reminders (best-effort, non-blocking)
+  ensureDefaultReminders({
+    userId: user.id,
+    identityId: data.id,
+    agentId,
+    deliveryChannel: user.telegram_id ? 'telegram' : user.whatsapp_id ? 'whatsapp' : undefined,
+    deliveryTarget: user.telegram_id?.toString() ?? user.whatsapp_id ?? undefined,
+  }).catch(() => {});
 
   // Sync to file system
   let filePath: string | undefined;

--- a/packages/api/src/services/heartbeat.test.ts
+++ b/packages/api/src/services/heartbeat.test.ts
@@ -63,6 +63,8 @@ function createChainableQueryBuilder(table: string) {
     'range',
     'ilike',
     'like',
+    'filter',
+    'contains',
   ];
 
   for (const method of chainable) {
@@ -109,6 +111,7 @@ import {
   stopHeartbeatService,
   processHeartbeat,
   createReminder,
+  ensureDefaultReminders,
 } from './heartbeat.js';
 
 // ─── Helpers ───
@@ -381,6 +384,110 @@ describe('Heartbeat Service', () => {
 
       expect(stats).toEqual({ processed: 0, delivered: 0, failed: 0, skipped: 0 });
       expect(mockDeliver).not.toHaveBeenCalled();
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════════
+  // ensureDefaultReminders — identity-creation seeding
+  // ═══════════════════════════════════════════════════════════════
+  describe('ensureDefaultReminders', () => {
+    it('should create a daily-checkin reminder for a new identity', async () => {
+      // No existing checkin (idempotency check returns empty)
+      setQueryResult('scheduled_reminders', []);
+      // getUserTimezone returns UTC
+      setQueryResult('users', { timezone: null });
+      // createReminder insert succeeds
+      setQueryResult('scheduled_reminders', { id: 'rem-default-001' });
+
+      await ensureDefaultReminders({
+        userId: TEST_USER_ID,
+        identityId: 'identity-001',
+        agentId: 'wren',
+        deliveryChannel: 'telegram',
+        deliveryTarget: '123456789',
+      });
+
+      const builder = tableBuilders.get('scheduled_reminders')!;
+      expect(builder.insert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Daily check-in',
+          identity_id: 'identity-001',
+          cron_expression: '0 9 * * *',
+          delivery_channel: 'telegram',
+          delivery_target: '123456789',
+          metadata: { autoCreated: true, reminderType: 'daily-checkin' },
+        })
+      );
+    });
+
+    it('should skip if daily-checkin already exists (idempotency)', async () => {
+      // Idempotency check finds existing reminder
+      setQueryResult('scheduled_reminders', [{ id: 'existing-rem' }]);
+
+      await ensureDefaultReminders({
+        userId: TEST_USER_ID,
+        identityId: 'identity-001',
+        agentId: 'wren',
+        deliveryChannel: 'telegram',
+        deliveryTarget: '123456789',
+      });
+
+      const builder = tableBuilders.get('scheduled_reminders')!;
+      expect(builder.insert).not.toHaveBeenCalled();
+    });
+
+    it('should resolve delivery channel from user when not pre-resolved', async () => {
+      // User lookup returns telegram_id
+      setQueryResult('users', { telegram_id: '987654321', whatsapp_id: null });
+      // Idempotency check returns empty
+      setQueryResult('scheduled_reminders', []);
+      // getUserTimezone
+      setQueryResult('users', { timezone: null });
+      // createReminder insert succeeds
+      setQueryResult('scheduled_reminders', { id: 'rem-default-002' });
+
+      await ensureDefaultReminders({
+        userId: TEST_USER_ID,
+        identityId: 'identity-002',
+        agentId: 'myra',
+        // No deliveryChannel/deliveryTarget — should resolve from user
+      });
+
+      const builder = tableBuilders.get('scheduled_reminders')!;
+      expect(builder.insert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          delivery_channel: 'telegram',
+          delivery_target: '987654321',
+        })
+      );
+    });
+
+    it('should skip if no delivery channel available', async () => {
+      // User has neither telegram nor whatsapp
+      setQueryResult('users', { telegram_id: null, whatsapp_id: null });
+
+      await ensureDefaultReminders({
+        userId: TEST_USER_ID,
+        identityId: 'identity-003',
+        agentId: 'wren',
+      });
+
+      // No scheduled_reminders queries should happen at all
+      const builder = tableBuilders.get('scheduled_reminders');
+      expect(builder).toBeUndefined();
+    });
+
+    it('should not throw on database errors', async () => {
+      // User lookup fails
+      setQueryResult('users', null, { message: 'Connection refused' });
+
+      await expect(
+        ensureDefaultReminders({
+          userId: TEST_USER_ID,
+          identityId: 'identity-004',
+          agentId: 'wren',
+        })
+      ).resolves.toBeUndefined();
     });
   });
 });

--- a/packages/api/src/services/heartbeat.ts
+++ b/packages/api/src/services/heartbeat.ts
@@ -316,6 +316,8 @@ export async function createReminder(params: {
   cronExpression?: string;
   runAt?: Date;
   maxRuns?: number;
+  identityId?: string;
+  metadata?: Record<string, unknown>;
 }): Promise<{ id: string } | null> {
   if (!supabase) {
     supabase = createClient<Database>(env.SUPABASE_URL, env.SUPABASE_SECRET_KEY);
@@ -341,6 +343,8 @@ export async function createReminder(params: {
       cron_expression: params.cronExpression || null,
       next_run_at: nextRunAt.toISOString(),
       max_runs: params.maxRuns || null,
+      identity_id: params.identityId || null,
+      metadata: (params.metadata as Record<string, unknown>) || {},
     })
     .select('id')
     .single();
@@ -352,6 +356,101 @@ export async function createReminder(params: {
 
   logger.info('Created reminder', { id: data.id, title: params.title });
   return { id: data.id };
+}
+
+/**
+ * Ensure default reminders exist for a newly created identity.
+ * Idempotent: checks metadata->>reminderType to avoid duplicates.
+ * Fails gracefully: logs warnings but never throws.
+ */
+export async function ensureDefaultReminders(params: {
+  userId: string;
+  identityId: string;
+  agentId: string;
+  deliveryChannel?: string;
+  deliveryTarget?: string;
+}): Promise<void> {
+  try {
+    if (!supabase) {
+      supabase = createClient<Database>(env.SUPABASE_URL, env.SUPABASE_SECRET_KEY);
+    }
+
+    // Resolve delivery channel if not pre-resolved by caller
+    let deliveryChannel = params.deliveryChannel;
+    let deliveryTarget = params.deliveryTarget;
+
+    if (!deliveryChannel || !deliveryTarget) {
+      const { data: user } = await supabase
+        .from('users')
+        .select('telegram_id, whatsapp_id')
+        .eq('id', params.userId)
+        .single();
+
+      if (!user) {
+        logger.warn('ensureDefaultReminders: user not found, skipping', {
+          userId: params.userId,
+        });
+        return;
+      }
+
+      if (user.telegram_id) {
+        deliveryChannel = 'telegram';
+        deliveryTarget = user.telegram_id.toString();
+      } else if (user.whatsapp_id) {
+        deliveryChannel = 'whatsapp';
+        deliveryTarget = user.whatsapp_id;
+      } else {
+        logger.warn('ensureDefaultReminders: no delivery channel available, skipping', {
+          userId: params.userId,
+          agentId: params.agentId,
+        });
+        return;
+      }
+    }
+
+    // Idempotency: check if a daily-checkin already exists for this identity
+    const { data: existing } = await supabase
+      .from('scheduled_reminders')
+      .select('id')
+      .eq('user_id', params.userId)
+      .eq('identity_id', params.identityId)
+      .in('status', ['active', 'paused'])
+      .filter('metadata->>reminderType', 'eq', 'daily-checkin')
+      .limit(1);
+
+    if (existing && existing.length > 0) {
+      logger.debug('ensureDefaultReminders: daily-checkin already exists, skipping', {
+        identityId: params.identityId,
+        existingReminderId: existing[0].id,
+      });
+      return;
+    }
+
+    const result = await createReminder({
+      userId: params.userId,
+      title: 'Daily check-in',
+      description: `Good morning! Time for your daily check-in with ${params.agentId}.`,
+      deliveryChannel,
+      deliveryTarget,
+      cronExpression: '0 9 * * *',
+      identityId: params.identityId,
+      metadata: { autoCreated: true, reminderType: 'daily-checkin' },
+    });
+
+    if (result) {
+      logger.info('ensureDefaultReminders: created daily check-in', {
+        reminderId: result.id,
+        identityId: params.identityId,
+        agentId: params.agentId,
+      });
+    }
+  } catch (error) {
+    logger.error('ensureDefaultReminders: failed (non-fatal)', {
+      error: error instanceof Error ? error.message : error,
+      userId: params.userId,
+      identityId: params.identityId,
+    });
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

- **Auto-seed daily check-in reminder** when a new SB identity is created via `choose_name` or `save_identity` (version === 1)
- **Idempotent**: checks `metadata->>reminderType = 'daily-checkin'` before creating — won't duplicate if called twice
- **Fire-and-forget**: never blocks or fails identity creation (wrapped in try/catch, called with `.catch(() => {})`)
- **Delivery channel resolution**: pre-resolved from the already-fetched user object (telegram > whatsapp), skips gracefully if neither available

### Implementation
- Extended `createReminder()` in `heartbeat.ts` with optional `identityId` and `metadata` params (backwards-compatible)
- Added `ensureDefaultReminders()` service function in `heartbeat.ts`
- Hooked into `handleChooseName` (always) and `handleSaveIdentity` (version === 1 only)
- NOT called from Kindle `startOnboarding` (temp identities get renamed — `choose_name` fires at onboarding completion)

### Default reminder
- Title: "Daily check-in"
- Cron: `0 9 * * *` (9am daily in user's timezone)
- Metadata: `{ autoCreated: true, reminderType: "daily-checkin" }`

## Test plan
- [x] 5 new unit tests in `heartbeat.test.ts` (happy path, idempotency, delivery resolution, no channel skip, error handling)
- [x] All 858 tests pass
- [ ] Manual: call `choose_name` → verify reminder auto-created in dashboard
- [ ] Manual: call `choose_name` again (same agent) → no duplicate reminder

🤖 Generated with [Claude Code](https://claude.com/claude-code)