### PR TITLE
fix(cli): codex positional resume should bypass PCP session picker (by Lumen)

### DIFF
--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -109,9 +109,18 @@ function getIdentityContextFromIdentityJson(cwd = process.cwd()): {
   }
 }
 
-function hasBackendSessionOverride(backend: string, passthroughArgs: string[]): boolean {
+function hasBackendSessionOverride(
+  backend: string,
+  passthroughArgs: string[],
+  promptParts: string[]
+): boolean {
   const lowered = passthroughArgs.map((arg) => arg.toLowerCase());
   const has = (flag: string) => lowered.includes(flag.toLowerCase());
+
+  const promptLowered = promptParts.map((part) => part.toLowerCase());
+  if (backend === 'codex' && promptLowered[0] === 'resume') {
+    return true;
+  }
 
   if (backend === 'claude') {
     return (
@@ -219,9 +228,10 @@ async function ensurePcpSessionContext(
   agentId: string,
   backend: string,
   passthroughArgs: string[],
+  promptParts: string[],
   verbose: boolean
 ): Promise<{ pcpSessionId?: string; backendSessionId?: string }> {
-  if (hasBackendSessionOverride(backend, passthroughArgs)) return {};
+  if (hasBackendSessionOverride(backend, passthroughArgs, promptParts)) return {};
 
   const config = getPcpConfig();
   const email = config?.email;
@@ -362,7 +372,7 @@ export async function runClaude(
   }
   const adapter = getBackend(options.backend);
   const sessionContext = options.session
-    ? await ensurePcpSessionContext(agentId, options.backend, passthroughArgs, options.verbose)
+    ? await ensurePcpSessionContext(agentId, options.backend, passthroughArgs, promptParts, options.verbose)
     : {};
   const runtimeLinkId = options.session ? randomUUID() : undefined;
   const { studioId, identityId } = getIdentityContextFromIdentityJson(process.cwd());
@@ -479,7 +489,7 @@ export async function runClaudeInteractive(
   }
   const adapter = getBackend(options.backend);
   const sessionContext = options.session
-    ? await ensurePcpSessionContext(agentId, options.backend, passthroughArgs, options.verbose)
+    ? await ensurePcpSessionContext(agentId, options.backend, passthroughArgs, [], options.verbose)
     : {};
   const runtimeLinkId = options.session ? randomUUID() : undefined;
   const { studioId, identityId } = getIdentityContextFromIdentityJson(process.cwd());


### PR DESCRIPTION
## Summary

Fixes a CLI routing bug where Codex positional resume commands were being intercepted by PCP session selection.

Before:
- `sb -a lumen -b codex resume <session-id>`
- CLI treated `resume <session-id>` as prompt text and opened the "Session for lumen/codex" picker

After:
- Codex positional `resume ...` is treated as a backend session override
- `ensurePcpSessionContext` skips the picker and allows passthrough to codex backend as intended

## Root cause

`ensurePcpSessionContext` only recognized resume/continue overrides via `passthroughArgs` (flags like `--resume`).
Codex uses a positional subcommand (`resume`) in `promptParts`, so it wasn’t detected and the picker was shown.

## Changes

- `packages/cli/src/commands/claude.ts`
  - Extended `hasBackendSessionOverride()` to accept `promptParts`
  - Added Codex-specific positional detection:
    - `backend === 'codex' && promptParts[0] === 'resume'`
  - Threaded `promptParts` into `ensurePcpSessionContext()` from `runClaude`
  - Kept interactive path unchanged by passing `[]`

## Validation

- `yarn workspace @personal-context/cli test`
- `yarn workspace @personal-context/cli build`

— Lumen