### PR TITLE
fix(cli): codex positional resume should skip PCP session picker (by Lumen)

### DIFF
--- a/packages/cli/src/commands/claude.test.ts
+++ b/packages/cli/src/commands/claude.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { hasBackendSessionOverride } from './claude.js';
+
+describe('hasBackendSessionOverride', () => {
+  it('detects explicit Codex resume subcommand in positional prompt parts', () => {
+    expect(hasBackendSessionOverride('codex', [], ['resume', '019c44fd-68f6-7332-9eda-2dc7c8afcedf'])).toBe(
+      true
+    );
+  });
+
+  it('does not treat plain prompt text as resume override', () => {
+    expect(hasBackendSessionOverride('codex', [], ['resume this bug'])).toBe(false);
+    expect(hasBackendSessionOverride('codex', [], ['resume'])).toBe(false);
+  });
+
+  it('still respects flag-based resume overrides', () => {
+    expect(hasBackendSessionOverride('codex', ['--resume', 'abc123'])).toBe(true);
+    expect(hasBackendSessionOverride('claude', ['--resume', 'abc123'])).toBe(true);
+    expect(hasBackendSessionOverride('gemini', ['--session-id', 'abc123'])).toBe(true);
+  });
+});

--- a/packages/cli/src/commands/claude.test.ts
+++ b/packages/cli/src/commands/claude.test.ts
@@ -8,9 +8,17 @@ describe('hasBackendSessionOverride', () => {
     );
   });
 
+  it('detects explicit Codex resume subcommand in passthrough args', () => {
+    expect(hasBackendSessionOverride('codex', ['resume', '019c44fd-68f6-7332-9eda-2dc7c8afcedf'])).toBe(
+      true
+    );
+  });
+
   it('does not treat plain prompt text as resume override', () => {
     expect(hasBackendSessionOverride('codex', [], ['resume this bug'])).toBe(false);
     expect(hasBackendSessionOverride('codex', [], ['resume'])).toBe(false);
+    expect(hasBackendSessionOverride('codex', ['resume'])).toBe(false);
+    expect(hasBackendSessionOverride('codex', ['resume', '--latest'])).toBe(false);
   });
 
   it('still respects flag-based resume overrides', () => {

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -109,18 +109,25 @@ function getIdentityContextFromIdentityJson(cwd = process.cwd()): {
   }
 }
 
-function hasBackendSessionOverride(
+export function hasBackendSessionOverride(
   backend: string,
   passthroughArgs: string[],
-  promptParts: string[]
+  promptParts: string[] = []
 ): boolean {
   const lowered = passthroughArgs.map((arg) => arg.toLowerCase());
   const has = (flag: string) => lowered.includes(flag.toLowerCase());
+  const isCodexResumePrompt =
+    backend === 'codex' &&
+    promptParts[0]?.toLowerCase() === 'resume' &&
+    Boolean(promptParts[1]) &&
+    !promptParts[1]?.startsWith('-');
+  const isCodexResumePassthrough =
+    backend === 'codex' &&
+    passthroughArgs[0]?.toLowerCase() === 'resume' &&
+    Boolean(passthroughArgs[1]) &&
+    !passthroughArgs[1]?.startsWith('-');
 
-  const promptLowered = promptParts.map((part) => part.toLowerCase());
-  if (backend === 'codex' && promptLowered[0] === 'resume') {
-    return true;
-  }
+  if (isCodexResumePrompt || isCodexResumePassthrough) return true;
 
   if (backend === 'claude') {
     return (
@@ -228,8 +235,8 @@ async function ensurePcpSessionContext(
   agentId: string,
   backend: string,
   passthroughArgs: string[],
-  promptParts: string[],
-  verbose: boolean
+  verbose: boolean,
+  promptParts: string[] = []
 ): Promise<{ pcpSessionId?: string; backendSessionId?: string }> {
   if (hasBackendSessionOverride(backend, passthroughArgs, promptParts)) return {};
 
@@ -372,7 +379,13 @@ export async function runClaude(
   }
   const adapter = getBackend(options.backend);
   const sessionContext = options.session
-    ? await ensurePcpSessionContext(agentId, options.backend, passthroughArgs, promptParts, options.verbose)
+    ? await ensurePcpSessionContext(
+        agentId,
+        options.backend,
+        passthroughArgs,
+        options.verbose,
+        promptParts
+      )
     : {};
   const runtimeLinkId = options.session ? randomUUID() : undefined;
   const { studioId, identityId } = getIdentityContextFromIdentityJson(process.cwd());


### PR DESCRIPTION
## Problem
`sb -a lumen -b codex resume <sessionId>` was still showing the PCP picker prompt:

- `? Session for lumen/codex`
- `Start new session`

That defeats explicit backend resume.

## Root cause
`ensurePcpSessionContext()` only bypassed PCP session selection when `hasBackendSessionOverride()` detected resume flags in passthrough args (`--resume`, `--session-id`, etc.).

For Codex, `resume <sessionId>` is commonly passed as positional args, so the override detection never fired.

## Fix
- Extended `hasBackendSessionOverride()` to also consider positional command intent for Codex:
  - `codex resume <sessionId>`
- Threaded `promptParts` into `ensurePcpSessionContext()` so this check runs in the same place as existing flag-based override checks.

## Tests
Added `packages/cli/src/commands/claude.test.ts`:
- detects positional Codex resume override
- does not misclassify plain prompt text (`"resume this bug"`)
- preserves existing flag-based override behavior

Run:
- `yarn workspace @personal-context/cli test src/commands/claude.test.ts`

## Manual verification
- `node packages/cli/dist/cli.js -a lumen -b codex hello`
  - still shows picker (expected)
- `node packages/cli/dist/cli.js -a lumen -b codex resume 019c44fd-68f6-7332-9eda-2dc7c8afcedf`
  - no picker shown; proceeds directly to backend invocation path (expected)