### PR TITLE
feat: routing dashboard + channel route management + heartbeat dev controls (by Lumen)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,13 @@ MYRA_HTTP_PORT=3003
 # Web dashboard (used by PM2 ecosystem config)
 WEB_PORT=3002
 
+# Heartbeat / Reminders
+# Disable on secondary dev servers to avoid misrouting reminder wake-ups
+# (e.g., when running dev:direct from a personal studio).
+ENABLE_HEARTBEAT_SERVICE=true
+# Optional local scheduler toggle (defaults to true in development, false in production)
+# ENABLE_LOCAL_CRON=true
+
 # Authentication
 JWT_SECRET=your-jwt-secret-key-min-32-chars-long
 JWT_EXPIRES_IN=7d

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -521,6 +521,7 @@ Defined in [CONTRIBUTING.md](./CONTRIBUTING.md). Key SB-specific reminders:
 
 - **Title format**: `feat: description (by <SB name>)` — the `(by <name>)` suffix attributes work.
 - **Sign reviews**: end PR comments with `— Wren`, `— Lumen`, etc.
+- **Do not wait for permission to open a PR** once implementation is ready. Create the PR proactively unless the user explicitly asked you not to.
 - **Never push directly to main** from a feature branch. Always use PRs.
 
 ## Architecture Notes

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -1284,8 +1284,22 @@ router.post('/whatsapp/logout', async (_req: Request, res: Response) => {
  * Process heartbeat - check for due reminders and execute them
  * Called by pg_cron in production or node-cron locally
  */
-router.post('/heartbeat', async (_req: Request, res: Response) => {
+router.post('/heartbeat', async (req: Request, res: Response) => {
   try {
+    const heartbeatEnabled =
+      process.env.ENABLE_HEARTBEAT_SERVICE !== 'false' &&
+      process.env.ENABLE_HEARTBEATS !== 'false' &&
+      process.env.ENABLE_REMINDERS !== 'false';
+    const forceRun = req.query.force === 'true';
+
+    if (!heartbeatEnabled && !forceRun) {
+      res.status(503).json({
+        error:
+          'Heartbeat processing is disabled on this server. Set ENABLE_HEARTBEAT_SERVICE=true or call with ?force=true for a manual run.',
+      });
+      return;
+    }
+
     // Import dynamically to avoid circular dependencies
     const { processHeartbeat } = await import('../services/heartbeat.js');
     const stats = await processHeartbeat();

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -48,6 +48,29 @@ type CommentAuthorUser = {
   email: string | null;
 };
 
+type ChannelRouteIdentityRow = {
+  id: string;
+  agent_id: string;
+  name: string;
+  role: string;
+  backend: string | null;
+  workspace_id?: string | null;
+};
+
+type ChannelRouteRow = {
+  id: string;
+  user_id: string;
+  identity_id: string;
+  platform: string;
+  platform_account_id: string | null;
+  chat_id: string | null;
+  is_active: boolean;
+  metadata: Record<string, unknown> | null;
+  created_at: string;
+  updated_at: string;
+  agent_identities: ChannelRouteIdentityRow | ChannelRouteIdentityRow[] | null;
+};
+
 const ADMIN_ACCESS_TOKEN_LIFETIME_SECONDS = 3600; // 1 hour
 const ADMIN_REFRESH_TOKEN_LIFETIME_DAYS = 90;
 const ADMIN_CLIENT_ID = 'dashboard';
@@ -81,6 +104,55 @@ function truncateText(input: string, max = 280): string {
   const compact = input.replace(/\s+/g, ' ').trim();
   if (compact.length <= max) return compact;
   return `${compact.slice(0, max - 1)}…`;
+}
+
+function normalizeNullableText(input: unknown): string | null {
+  if (typeof input !== 'string') return null;
+  const normalized = input.trim();
+  return normalized.length > 0 ? normalized : null;
+}
+
+function parseRouteMetadata(input: unknown): Record<string, unknown> {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    return {};
+  }
+
+  return input as Record<string, unknown>;
+}
+
+function extractRouteIdentity(route: ChannelRouteRow): ChannelRouteIdentityRow | null {
+  if (!route.agent_identities) return null;
+  if (Array.isArray(route.agent_identities)) {
+    return route.agent_identities[0] || null;
+  }
+
+  return route.agent_identities;
+}
+
+function toRoutingRoute(
+  route: ChannelRouteRow,
+  reminderCountByIdentity: Map<string, number>,
+  nextReminderByIdentity: Map<string, string | null>
+) {
+  const identity = extractRouteIdentity(route);
+
+  return {
+    id: route.id,
+    identityId: route.identity_id,
+    agentId: identity?.agent_id ?? null,
+    agentName: identity?.name ?? null,
+    agentRole: identity?.role ?? null,
+    backend: identity?.backend ?? null,
+    platform: route.platform,
+    platformAccountId: route.platform_account_id,
+    chatId: route.chat_id,
+    isActive: route.is_active,
+    metadata: route.metadata || {},
+    createdAt: route.created_at,
+    updatedAt: route.updated_at,
+    activeReminderCount: reminderCountByIdentity.get(route.identity_id) || 0,
+    nextReminderAt: nextReminderByIdentity.get(route.identity_id) || null,
+  };
 }
 
 function pickContentFromUnknown(input: unknown): string {
@@ -1315,6 +1387,579 @@ router.post('/heartbeat', async (req: Request, res: Response) => {
   }
 });
 
+// =============================================================================
+// Routing
+// =============================================================================
+
+/**
+ * GET /api/admin/routing
+ * List channel_routes for the active workspace + route health summary.
+ */
+router.get('/routing', async (req: Request, res: Response) => {
+  try {
+    const authReq = req as AdminAuthRequest;
+    const supabase = createClient(env.SUPABASE_URL, env.SUPABASE_SECRET_KEY, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+
+    const { data: routesData, error: routesError } = await supabase
+      .from('channel_routes')
+      .select(
+        `
+        id,
+        user_id,
+        identity_id,
+        platform,
+        platform_account_id,
+        chat_id,
+        is_active,
+        metadata,
+        created_at,
+        updated_at,
+        agent_identities!inner (
+          id,
+          agent_id,
+          name,
+          role,
+          backend,
+          workspace_id
+        )
+      `
+      )
+      .eq('user_id', authReq.pcpUserId)
+      .eq('agent_identities.workspace_id', authReq.pcpWorkspaceId)
+      .order('updated_at', { ascending: false });
+
+    if (routesError) {
+      logger.error('Failed to list channel routes:', routesError);
+      res.status(500).json({ error: 'Failed to list channel routes' });
+      return;
+    }
+
+    const routeRows = (routesData || []) as unknown as ChannelRouteRow[];
+
+    const { data: identitiesData, error: identitiesError } = await supabase
+      .from('agent_identities')
+      .select('id, agent_id, name, role, backend')
+      .eq('user_id', authReq.pcpUserId)
+      .eq('workspace_id', authReq.pcpWorkspaceId)
+      .order('agent_id', { ascending: true });
+
+    if (identitiesError) {
+      logger.error('Failed to list identities for routing:', identitiesError);
+      res.status(500).json({ error: 'Failed to list identities' });
+      return;
+    }
+
+    const identityIds = (identitiesData || []).map((identity) => identity.id);
+    const reminderCountByIdentity = new Map<string, number>();
+    const nextReminderByIdentity = new Map<string, string | null>();
+
+    if (identityIds.length > 0) {
+      const { data: remindersData, error: remindersError } = await supabase
+        .from('scheduled_reminders')
+        .select('identity_id, next_run_at, status')
+        .eq('user_id', authReq.pcpUserId)
+        .in('identity_id', identityIds)
+        .in('status', ['active', 'paused']);
+
+      if (remindersError) {
+        logger.error('Failed to summarize reminders for routing:', remindersError);
+      } else {
+        for (const reminder of remindersData || []) {
+          if (!reminder.identity_id) continue;
+          const currentCount = reminderCountByIdentity.get(reminder.identity_id) || 0;
+          reminderCountByIdentity.set(reminder.identity_id, currentCount + 1);
+
+          const nextExisting = nextReminderByIdentity.get(reminder.identity_id);
+          if (!reminder.next_run_at) continue;
+          if (!nextExisting || new Date(reminder.next_run_at) < new Date(nextExisting)) {
+            nextReminderByIdentity.set(reminder.identity_id, reminder.next_run_at);
+          }
+        }
+      }
+    }
+
+    const { count: unassignedReminderCount, error: unassignedReminderError } = await supabase
+      .from('scheduled_reminders')
+      .select('*', { count: 'exact', head: true })
+      .eq('user_id', authReq.pcpUserId)
+      .is('identity_id', null)
+      .in('status', ['active', 'paused']);
+
+    if (unassignedReminderError) {
+      logger.error('Failed to count unassigned reminders for routing:', unassignedReminderError);
+    }
+
+    const routes = routeRows.map((route) =>
+      toRoutingRoute(route, reminderCountByIdentity, nextReminderByIdentity)
+    );
+
+    const heartbeatProcessingEnabled =
+      process.env.ENABLE_HEARTBEAT_SERVICE !== 'false' &&
+      process.env.ENABLE_HEARTBEATS !== 'false' &&
+      process.env.ENABLE_REMINDERS !== 'false';
+
+    const uniqueAgents = new Set(routes.map((route) => route.agentId).filter(Boolean));
+    const uniquePlatforms = new Set(routes.map((route) => route.platform));
+
+    res.json({
+      heartbeatProcessingEnabled,
+      summary: {
+        totalRoutes: routes.length,
+        activeRoutes: routes.filter((route) => route.isActive).length,
+        agentsWithRoutes: uniqueAgents.size,
+        platformsCovered: uniquePlatforms.size,
+        unassignedReminderCount: unassignedReminderCount || 0,
+      },
+      identities: (identitiesData || []).map((identity) => ({
+        id: identity.id,
+        agentId: identity.agent_id,
+        name: identity.name,
+        role: identity.role,
+        backend: identity.backend,
+      })),
+      routes,
+    });
+  } catch (error) {
+    logger.error('Failed to list routing data:', error);
+    res.status(500).json({ error: 'Failed to list routing data' });
+  }
+});
+
+/**
+ * GET /api/admin/routing/agents/:agentId
+ * Get routing detail for a specific SB.
+ */
+router.get('/routing/agents/:agentId', async (req: Request, res: Response) => {
+  try {
+    const { agentId } = req.params;
+    const authReq = req as AdminAuthRequest;
+    const supabase = createClient(env.SUPABASE_URL, env.SUPABASE_SECRET_KEY, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+
+    const { data: identity, error: identityError } = await supabase
+      .from('agent_identities')
+      .select('id, agent_id, name, role, description, backend, workspace_id, updated_at')
+      .eq('user_id', authReq.pcpUserId)
+      .eq('workspace_id', authReq.pcpWorkspaceId)
+      .eq('agent_id', agentId)
+      .single();
+
+    if (identityError || !identity) {
+      res.status(404).json({ error: 'Agent not found for this workspace' });
+      return;
+    }
+
+    const { data: routesData, error: routesError } = await supabase
+      .from('channel_routes')
+      .select(
+        `
+        id,
+        user_id,
+        identity_id,
+        platform,
+        platform_account_id,
+        chat_id,
+        is_active,
+        metadata,
+        created_at,
+        updated_at,
+        agent_identities!inner (
+          id,
+          agent_id,
+          name,
+          role,
+          backend,
+          workspace_id
+        )
+      `
+      )
+      .eq('user_id', authReq.pcpUserId)
+      .eq('identity_id', identity.id)
+      .eq('agent_identities.workspace_id', authReq.pcpWorkspaceId)
+      .order('updated_at', { ascending: false });
+
+    if (routesError) {
+      logger.error('Failed to list routes for agent:', routesError);
+      res.status(500).json({ error: 'Failed to list routes for agent' });
+      return;
+    }
+
+    const { data: remindersData, error: remindersError } = await supabase
+      .from('scheduled_reminders')
+      .select(
+        `
+        id,
+        title,
+        description,
+        delivery_channel,
+        delivery_target,
+        cron_expression,
+        next_run_at,
+        last_run_at,
+        status,
+        run_count,
+        max_runs,
+        identity_id
+      `
+      )
+      .eq('user_id', authReq.pcpUserId)
+      .eq('identity_id', identity.id)
+      .order('next_run_at', { ascending: true })
+      .limit(100);
+
+    if (remindersError) {
+      logger.error('Failed to list reminders for route detail:', remindersError);
+      res.status(500).json({ error: 'Failed to list reminders for route detail' });
+      return;
+    }
+
+    const reminderCountByIdentity = new Map<string, number>();
+    const nextReminderByIdentity = new Map<string, string | null>();
+    if ((remindersData || []).length > 0) {
+      reminderCountByIdentity.set(identity.id, remindersData?.length || 0);
+      const nextReminder = (remindersData || [])
+        .map((reminder) => reminder.next_run_at)
+        .find((nextRunAt) => nextRunAt != null);
+      nextReminderByIdentity.set(identity.id, nextReminder || null);
+    }
+
+    const routeRows = (routesData || []) as unknown as ChannelRouteRow[];
+    const routes = routeRows.map((route) =>
+      toRoutingRoute(route, reminderCountByIdentity, nextReminderByIdentity)
+    );
+
+    const heartbeatProcessingEnabled =
+      process.env.ENABLE_HEARTBEAT_SERVICE !== 'false' &&
+      process.env.ENABLE_HEARTBEATS !== 'false' &&
+      process.env.ENABLE_REMINDERS !== 'false';
+
+    res.json({
+      heartbeatProcessingEnabled,
+      agent: {
+        id: identity.id,
+        agentId: identity.agent_id,
+        name: identity.name,
+        role: identity.role,
+        description: identity.description,
+        backend: identity.backend,
+        updatedAt: identity.updated_at,
+      },
+      routes,
+      reminders: (remindersData || []).map((reminder) => ({
+        id: reminder.id,
+        title: reminder.title,
+        description: reminder.description,
+        deliveryChannel: reminder.delivery_channel,
+        deliveryTarget: reminder.delivery_target,
+        cronExpression: reminder.cron_expression,
+        nextRunAt: reminder.next_run_at,
+        lastRunAt: reminder.last_run_at,
+        status: reminder.status,
+        runCount: reminder.run_count,
+        maxRuns: reminder.max_runs,
+        identityId: reminder.identity_id,
+      })),
+    });
+  } catch (error) {
+    logger.error('Failed to load routing agent detail:', error);
+    res.status(500).json({ error: 'Failed to load routing agent detail' });
+  }
+});
+
+/**
+ * POST /api/admin/routing/routes
+ * Create a channel route.
+ */
+router.post('/routing/routes', async (req: Request, res: Response) => {
+  try {
+    const authReq = req as AdminAuthRequest;
+    const supabase = createClient(env.SUPABASE_URL, env.SUPABASE_SECRET_KEY, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+    const body = (req.body || {}) as Record<string, unknown>;
+
+    const identityId = normalizeNullableText(body.identityId);
+    const platform = normalizeNullableText(body.platform)?.toLowerCase();
+    const platformAccountId = normalizeNullableText(body.platformAccountId);
+    const chatId = normalizeNullableText(body.chatId);
+    const isActive = typeof body.isActive === 'boolean' ? body.isActive : true;
+    const metadata = parseRouteMetadata(body.metadata);
+
+    if (!identityId || !platform) {
+      res.status(400).json({ error: 'identityId and platform are required' });
+      return;
+    }
+
+    const { data: identity, error: identityError } = await supabase
+      .from('agent_identities')
+      .select('id')
+      .eq('id', identityId)
+      .eq('user_id', authReq.pcpUserId)
+      .eq('workspace_id', authReq.pcpWorkspaceId)
+      .single();
+
+    if (identityError || !identity) {
+      res.status(400).json({ error: 'identityId must belong to an agent in the active workspace' });
+      return;
+    }
+
+    const { data: inserted, error: insertError } = await supabase
+      .from('channel_routes')
+      .insert({
+        user_id: authReq.pcpUserId,
+        identity_id: identityId,
+        platform,
+        platform_account_id: platformAccountId,
+        chat_id: chatId,
+        is_active: isActive,
+        metadata,
+      })
+      .select(
+        `
+        id,
+        user_id,
+        identity_id,
+        platform,
+        platform_account_id,
+        chat_id,
+        is_active,
+        metadata,
+        created_at,
+        updated_at,
+        agent_identities!inner (
+          id,
+          agent_id,
+          name,
+          role,
+          backend,
+          workspace_id
+        )
+      `
+      )
+      .single();
+
+    if (insertError) {
+      if (insertError.code === '23505') {
+        res.status(409).json({
+          error:
+            'A route already exists for this platform/account/chat scope. Edit that route instead.',
+        });
+        return;
+      }
+
+      logger.error('Failed to create channel route:', insertError);
+      res.status(500).json({ error: 'Failed to create channel route' });
+      return;
+    }
+
+    const insertedRoute = inserted as unknown as ChannelRouteRow;
+    res.status(201).json({
+      route: toRoutingRoute(insertedRoute, new Map(), new Map()),
+    });
+  } catch (error) {
+    logger.error('Failed to create channel route:', error);
+    res.status(500).json({ error: 'Failed to create channel route' });
+  }
+});
+
+/**
+ * PATCH /api/admin/routing/routes/:routeId
+ * Update a channel route.
+ */
+router.patch('/routing/routes/:routeId', async (req: Request, res: Response) => {
+  try {
+    const { routeId } = req.params;
+    const authReq = req as AdminAuthRequest;
+    const supabase = createClient(env.SUPABASE_URL, env.SUPABASE_SECRET_KEY, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+
+    const { data: existing, error: existingError } = await supabase
+      .from('channel_routes')
+      .select(
+        `
+        id,
+        identity_id,
+        agent_identities!inner ( workspace_id )
+      `
+      )
+      .eq('id', routeId)
+      .eq('user_id', authReq.pcpUserId)
+      .eq('agent_identities.workspace_id', authReq.pcpWorkspaceId)
+      .single();
+
+    if (existingError || !existing) {
+      res.status(404).json({ error: 'Route not found in the active workspace' });
+      return;
+    }
+
+    const body = (req.body || {}) as Record<string, unknown>;
+    const updates: Record<string, unknown> = {};
+
+    if ('identityId' in body) {
+      const identityId = normalizeNullableText(body.identityId);
+      if (!identityId) {
+        res.status(400).json({ error: 'identityId cannot be empty' });
+        return;
+      }
+
+      const { data: identity, error: identityError } = await supabase
+        .from('agent_identities')
+        .select('id')
+        .eq('id', identityId)
+        .eq('user_id', authReq.pcpUserId)
+        .eq('workspace_id', authReq.pcpWorkspaceId)
+        .single();
+
+      if (identityError || !identity) {
+        res
+          .status(400)
+          .json({ error: 'identityId must belong to an agent in the active workspace' });
+        return;
+      }
+
+      updates.identity_id = identityId;
+    }
+
+    if ('platform' in body) {
+      const platform = normalizeNullableText(body.platform)?.toLowerCase();
+      if (!platform) {
+        res.status(400).json({ error: 'platform cannot be empty' });
+        return;
+      }
+      updates.platform = platform;
+    }
+
+    if ('platformAccountId' in body) {
+      updates.platform_account_id = normalizeNullableText(body.platformAccountId);
+    }
+
+    if ('chatId' in body) {
+      updates.chat_id = normalizeNullableText(body.chatId);
+    }
+
+    if ('isActive' in body) {
+      if (typeof body.isActive !== 'boolean') {
+        res.status(400).json({ error: 'isActive must be a boolean' });
+        return;
+      }
+      updates.is_active = body.isActive;
+    }
+
+    if ('metadata' in body) {
+      updates.metadata = parseRouteMetadata(body.metadata);
+    }
+
+    if (Object.keys(updates).length === 0) {
+      res.status(400).json({ error: 'No valid fields provided for update' });
+      return;
+    }
+
+    const { data: updated, error: updateError } = await supabase
+      .from('channel_routes')
+      .update(updates)
+      .eq('id', routeId)
+      .eq('user_id', authReq.pcpUserId)
+      .select(
+        `
+        id,
+        user_id,
+        identity_id,
+        platform,
+        platform_account_id,
+        chat_id,
+        is_active,
+        metadata,
+        created_at,
+        updated_at,
+        agent_identities!inner (
+          id,
+          agent_id,
+          name,
+          role,
+          backend,
+          workspace_id
+        )
+      `
+      )
+      .single();
+
+    if (updateError) {
+      if (updateError.code === '23505') {
+        res.status(409).json({
+          error:
+            'A route already exists for this platform/account/chat scope. Edit that route instead.',
+        });
+        return;
+      }
+
+      logger.error('Failed to update channel route:', updateError);
+      res.status(500).json({ error: 'Failed to update channel route' });
+      return;
+    }
+
+    const updatedRoute = updated as unknown as ChannelRouteRow;
+    res.json({
+      route: toRoutingRoute(updatedRoute, new Map(), new Map()),
+    });
+  } catch (error) {
+    logger.error('Failed to update channel route:', error);
+    res.status(500).json({ error: 'Failed to update channel route' });
+  }
+});
+
+/**
+ * DELETE /api/admin/routing/routes/:routeId
+ * Delete a channel route.
+ */
+router.delete('/routing/routes/:routeId', async (req: Request, res: Response) => {
+  try {
+    const { routeId } = req.params;
+    const authReq = req as AdminAuthRequest;
+    const supabase = createClient(env.SUPABASE_URL, env.SUPABASE_SECRET_KEY, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+
+    const { data: existing, error: existingError } = await supabase
+      .from('channel_routes')
+      .select(
+        `
+        id,
+        agent_identities!inner ( workspace_id )
+      `
+      )
+      .eq('id', routeId)
+      .eq('user_id', authReq.pcpUserId)
+      .eq('agent_identities.workspace_id', authReq.pcpWorkspaceId)
+      .single();
+
+    if (existingError || !existing) {
+      res.status(404).json({ error: 'Route not found in the active workspace' });
+      return;
+    }
+
+    const { error: deleteError } = await supabase
+      .from('channel_routes')
+      .delete()
+      .eq('id', routeId)
+      .eq('user_id', authReq.pcpUserId);
+
+    if (deleteError) {
+      logger.error('Failed to delete channel route:', deleteError);
+      res.status(500).json({ error: 'Failed to delete channel route' });
+      return;
+    }
+
+    res.json({ success: true });
+  } catch (error) {
+    logger.error('Failed to delete channel route:', error);
+    res.status(500).json({ error: 'Failed to delete channel route' });
+  }
+});
+
 /**
  * GET /api/admin/reminders
  * List reminders for the active user (admin view)
@@ -1340,12 +1985,14 @@ router.get('/reminders', async (req: Request, res: Response) => {
       reminders: (data || []).map((r) => ({
         id: r.id,
         userId: r.user_id,
+        identityId: r.identity_id,
         title: r.title,
         description: r.description,
         cronExpression: r.cron_expression,
         nextRunAt: r.next_run_at,
         lastRunAt: r.last_run_at,
         deliveryChannel: r.delivery_channel,
+        deliveryTarget: r.delivery_target,
         status: r.status,
         runCount: r.run_count,
       })),

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -339,7 +339,16 @@ async function startServer(config: ServerConfig = {}): Promise<void> {
   }
 
   // 6. Initialize heartbeat service for scheduled reminders
-  const enableLocalCron = process.env.NODE_ENV !== 'production';
+  // Useful for secondary/local dev servers where we want API/MCP without
+  // participating in global reminder delivery.
+  const heartbeatServiceEnabled =
+    process.env.ENABLE_HEARTBEAT_SERVICE !== 'false' &&
+    process.env.ENABLE_HEARTBEATS !== 'false' &&
+    process.env.ENABLE_REMINDERS !== 'false';
+  const enableLocalCron =
+    process.env.ENABLE_LOCAL_CRON !== undefined
+      ? process.env.ENABLE_LOCAL_CRON === 'true'
+      : process.env.NODE_ENV !== 'production';
   const heartbeatInterval = process.env.HEARTBEAT_INTERVAL || '*/5 * * * *';
 
   /**
@@ -405,18 +414,24 @@ Do NOT just respond here — you MUST explicitly call send_response to reach ext
     }
   };
 
-  initHeartbeatService({
-    interval: heartbeatInterval,
-    enableLocalCron,
-    onHeartbeat: async () => {
-      logger.info('Heartbeat tick — processing due reminders');
-      const stats = await processHeartbeat(deliverReminderViaSession);
-      logger.info('Heartbeat complete', stats);
-    },
-  });
-  logger.info(
-    `Heartbeat service started (interval: ${heartbeatInterval}, local cron: ${enableLocalCron})`
-  );
+  if (heartbeatServiceEnabled) {
+    initHeartbeatService({
+      interval: heartbeatInterval,
+      enableLocalCron,
+      onHeartbeat: async () => {
+        logger.info('Heartbeat tick — processing due reminders');
+        const stats = await processHeartbeat(deliverReminderViaSession);
+        logger.info('Heartbeat complete', stats);
+      },
+    });
+    logger.info(
+      `Heartbeat service started (interval: ${heartbeatInterval}, local cron: ${enableLocalCron})`
+    );
+  } else {
+    logger.warn(
+      'Heartbeat service disabled via env (ENABLE_HEARTBEAT_SERVICE/ENABLE_HEARTBEATS/ENABLE_REMINDERS=false). Scheduled reminders will not be processed on this server.'
+    );
+  }
 
   // 7. Register default trigger handler for stateless, database-driven agent routing
   // This handles triggers for ANY agent by looking up config from the database

--- a/packages/web/src/app/(dashboard)/routing/[agentId]/page.tsx
+++ b/packages/web/src/app/(dashboard)/routing/[agentId]/page.tsx
@@ -1,0 +1,508 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import { useMutation } from '@tanstack/react-query';
+import { ArrowLeft, Bell, Save, Trash2, Plus } from 'lucide-react';
+import { apiDelete, apiPatch, useApiPost, useApiQuery, useQueryClient } from '@/lib/api';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+
+interface AgentRoute {
+  id: string;
+  identityId: string;
+  agentId: string | null;
+  agentName: string | null;
+  agentRole: string | null;
+  backend: string | null;
+  platform: string;
+  platformAccountId: string | null;
+  chatId: string | null;
+  isActive: boolean;
+  metadata: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+  activeReminderCount: number;
+  nextReminderAt: string | null;
+}
+
+interface AgentReminder {
+  id: string;
+  title: string;
+  description: string | null;
+  deliveryChannel: string;
+  deliveryTarget: string | null;
+  cronExpression: string | null;
+  nextRunAt: string | null;
+  lastRunAt: string | null;
+  status: 'active' | 'paused' | 'completed' | 'cancelled' | 'failed';
+  runCount: number;
+  maxRuns: number | null;
+  identityId: string | null;
+}
+
+interface AgentRoutingResponse {
+  heartbeatProcessingEnabled: boolean;
+  agent: {
+    id: string;
+    agentId: string;
+    name: string;
+    role: string;
+    description: string | null;
+    backend: string | null;
+    updatedAt: string;
+  };
+  routes: AgentRoute[];
+  reminders: AgentReminder[];
+}
+
+interface RouteFormState {
+  platform: string;
+  platformAccountId: string;
+  chatId: string;
+  isActive: boolean;
+}
+
+const PLATFORM_OPTIONS = ['telegram', 'whatsapp', 'discord', 'slack', 'email'];
+
+function formatPlatform(value: string): string {
+  if (!value) return 'Unknown';
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+function formatTime(value: string | null): string {
+  if (!value) return '—';
+  return new Date(value).toLocaleString();
+}
+
+function initialFormFromRoute(route: AgentRoute): RouteFormState {
+  return {
+    platform: route.platform,
+    platformAccountId: route.platformAccountId || '',
+    chatId: route.chatId || '',
+    isActive: route.isActive,
+  };
+}
+
+export default function AgentRoutingPage() {
+  const params = useParams<{ agentId: string }>();
+  const agentId = decodeURIComponent(params?.agentId || '');
+  const queryClient = useQueryClient();
+
+  const { data, isLoading, error } = useApiQuery<AgentRoutingResponse>(
+    ['routing-agent', agentId],
+    `/api/admin/routing/agents/${encodeURIComponent(agentId)}`,
+    {
+      enabled: !!agentId,
+    }
+  );
+
+  const [newRoute, setNewRoute] = useState<RouteFormState>({
+    platform: 'telegram',
+    platformAccountId: '',
+    chatId: '',
+    isActive: true,
+  });
+  const [editingRouteId, setEditingRouteId] = useState<string | null>(null);
+  const [editForm, setEditForm] = useState<RouteFormState>({
+    platform: 'telegram',
+    platformAccountId: '',
+    chatId: '',
+    isActive: true,
+  });
+
+  useEffect(() => {
+    if (!editingRouteId || !data?.routes) return;
+    const selectedRoute = data.routes.find((route) => route.id === editingRouteId);
+    if (!selectedRoute) return;
+    setEditForm(initialFormFromRoute(selectedRoute));
+  }, [editingRouteId, data?.routes]);
+
+  const createRouteMutation = useApiPost<{ route: AgentRoute }, Record<string, unknown>>(
+    '/api/admin/routing/routes',
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: ['routing'] });
+        queryClient.invalidateQueries({ queryKey: ['routing-agent', agentId] });
+        setNewRoute({
+          platform: 'telegram',
+          platformAccountId: '',
+          chatId: '',
+          isActive: true,
+        });
+      },
+    }
+  );
+
+  const updateRouteMutation = useMutation({
+    mutationFn: ({ routeId, payload }: { routeId: string; payload: Record<string, unknown> }) =>
+      apiPatch(`/api/admin/routing/routes/${routeId}`, payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['routing'] });
+      queryClient.invalidateQueries({ queryKey: ['routing-agent', agentId] });
+    },
+  });
+
+  const deleteRouteMutation = useMutation({
+    mutationFn: (routeId: string) => apiDelete(`/api/admin/routing/routes/${routeId}`),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['routing'] });
+      queryClient.invalidateQueries({ queryKey: ['routing-agent', agentId] });
+      setEditingRouteId(null);
+    },
+  });
+
+  const mutationError =
+    createRouteMutation.error?.message ||
+    updateRouteMutation.error?.message ||
+    deleteRouteMutation.error?.message;
+
+  return (
+    <div>
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <Button variant="ghost" size="sm" asChild className="mb-2 px-0">
+            <Link href="/routing">
+              <ArrowLeft className="mr-2 h-4 w-4" />
+              Back to routing
+            </Link>
+          </Button>
+          <h1 className="text-3xl font-bold text-gray-900">
+            {data?.agent?.name || agentId} routing
+          </h1>
+          <p className="mt-2 text-gray-600">
+            {data?.agent?.role || 'Configure channel route scope and routing behavior for this SB.'}
+          </p>
+        </div>
+        {data?.agent?.backend && (
+          <Badge variant="secondary" className="text-sm">
+            {data.agent.backend}
+          </Badge>
+        )}
+      </div>
+
+      {data && !data.heartbeatProcessingEnabled && (
+        <div className="mt-4 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900">
+          Heartbeat/reminder processing is disabled on this server instance. Routing edits still
+          persist, but reminder execution won’t run here.
+        </div>
+      )}
+
+      {(error || mutationError) && (
+        <div className="mt-4 rounded-md bg-red-50 p-4 text-red-800">
+          {error?.message || mutationError}
+        </div>
+      )}
+
+      <Card className="mt-6">
+        <CardHeader>
+          <CardTitle>Add route for {data?.agent?.name || agentId}</CardTitle>
+          <CardDescription>
+            Start broad (platform only) then narrow to account/chat when needed.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form
+            className="space-y-4"
+            onSubmit={(event) => {
+              event.preventDefault();
+              if (!data?.agent?.id) return;
+              createRouteMutation.mutate({
+                identityId: data.agent.id,
+                platform: newRoute.platform,
+                platformAccountId: newRoute.platformAccountId || null,
+                chatId: newRoute.chatId || null,
+                isActive: newRoute.isActive,
+              });
+            }}
+          >
+            <div className="grid gap-4 md:grid-cols-3">
+              <div className="space-y-2">
+                <label className="text-sm font-medium">Platform</label>
+                <select
+                  className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                  value={newRoute.platform}
+                  onChange={(event) =>
+                    setNewRoute((previous) => ({
+                      ...previous,
+                      platform: event.target.value,
+                    }))
+                  }
+                >
+                  {PLATFORM_OPTIONS.map((platform) => (
+                    <option key={platform} value={platform}>
+                      {formatPlatform(platform)}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="space-y-2">
+                <label className="text-sm font-medium">Platform account</label>
+                <Input
+                  placeholder="myra_help_bot or +14155551234"
+                  value={newRoute.platformAccountId}
+                  onChange={(event) =>
+                    setNewRoute((previous) => ({
+                      ...previous,
+                      platformAccountId: event.target.value,
+                    }))
+                  }
+                />
+              </div>
+              <div className="space-y-2">
+                <label className="text-sm font-medium">Chat ID</label>
+                <Input
+                  placeholder="chat/thread identifier"
+                  value={newRoute.chatId}
+                  onChange={(event) =>
+                    setNewRoute((previous) => ({
+                      ...previous,
+                      chatId: event.target.value,
+                    }))
+                  }
+                />
+              </div>
+            </div>
+
+            <div className="flex items-center justify-between">
+              <label className="flex items-center gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  checked={newRoute.isActive}
+                  onChange={(event) =>
+                    setNewRoute((previous) => ({
+                      ...previous,
+                      isActive: event.target.checked,
+                    }))
+                  }
+                />
+                Route active
+              </label>
+              <Button type="submit" disabled={createRouteMutation.isPending}>
+                <Plus className="mr-2 h-4 w-4" />
+                {createRouteMutation.isPending ? 'Creating...' : 'Add route'}
+              </Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+
+      <Card className="mt-6">
+        <CardHeader>
+          <CardTitle>Routes</CardTitle>
+          <CardDescription>Edit or disable route scopes for this SB.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <p className="text-gray-500">Loading...</p>
+          ) : !data || data.routes.length === 0 ? (
+            <p className="text-gray-500">No routes configured for this SB yet.</p>
+          ) : (
+            <div className="space-y-4">
+              {data.routes.map((route) => {
+                const isEditing = editingRouteId === route.id;
+                return (
+                  <div key={route.id} className="rounded-lg border p-4">
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center gap-2">
+                        <Badge variant="outline">{formatPlatform(route.platform)}</Badge>
+                        <Badge
+                          className={
+                            route.isActive
+                              ? 'bg-green-100 text-green-700 hover:bg-green-100'
+                              : 'bg-gray-100 text-gray-600 hover:bg-gray-100'
+                          }
+                        >
+                          {route.isActive ? 'Active' : 'Inactive'}
+                        </Badge>
+                      </div>
+                      <div className="text-xs text-gray-500">
+                        Updated {new Date(route.updatedAt).toLocaleString()}
+                      </div>
+                    </div>
+
+                    <div className="mt-3 grid gap-3 md:grid-cols-2 text-sm">
+                      <div>
+                        <div className="text-gray-500">Account</div>
+                        <div className="font-mono text-xs">{route.platformAccountId || 'Any account'}</div>
+                      </div>
+                      <div>
+                        <div className="text-gray-500">Chat</div>
+                        <div className="font-mono text-xs">{route.chatId || 'Any chat'}</div>
+                      </div>
+                    </div>
+
+                    {isEditing ? (
+                      <form
+                        className="mt-4 space-y-3 rounded-md border bg-gray-50 p-3"
+                        onSubmit={(event) => {
+                          event.preventDefault();
+                          updateRouteMutation.mutate({
+                            routeId: route.id,
+                            payload: {
+                              platform: editForm.platform,
+                              platformAccountId: editForm.platformAccountId || null,
+                              chatId: editForm.chatId || null,
+                              isActive: editForm.isActive,
+                            },
+                          });
+                          setEditingRouteId(null);
+                        }}
+                      >
+                        <div className="grid gap-3 md:grid-cols-3">
+                          <select
+                            className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                            value={editForm.platform}
+                            onChange={(event) =>
+                              setEditForm((previous) => ({
+                                ...previous,
+                                platform: event.target.value,
+                              }))
+                            }
+                          >
+                            {PLATFORM_OPTIONS.map((platform) => (
+                              <option key={platform} value={platform}>
+                                {formatPlatform(platform)}
+                              </option>
+                            ))}
+                          </select>
+                          <Input
+                            placeholder="Platform account"
+                            value={editForm.platformAccountId}
+                            onChange={(event) =>
+                              setEditForm((previous) => ({
+                                ...previous,
+                                platformAccountId: event.target.value,
+                              }))
+                            }
+                          />
+                          <Input
+                            placeholder="Chat ID"
+                            value={editForm.chatId}
+                            onChange={(event) =>
+                              setEditForm((previous) => ({
+                                ...previous,
+                                chatId: event.target.value,
+                              }))
+                            }
+                          />
+                        </div>
+                        <div className="flex items-center justify-between">
+                          <label className="flex items-center gap-2 text-sm">
+                            <input
+                              type="checkbox"
+                              checked={editForm.isActive}
+                              onChange={(event) =>
+                                setEditForm((previous) => ({
+                                  ...previous,
+                                  isActive: event.target.checked,
+                                }))
+                              }
+                            />
+                            Active
+                          </label>
+                          <div className="flex items-center gap-2">
+                            <Button
+                              type="button"
+                              variant="outline"
+                              size="sm"
+                              onClick={() => setEditingRouteId(null)}
+                            >
+                              Cancel
+                            </Button>
+                            <Button type="submit" size="sm" disabled={updateRouteMutation.isPending}>
+                              <Save className="mr-2 h-4 w-4" />
+                              Save
+                            </Button>
+                          </div>
+                        </div>
+                      </form>
+                    ) : (
+                      <div className="mt-4 flex items-center gap-2">
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => {
+                            setEditForm(initialFormFromRoute(route));
+                            setEditingRouteId(route.id);
+                          }}
+                        >
+                          Edit
+                        </Button>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() =>
+                            updateRouteMutation.mutate({
+                              routeId: route.id,
+                              payload: { isActive: !route.isActive },
+                            })
+                          }
+                          disabled={updateRouteMutation.isPending}
+                        >
+                          {route.isActive ? 'Disable' : 'Enable'}
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => {
+                            if (!confirm('Delete this route? This cannot be undone.')) return;
+                            deleteRouteMutation.mutate(route.id);
+                          }}
+                          disabled={deleteRouteMutation.isPending}
+                        >
+                          <Trash2 className="h-4 w-4 text-red-500" />
+                        </Button>
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card className="mt-6">
+        <CardHeader>
+          <CardTitle>Scheduled reminders for this SB</CardTitle>
+          <CardDescription>Identity-bound reminders that will route to this agent.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {!data || data.reminders.length === 0 ? (
+            <p className="text-sm text-gray-500">No reminders assigned to this SB.</p>
+          ) : (
+            <div className="space-y-3">
+              {data.reminders.map((reminder) => (
+                <div key={reminder.id} className="rounded-md border p-3">
+                  <div className="flex items-center justify-between gap-3">
+                    <div>
+                      <div className="font-medium text-gray-900">{reminder.title}</div>
+                      <div className="text-xs text-gray-500 mt-1">
+                        {formatPlatform(reminder.deliveryChannel)}
+                        {reminder.deliveryTarget ? ` → ${reminder.deliveryTarget}` : ''}
+                      </div>
+                    </div>
+                    <Badge variant="outline">{reminder.status}</Badge>
+                  </div>
+                  <div className="mt-2 grid gap-2 md:grid-cols-2 text-xs text-gray-600">
+                    <div className="flex items-center gap-1">
+                      <Bell className="h-3 w-3" />
+                      Next: {formatTime(reminder.nextRunAt)}
+                    </div>
+                    <div>Runs: {reminder.runCount}</div>
+                    {reminder.cronExpression && <div>Cron: {reminder.cronExpression}</div>}
+                    {reminder.lastRunAt && <div>Last: {formatTime(reminder.lastRunAt)}</div>}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/packages/web/src/app/(dashboard)/routing/page.tsx
+++ b/packages/web/src/app/(dashboard)/routing/page.tsx
@@ -1,0 +1,430 @@
+'use client';
+
+import Link from 'next/link';
+import { useState } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { Route, Plus, BellRing, AlertTriangle } from 'lucide-react';
+import { apiPatch, useApiPost, useApiQuery, useQueryClient } from '@/lib/api';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+
+interface RoutingIdentity {
+  id: string;
+  agentId: string;
+  name: string;
+  role: string;
+  backend: string | null;
+}
+
+interface RoutingRoute {
+  id: string;
+  identityId: string;
+  agentId: string | null;
+  agentName: string | null;
+  agentRole: string | null;
+  backend: string | null;
+  platform: string;
+  platformAccountId: string | null;
+  chatId: string | null;
+  isActive: boolean;
+  metadata: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+  activeReminderCount: number;
+  nextReminderAt: string | null;
+}
+
+interface RoutingResponse {
+  heartbeatProcessingEnabled: boolean;
+  summary: {
+    totalRoutes: number;
+    activeRoutes: number;
+    agentsWithRoutes: number;
+    platformsCovered: number;
+    unassignedReminderCount: number;
+  };
+  identities: RoutingIdentity[];
+  routes: RoutingRoute[];
+}
+
+interface CreateRouteInput {
+  identityId: string;
+  platform: string;
+  platformAccountId?: string | null;
+  chatId?: string | null;
+  isActive?: boolean;
+}
+
+const PLATFORM_OPTIONS = ['telegram', 'whatsapp', 'discord', 'slack', 'email'];
+
+function formatPlatform(value: string): string {
+  if (!value) return 'Unknown';
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+function formatTimestamp(value: string | null): string {
+  if (!value) return '—';
+  return new Date(value).toLocaleString();
+}
+
+export default function RoutingPage() {
+  const queryClient = useQueryClient();
+  const [showCreateForm, setShowCreateForm] = useState(false);
+  const [newRoute, setNewRoute] = useState<CreateRouteInput>({
+    identityId: '',
+    platform: 'telegram',
+    platformAccountId: '',
+    chatId: '',
+    isActive: true,
+  });
+
+  const { data, isLoading, error } = useApiQuery<RoutingResponse>(['routing'], '/api/admin/routing');
+
+  const createRouteMutation = useApiPost<{ route: RoutingRoute }, CreateRouteInput>(
+    '/api/admin/routing/routes',
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: ['routing'] });
+        setShowCreateForm(false);
+        setNewRoute({
+          identityId: '',
+          platform: 'telegram',
+          platformAccountId: '',
+          chatId: '',
+          isActive: true,
+        });
+      },
+    }
+  );
+
+  const toggleRouteMutation = useMutation({
+    mutationFn: ({ routeId, isActive }: { routeId: string; isActive: boolean }) =>
+      apiPatch(`/api/admin/routing/routes/${routeId}`, { isActive }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['routing'] });
+    },
+  });
+
+  const routes = data?.routes || [];
+  const identities = data?.identities || [];
+  const summary = data?.summary || {
+    totalRoutes: 0,
+    activeRoutes: 0,
+    agentsWithRoutes: 0,
+    platformsCovered: 0,
+    unassignedReminderCount: 0,
+  };
+
+  const mutationError = createRouteMutation.error?.message || toggleRouteMutation.error?.message;
+
+  return (
+    <div>
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-3xl font-bold text-gray-900">Routing</h1>
+          <p className="mt-2 text-gray-600">
+            Control where channel traffic and reminder execution are routed across SBs.
+          </p>
+        </div>
+        <Button onClick={() => setShowCreateForm((value) => !value)} size="sm">
+          <Plus className="mr-2 h-4 w-4" />
+          Add Route
+        </Button>
+      </div>
+
+      {data && !data.heartbeatProcessingEnabled && (
+        <Card className="mt-6 border-amber-200 bg-amber-50/70">
+          <CardContent className="flex items-start gap-3 p-4">
+            <AlertTriangle className="h-5 w-5 text-amber-600 mt-0.5" />
+            <div className="text-sm text-amber-900">
+              Heartbeat/reminder processing is disabled on this server instance
+              ({' '}
+              <code className="bg-amber-100 px-1 py-0.5 rounded text-xs">
+                ENABLE_HEARTBEAT_SERVICE=false
+              </code>{' '}
+              or related flags). This is ideal for secondary dev servers.
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {(error || mutationError) && (
+        <div className="mt-4 rounded-md bg-red-50 p-4 text-red-800">
+          {error?.message || mutationError}
+        </div>
+      )}
+
+      <div className="mt-6 grid gap-4 md:grid-cols-5">
+        <Card>
+          <CardContent className="p-4">
+            <div className="text-xs text-gray-500">Total routes</div>
+            <div className="text-2xl font-semibold text-gray-900">{summary.totalRoutes}</div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-4">
+            <div className="text-xs text-gray-500">Active</div>
+            <div className="text-2xl font-semibold text-green-700">{summary.activeRoutes}</div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-4">
+            <div className="text-xs text-gray-500">SBs with routes</div>
+            <div className="text-2xl font-semibold text-gray-900">{summary.agentsWithRoutes}</div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-4">
+            <div className="text-xs text-gray-500">Platforms</div>
+            <div className="text-2xl font-semibold text-gray-900">{summary.platformsCovered}</div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-4">
+            <div className="text-xs text-gray-500">Unassigned reminders</div>
+            <div className="text-2xl font-semibold text-amber-700">
+              {summary.unassignedReminderCount}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {showCreateForm && (
+        <Card className="mt-6">
+          <CardHeader>
+            <CardTitle>Create route</CardTitle>
+            <CardDescription>
+              Scope by platform, then optionally account + chat for more specific routing.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <form
+              className="space-y-4"
+              onSubmit={(event) => {
+                event.preventDefault();
+                createRouteMutation.mutate({
+                  identityId: newRoute.identityId,
+                  platform: newRoute.platform,
+                  platformAccountId: newRoute.platformAccountId || null,
+                  chatId: newRoute.chatId || null,
+                  isActive: newRoute.isActive ?? true,
+                });
+              }}
+            >
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="space-y-2">
+                  <label className="text-sm font-medium">SB</label>
+                  <select
+                    className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                    value={newRoute.identityId}
+                    onChange={(event) =>
+                      setNewRoute((previous) => ({
+                        ...previous,
+                        identityId: event.target.value,
+                      }))
+                    }
+                    required
+                  >
+                    <option value="">Select an SB</option>
+                    {identities.map((identity) => (
+                      <option key={identity.id} value={identity.id}>
+                        {identity.name} ({identity.agentId})
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div className="space-y-2">
+                  <label className="text-sm font-medium">Platform</label>
+                  <select
+                    className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                    value={newRoute.platform}
+                    onChange={(event) =>
+                      setNewRoute((previous) => ({
+                        ...previous,
+                        platform: event.target.value,
+                      }))
+                    }
+                    required
+                  >
+                    {PLATFORM_OPTIONS.map((platform) => (
+                      <option key={platform} value={platform}>
+                        {formatPlatform(platform)}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="space-y-2">
+                  <label className="text-sm font-medium">Platform account (optional)</label>
+                  <Input
+                    placeholder="myra_help_bot or +14155551234"
+                    value={newRoute.platformAccountId || ''}
+                    onChange={(event) =>
+                      setNewRoute((previous) => ({
+                        ...previous,
+                        platformAccountId: event.target.value,
+                      }))
+                    }
+                  />
+                </div>
+                <div className="space-y-2">
+                  <label className="text-sm font-medium">Chat ID (optional)</label>
+                  <Input
+                    placeholder="group_id / thread_id"
+                    value={newRoute.chatId || ''}
+                    onChange={(event) =>
+                      setNewRoute((previous) => ({
+                        ...previous,
+                        chatId: event.target.value,
+                      }))
+                    }
+                  />
+                </div>
+              </div>
+
+              <div className="flex items-center justify-between">
+                <label className="flex items-center gap-2 text-sm">
+                  <input
+                    type="checkbox"
+                    checked={newRoute.isActive ?? true}
+                    onChange={(event) =>
+                      setNewRoute((previous) => ({
+                        ...previous,
+                        isActive: event.target.checked,
+                      }))
+                    }
+                  />
+                  Route active
+                </label>
+                <div className="flex gap-2">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => {
+                      setShowCreateForm(false);
+                    }}
+                  >
+                    Cancel
+                  </Button>
+                  <Button type="submit" disabled={createRouteMutation.isPending}>
+                    {createRouteMutation.isPending ? 'Creating...' : 'Create route'}
+                  </Button>
+                </div>
+              </div>
+            </form>
+          </CardContent>
+        </Card>
+      )}
+
+      <Card className="mt-6">
+        <CardHeader>
+          <CardTitle>Route matrix</CardTitle>
+          <CardDescription>
+            Specificity cascade: platform + account + chat → platform + account → platform default.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <p className="text-gray-500">Loading...</p>
+          ) : routes.length === 0 ? (
+            <div className="py-10 text-center text-gray-500">
+              <Route className="h-10 w-10 mx-auto text-gray-300 mb-3" />
+              No channel routes yet. Add your first route above.
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full">
+                <thead>
+                  <tr className="border-b text-left text-sm text-gray-600">
+                    <th className="pb-3 font-medium">SB</th>
+                    <th className="pb-3 font-medium">Platform</th>
+                    <th className="pb-3 font-medium">Account</th>
+                    <th className="pb-3 font-medium">Chat</th>
+                    <th className="pb-3 font-medium">Reminders</th>
+                    <th className="pb-3 font-medium">Updated</th>
+                    <th className="pb-3 font-medium">Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {routes.map((route) => (
+                    <tr key={route.id} className="border-b align-top">
+                      <td className="py-3">
+                        <div className="flex flex-col gap-1">
+                          <Link
+                            href={route.agentId ? `/routing/${route.agentId}` : '/routing'}
+                            className="font-semibold text-gray-900 hover:underline"
+                          >
+                            {route.agentName || route.agentId || 'Unknown agent'}
+                          </Link>
+                          {route.agentRole && <span className="text-xs text-gray-500">{route.agentRole}</span>}
+                        </div>
+                      </td>
+                      <td className="py-3">
+                        <Badge variant="outline">{formatPlatform(route.platform)}</Badge>
+                      </td>
+                      <td className="py-3 font-mono text-xs text-gray-700">
+                        {route.platformAccountId || <span className="text-gray-400">Any account</span>}
+                      </td>
+                      <td className="py-3 font-mono text-xs text-gray-700">
+                        {route.chatId || <span className="text-gray-400">Any chat</span>}
+                      </td>
+                      <td className="py-3">
+                        <div className="flex flex-col gap-1 text-sm">
+                          <span className="inline-flex items-center gap-1 text-gray-700">
+                            <BellRing className="h-3 w-3" />
+                            {route.activeReminderCount}
+                          </span>
+                          <span className="text-xs text-gray-500">
+                            {route.nextReminderAt
+                              ? `Next: ${formatTimestamp(route.nextReminderAt)}`
+                              : 'No upcoming reminder'}
+                          </span>
+                        </div>
+                      </td>
+                      <td className="py-3 text-xs text-gray-500">{formatTimestamp(route.updatedAt)}</td>
+                      <td className="py-3">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <Badge
+                            className={
+                              route.isActive
+                                ? 'bg-green-100 text-green-700 hover:bg-green-100'
+                                : 'bg-gray-100 text-gray-600 hover:bg-gray-100'
+                            }
+                          >
+                            {route.isActive ? 'Active' : 'Inactive'}
+                          </Badge>
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() =>
+                              toggleRouteMutation.mutate({
+                                routeId: route.id,
+                                isActive: !route.isActive,
+                              })
+                            }
+                            disabled={toggleRouteMutation.isPending}
+                          >
+                            {route.isActive ? 'Disable' : 'Enable'}
+                          </Button>
+                          {route.agentId && (
+                            <Button variant="ghost" size="sm" asChild>
+                              <Link href={`/routing/${route.agentId}`}>Manage</Link>
+                            </Button>
+                          )}
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/packages/web/src/components/layout/sidebar.tsx
+++ b/packages/web/src/components/layout/sidebar.tsx
@@ -21,6 +21,7 @@ import {
   Check,
   Settings,
   Activity,
+  Route,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useRouter } from 'next/navigation';
@@ -49,6 +50,7 @@ const navigation = [
   { name: 'Individuals', href: '/individuals', icon: Bot },
   { name: 'Artifacts', href: '/artifacts', icon: FileText },
   { name: 'Reminders', href: '/reminders', icon: Bell },
+  { name: 'Routing', href: '/routing', icon: Route },
   { name: 'Connections', href: '/connected-accounts', icon: Link2 },
   { name: 'Skills', href: '/skills', icon: Puzzle },
 ];


### PR DESCRIPTION
## Summary
Adds a dedicated Routing admin surface and channel route management APIs, plus heartbeat/reminder dev-server safety controls.

### Included work
1. **Routing dashboard UI**
   - New `/routing` page with:
     - route matrix (SB, platform, account, chat, status)
     - route create form
     - quick enable/disable actions
     - reminder visibility and unassigned reminder count
     - heartbeat processing status banner
   - New `/routing/[agentId]` page with:
     - SB-specific route editing (platform/account/chat/active)
     - add/delete/toggle controls
     - SB-assigned reminder visibility

2. **Routing admin APIs** (`packages/api/src/routes/admin.ts`)
   - `GET /api/admin/routing`
   - `GET /api/admin/routing/agents/:agentId`
   - `POST /api/admin/routing/routes`
   - `PATCH /api/admin/routing/routes/:routeId`
   - `DELETE /api/admin/routing/routes/:routeId`

3. **Reminders API enrichment**
   - `GET /api/admin/reminders` now includes `identityId` and `deliveryTarget` in response payload.

4. **Sidebar navigation**
   - Adds **Routing** entry to dashboard nav.

5. **Dev-server safety (already on this branch)**
   - Heartbeat/reminder kill switch support (`ENABLE_HEARTBEAT_SERVICE`, plus compatibility flags) for secondary dev servers.

6. **Agent workflow docs**
   - AGENTS.md now explicitly states that agents should open PRs proactively when ready (unless user explicitly asks not to).

## Why
- Users currently have no easy way to edit `channel_routes`.
- Routing visibility is crucial for understanding where Telegram/WhatsApp traffic and heartbeat/reminder events are going.
- Secondary dev servers (e.g., REPL/test instances) should not accidentally process global reminders/heartbeats.

## Validation
- ✅ `yarn workspace @personal-context/web type-check`
- ✅ `SUPABASE_URL=https://example.supabase.co SUPABASE_PUBLISHABLE_KEY=test SUPABASE_SECRET_KEY=test JWT_SECRET=12345678901234567890123456789012 yarn workspace @personal-context/api test src/services/routing/resolve-route.test.ts`
- ⚠️ Web production build in sandbox fails due to blocked Google Fonts fetch (network-restricted environment), not app logic.

## Notes
This is intentionally a dedicated top-level Routing page (not nested under Individuals) to speed iteration on routing UX and operational clarity.