### PR TITLE
feat(web): group routing + reminders pages by SB (by Wren)

### DIFF
--- a/packages/api/src/channels/agent-gateway.ts
+++ b/packages/api/src/channels/agent-gateway.ts
@@ -32,8 +32,8 @@ export interface AgentTriggerPayload {
   threadKey?: string;
   /** Explicit studio/worktree scope for the target agent */
   studioId?: string;
-  /** Convenience studio routing hint */
-  studioHint?: 'main';
+  /** Convenience studio routing hint (e.g., 'main' or a studio name) */
+  studioHint?: string;
   /** Recipient session to inherit studio scope from */
   recipientSessionId?: string;
   /** Additional metadata */

--- a/packages/api/src/mcp/tools/agent-triggers.ts
+++ b/packages/api/src/mcp/tools/agent-triggers.ts
@@ -56,9 +56,9 @@ export const triggerAgentSchema = z.object({
     .optional()
     .describe('Optional explicit studio ID for the target agent session'),
   studioHint: z
-    .enum(['main'])
+    .string()
     .optional()
-    .describe('Convenience studio routing hint (e.g., "main" to force shared main studio)'),
+    .describe('Convenience studio routing hint (e.g., "main" for shared main studio, or a studio name)'),
   recipientSessionId: z
     .string()
     .uuid()

--- a/packages/api/src/mcp/tools/inbox-handlers.test.ts
+++ b/packages/api/src/mcp/tools/inbox-handlers.test.ts
@@ -66,6 +66,15 @@ function createMockSupabase(
 
   const insertReturn = overrides.insertReturn || { data: defaultMessage, error: null };
 
+  const updateChainable = {
+    eq: vi.fn().mockReturnThis(),
+    mockResolvedValue: undefined as unknown,
+  };
+  // Make the last .eq() resolve
+  updateChainable.eq = vi.fn().mockReturnValue({
+    eq: vi.fn().mockResolvedValue({ data: null, error: null }),
+  });
+
   const chainable = {
     insert: vi.fn().mockReturnValue({
       select: vi.fn().mockReturnValue({
@@ -80,6 +89,7 @@ function createMockSupabase(
         .fn()
         .mockResolvedValue(overrides.selectReturn || { data: [defaultMessage], error: null }),
     }),
+    update: vi.fn().mockReturnValue(updateChainable),
   };
 
   // For count query

--- a/packages/api/src/mcp/tools/inbox-handlers.ts
+++ b/packages/api/src/mcp/tools/inbox-handlers.ts
@@ -263,6 +263,16 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
       accepted: result.accepted,
       error: result.error,
     };
+
+    // Auto-mark as read: if the trigger was accepted, the recipient agent
+    // has been woken up to process this message.
+    if (result.accepted) {
+      await supabase
+        .from('agent_inbox')
+        .update({ status: 'read', read_at: new Date().toISOString() })
+        .eq('id', message.id)
+        .eq('status', 'unread'); // Only transition unread → read
+    }
   }
 
   return {

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -1651,6 +1651,15 @@ router.get('/routing/agents/:agentId', async (req: Request, res: Response) => {
       toRoutingRoute(route, reminderCountByIdentity, nextReminderByIdentity)
     );
 
+    // Fetch studios owned by this agent
+    const { data: studiosData } = await supabase
+      .from('studios')
+      .select('id, name, branch, status')
+      .eq('user_id', authReq.pcpUserId)
+      .eq('agent_id', identity.agent_id)
+      .in('status', ['active', 'idle'])
+      .order('name', { ascending: true });
+
     const heartbeatProcessingEnabled =
       process.env.ENABLE_HEARTBEAT_SERVICE !== 'false' &&
       process.env.ENABLE_HEARTBEATS !== 'false' &&
@@ -1667,6 +1676,12 @@ router.get('/routing/agents/:agentId', async (req: Request, res: Response) => {
         backend: identity.backend,
         updatedAt: identity.updated_at,
       },
+      studios: (studiosData || []).map((s) => ({
+        id: s.id,
+        name: s.name,
+        branch: s.branch,
+        status: s.status,
+      })),
       routes,
       reminders: (remindersData || []).map((reminder) => ({
         id: reminder.id,

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -80,6 +80,7 @@ type ChannelRouteRow = {
   platform: string;
   platform_account_id: string | null;
   chat_id: string | null;
+  studio_id: string | null;
   is_active: boolean;
   metadata: Record<string, unknown> | null;
   created_at: string;
@@ -162,6 +163,7 @@ function toRoutingRoute(
     platform: route.platform,
     platformAccountId: route.platform_account_id,
     chatId: route.chat_id,
+    studioId: route.studio_id,
     isActive: route.is_active,
     metadata: route.metadata || {},
     createdAt: route.created_at,
@@ -1428,6 +1430,7 @@ router.get('/routing', async (req: Request, res: Response) => {
         platform,
         platform_account_id,
         chat_id,
+        studio_id,
         is_active,
         metadata,
         created_at,
@@ -1511,6 +1514,15 @@ router.get('/routing', async (req: Request, res: Response) => {
       toRoutingRoute(route, reminderCountByIdentity, nextReminderByIdentity)
     );
 
+    // Fetch studios for the workspace so the UI can offer a studio picker
+    const { data: studiosData } = await supabase
+      .from('studios')
+      .select('id, name, branch, status, agent_id')
+      .eq('user_id', authReq.pcpUserId)
+      .eq('workspace_id', authReq.pcpWorkspaceId)
+      .in('status', ['active', 'idle'])
+      .order('name', { ascending: true });
+
     const heartbeatProcessingEnabled =
       process.env.ENABLE_HEARTBEAT_SERVICE !== 'false' &&
       process.env.ENABLE_HEARTBEATS !== 'false' &&
@@ -1534,6 +1546,13 @@ router.get('/routing', async (req: Request, res: Response) => {
         name: identity.name,
         role: identity.role,
         backend: identity.backend,
+      })),
+      studios: (studiosData || []).map((s) => ({
+        id: s.id,
+        name: s.name,
+        branch: s.branch,
+        status: s.status,
+        agentId: s.agent_id,
       })),
       routes,
     });
@@ -1578,6 +1597,7 @@ router.get('/routing/agents/:agentId', async (req: Request, res: Response) => {
         platform,
         platform_account_id,
         chat_id,
+        studio_id,
         is_active,
         metadata,
         created_at,
@@ -1647,6 +1667,15 @@ router.get('/routing/agents/:agentId', async (req: Request, res: Response) => {
       toRoutingRoute(route, reminderCountByIdentity, nextReminderByIdentity)
     );
 
+    // Fetch studios for the workspace
+    const { data: studiosData } = await supabase
+      .from('studios')
+      .select('id, name, branch, status, agent_id')
+      .eq('user_id', authReq.pcpUserId)
+      .eq('workspace_id', authReq.pcpWorkspaceId)
+      .in('status', ['active', 'idle'])
+      .order('name', { ascending: true });
+
     const heartbeatProcessingEnabled =
       process.env.ENABLE_HEARTBEAT_SERVICE !== 'false' &&
       process.env.ENABLE_HEARTBEATS !== 'false' &&
@@ -1663,6 +1692,13 @@ router.get('/routing/agents/:agentId', async (req: Request, res: Response) => {
         backend: identity.backend,
         updatedAt: identity.updated_at,
       },
+      studios: (studiosData || []).map((s) => ({
+        id: s.id,
+        name: s.name,
+        branch: s.branch,
+        status: s.status,
+        agentId: s.agent_id,
+      })),
       routes,
       reminders: (remindersData || []).map((reminder) => ({
         id: reminder.id,
@@ -1701,6 +1737,7 @@ router.post('/routing/routes', async (req: Request, res: Response) => {
     const platform = normalizeNullableText(body.platform)?.toLowerCase();
     const platformAccountId = normalizeNullableText(body.platformAccountId);
     const chatId = normalizeNullableText(body.chatId);
+    const studioId = normalizeNullableText(body.studioId);
     const isActive = typeof body.isActive === 'boolean' ? body.isActive : true;
     const metadata = parseRouteMetadata(body.metadata);
 
@@ -1730,6 +1767,7 @@ router.post('/routing/routes', async (req: Request, res: Response) => {
         platform,
         platform_account_id: platformAccountId,
         chat_id: chatId,
+        studio_id: studioId,
         is_active: isActive,
         metadata,
       })
@@ -1741,6 +1779,7 @@ router.post('/routing/routes', async (req: Request, res: Response) => {
         platform,
         platform_account_id,
         chat_id,
+        studio_id,
         is_active,
         metadata,
         created_at,
@@ -1865,6 +1904,10 @@ router.patch('/routing/routes/:routeId', async (req: Request, res: Response) => 
       updates.is_active = body.isActive;
     }
 
+    if ('studioId' in body) {
+      updates.studio_id = normalizeNullableText(body.studioId);
+    }
+
     if ('metadata' in body) {
       updates.metadata = parseRouteMetadata(body.metadata);
     }
@@ -1887,6 +1930,7 @@ router.patch('/routing/routes/:routeId', async (req: Request, res: Response) => 
         platform,
         platform_account_id,
         chat_id,
+        studio_id,
         is_active,
         metadata,
         created_at,

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -80,7 +80,7 @@ type ChannelRouteRow = {
   platform: string;
   platform_account_id: string | null;
   chat_id: string | null;
-  studio_id: string | null;
+  studio_hint: string | null;
   is_active: boolean;
   metadata: Record<string, unknown> | null;
   created_at: string;
@@ -163,7 +163,7 @@ function toRoutingRoute(
     platform: route.platform,
     platformAccountId: route.platform_account_id,
     chatId: route.chat_id,
-    studioId: route.studio_id,
+    studioHint: route.studio_hint,
     isActive: route.is_active,
     metadata: route.metadata || {},
     createdAt: route.created_at,
@@ -1430,7 +1430,7 @@ router.get('/routing', async (req: Request, res: Response) => {
         platform,
         platform_account_id,
         chat_id,
-        studio_id,
+        studio_hint,
         is_active,
         metadata,
         created_at,
@@ -1514,15 +1514,6 @@ router.get('/routing', async (req: Request, res: Response) => {
       toRoutingRoute(route, reminderCountByIdentity, nextReminderByIdentity)
     );
 
-    // Fetch studios for the workspace so the UI can offer a studio picker
-    const { data: studiosData } = await supabase
-      .from('studios')
-      .select('id, name, branch, status, agent_id')
-      .eq('user_id', authReq.pcpUserId)
-      .eq('workspace_id', authReq.pcpWorkspaceId)
-      .in('status', ['active', 'idle'])
-      .order('name', { ascending: true });
-
     const heartbeatProcessingEnabled =
       process.env.ENABLE_HEARTBEAT_SERVICE !== 'false' &&
       process.env.ENABLE_HEARTBEATS !== 'false' &&
@@ -1546,13 +1537,6 @@ router.get('/routing', async (req: Request, res: Response) => {
         name: identity.name,
         role: identity.role,
         backend: identity.backend,
-      })),
-      studios: (studiosData || []).map((s) => ({
-        id: s.id,
-        name: s.name,
-        branch: s.branch,
-        status: s.status,
-        agentId: s.agent_id,
       })),
       routes,
     });
@@ -1597,7 +1581,7 @@ router.get('/routing/agents/:agentId', async (req: Request, res: Response) => {
         platform,
         platform_account_id,
         chat_id,
-        studio_id,
+        studio_hint,
         is_active,
         metadata,
         created_at,
@@ -1667,15 +1651,6 @@ router.get('/routing/agents/:agentId', async (req: Request, res: Response) => {
       toRoutingRoute(route, reminderCountByIdentity, nextReminderByIdentity)
     );
 
-    // Fetch studios for the workspace
-    const { data: studiosData } = await supabase
-      .from('studios')
-      .select('id, name, branch, status, agent_id')
-      .eq('user_id', authReq.pcpUserId)
-      .eq('workspace_id', authReq.pcpWorkspaceId)
-      .in('status', ['active', 'idle'])
-      .order('name', { ascending: true });
-
     const heartbeatProcessingEnabled =
       process.env.ENABLE_HEARTBEAT_SERVICE !== 'false' &&
       process.env.ENABLE_HEARTBEATS !== 'false' &&
@@ -1692,13 +1667,6 @@ router.get('/routing/agents/:agentId', async (req: Request, res: Response) => {
         backend: identity.backend,
         updatedAt: identity.updated_at,
       },
-      studios: (studiosData || []).map((s) => ({
-        id: s.id,
-        name: s.name,
-        branch: s.branch,
-        status: s.status,
-        agentId: s.agent_id,
-      })),
       routes,
       reminders: (remindersData || []).map((reminder) => ({
         id: reminder.id,
@@ -1737,7 +1705,7 @@ router.post('/routing/routes', async (req: Request, res: Response) => {
     const platform = normalizeNullableText(body.platform)?.toLowerCase();
     const platformAccountId = normalizeNullableText(body.platformAccountId);
     const chatId = normalizeNullableText(body.chatId);
-    const studioId = normalizeNullableText(body.studioId);
+    const studioHint = normalizeNullableText(body.studioHint);
     const isActive = typeof body.isActive === 'boolean' ? body.isActive : true;
     const metadata = parseRouteMetadata(body.metadata);
 
@@ -1767,7 +1735,7 @@ router.post('/routing/routes', async (req: Request, res: Response) => {
         platform,
         platform_account_id: platformAccountId,
         chat_id: chatId,
-        studio_id: studioId,
+        studio_hint: studioHint,
         is_active: isActive,
         metadata,
       })
@@ -1779,7 +1747,7 @@ router.post('/routing/routes', async (req: Request, res: Response) => {
         platform,
         platform_account_id,
         chat_id,
-        studio_id,
+        studio_hint,
         is_active,
         metadata,
         created_at,
@@ -1904,8 +1872,8 @@ router.patch('/routing/routes/:routeId', async (req: Request, res: Response) => 
       updates.is_active = body.isActive;
     }
 
-    if ('studioId' in body) {
-      updates.studio_id = normalizeNullableText(body.studioId);
+    if ('studioHint' in body) {
+      updates.studio_hint = normalizeNullableText(body.studioHint);
     }
 
     if ('metadata' in body) {
@@ -1930,7 +1898,7 @@ router.patch('/routing/routes/:routeId', async (req: Request, res: Response) => 
         platform,
         platform_account_id,
         chat_id,
-        studio_id,
+        studio_hint,
         is_active,
         metadata,
         created_at,

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -179,7 +179,7 @@ async function startServer(config: ServerConfig = {}): Promise<void> {
     }
 
     // If mention didn't match, try channel_routes specificity cascade
-    let routeStudioId: string | null = null;
+    let routeStudioHint: string | null = null;
     if (routedAgentId === agentId) {
       const route = await resolveRouteAgentId(
         dataComposer!.getClient(),
@@ -190,13 +190,13 @@ async function startServer(config: ServerConfig = {}): Promise<void> {
       );
       if (route) {
         routedAgentId = route.agentId;
-        routeStudioId = route.studioId;
+        routeStudioHint = route.studioHint;
         logger.debug(`[Route] Resolved agent from channel_routes`, {
           platform: channel,
           agentId: route.agentId,
           identityId: route.identityId,
           routeId: route.routeId,
-          studioId: route.studioId,
+          studioHint: route.studioHint,
         });
       } else {
         logger.warn(
@@ -223,7 +223,7 @@ async function startServer(config: ServerConfig = {}): Promise<void> {
         chatType: metadata?.chatType,
         media: metadata?.media,
         triggerType: 'message',
-        ...(routeStudioId ? { studioId: routeStudioId } : {}),
+        ...(routeStudioHint ? { studioHint: routeStudioHint } : {}),
       },
     };
 

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -559,7 +559,8 @@ Type: ${payload.triggerType}`;
 ---
 IMPORTANT: This is a system trigger, NOT a user message on Telegram/WhatsApp.
 Check your inbox for the full message using get_inbox.
-If you need to message a user, use send_response with the appropriate channel and conversationId.`;
+If you need to message a user, use send_response with the appropriate channel and conversationId.
+When you complete a task_request, mark it as completed using update_inbox_message(messageId, status: "completed").`;
 
     // 4. Process via SessionService (stateless - looks up session from DB)
     const request: SessionRequest = {

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -179,6 +179,7 @@ async function startServer(config: ServerConfig = {}): Promise<void> {
     }
 
     // If mention didn't match, try channel_routes specificity cascade
+    let routeStudioId: string | null = null;
     if (routedAgentId === agentId) {
       const route = await resolveRouteAgentId(
         dataComposer!.getClient(),
@@ -189,11 +190,13 @@ async function startServer(config: ServerConfig = {}): Promise<void> {
       );
       if (route) {
         routedAgentId = route.agentId;
+        routeStudioId = route.studioId;
         logger.debug(`[Route] Resolved agent from channel_routes`, {
           platform: channel,
           agentId: route.agentId,
           identityId: route.identityId,
           routeId: route.routeId,
+          studioId: route.studioId,
         });
       } else {
         logger.warn(
@@ -220,6 +223,7 @@ async function startServer(config: ServerConfig = {}): Promise<void> {
         chatType: metadata?.chatType,
         media: metadata?.media,
         triggerType: 'message',
+        ...(routeStudioId ? { studioId: routeStudioId } : {}),
       },
     };
 

--- a/packages/api/src/services/routing/resolve-route.test.ts
+++ b/packages/api/src/services/routing/resolve-route.test.ts
@@ -68,7 +68,7 @@ describe('resolveRouteAgentId', () => {
       agentId: 'myra',
       identityId: 'id-1',
       routeId: 'route-1',
-      studioId: null,
+      studioHint: null,
     });
   });
 

--- a/packages/api/src/services/routing/resolve-route.test.ts
+++ b/packages/api/src/services/routing/resolve-route.test.ts
@@ -68,6 +68,7 @@ describe('resolveRouteAgentId', () => {
       agentId: 'myra',
       identityId: 'id-1',
       routeId: 'route-1',
+      studioId: null,
     });
   });
 

--- a/packages/api/src/services/routing/resolve-route.ts
+++ b/packages/api/src/services/routing/resolve-route.ts
@@ -17,6 +17,7 @@ export interface ResolvedRoute {
   agentId: string;
   identityId: string;
   routeId: string;
+  studioId: string | null;
 }
 
 /**
@@ -41,6 +42,7 @@ export async function resolveRouteAgentId(
       platform_account_id,
       chat_id,
       identity_id,
+      studio_id,
       agent_identities!inner ( agent_id )
     `
     )
@@ -113,5 +115,6 @@ export async function resolveRouteAgentId(
     agentId,
     identityId: bestMatch.identity_id,
     routeId: bestMatch.id,
+    studioId: (bestMatch as unknown as { studio_id: string | null }).studio_id ?? null,
   };
 }

--- a/packages/api/src/services/routing/resolve-route.ts
+++ b/packages/api/src/services/routing/resolve-route.ts
@@ -17,7 +17,7 @@ export interface ResolvedRoute {
   agentId: string;
   identityId: string;
   routeId: string;
-  studioId: string | null;
+  studioHint: string | null;
 }
 
 /**
@@ -42,7 +42,7 @@ export async function resolveRouteAgentId(
       platform_account_id,
       chat_id,
       identity_id,
-      studio_id,
+      studio_hint,
       agent_identities!inner ( agent_id )
     `
     )
@@ -115,6 +115,6 @@ export async function resolveRouteAgentId(
     agentId,
     identityId: bestMatch.identity_id,
     routeId: bestMatch.id,
-    studioId: (bestMatch as unknown as { studio_id: string | null }).studio_id ?? null,
+    studioHint: (bestMatch as unknown as { studio_hint: string | null }).studio_hint ?? null,
   };
 }

--- a/packages/api/src/services/sessions/session-service.ts
+++ b/packages/api/src/services/sessions/session-service.ts
@@ -460,7 +460,7 @@ export class SessionService implements ISessionService {
       parentSessionId?: string;
       threadKey?: string;
       studioId?: string;
-      studioHint?: 'main';
+      studioHint?: string;
       recipientSessionId?: string;
     }
   ): Promise<Session> {
@@ -577,7 +577,7 @@ export class SessionService implements ISessionService {
     options: {
       threadKey?: string;
       explicitStudioId?: string;
-      studioHint?: 'main';
+      studioHint?: string;
       recipientSessionId?: string;
       backend?: string;
     }
@@ -590,9 +590,33 @@ export class SessionService implements ISessionService {
       return undefined;
     }
 
-    // Explicit convenience hint: route directly to user's shared main studio.
-    if (options.studioHint === 'main') {
-      return this.resolveMainStudioId(userId);
+    // Explicit convenience hint: resolve studio by name.
+    // 'main' is a special case resolved by worktree path / branch.
+    // Other hints resolve by matching the studio name for this user + agent.
+    if (options.studioHint) {
+      if (options.studioHint === 'main') {
+        return this.resolveMainStudioId(userId);
+      }
+
+      const { data: namedStudio } = await this.supabase
+        .from('studios')
+        .select('id')
+        .eq('user_id', userId)
+        .eq('agent_id', agentId)
+        .eq('name', options.studioHint)
+        .in('status', ['active', 'idle'])
+        .limit(1)
+        .maybeSingle();
+
+      if (namedStudio?.id) {
+        return namedStudio.id;
+      }
+
+      logger.warn('[StudioResolve] Studio hint did not match any studio, falling through', {
+        userId,
+        agentId,
+        studioHint: options.studioHint,
+      });
     }
 
     // 1) Related session scope (explicit resume continuity)

--- a/packages/api/src/services/sessions/types.ts
+++ b/packages/api/src/services/sessions/types.ts
@@ -115,7 +115,7 @@ export interface SessionRequest {
     // Explicit studio/worktree scope for this request
     studioId?: string;
     // Convenience routing hint (e.g., force main studio without UUID lookup)
-    studioHint?: 'main';
+    studioHint?: string;
     // Recipient session to inherit studio scope from
     recipientSessionId?: string;
     // For task sessions
@@ -246,7 +246,7 @@ export interface ISessionService {
       parentSessionId?: string;
       threadKey?: string;
       studioId?: string;
-      studioHint?: 'main';
+      studioHint?: string;
       recipientSessionId?: string;
     }
   ): Promise<Session>;

--- a/packages/cli/src/commands/hooks.test.ts
+++ b/packages/cli/src/commands/hooks.test.ts
@@ -366,18 +366,45 @@ vi.mock('../auth/tokens.js', () => ({
 import * as tokensMod from '../auth/tokens.js';
 const mockedGetValidAccessToken = vi.mocked(tokensMod.getValidAccessToken);
 
+// ============================================================================
+// Helpers for mock fetch responses
+// ============================================================================
+
+/** Build a mock Response that returns JSON (application/json) */
+function mockJsonResponse(payload: Record<string, unknown>): Partial<Response> {
+  return {
+    ok: true,
+    headers: new Headers({ 'content-type': 'application/json' }),
+    json: async () => payload,
+    text: async () => JSON.stringify(payload),
+  };
+}
+
+/** Build a mock Response that returns SSE (text/event-stream) */
+function mockSseResponse(payload: Record<string, unknown>): Partial<Response> {
+  const sseBody = `event: message\ndata: ${JSON.stringify(payload)}\n\n`;
+  return {
+    ok: true,
+    headers: new Headers({ 'content-type': 'text/event-stream' }),
+    text: async () => sseBody,
+  };
+}
+
+const TOOL_RESULT_PAYLOAD = {
+  jsonrpc: '2.0',
+  result: { content: [{ text: '{"success":true}' }] },
+  id: 1,
+};
+
+// ============================================================================
+// callPcpTool: auth header
+// ============================================================================
+
 describe('callPcpTool: auth header', () => {
   let fetchSpy: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
-    fetchSpy = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        jsonrpc: '2.0',
-        result: { content: [{ text: '{"success":true}' }] },
-        id: 1,
-      }),
-    });
+    fetchSpy = vi.fn().mockResolvedValue(mockJsonResponse(TOOL_RESULT_PAYLOAD));
     vi.stubGlobal('fetch', fetchSpy);
   });
 
@@ -417,5 +444,151 @@ describe('callPcpTool: auth header', () => {
     expect(body.method).toBe('tools/call');
     expect(body.params.name).toBe('get_inbox');
     expect(body.params.arguments).toEqual({ agentId: 'wren', status: 'unread' });
+  });
+
+  it('should send spec-compliant Accept header (both JSON and SSE)', async () => {
+    mockedGetValidAccessToken.mockResolvedValue('token');
+
+    await callPcpTool('bootstrap', { agentId: 'wren' });
+
+    const [, options] = fetchSpy.mock.calls[0];
+    expect(options.headers.Accept).toBe('application/json, text/event-stream');
+  });
+});
+
+// ============================================================================
+// callPcpTool: Streamable HTTP response format handling
+// ============================================================================
+
+describe('callPcpTool: Streamable HTTP response formats', () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockedGetValidAccessToken.mockResolvedValue('token');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('should parse application/json response (enableJsonResponse mode)', async () => {
+    fetchSpy = vi.fn().mockResolvedValue(mockJsonResponse(TOOL_RESULT_PAYLOAD));
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const result = await callPcpTool('bootstrap', { agentId: 'wren' });
+    expect(result).toEqual({ success: true });
+  });
+
+  it('should parse text/event-stream SSE response (default Streamable HTTP)', async () => {
+    fetchSpy = vi.fn().mockResolvedValue(mockSseResponse(TOOL_RESULT_PAYLOAD));
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const result = await callPcpTool('bootstrap', { agentId: 'wren' });
+    expect(result).toEqual({ success: true });
+  });
+
+  it('should handle SSE response with multiple events (uses last data line)', async () => {
+    const sseBody = [
+      'event: message',
+      'data: {"jsonrpc":"2.0","result":{"content":[{"text":"partial"}]},"id":1}',
+      '',
+      'event: message',
+      'data: {"jsonrpc":"2.0","result":{"content":[{"text":"{\\"final\\":true}"}]},"id":1}',
+      '',
+    ].join('\n');
+    fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: new Headers({ 'content-type': 'text/event-stream' }),
+      text: async () => sseBody,
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const result = await callPcpTool('bootstrap', { agentId: 'wren' });
+    expect(result).toEqual({ final: true });
+  });
+
+  it('should throw on SSE response with no data lines', async () => {
+    fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: new Headers({ 'content-type': 'text/event-stream' }),
+      text: async () => 'event: message\n\n',
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+
+    await expect(callPcpTool('bootstrap', { agentId: 'wren' })).rejects.toThrow(
+      'PCP SSE response contained no data lines'
+    );
+  });
+
+  it('should throw on non-OK HTTP status', async () => {
+    fetchSpy = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 406,
+      headers: new Headers({ 'content-type': 'application/json' }),
+      text: async () => '{"error":"Not Acceptable"}',
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+
+    await expect(callPcpTool('bootstrap', { agentId: 'wren' })).rejects.toThrow(
+      'PCP call failed (406)'
+    );
+  });
+
+  it('should throw on JSON-RPC error in JSON response', async () => {
+    fetchSpy = vi.fn().mockResolvedValue(
+      mockJsonResponse({
+        jsonrpc: '2.0',
+        error: { code: -32001, message: 'Authentication required' },
+        id: null,
+      })
+    );
+    vi.stubGlobal('fetch', fetchSpy);
+
+    await expect(callPcpTool('bootstrap', { agentId: 'wren' })).rejects.toThrow(
+      'PCP tool error (-32001): Authentication required'
+    );
+  });
+
+  it('should throw on JSON-RPC error in SSE response', async () => {
+    fetchSpy = vi.fn().mockResolvedValue(
+      mockSseResponse({
+        jsonrpc: '2.0',
+        error: { code: -32602, message: 'Invalid params' },
+        id: 1,
+      })
+    );
+    vi.stubGlobal('fetch', fetchSpy);
+
+    await expect(callPcpTool('bootstrap', { agentId: 'wren' })).rejects.toThrow(
+      'PCP tool error (-32602): Invalid params'
+    );
+  });
+
+  it('should handle content-type with charset suffix', async () => {
+    fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: new Headers({ 'content-type': 'application/json; charset=utf-8' }),
+      json: async () => TOOL_RESULT_PAYLOAD,
+      text: async () => JSON.stringify(TOOL_RESULT_PAYLOAD),
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const result = await callPcpTool('bootstrap', { agentId: 'wren' });
+    expect(result).toEqual({ success: true });
+  });
+
+  it('should return raw text when MCP content is not valid JSON', async () => {
+    fetchSpy = vi.fn().mockResolvedValue(
+      mockJsonResponse({
+        jsonrpc: '2.0',
+        result: { content: [{ text: 'plain text result' }] },
+        id: 1,
+      })
+    );
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const result = await callPcpTool('bootstrap', { agentId: 'wren' });
+    expect(result).toEqual({ text: 'plain text result' });
   });
 });

--- a/packages/cli/src/commands/hooks.ts
+++ b/packages/cli/src/commands/hooks.ts
@@ -220,7 +220,7 @@ export async function callPcpTool(
 
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
-    Accept: 'application/json',
+    Accept: 'application/json, text/event-stream',
   };
 
   // Attach CLI auth token so hooks pass OAuth checks on the MCP server
@@ -244,7 +244,27 @@ export async function callPcpTool(
     throw new Error(`PCP call failed (${response.status}): ${await response.text()}`);
   }
 
-  const payload = (await response.json()) as Record<string, unknown>;
+  // The MCP server uses Streamable HTTP transport, which may respond with
+  // text/event-stream (SSE) even for single JSON-RPC responses. Parse
+  // accordingly based on the Content-Type header.
+  const contentType = response.headers.get('content-type') || '';
+  let payload: Record<string, unknown>;
+
+  if (contentType.includes('text/event-stream')) {
+    // Parse SSE: extract the last `data:` line from the stream
+    const text = await response.text();
+    const dataLines = text
+      .split('\n')
+      .filter((line) => line.startsWith('data: '))
+      .map((line) => line.slice(6));
+    const lastData = dataLines[dataLines.length - 1];
+    if (!lastData) {
+      throw new Error('PCP SSE response contained no data lines');
+    }
+    payload = JSON.parse(lastData) as Record<string, unknown>;
+  } else {
+    payload = (await response.json()) as Record<string, unknown>;
+  }
 
   // JSON-RPC error
   if (payload.error) {

--- a/packages/web/src/app/(dashboard)/reminders/page.tsx
+++ b/packages/web/src/app/(dashboard)/reminders/page.tsx
@@ -1,11 +1,27 @@
 'use client';
 
 import { useState, useMemo } from 'react';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import Link from 'next/link';
+import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { Bell, Clock, CheckCircle, XCircle, PauseCircle, User, Repeat, Hash } from 'lucide-react';
+import {
+  Bell,
+  Clock,
+  CheckCircle,
+  XCircle,
+  PauseCircle,
+  Repeat,
+  Hash,
+  ChevronDown,
+  ChevronRight,
+  Send,
+  MessageCircle,
+  Mail,
+} from 'lucide-react';
 import { useApiQuery } from '@/lib/api';
 import clsx from 'clsx';
+
+// ─── Types ───
 
 interface Reminder {
   id: string;
@@ -28,97 +44,228 @@ interface RemindersResponse {
   reminders: Reminder[];
 }
 
-type StatusFilter = 'all' | 'active' | 'paused' | 'completed' | 'cancelled';
+type StatusFilter = 'all' | 'active' | 'paused' | 'completed';
 
-const STATUS_ORDER: Record<string, number> = {
-  active: 0,
-  paused: 1,
-  completed: 2,
-  cancelled: 3,
+interface SBReminderGroup {
+  agentId: string | null;
+  agentName: string;
+  reminders: Reminder[];
+  activeCount: number;
+  totalCount: number;
+}
+
+// ─── Constants ───
+
+const STATUS_ORDER: Record<string, number> = { active: 0, paused: 1, completed: 2, cancelled: 3 };
+
+const statusConfig: Record<string, { icon: typeof Bell; label: string; color: string; bgColor: string; borderColor: string }> = {
+  active: { icon: Bell, label: 'Active', color: 'text-green-700', bgColor: 'bg-green-50', borderColor: 'border-green-200' },
+  paused: { icon: PauseCircle, label: 'Paused', color: 'text-amber-700', bgColor: 'bg-amber-50', borderColor: 'border-amber-200' },
+  completed: { icon: CheckCircle, label: 'Completed', color: 'text-gray-500', bgColor: 'bg-gray-50', borderColor: 'border-gray-200' },
+  cancelled: { icon: XCircle, label: 'Cancelled', color: 'text-gray-400', bgColor: 'bg-gray-50', borderColor: 'border-gray-200' },
 };
 
-const statusConfig = {
-  active: {
-    icon: Bell,
-    label: 'Active',
-    color: 'text-green-600',
-    bgColor: 'bg-green-100',
-  },
-  paused: {
-    icon: PauseCircle,
-    label: 'Paused',
-    color: 'text-yellow-600',
-    bgColor: 'bg-yellow-100',
-  },
-  completed: {
-    icon: CheckCircle,
-    label: 'Completed',
-    color: 'text-blue-600',
-    bgColor: 'bg-blue-100',
-  },
-  cancelled: {
-    icon: XCircle,
-    label: 'Cancelled',
-    color: 'text-gray-500',
-    bgColor: 'bg-gray-100',
-  },
+const channelConfig: Record<string, { icon: typeof Send; label: string }> = {
+  telegram: { icon: Send, label: 'Telegram' },
+  whatsapp: { icon: MessageCircle, label: 'WhatsApp' },
+  email: { icon: Mail, label: 'Email' },
+  push: { icon: Bell, label: 'Push' },
 };
 
-const channelLabels: Record<string, string> = {
-  telegram: 'Telegram',
-  whatsapp: 'WhatsApp',
-  email: 'Email',
-  push: 'Push',
-};
+const INITIAL_COLORS = [
+  'from-violet-500 to-purple-600',
+  'from-sky-500 to-blue-600',
+  'from-emerald-500 to-teal-600',
+  'from-amber-500 to-orange-600',
+  'from-rose-500 to-pink-600',
+];
+
+// ─── Helpers ───
+
+function getColorForAgent(name: string): string {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) hash = name.charCodeAt(i) + ((hash << 5) - hash);
+  return INITIAL_COLORS[Math.abs(hash) % INITIAL_COLORS.length];
+}
 
 function formatCron(cron: string | null): string {
   if (!cron) return 'One-time';
-
   const parts = cron.split(' ');
   if (parts.length !== 5) return cron;
-
-  const [minute, hour, dayOfMonth, month, dayOfWeek] = parts;
-  const timeStr = `${hour}:${minute.padStart(2, '0')}`;
-
-  if (dayOfMonth === '*' && month === '*' && dayOfWeek === '*') {
-    return `Daily at ${timeStr}`;
-  }
-  if (dayOfMonth === '*' && month === '*' && dayOfWeek === '1-5') {
-    return `Weekdays at ${timeStr}`;
-  }
-  if (dayOfMonth === '*' && month === '*' && dayOfWeek === '0,6') {
-    return `Weekends at ${timeStr}`;
-  }
-  if (dayOfMonth === '*' && month === '*') {
-    const dayNames: Record<string, string> = {
-      '0': 'Sun', '1': 'Mon', '2': 'Tue', '3': 'Wed',
-      '4': 'Thu', '5': 'Fri', '6': 'Sat',
-    };
-    const dayLabel = dayNames[dayOfWeek] || dayOfWeek;
-    return `${dayLabel} at ${timeStr}`;
-  }
-
-  return cron;
+  const [minute, hour, , , dayOfWeek] = parts;
+  const time = `${hour}:${minute.padStart(2, '0')}`;
+  if (dayOfWeek === '*') return `Daily at ${time}`;
+  if (dayOfWeek === '1-5') return `Weekdays at ${time}`;
+  const days: Record<string, string> = { '0': 'Sun', '1': 'Mon', '2': 'Tue', '3': 'Wed', '4': 'Thu', '5': 'Fri', '6': 'Sat' };
+  return `${days[dayOfWeek] || dayOfWeek} at ${time}`;
 }
 
 function formatRelativeTime(date: string): string {
-  const now = new Date();
-  const target = new Date(date);
-  const diffMs = target.getTime() - now.getTime();
-  const diffMins = Math.round(diffMs / 60000);
-  const diffHours = Math.round(diffMs / 3600000);
-  const diffDays = Math.round(diffMs / 86400000);
-
-  if (diffMs < 0) {
-    if (diffMins > -60) return `${Math.abs(diffMins)} min ago`;
-    if (diffHours > -24) return `${Math.abs(diffHours)} hours ago`;
-    return `${Math.abs(diffDays)} days ago`;
-  } else {
-    if (diffMins < 60) return `in ${diffMins} min`;
-    if (diffHours < 24) return `in ${diffHours} hours`;
-    return `in ${diffDays} days`;
-  }
+  const diffMs = new Date(date).getTime() - Date.now();
+  const abs = Math.abs(diffMs);
+  const mins = Math.round(abs / 60000);
+  const hours = Math.round(abs / 3600000);
+  const days = Math.round(abs / 86400000);
+  const suffix = diffMs < 0 ? ' ago' : '';
+  const prefix = diffMs >= 0 ? 'in ' : '';
+  if (mins < 60) return `${prefix}${mins}m${suffix}`;
+  if (hours < 24) return `${prefix}${hours}h${suffix}`;
+  return `${prefix}${days}d${suffix}`;
 }
+
+function sortReminders(reminders: Reminder[]): Reminder[] {
+  return [...reminders].sort((a, b) => {
+    const sd = (STATUS_ORDER[a.status] ?? 9) - (STATUS_ORDER[b.status] ?? 9);
+    if (sd !== 0) return sd;
+    if (a.nextRunAt && b.nextRunAt) return new Date(a.nextRunAt).getTime() - new Date(b.nextRunAt).getTime();
+    if (a.nextRunAt) return -1;
+    if (b.nextRunAt) return 1;
+    return 0;
+  });
+}
+
+// ─── Sub-components ───
+
+function ReminderCard({ reminder }: { reminder: Reminder }) {
+  const config = statusConfig[reminder.status] || statusConfig.active;
+  const StatusIcon = config.icon;
+  const channel = channelConfig[reminder.deliveryChannel];
+  const ChannelIcon = channel?.icon || Bell;
+  const isRecurring = !!reminder.cronExpression;
+
+  return (
+    <div
+      className={clsx(
+        'rounded-lg border p-4 transition-all',
+        reminder.status === 'active' && 'border-green-200 bg-green-50/30',
+        reminder.status === 'paused' && 'border-amber-200 bg-amber-50/20',
+        (reminder.status === 'completed' || reminder.status === 'cancelled') && 'border-gray-100 bg-gray-50/30',
+      )}
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <h4 className="font-medium text-gray-900 text-sm">{reminder.title}</h4>
+            <Badge className={clsx('text-[10px] font-medium border', config.bgColor, config.color, config.borderColor)}>
+              <StatusIcon className="h-3 w-3 mr-0.5" />
+              {config.label}
+            </Badge>
+            {isRecurring && (
+              <Badge variant="outline" className="text-[10px] text-purple-600 border-purple-200">
+                <Repeat className="h-3 w-3 mr-0.5" />
+                Recurring
+              </Badge>
+            )}
+          </div>
+          {reminder.description && (
+            <p className="text-xs text-gray-500 mt-1.5 line-clamp-2">{reminder.description}</p>
+          )}
+          <div className="flex items-center gap-3 mt-2 text-[11px] text-gray-400">
+            <span className="flex items-center gap-1">
+              <Clock className="h-3 w-3" />
+              {formatCron(reminder.cronExpression)}
+            </span>
+            <span className="flex items-center gap-1">
+              <ChannelIcon className="h-3 w-3" />
+              {channel?.label || reminder.deliveryChannel}
+            </span>
+            {reminder.runCount > 0 && (
+              <span className="flex items-center gap-1">
+                <Hash className="h-3 w-3" />
+                {reminder.runCount}{reminder.maxRuns ? `/${reminder.maxRuns}` : ''} run{reminder.runCount !== 1 ? 's' : ''}
+              </span>
+            )}
+          </div>
+        </div>
+        <div className="text-right shrink-0">
+          {reminder.nextRunAt && reminder.status === 'active' && (
+            <div>
+              <div className="text-sm font-medium text-gray-900">
+                {formatRelativeTime(reminder.nextRunAt)}
+              </div>
+              <div className="text-[10px] text-gray-400 mt-0.5">
+                {new Date(reminder.nextRunAt).toLocaleString([], { dateStyle: 'short', timeStyle: 'short' })}
+              </div>
+            </div>
+          )}
+          {reminder.lastRunAt && (
+            <div className="text-[10px] text-gray-400 mt-1">
+              Last: {formatRelativeTime(reminder.lastRunAt)}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SBSection({ group, statusFilter }: { group: SBReminderGroup; statusFilter: StatusFilter }) {
+  const [collapsed, setCollapsed] = useState(group.activeCount === 0);
+  const gradient = getColorForAgent(group.agentName);
+
+  const filtered = statusFilter === 'all'
+    ? group.reminders
+    : group.reminders.filter((r) => r.status === statusFilter);
+
+  if (filtered.length === 0) return null;
+
+  const activeInGroup = group.reminders.filter((r) => r.status === 'active').length;
+
+  return (
+    <div className="rounded-xl border bg-white overflow-hidden">
+      {/* SB Header */}
+      <button
+        onClick={() => setCollapsed(!collapsed)}
+        className="flex items-center gap-3 w-full px-5 py-3.5 text-left hover:bg-gray-50/50 transition-colors"
+      >
+        {group.agentId ? (
+          <div className={clsx(
+            'h-9 w-9 rounded-full bg-gradient-to-br flex items-center justify-center text-white font-semibold text-sm shrink-0',
+            gradient
+          )}>
+            {group.agentName.charAt(0).toUpperCase()}
+          </div>
+        ) : (
+          <div className="h-9 w-9 rounded-full bg-gray-200 flex items-center justify-center text-gray-500 shrink-0">
+            <Bell className="h-4 w-4" />
+          </div>
+        )}
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2">
+            <span className="font-semibold text-gray-900 text-sm">{group.agentName}</span>
+            {group.agentId && (
+              <span className="text-xs text-gray-400">@{group.agentId}</span>
+            )}
+          </div>
+        </div>
+        <div className="flex items-center gap-3 shrink-0">
+          {activeInGroup > 0 && (
+            <Badge className="bg-green-50 text-green-700 border border-green-200 text-[10px] hover:bg-green-50">
+              {activeInGroup} active
+            </Badge>
+          )}
+          <span className="text-xs text-gray-400">{filtered.length} reminder{filtered.length !== 1 ? 's' : ''}</span>
+          {collapsed ? (
+            <ChevronRight className="h-4 w-4 text-gray-400" />
+          ) : (
+            <ChevronDown className="h-4 w-4 text-gray-400" />
+          )}
+        </div>
+      </button>
+
+      {/* Reminders */}
+      {!collapsed && (
+        <div className="px-5 pb-4 space-y-2">
+          {filtered.map((reminder) => (
+            <ReminderCard key={reminder.id} reminder={reminder} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Main Page ───
 
 export default function RemindersPage() {
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
@@ -130,22 +277,36 @@ export default function RemindersPage() {
 
   const allReminders = data?.reminders ?? [];
 
-  // Sort: active first, then paused, then completed/cancelled. Within each group, by next_run_at.
-  const sortedReminders = useMemo(() => {
-    return [...allReminders].sort((a, b) => {
-      const statusDiff = (STATUS_ORDER[a.status] ?? 9) - (STATUS_ORDER[b.status] ?? 9);
-      if (statusDiff !== 0) return statusDiff;
-      // Within same status: soonest next_run_at first (nulls last)
-      if (a.nextRunAt && b.nextRunAt) return new Date(a.nextRunAt).getTime() - new Date(b.nextRunAt).getTime();
-      if (a.nextRunAt) return -1;
-      if (b.nextRunAt) return 1;
-      return 0;
+  // Group by SB, sorted with active-first
+  const sbGroups = useMemo<SBReminderGroup[]>(() => {
+    const groups = new Map<string, SBReminderGroup>();
+
+    for (const r of sortReminders(allReminders)) {
+      const key = r.agentId || '__unassigned__';
+      if (!groups.has(key)) {
+        groups.set(key, {
+          agentId: r.agentId,
+          agentName: r.agentName || (r.agentId ? r.agentId : 'Unassigned'),
+          reminders: [],
+          activeCount: 0,
+          totalCount: 0,
+        });
+      }
+      const group = groups.get(key)!;
+      group.reminders.push(r);
+      group.totalCount++;
+      if (r.status === 'active') group.activeCount++;
+    }
+
+    // Sort groups: those with active reminders first, then alphabetically
+    return [...groups.values()].sort((a, b) => {
+      if (a.activeCount > 0 && b.activeCount === 0) return -1;
+      if (a.activeCount === 0 && b.activeCount > 0) return 1;
+      if (a.agentId === null) return 1; // Unassigned last
+      if (b.agentId === null) return -1;
+      return a.agentName.localeCompare(b.agentName);
     });
   }, [allReminders]);
-
-  const reminders = statusFilter === 'all'
-    ? sortedReminders
-    : sortedReminders.filter((r) => r.status === statusFilter);
 
   const stats = {
     active: allReminders.filter((r) => r.status === 'active').length,
@@ -162,187 +323,90 @@ export default function RemindersPage() {
   ];
 
   return (
-    <div>
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-3xl font-bold text-gray-900">Reminders</h1>
-          <p className="mt-2 text-gray-600">Scheduled reminders and recurring check-ins.</p>
+    <div className="max-w-5xl">
+      {/* Header */}
+      <div>
+        <h1 className="text-3xl font-bold text-gray-900">Reminders</h1>
+        <p className="mt-1 text-gray-500">Scheduled reminders and recurring check-ins, grouped by SB.</p>
+      </div>
+
+      {error && (
+        <div className="mt-4 rounded-lg bg-red-50 border border-red-200 p-4 text-sm text-red-800">
+          {error.message}
         </div>
-      </div>
+      )}
 
-      {error && <div className="mt-4 rounded-md bg-red-50 p-4 text-red-800">{error.message}</div>}
-
-      {/* Stats */}
-      <div className="grid grid-cols-4 gap-4 mt-6">
-        <Card>
-          <CardContent className="p-4 text-center">
-            <Bell className="h-5 w-5 mx-auto text-green-600 mb-1" />
-            <div className="text-2xl font-bold text-green-600">{stats.active}</div>
-            <div className="text-xs text-gray-500">Active</div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="p-4 text-center">
-            <PauseCircle className="h-5 w-5 mx-auto text-yellow-600 mb-1" />
-            <div className="text-2xl font-bold text-yellow-600">{stats.paused}</div>
-            <div className="text-xs text-gray-500">Paused</div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="p-4 text-center">
-            <CheckCircle className="h-5 w-5 mx-auto text-blue-600 mb-1" />
-            <div className="text-2xl font-bold text-blue-600">{stats.completed}</div>
-            <div className="text-xs text-gray-500">Completed</div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="p-4 text-center">
-            <Clock className="h-5 w-5 mx-auto text-gray-600 mb-1" />
-            <div className="text-2xl font-bold text-gray-600">{stats.total}</div>
-            <div className="text-xs text-gray-500">Total</div>
-          </CardContent>
-        </Card>
-      </div>
-
-      {/* Filter Tabs + List */}
-      <Card className="mt-6">
-        <CardHeader>
-          <div className="flex items-center justify-between">
-            <div>
-              <CardTitle>Reminders</CardTitle>
-              <CardDescription>Active reminders sorted first, then by next run time</CardDescription>
-            </div>
-            <div className="flex gap-1">
-              {filterButtons.map((btn) => (
-                <button
-                  key={btn.key}
-                  onClick={() => setStatusFilter(btn.key)}
-                  className={clsx(
-                    'px-3 py-1.5 text-xs font-medium rounded-md transition-colors',
-                    statusFilter === btn.key
-                      ? 'bg-gray-900 text-white'
-                      : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
-                  )}
-                >
-                  {btn.label}
-                  {btn.count > 0 && (
-                    <span className={clsx(
-                      'ml-1.5 px-1.5 py-0.5 rounded-full text-[10px]',
-                      statusFilter === btn.key ? 'bg-white/20' : 'bg-gray-200'
-                    )}>
-                      {btn.count}
-                    </span>
-                  )}
-                </button>
-              ))}
-            </div>
+      {/* Stats row */}
+      <div className="mt-6 grid grid-cols-2 gap-3 sm:grid-cols-4">
+        {[
+          { label: 'Active', value: stats.active, color: 'text-green-700' },
+          { label: 'Paused', value: stats.paused, color: 'text-amber-600' },
+          { label: 'Completed', value: stats.completed, color: 'text-gray-500' },
+          { label: 'Total', value: stats.total, color: 'text-gray-900' },
+        ].map((stat) => (
+          <div key={stat.label} className="rounded-lg border bg-white p-3">
+            <div className="text-xs text-gray-500">{stat.label}</div>
+            <div className={clsx('text-2xl font-semibold', stat.color)}>{stat.value}</div>
           </div>
-        </CardHeader>
-        <CardContent>
-          {isLoading ? (
-            <p className="text-gray-500">Loading...</p>
-          ) : reminders.length === 0 ? (
-            <div className="text-center py-8">
-              <Bell className="h-12 w-12 mx-auto text-gray-300 mb-3" />
-              {statusFilter !== 'all' ? (
-                <p className="text-gray-500">No {statusFilter} reminders.</p>
-              ) : (
-                <>
-                  <p className="text-gray-500">No reminders scheduled yet.</p>
-                  <p className="text-sm text-gray-400 mt-1">
-                    Use the <code className="bg-gray-100 px-1 rounded">create_reminder</code> tool to
-                    schedule one.
-                  </p>
-                </>
-              )}
-            </div>
-          ) : (
-            <div className="space-y-3">
-              {reminders.map((reminder) => {
-                const config = statusConfig[reminder.status] || statusConfig.active;
-                const StatusIcon = config.icon;
-                const isRecurring = !!reminder.cronExpression;
+        ))}
+      </div>
 
-                return (
-                  <div
-                    key={reminder.id}
-                    className={clsx(
-                      'rounded-lg border p-4 transition-colors',
-                      reminder.status === 'active'
-                        ? 'border-green-200 bg-green-50/50'
-                        : reminder.status === 'paused'
-                          ? 'border-yellow-200 bg-yellow-50/30'
-                          : 'border-gray-200'
-                    )}
-                  >
-                    <div className="flex items-start justify-between">
-                      <div className="flex-1 min-w-0">
-                        <div className="flex items-center gap-2 flex-wrap">
-                          <h3 className="font-semibold text-gray-900">{reminder.title}</h3>
-                          <Badge className={clsx('text-xs', config.bgColor, config.color)}>
-                            <StatusIcon className="h-3 w-3 mr-1" />
-                            {config.label}
-                          </Badge>
-                          {isRecurring && (
-                            <Badge variant="outline" className="text-xs text-purple-600 border-purple-200">
-                              <Repeat className="h-3 w-3 mr-1" />
-                              Recurring
-                            </Badge>
-                          )}
-                        </div>
-                        {reminder.description && (
-                          <p className="text-sm text-gray-600 mt-1">{reminder.description}</p>
-                        )}
-                        <div className="flex items-center gap-4 mt-3 text-xs text-gray-500 flex-wrap">
-                          <span className="flex items-center gap-1">
-                            <Clock className="h-3 w-3" />
-                            {formatCron(reminder.cronExpression)}
-                          </span>
-                          <span className="flex items-center gap-1">
-                            {channelLabels[reminder.deliveryChannel] || reminder.deliveryChannel}
-                          </span>
-                          {reminder.agentName && (
-                            <span className="flex items-center gap-1">
-                              <User className="h-3 w-3" />
-                              {reminder.agentName}
-                            </span>
-                          )}
-                          {reminder.runCount > 0 && (
-                            <span className="flex items-center gap-1">
-                              <Hash className="h-3 w-3" />
-                              {reminder.runCount}{reminder.maxRuns ? `/${reminder.maxRuns}` : ''} run{reminder.runCount !== 1 ? 's' : ''}
-                            </span>
-                          )}
-                        </div>
-                      </div>
-                      <div className="text-right text-sm ml-4 shrink-0">
-                        {reminder.nextRunAt && reminder.status === 'active' && (
-                          <div>
-                            <div className="text-gray-500">Next run</div>
-                            <div className="font-medium text-gray-900">
-                              {formatRelativeTime(reminder.nextRunAt)}
-                            </div>
-                            <div className="text-xs text-gray-400">
-                              {new Date(reminder.nextRunAt).toLocaleString()}
-                            </div>
-                          </div>
-                        )}
-                        {reminder.lastRunAt && (
-                          <div className={reminder.nextRunAt && reminder.status === 'active' ? 'mt-2' : ''}>
-                            <div className="text-xs text-gray-400">
-                              Last: {formatRelativeTime(reminder.lastRunAt)}
-                            </div>
-                          </div>
-                        )}
-                      </div>
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
-          )}
-        </CardContent>
-      </Card>
+      {/* Filter pills */}
+      <div className="mt-6 flex items-center justify-between">
+        <div className="flex gap-1">
+          {filterButtons.map((btn) => (
+            <button
+              key={btn.key}
+              onClick={() => setStatusFilter(btn.key)}
+              className={clsx(
+                'px-3 py-1.5 text-xs font-medium rounded-full transition-colors',
+                statusFilter === btn.key
+                  ? 'bg-gray-900 text-white'
+                  : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+              )}
+            >
+              {btn.label}
+              {btn.count > 0 && (
+                <span className={clsx(
+                  'ml-1.5 tabular-nums',
+                  statusFilter === btn.key ? 'text-gray-300' : 'text-gray-400'
+                )}>
+                  {btn.count}
+                </span>
+              )}
+            </button>
+          ))}
+        </div>
+        <Link
+          href="/routing"
+          className="text-xs text-gray-400 hover:text-gray-600 transition-colors"
+        >
+          Manage routing
+        </Link>
+      </div>
+
+      {/* SB Groups */}
+      <div className="mt-4 space-y-3">
+        {isLoading ? (
+          <Card>
+            <CardContent className="py-12 text-center text-gray-500">Loading...</CardContent>
+          </Card>
+        ) : sbGroups.length === 0 ? (
+          <Card>
+            <CardContent className="py-12 text-center">
+              <Bell className="h-10 w-10 mx-auto text-gray-300 mb-3" />
+              <p className="text-gray-500">No reminders scheduled yet.</p>
+              <p className="text-sm text-gray-400 mt-1">
+                Use <code className="bg-gray-100 px-1.5 py-0.5 rounded text-xs">create_reminder</code> to schedule one.
+              </p>
+            </CardContent>
+          </Card>
+        ) : (
+          sbGroups.map((group) => (
+            <SBSection key={group.agentId || '__unassigned__'} group={group} statusFilter={statusFilter} />
+          ))
+        )}
+      </div>
     </div>
   );
 }

--- a/packages/web/src/app/(dashboard)/reminders/page.tsx
+++ b/packages/web/src/app/(dashboard)/reminders/page.tsx
@@ -20,6 +20,7 @@ import {
 } from 'lucide-react';
 import { useApiQuery } from '@/lib/api';
 import clsx from 'clsx';
+import { getAgentGradient } from '@/lib/utils';
 
 // ─── Types ───
 
@@ -72,21 +73,7 @@ const channelConfig: Record<string, { icon: typeof Send; label: string }> = {
   push: { icon: Bell, label: 'Push' },
 };
 
-const INITIAL_COLORS = [
-  'from-violet-500 to-purple-600',
-  'from-sky-500 to-blue-600',
-  'from-emerald-500 to-teal-600',
-  'from-amber-500 to-orange-600',
-  'from-rose-500 to-pink-600',
-];
-
 // ─── Helpers ───
-
-function getColorForAgent(name: string): string {
-  let hash = 0;
-  for (let i = 0; i < name.length; i++) hash = name.charCodeAt(i) + ((hash << 5) - hash);
-  return INITIAL_COLORS[Math.abs(hash) % INITIAL_COLORS.length];
-}
 
 function formatCron(cron: string | null): string {
   if (!cron) return 'One-time';
@@ -201,7 +188,7 @@ function ReminderCard({ reminder }: { reminder: Reminder }) {
 
 function SBSection({ group, statusFilter }: { group: SBReminderGroup; statusFilter: StatusFilter }) {
   const [collapsed, setCollapsed] = useState(group.activeCount === 0);
-  const gradient = getColorForAgent(group.agentName);
+  const gradient = getAgentGradient(group.agentId || '__unassigned__');
 
   const filtered = statusFilter === 'all'
     ? group.reminders

--- a/packages/web/src/app/(dashboard)/routing/[agentId]/page.tsx
+++ b/packages/web/src/app/(dashboard)/routing/[agentId]/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useParams } from 'next/navigation';
 import { useMutation } from '@tanstack/react-query';
 import { ArrowLeft, Bell, Save, Trash2, Plus, GitBranch } from 'lucide-react';
@@ -45,6 +45,13 @@ interface AgentReminder {
   identityId: string | null;
 }
 
+interface AgentStudio {
+  id: string;
+  name: string;
+  branch: string | null;
+  status: string;
+}
+
 interface AgentRoutingResponse {
   heartbeatProcessingEnabled: boolean;
   agent: {
@@ -56,6 +63,7 @@ interface AgentRoutingResponse {
     backend: string | null;
     updatedAt: string;
   };
+  studios: AgentStudio[];
   routes: AgentRoute[];
   reminders: AgentReminder[];
 }
@@ -70,11 +78,6 @@ interface RouteFormState {
 
 const PLATFORM_OPTIONS = ['telegram', 'whatsapp', 'discord', 'slack', 'email'];
 
-const STUDIO_HINT_OPTIONS: { value: string; label: string }[] = [
-  { value: '', label: 'Auto (nearest session)' },
-  { value: 'main', label: 'Main' },
-];
-
 function formatPlatform(value: string): string {
   if (!value) return 'Unknown';
   return value.charAt(0).toUpperCase() + value.slice(1);
@@ -85,9 +88,23 @@ function formatTime(value: string | null): string {
   return new Date(value).toLocaleString();
 }
 
-function studioHintLabel(hint: string | null): string {
-  if (!hint) return 'Auto (nearest session)';
+function buildStudioOptions(studios: AgentStudio[]): { value: string; label: string }[] {
+  const options: { value: string; label: string }[] = [
+    { value: 'main', label: 'Main' },
+  ];
+  for (const s of studios) {
+    // Skip if this IS the main branch studio (already covered by "Main" option)
+    if (s.branch === 'main') continue;
+    options.push({ value: s.name, label: s.name });
+  }
+  return options;
+}
+
+function studioHintLabel(hint: string | null, studios: AgentStudio[]): string {
+  if (!hint) return 'Not set';
   if (hint === 'main') return 'Main';
+  const match = studios.find((s) => s.name === hint);
+  if (match) return match.name;
   return hint;
 }
 
@@ -113,6 +130,9 @@ export default function AgentRoutingPage() {
       enabled: !!agentId,
     }
   );
+
+  const studios = data?.studios ?? [];
+  const studioOptions = useMemo(() => buildStudioOptions(studios), [studios]);
 
   const [newRoute, setNewRoute] = useState<RouteFormState>({
     platform: 'telegram',
@@ -272,7 +292,7 @@ export default function AgentRoutingPage() {
                     }))
                   }
                 >
-                  {STUDIO_HINT_OPTIONS.map((opt) => (
+                  {studioOptions.map((opt) => (
                     <option key={opt.value} value={opt.value}>
                       {opt.label}
                     </option>
@@ -379,7 +399,7 @@ export default function AgentRoutingPage() {
                         <div className="text-gray-500">Studio</div>
                         <div className="flex items-center gap-1 text-xs">
                           <GitBranch className="h-3 w-3 text-gray-400" />
-                          {studioHintLabel(route.studioHint)}
+                          {studioHintLabel(route.studioHint, studios)}
                         </div>
                       </div>
                     </div>
@@ -429,7 +449,7 @@ export default function AgentRoutingPage() {
                               }))
                             }
                           >
-                            {STUDIO_HINT_OPTIONS.map((opt) => (
+                            {studioOptions.map((opt) => (
                               <option key={opt.value} value={opt.value}>
                                 {opt.label}
                               </option>

--- a/packages/web/src/app/(dashboard)/routing/[agentId]/page.tsx
+++ b/packages/web/src/app/(dashboard)/routing/[agentId]/page.tsx
@@ -4,12 +4,20 @@ import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import { useParams } from 'next/navigation';
 import { useMutation } from '@tanstack/react-query';
-import { ArrowLeft, Bell, Save, Trash2, Plus } from 'lucide-react';
+import { ArrowLeft, Bell, Save, Trash2, Plus, GitBranch } from 'lucide-react';
 import { apiDelete, apiPatch, useApiPost, useApiQuery, useQueryClient } from '@/lib/api';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
+
+interface Studio {
+  id: string;
+  name: string;
+  branch: string | null;
+  status: string;
+  agentId: string | null;
+}
 
 interface AgentRoute {
   id: string;
@@ -21,6 +29,7 @@ interface AgentRoute {
   platform: string;
   platformAccountId: string | null;
   chatId: string | null;
+  studioId: string | null;
   isActive: boolean;
   metadata: Record<string, unknown>;
   createdAt: string;
@@ -55,6 +64,7 @@ interface AgentRoutingResponse {
     backend: string | null;
     updatedAt: string;
   };
+  studios: Studio[];
   routes: AgentRoute[];
   reminders: AgentReminder[];
 }
@@ -63,6 +73,7 @@ interface RouteFormState {
   platform: string;
   platformAccountId: string;
   chatId: string;
+  studioId: string;
   isActive: boolean;
 }
 
@@ -74,8 +85,15 @@ function formatPlatform(value: string): string {
 }
 
 function formatTime(value: string | null): string {
-  if (!value) return '—';
+  if (!value) return '\u2014';
   return new Date(value).toLocaleString();
+}
+
+function studioLabel(studios: Studio[], studioId: string | null): string {
+  if (!studioId) return 'Auto (nearest session)';
+  const studio = studios.find((s) => s.id === studioId);
+  if (!studio) return 'Unknown studio';
+  return studio.name + (studio.branch ? ` (${studio.branch})` : '');
 }
 
 function initialFormFromRoute(route: AgentRoute): RouteFormState {
@@ -83,6 +101,7 @@ function initialFormFromRoute(route: AgentRoute): RouteFormState {
     platform: route.platform,
     platformAccountId: route.platformAccountId || '',
     chatId: route.chatId || '',
+    studioId: route.studioId || '',
     isActive: route.isActive,
   };
 }
@@ -100,10 +119,13 @@ export default function AgentRoutingPage() {
     }
   );
 
+  const studios = data?.studios ?? [];
+
   const [newRoute, setNewRoute] = useState<RouteFormState>({
     platform: 'telegram',
     platformAccountId: '',
     chatId: '',
+    studioId: '',
     isActive: true,
   });
   const [editingRouteId, setEditingRouteId] = useState<string | null>(null);
@@ -111,6 +133,7 @@ export default function AgentRoutingPage() {
     platform: 'telegram',
     platformAccountId: '',
     chatId: '',
+    studioId: '',
     isActive: true,
   });
 
@@ -131,6 +154,7 @@ export default function AgentRoutingPage() {
           platform: 'telegram',
           platformAccountId: '',
           chatId: '',
+          studioId: '',
           isActive: true,
         });
       },
@@ -160,6 +184,9 @@ export default function AgentRoutingPage() {
     updateRouteMutation.error?.message ||
     deleteRouteMutation.error?.message;
 
+  const selectClassName =
+    'flex h-9 w-full rounded-md border border-input bg-background px-3 py-2 text-sm';
+
   return (
     <div>
       <div className="flex items-center justify-between gap-4">
@@ -187,7 +214,7 @@ export default function AgentRoutingPage() {
       {data && !data.heartbeatProcessingEnabled && (
         <div className="mt-4 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900">
           Heartbeat/reminder processing is disabled on this server instance. Routing edits still
-          persist, but reminder execution won’t run here.
+          persist, but reminder execution won't run here.
         </div>
       )}
 
@@ -215,11 +242,12 @@ export default function AgentRoutingPage() {
                 platform: newRoute.platform,
                 platformAccountId: newRoute.platformAccountId || null,
                 chatId: newRoute.chatId || null,
+                studioId: newRoute.studioId || null,
                 isActive: newRoute.isActive,
               });
             }}
           >
-            <div className="grid gap-4 md:grid-cols-3">
+            <div className="grid gap-4 md:grid-cols-2">
               <div className="space-y-2">
                 <label className="text-sm font-medium">Platform</label>
                 <select
@@ -239,6 +267,28 @@ export default function AgentRoutingPage() {
                   ))}
                 </select>
               </div>
+              <div className="space-y-2">
+                <label className="text-sm font-medium">Studio</label>
+                <select
+                  className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                  value={newRoute.studioId}
+                  onChange={(event) =>
+                    setNewRoute((previous) => ({
+                      ...previous,
+                      studioId: event.target.value,
+                    }))
+                  }
+                >
+                  <option value="">Auto (nearest session)</option>
+                  {studios.map((studio) => (
+                    <option key={studio.id} value={studio.id}>
+                      {studio.name}{studio.branch ? ` (${studio.branch})` : ''}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+            <div className="grid gap-4 md:grid-cols-2">
               <div className="space-y-2">
                 <label className="text-sm font-medium">Platform account</label>
                 <Input
@@ -324,14 +374,21 @@ export default function AgentRoutingPage() {
                       </div>
                     </div>
 
-                    <div className="mt-3 grid gap-3 md:grid-cols-2 text-sm">
+                    <div className="mt-3 grid gap-3 md:grid-cols-3 text-sm">
                       <div>
                         <div className="text-gray-500">Account</div>
-                        <div className="font-mono text-xs">{route.platformAccountId || 'Any account'}</div>
+                        <div className="font-mono text-xs">{route.platformAccountId || 'All accounts'}</div>
                       </div>
                       <div>
                         <div className="text-gray-500">Chat</div>
-                        <div className="font-mono text-xs">{route.chatId || 'Any chat'}</div>
+                        <div className="font-mono text-xs">{route.chatId || 'All chats'}</div>
+                      </div>
+                      <div>
+                        <div className="text-gray-500">Studio</div>
+                        <div className="flex items-center gap-1 text-xs">
+                          <GitBranch className="h-3 w-3 text-gray-400" />
+                          {studioLabel(studios, route.studioId)}
+                        </div>
                       </div>
                     </div>
 
@@ -346,15 +403,16 @@ export default function AgentRoutingPage() {
                               platform: editForm.platform,
                               platformAccountId: editForm.platformAccountId || null,
                               chatId: editForm.chatId || null,
+                              studioId: editForm.studioId || null,
                               isActive: editForm.isActive,
                             },
                           });
                           setEditingRouteId(null);
                         }}
                       >
-                        <div className="grid gap-3 md:grid-cols-3">
+                        <div className="grid gap-3 md:grid-cols-2">
                           <select
-                            className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                            className={selectClassName}
                             value={editForm.platform}
                             onChange={(event) =>
                               setEditForm((previous) => ({
@@ -369,6 +427,25 @@ export default function AgentRoutingPage() {
                               </option>
                             ))}
                           </select>
+                          <select
+                            className={selectClassName}
+                            value={editForm.studioId}
+                            onChange={(event) =>
+                              setEditForm((previous) => ({
+                                ...previous,
+                                studioId: event.target.value,
+                              }))
+                            }
+                          >
+                            <option value="">Auto (nearest session)</option>
+                            {studios.map((studio) => (
+                              <option key={studio.id} value={studio.id}>
+                                {studio.name}{studio.branch ? ` (${studio.branch})` : ''}
+                              </option>
+                            ))}
+                          </select>
+                        </div>
+                        <div className="grid gap-3 md:grid-cols-2">
                           <Input
                             placeholder="Platform account"
                             value={editForm.platformAccountId}
@@ -483,7 +560,7 @@ export default function AgentRoutingPage() {
                       <div className="font-medium text-gray-900">{reminder.title}</div>
                       <div className="text-xs text-gray-500 mt-1">
                         {formatPlatform(reminder.deliveryChannel)}
-                        {reminder.deliveryTarget ? ` → ${reminder.deliveryTarget}` : ''}
+                        {reminder.deliveryTarget ? ` \u2192 ${reminder.deliveryTarget}` : ''}
                       </div>
                     </div>
                     <Badge variant="outline">{reminder.status}</Badge>

--- a/packages/web/src/app/(dashboard)/routing/[agentId]/page.tsx
+++ b/packages/web/src/app/(dashboard)/routing/[agentId]/page.tsx
@@ -11,14 +11,6 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 
-interface Studio {
-  id: string;
-  name: string;
-  branch: string | null;
-  status: string;
-  agentId: string | null;
-}
-
 interface AgentRoute {
   id: string;
   identityId: string;
@@ -29,7 +21,7 @@ interface AgentRoute {
   platform: string;
   platformAccountId: string | null;
   chatId: string | null;
-  studioId: string | null;
+  studioHint: string | null;
   isActive: boolean;
   metadata: Record<string, unknown>;
   createdAt: string;
@@ -64,7 +56,6 @@ interface AgentRoutingResponse {
     backend: string | null;
     updatedAt: string;
   };
-  studios: Studio[];
   routes: AgentRoute[];
   reminders: AgentReminder[];
 }
@@ -73,11 +64,16 @@ interface RouteFormState {
   platform: string;
   platformAccountId: string;
   chatId: string;
-  studioId: string;
+  studioHint: string;
   isActive: boolean;
 }
 
 const PLATFORM_OPTIONS = ['telegram', 'whatsapp', 'discord', 'slack', 'email'];
+
+const STUDIO_HINT_OPTIONS: { value: string; label: string }[] = [
+  { value: '', label: 'Auto (nearest session)' },
+  { value: 'main', label: 'Main' },
+];
 
 function formatPlatform(value: string): string {
   if (!value) return 'Unknown';
@@ -89,11 +85,10 @@ function formatTime(value: string | null): string {
   return new Date(value).toLocaleString();
 }
 
-function studioLabel(studios: Studio[], studioId: string | null): string {
-  if (!studioId) return 'Auto (nearest session)';
-  const studio = studios.find((s) => s.id === studioId);
-  if (!studio) return 'Unknown studio';
-  return studio.name + (studio.branch ? ` (${studio.branch})` : '');
+function studioHintLabel(hint: string | null): string {
+  if (!hint) return 'Auto (nearest session)';
+  if (hint === 'main') return 'Main';
+  return hint;
 }
 
 function initialFormFromRoute(route: AgentRoute): RouteFormState {
@@ -101,7 +96,7 @@ function initialFormFromRoute(route: AgentRoute): RouteFormState {
     platform: route.platform,
     platformAccountId: route.platformAccountId || '',
     chatId: route.chatId || '',
-    studioId: route.studioId || '',
+    studioHint: route.studioHint || '',
     isActive: route.isActive,
   };
 }
@@ -119,13 +114,11 @@ export default function AgentRoutingPage() {
     }
   );
 
-  const studios = data?.studios ?? [];
-
   const [newRoute, setNewRoute] = useState<RouteFormState>({
     platform: 'telegram',
     platformAccountId: '',
     chatId: '',
-    studioId: '',
+    studioHint: 'main',
     isActive: true,
   });
   const [editingRouteId, setEditingRouteId] = useState<string | null>(null);
@@ -133,7 +126,7 @@ export default function AgentRoutingPage() {
     platform: 'telegram',
     platformAccountId: '',
     chatId: '',
-    studioId: '',
+    studioHint: '',
     isActive: true,
   });
 
@@ -154,7 +147,7 @@ export default function AgentRoutingPage() {
           platform: 'telegram',
           platformAccountId: '',
           chatId: '',
-          studioId: '',
+          studioHint: 'main',
           isActive: true,
         });
       },
@@ -242,7 +235,7 @@ export default function AgentRoutingPage() {
                 platform: newRoute.platform,
                 platformAccountId: newRoute.platformAccountId || null,
                 chatId: newRoute.chatId || null,
-                studioId: newRoute.studioId || null,
+                studioHint: newRoute.studioHint || null,
                 isActive: newRoute.isActive,
               });
             }}
@@ -271,18 +264,17 @@ export default function AgentRoutingPage() {
                 <label className="text-sm font-medium">Studio</label>
                 <select
                   className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-                  value={newRoute.studioId}
+                  value={newRoute.studioHint}
                   onChange={(event) =>
                     setNewRoute((previous) => ({
                       ...previous,
-                      studioId: event.target.value,
+                      studioHint: event.target.value,
                     }))
                   }
                 >
-                  <option value="">Auto (nearest session)</option>
-                  {studios.map((studio) => (
-                    <option key={studio.id} value={studio.id}>
-                      {studio.name}{studio.branch ? ` (${studio.branch})` : ''}
+                  {STUDIO_HINT_OPTIONS.map((opt) => (
+                    <option key={opt.value} value={opt.value}>
+                      {opt.label}
                     </option>
                   ))}
                 </select>
@@ -387,7 +379,7 @@ export default function AgentRoutingPage() {
                         <div className="text-gray-500">Studio</div>
                         <div className="flex items-center gap-1 text-xs">
                           <GitBranch className="h-3 w-3 text-gray-400" />
-                          {studioLabel(studios, route.studioId)}
+                          {studioHintLabel(route.studioHint)}
                         </div>
                       </div>
                     </div>
@@ -403,7 +395,7 @@ export default function AgentRoutingPage() {
                               platform: editForm.platform,
                               platformAccountId: editForm.platformAccountId || null,
                               chatId: editForm.chatId || null,
-                              studioId: editForm.studioId || null,
+                              studioHint: editForm.studioHint || null,
                               isActive: editForm.isActive,
                             },
                           });
@@ -429,18 +421,17 @@ export default function AgentRoutingPage() {
                           </select>
                           <select
                             className={selectClassName}
-                            value={editForm.studioId}
+                            value={editForm.studioHint}
                             onChange={(event) =>
                               setEditForm((previous) => ({
                                 ...previous,
-                                studioId: event.target.value,
+                                studioHint: event.target.value,
                               }))
                             }
                           >
-                            <option value="">Auto (nearest session)</option>
-                            {studios.map((studio) => (
-                              <option key={studio.id} value={studio.id}>
-                                {studio.name}{studio.branch ? ` (${studio.branch})` : ''}
+                            {STUDIO_HINT_OPTIONS.map((opt) => (
+                              <option key={opt.value} value={opt.value}>
+                                {opt.label}
                               </option>
                             ))}
                           </select>

--- a/packages/web/src/app/(dashboard)/routing/page.tsx
+++ b/packages/web/src/app/(dashboard)/routing/page.tsx
@@ -21,6 +21,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import clsx from 'clsx';
+import { getAgentGradient } from '@/lib/utils';
 
 // ─── Types ───
 
@@ -108,21 +109,6 @@ function formatScopeLabel(platformAccountId: string | null, chatId: string | nul
 
 function getInitial(name: string): string {
   return name.charAt(0).toUpperCase();
-}
-
-const INITIAL_COLORS = [
-  'from-violet-500 to-purple-600',
-  'from-sky-500 to-blue-600',
-  'from-emerald-500 to-teal-600',
-  'from-amber-500 to-orange-600',
-  'from-rose-500 to-pink-600',
-  'from-cyan-500 to-teal-600',
-];
-
-function getColorForAgent(name: string): string {
-  let hash = 0;
-  for (let i = 0; i < name.length; i++) hash = name.charCodeAt(i) + ((hash << 5) - hash);
-  return INITIAL_COLORS[Math.abs(hash) % INITIAL_COLORS.length];
 }
 
 // ─── Component ───
@@ -349,7 +335,7 @@ export default function RoutingPage() {
           </Card>
         ) : (
           sbGroups.map((group) => {
-            const gradient = getColorForAgent(group.agentName);
+            const gradient = getAgentGradient(group.agentId);
             return (
               <Card key={group.agentId} className="overflow-hidden">
                 {/* SB Header */}

--- a/packages/web/src/app/(dashboard)/routing/page.tsx
+++ b/packages/web/src/app/(dashboard)/routing/page.tsx
@@ -34,14 +34,6 @@ interface RoutingIdentity {
   backend: string | null;
 }
 
-interface RoutingStudio {
-  id: string;
-  name: string;
-  branch: string | null;
-  status: string;
-  agentId: string | null;
-}
-
 interface RoutingRoute {
   id: string;
   identityId: string;
@@ -52,7 +44,7 @@ interface RoutingRoute {
   platform: string;
   platformAccountId: string | null;
   chatId: string | null;
-  studioId: string | null;
+  studioHint: string | null;
   isActive: boolean;
   metadata: Record<string, unknown>;
   createdAt: string;
@@ -71,7 +63,6 @@ interface RoutingResponse {
     unassignedReminderCount: number;
   };
   identities: RoutingIdentity[];
-  studios: RoutingStudio[];
   routes: RoutingRoute[];
 }
 
@@ -156,12 +147,6 @@ export default function RoutingPage() {
 
   const routes = data?.routes || [];
   const identities = data?.identities || [];
-  const studios = data?.studios || [];
-  const studioMap = useMemo(() => {
-    const m = new Map<string, RoutingStudio>();
-    for (const s of studios) m.set(s.id, s);
-    return m;
-  }, [studios]);
   const summary = data?.summary || {
     totalRoutes: 0, activeRoutes: 0, agentsWithRoutes: 0, platformsCovered: 0, unassignedReminderCount: 0,
   };
@@ -416,10 +401,10 @@ export default function RoutingPage() {
                           <span className="text-sm text-gray-500 truncate">
                             {formatScopeLabel(route.platformAccountId, route.chatId)}
                           </span>
-                          {route.studioId && studioMap.get(route.studioId) && (
+                          {route.studioHint && (
                             <span className="flex items-center gap-1 text-[11px] text-gray-400">
                               <GitBranch className="h-3 w-3" />
-                              {studioMap.get(route.studioId)!.name}
+                              {route.studioHint === 'main' ? 'Main' : route.studioHint}
                             </span>
                           )}
                         </div>

--- a/packages/web/src/app/(dashboard)/routing/page.tsx
+++ b/packages/web/src/app/(dashboard)/routing/page.tsx
@@ -1,14 +1,28 @@
 'use client';
 
 import Link from 'next/link';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useMutation } from '@tanstack/react-query';
-import { Route, Plus, BellRing, AlertTriangle } from 'lucide-react';
+import {
+  Route,
+  Plus,
+  BellRing,
+  AlertTriangle,
+  ChevronRight,
+  Globe,
+  MessageCircle,
+  Send,
+  Hash,
+  Mail,
+} from 'lucide-react';
 import { apiPatch, useApiPost, useApiQuery, useQueryClient } from '@/lib/api';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
+import clsx from 'clsx';
+
+// ─── Types ───
 
 interface RoutingIdentity {
   id: string;
@@ -57,17 +71,61 @@ interface CreateRouteInput {
   isActive?: boolean;
 }
 
+interface SBGroup {
+  agentId: string;
+  agentName: string;
+  agentRole: string | null;
+  identityId: string;
+  routes: RoutingRoute[];
+  totalReminders: number;
+  activeRoutes: number;
+}
+
+// ─── Constants ───
+
 const PLATFORM_OPTIONS = ['telegram', 'whatsapp', 'discord', 'slack', 'email'];
 
+const PLATFORM_CONFIG: Record<string, { label: string; color: string; bgColor: string; icon: typeof Send }> = {
+  telegram: { label: 'Telegram', color: 'text-sky-700', bgColor: 'bg-sky-50 border-sky-200', icon: Send },
+  whatsapp: { label: 'WhatsApp', color: 'text-emerald-700', bgColor: 'bg-emerald-50 border-emerald-200', icon: MessageCircle },
+  discord: { label: 'Discord', color: 'text-indigo-700', bgColor: 'bg-indigo-50 border-indigo-200', icon: Hash },
+  slack: { label: 'Slack', color: 'text-purple-700', bgColor: 'bg-purple-50 border-purple-200', icon: MessageCircle },
+  email: { label: 'Email', color: 'text-amber-700', bgColor: 'bg-amber-50 border-amber-200', icon: Mail },
+};
+
+// ─── Helpers ───
+
 function formatPlatform(value: string): string {
-  if (!value) return 'Unknown';
-  return value.charAt(0).toUpperCase() + value.slice(1);
+  return PLATFORM_CONFIG[value]?.label || value.charAt(0).toUpperCase() + value.slice(1);
 }
 
-function formatTimestamp(value: string | null): string {
-  if (!value) return '—';
-  return new Date(value).toLocaleString();
+function formatScopeLabel(platformAccountId: string | null, chatId: string | null): string {
+  if (platformAccountId && chatId) return `${platformAccountId} / ${chatId}`;
+  if (platformAccountId) return `${platformAccountId} (all chats)`;
+  if (chatId) return `All accounts / ${chatId}`;
+  return 'All traffic';
 }
+
+function getInitial(name: string): string {
+  return name.charAt(0).toUpperCase();
+}
+
+const INITIAL_COLORS = [
+  'from-violet-500 to-purple-600',
+  'from-sky-500 to-blue-600',
+  'from-emerald-500 to-teal-600',
+  'from-amber-500 to-orange-600',
+  'from-rose-500 to-pink-600',
+  'from-cyan-500 to-teal-600',
+];
+
+function getColorForAgent(name: string): string {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) hash = name.charCodeAt(i) + ((hash << 5) - hash);
+  return INITIAL_COLORS[Math.abs(hash) % INITIAL_COLORS.length];
+}
+
+// ─── Component ───
 
 export default function RoutingPage() {
   const queryClient = useQueryClient();
@@ -88,13 +146,7 @@ export default function RoutingPage() {
       onSuccess: () => {
         queryClient.invalidateQueries({ queryKey: ['routing'] });
         setShowCreateForm(false);
-        setNewRoute({
-          identityId: '',
-          platform: 'telegram',
-          platformAccountId: '',
-          chatId: '',
-          isActive: true,
-        });
+        setNewRoute({ identityId: '', platform: 'telegram', platformAccountId: '', chatId: '', isActive: true });
       },
     }
   );
@@ -102,108 +154,103 @@ export default function RoutingPage() {
   const toggleRouteMutation = useMutation({
     mutationFn: ({ routeId, isActive }: { routeId: string; isActive: boolean }) =>
       apiPatch(`/api/admin/routing/routes/${routeId}`, { isActive }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['routing'] });
-    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['routing'] }),
   });
 
   const routes = data?.routes || [];
   const identities = data?.identities || [];
   const summary = data?.summary || {
-    totalRoutes: 0,
-    activeRoutes: 0,
-    agentsWithRoutes: 0,
-    platformsCovered: 0,
-    unassignedReminderCount: 0,
+    totalRoutes: 0, activeRoutes: 0, agentsWithRoutes: 0, platformsCovered: 0, unassignedReminderCount: 0,
   };
+
+  // Group routes by SB
+  const sbGroups = useMemo<SBGroup[]>(() => {
+    const groups = new Map<string, SBGroup>();
+    for (const route of routes) {
+      const key = route.agentId || route.identityId;
+      if (!groups.has(key)) {
+        groups.set(key, {
+          agentId: route.agentId || 'unknown',
+          agentName: route.agentName || route.agentId || 'Unknown agent',
+          agentRole: route.agentRole || null,
+          identityId: route.identityId,
+          routes: [],
+          totalReminders: 0,
+          activeRoutes: 0,
+        });
+      }
+      const group = groups.get(key)!;
+      group.routes.push(route);
+      group.totalReminders += route.activeReminderCount;
+      if (route.isActive) group.activeRoutes++;
+    }
+    return [...groups.values()].sort((a, b) => a.agentName.localeCompare(b.agentName));
+  }, [routes]);
 
   const mutationError = createRouteMutation.error?.message || toggleRouteMutation.error?.message;
 
   return (
-    <div>
+    <div className="max-w-5xl">
+      {/* Header */}
       <div className="flex items-start justify-between gap-4">
         <div>
           <h1 className="text-3xl font-bold text-gray-900">Routing</h1>
-          <p className="mt-2 text-gray-600">
-            Control where channel traffic and reminder execution are routed across SBs.
+          <p className="mt-1 text-gray-500">
+            Control where channel traffic and reminders are routed across SBs.
           </p>
         </div>
-        <Button onClick={() => setShowCreateForm((value) => !value)} size="sm">
+        <Button onClick={() => setShowCreateForm((v) => !v)} size="sm" className="shrink-0">
           <Plus className="mr-2 h-4 w-4" />
           Add Route
         </Button>
       </div>
 
+      {/* Heartbeat warning */}
       {data && !data.heartbeatProcessingEnabled && (
-        <Card className="mt-6 border-amber-200 bg-amber-50/70">
-          <CardContent className="flex items-start gap-3 p-4">
-            <AlertTriangle className="h-5 w-5 text-amber-600 mt-0.5" />
-            <div className="text-sm text-amber-900">
-              Heartbeat/reminder processing is disabled on this server instance
-              ({' '}
-              <code className="bg-amber-100 px-1 py-0.5 rounded text-xs">
-                ENABLE_HEARTBEAT_SERVICE=false
-              </code>{' '}
-              or related flags). This is ideal for secondary dev servers.
-            </div>
-          </CardContent>
-        </Card>
+        <div className="mt-6 flex items-start gap-3 rounded-lg border border-amber-200 bg-amber-50/70 p-4">
+          <AlertTriangle className="h-5 w-5 text-amber-600 mt-0.5 shrink-0" />
+          <p className="text-sm text-amber-900">
+            Heartbeat processing is disabled on this server.
+            Reminders won&apos;t fire until enabled.
+          </p>
+        </div>
       )}
 
       {(error || mutationError) && (
-        <div className="mt-4 rounded-md bg-red-50 p-4 text-red-800">
+        <div className="mt-4 rounded-lg bg-red-50 border border-red-200 p-4 text-sm text-red-800">
           {error?.message || mutationError}
         </div>
       )}
 
-      <div className="mt-6 grid gap-4 md:grid-cols-5">
-        <Card>
-          <CardContent className="p-4">
-            <div className="text-xs text-gray-500">Total routes</div>
-            <div className="text-2xl font-semibold text-gray-900">{summary.totalRoutes}</div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="p-4">
-            <div className="text-xs text-gray-500">Active</div>
-            <div className="text-2xl font-semibold text-green-700">{summary.activeRoutes}</div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="p-4">
-            <div className="text-xs text-gray-500">SBs with routes</div>
-            <div className="text-2xl font-semibold text-gray-900">{summary.agentsWithRoutes}</div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="p-4">
-            <div className="text-xs text-gray-500">Platforms</div>
-            <div className="text-2xl font-semibold text-gray-900">{summary.platformsCovered}</div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="p-4">
-            <div className="text-xs text-gray-500">Unassigned reminders</div>
-            <div className="text-2xl font-semibold text-amber-700">
-              {summary.unassignedReminderCount}
-            </div>
-          </CardContent>
-        </Card>
+      {/* Stats — compact row */}
+      <div className="mt-6 grid grid-cols-2 gap-3 sm:grid-cols-4">
+        {[
+          { label: 'Total routes', value: summary.totalRoutes, color: 'text-gray-900' },
+          { label: 'Active', value: summary.activeRoutes, color: 'text-green-700' },
+          { label: 'SBs', value: summary.agentsWithRoutes, color: 'text-gray-900' },
+          { label: 'Platforms', value: summary.platformsCovered, color: 'text-gray-900' },
+        ].map((stat) => (
+          <div key={stat.label} className="rounded-lg border bg-white p-3">
+            <div className="text-xs text-gray-500">{stat.label}</div>
+            <div className={clsx('text-2xl font-semibold', stat.color)}>{stat.value}</div>
+          </div>
+        ))}
       </div>
 
+      {/* Create form */}
       {showCreateForm && (
         <Card className="mt-6">
-          <CardHeader>
-            <CardTitle>Create route</CardTitle>
+          <CardHeader className="pb-4">
+            <CardTitle className="text-lg">Create route</CardTitle>
             <CardDescription>
-              Scope by platform, then optionally account + chat for more specific routing.
+              Assign a platform (and optionally a specific account or chat) to an SB.
             </CardDescription>
           </CardHeader>
           <CardContent>
             <form
               className="space-y-4"
-              onSubmit={(event) => {
-                event.preventDefault();
+              onSubmit={(e) => {
+                e.preventDefault();
                 createRouteMutation.mutate({
                   identityId: newRoute.identityId,
                   platform: newRoute.platform,
@@ -214,20 +261,15 @@ export default function RoutingPage() {
               }}
             >
               <div className="grid gap-4 md:grid-cols-2">
-                <div className="space-y-2">
-                  <label className="text-sm font-medium">SB</label>
+                <div className="space-y-1.5">
+                  <label className="text-sm font-medium text-gray-700">SB</label>
                   <select
-                    className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                    className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
                     value={newRoute.identityId}
-                    onChange={(event) =>
-                      setNewRoute((previous) => ({
-                        ...previous,
-                        identityId: event.target.value,
-                      }))
-                    }
+                    onChange={(e) => setNewRoute((p) => ({ ...p, identityId: e.target.value }))}
                     required
                   >
-                    <option value="">Select an SB</option>
+                    <option value="">Select an SB...</option>
                     {identities.map((identity) => (
                       <option key={identity.id} value={identity.id}>
                         {identity.name} ({identity.agentId})
@@ -235,82 +277,53 @@ export default function RoutingPage() {
                     ))}
                   </select>
                 </div>
-                <div className="space-y-2">
-                  <label className="text-sm font-medium">Platform</label>
+                <div className="space-y-1.5">
+                  <label className="text-sm font-medium text-gray-700">Platform</label>
                   <select
-                    className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                    className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
                     value={newRoute.platform}
-                    onChange={(event) =>
-                      setNewRoute((previous) => ({
-                        ...previous,
-                        platform: event.target.value,
-                      }))
-                    }
+                    onChange={(e) => setNewRoute((p) => ({ ...p, platform: e.target.value }))}
                     required
                   >
-                    {PLATFORM_OPTIONS.map((platform) => (
-                      <option key={platform} value={platform}>
-                        {formatPlatform(platform)}
-                      </option>
+                    {PLATFORM_OPTIONS.map((p) => (
+                      <option key={p} value={p}>{formatPlatform(p)}</option>
                     ))}
                   </select>
                 </div>
               </div>
-
               <div className="grid gap-4 md:grid-cols-2">
-                <div className="space-y-2">
-                  <label className="text-sm font-medium">Platform account (optional)</label>
+                <div className="space-y-1.5">
+                  <label className="text-sm font-medium text-gray-700">Account <span className="text-gray-400 font-normal">(optional)</span></label>
                   <Input
                     placeholder="myra_help_bot or +14155551234"
                     value={newRoute.platformAccountId || ''}
-                    onChange={(event) =>
-                      setNewRoute((previous) => ({
-                        ...previous,
-                        platformAccountId: event.target.value,
-                      }))
-                    }
+                    onChange={(e) => setNewRoute((p) => ({ ...p, platformAccountId: e.target.value }))}
                   />
                 </div>
-                <div className="space-y-2">
-                  <label className="text-sm font-medium">Chat ID (optional)</label>
+                <div className="space-y-1.5">
+                  <label className="text-sm font-medium text-gray-700">Chat <span className="text-gray-400 font-normal">(optional)</span></label>
                   <Input
                     placeholder="group_id / thread_id"
                     value={newRoute.chatId || ''}
-                    onChange={(event) =>
-                      setNewRoute((previous) => ({
-                        ...previous,
-                        chatId: event.target.value,
-                      }))
-                    }
+                    onChange={(e) => setNewRoute((p) => ({ ...p, chatId: e.target.value }))}
                   />
                 </div>
               </div>
-
-              <div className="flex items-center justify-between">
-                <label className="flex items-center gap-2 text-sm">
+              <div className="flex items-center justify-between pt-2">
+                <label className="flex items-center gap-2 text-sm text-gray-600">
                   <input
                     type="checkbox"
+                    className="rounded"
                     checked={newRoute.isActive ?? true}
-                    onChange={(event) =>
-                      setNewRoute((previous) => ({
-                        ...previous,
-                        isActive: event.target.checked,
-                      }))
-                    }
+                    onChange={(e) => setNewRoute((p) => ({ ...p, isActive: e.target.checked }))}
                   />
-                  Route active
+                  Active immediately
                 </label>
                 <div className="flex gap-2">
-                  <Button
-                    type="button"
-                    variant="outline"
-                    onClick={() => {
-                      setShowCreateForm(false);
-                    }}
-                  >
+                  <Button type="button" variant="outline" size="sm" onClick={() => setShowCreateForm(false)}>
                     Cancel
                   </Button>
-                  <Button type="submit" disabled={createRouteMutation.isPending}>
+                  <Button type="submit" size="sm" disabled={createRouteMutation.isPending}>
                     {createRouteMutation.isPending ? 'Creating...' : 'Create route'}
                   </Button>
                 </div>
@@ -320,111 +333,132 @@ export default function RoutingPage() {
         </Card>
       )}
 
-      <Card className="mt-6">
-        <CardHeader>
-          <CardTitle>Route matrix</CardTitle>
-          <CardDescription>
-            Specificity cascade: platform + account + chat → platform + account → platform default.
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          {isLoading ? (
-            <p className="text-gray-500">Loading...</p>
-          ) : routes.length === 0 ? (
-            <div className="py-10 text-center text-gray-500">
+      {/* SB Groups */}
+      <div className="mt-6 space-y-4">
+        {isLoading ? (
+          <Card>
+            <CardContent className="py-12 text-center text-gray-500">Loading...</CardContent>
+          </Card>
+        ) : sbGroups.length === 0 ? (
+          <Card>
+            <CardContent className="py-12 text-center">
               <Route className="h-10 w-10 mx-auto text-gray-300 mb-3" />
-              No channel routes yet. Add your first route above.
-            </div>
-          ) : (
-            <div className="overflow-x-auto">
-              <table className="w-full">
-                <thead>
-                  <tr className="border-b text-left text-sm text-gray-600">
-                    <th className="pb-3 font-medium">SB</th>
-                    <th className="pb-3 font-medium">Platform</th>
-                    <th className="pb-3 font-medium">Account</th>
-                    <th className="pb-3 font-medium">Chat</th>
-                    <th className="pb-3 font-medium">Reminders</th>
-                    <th className="pb-3 font-medium">Updated</th>
-                    <th className="pb-3 font-medium">Actions</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {routes.map((route) => (
-                    <tr key={route.id} className="border-b align-top">
-                      <td className="py-3">
-                        <div className="flex flex-col gap-1">
-                          <Link
-                            href={route.agentId ? `/routing/${route.agentId}` : '/routing'}
-                            className="font-semibold text-gray-900 hover:underline"
-                          >
-                            {route.agentName || route.agentId || 'Unknown agent'}
-                          </Link>
-                          {route.agentRole && <span className="text-xs text-gray-500">{route.agentRole}</span>}
-                        </div>
-                      </td>
-                      <td className="py-3">
-                        <Badge variant="outline">{formatPlatform(route.platform)}</Badge>
-                      </td>
-                      <td className="py-3 font-mono text-xs text-gray-700">
-                        {route.platformAccountId || <span className="text-gray-400">Any account</span>}
-                      </td>
-                      <td className="py-3 font-mono text-xs text-gray-700">
-                        {route.chatId || <span className="text-gray-400">Any chat</span>}
-                      </td>
-                      <td className="py-3">
-                        <div className="flex flex-col gap-1 text-sm">
-                          <span className="inline-flex items-center gap-1 text-gray-700">
-                            <BellRing className="h-3 w-3" />
-                            {route.activeReminderCount}
+              <p className="text-gray-500">No channel routes yet.</p>
+              <p className="text-sm text-gray-400 mt-1">Add your first route above to start routing traffic to an SB.</p>
+            </CardContent>
+          </Card>
+        ) : (
+          sbGroups.map((group) => {
+            const gradient = getColorForAgent(group.agentName);
+            return (
+              <Card key={group.agentId} className="overflow-hidden">
+                {/* SB Header */}
+                <div className="flex items-center gap-4 px-5 py-4 border-b bg-gray-50/50">
+                  <div className={clsx(
+                    'h-10 w-10 rounded-full bg-gradient-to-br flex items-center justify-center text-white font-semibold text-sm shrink-0',
+                    gradient
+                  )}>
+                    {getInitial(group.agentName)}
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2">
+                      <h3 className="font-semibold text-gray-900">{group.agentName}</h3>
+                      <span className="text-xs text-gray-400">@{group.agentId}</span>
+                    </div>
+                    {group.agentRole && (
+                      <p className="text-sm text-gray-500 truncate">{group.agentRole}</p>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-4 shrink-0">
+                    <div className="text-right">
+                      <div className="text-xs text-gray-400">Reminders</div>
+                      <div className="flex items-center gap-1 justify-end">
+                        <BellRing className="h-3.5 w-3.5 text-gray-500" />
+                        <span className="font-medium text-gray-700">{group.totalReminders}</span>
+                      </div>
+                    </div>
+                    <Link
+                      href={`/routing/${group.agentId}`}
+                      className="flex items-center gap-1 text-sm font-medium text-gray-600 hover:text-gray-900 transition-colors"
+                    >
+                      Manage
+                      <ChevronRight className="h-4 w-4" />
+                    </Link>
+                  </div>
+                </div>
+
+                {/* Platform routes */}
+                <div className="divide-y">
+                  {group.routes.map((route) => {
+                    const pConfig = PLATFORM_CONFIG[route.platform];
+                    const PlatformIcon = pConfig?.icon || Globe;
+
+                    return (
+                      <div
+                        key={route.id}
+                        className={clsx(
+                          'flex items-center gap-4 px-5 py-3 transition-colors',
+                          !route.isActive && 'opacity-50'
+                        )}
+                      >
+                        <div className="flex items-center gap-3 flex-1 min-w-0">
+                          <div className={clsx(
+                            'flex items-center gap-2 rounded-md border px-2.5 py-1 text-xs font-medium',
+                            pConfig?.bgColor || 'bg-gray-50 border-gray-200',
+                            pConfig?.color || 'text-gray-700'
+                          )}>
+                            <PlatformIcon className="h-3.5 w-3.5" />
+                            {formatPlatform(route.platform)}
+                          </div>
+                          <span className="text-sm text-gray-500 truncate">
+                            {formatScopeLabel(route.platformAccountId, route.chatId)}
                           </span>
-                          <span className="text-xs text-gray-500">
-                            {route.nextReminderAt
-                              ? `Next: ${formatTimestamp(route.nextReminderAt)}`
-                              : 'No upcoming reminder'}
-                          </span>
                         </div>
-                      </td>
-                      <td className="py-3 text-xs text-gray-500">{formatTimestamp(route.updatedAt)}</td>
-                      <td className="py-3">
-                        <div className="flex flex-wrap items-center gap-2">
+
+                        <div className="flex items-center gap-2 shrink-0">
                           <Badge
-                            className={
+                            className={clsx(
+                              'text-[11px] font-medium border',
                               route.isActive
-                                ? 'bg-green-100 text-green-700 hover:bg-green-100'
-                                : 'bg-gray-100 text-gray-600 hover:bg-gray-100'
-                            }
+                                ? 'bg-green-50 text-green-700 border-green-200 hover:bg-green-50'
+                                : 'bg-gray-50 text-gray-500 border-gray-200 hover:bg-gray-50'
+                            )}
                           >
                             {route.isActive ? 'Active' : 'Inactive'}
                           </Badge>
                           <Button
-                            variant="outline"
+                            variant="ghost"
                             size="sm"
+                            className="h-7 text-xs text-gray-500 hover:text-gray-900"
                             onClick={() =>
-                              toggleRouteMutation.mutate({
-                                routeId: route.id,
-                                isActive: !route.isActive,
-                              })
+                              toggleRouteMutation.mutate({ routeId: route.id, isActive: !route.isActive })
                             }
                             disabled={toggleRouteMutation.isPending}
                           >
                             {route.isActive ? 'Disable' : 'Enable'}
                           </Button>
-                          {route.agentId && (
-                            <Button variant="ghost" size="sm" asChild>
-                              <Link href={`/routing/${route.agentId}`}>Manage</Link>
-                            </Button>
-                          )}
                         </div>
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          )}
-        </CardContent>
-      </Card>
+                      </div>
+                    );
+                  })}
+                </div>
+              </Card>
+            );
+          })
+        )}
+      </div>
+
+      {/* Unassigned reminders callout */}
+      {summary.unassignedReminderCount > 0 && (
+        <div className="mt-4 flex items-center gap-3 rounded-lg border border-amber-200 bg-amber-50/50 px-4 py-3">
+          <AlertTriangle className="h-4 w-4 text-amber-600 shrink-0" />
+          <p className="text-sm text-amber-800">
+            <span className="font-medium">{summary.unassignedReminderCount} reminder{summary.unassignedReminderCount !== 1 ? 's' : ''}</span>{' '}
+            not assigned to any SB.{' '}
+            <Link href="/reminders" className="underline hover:text-amber-900">View reminders</Link>
+          </p>
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/web/src/app/(dashboard)/routing/page.tsx
+++ b/packages/web/src/app/(dashboard)/routing/page.tsx
@@ -14,6 +14,7 @@ import {
   Send,
   Hash,
   Mail,
+  GitBranch,
 } from 'lucide-react';
 import { apiPatch, useApiPost, useApiQuery, useQueryClient } from '@/lib/api';
 import { Badge } from '@/components/ui/badge';
@@ -33,6 +34,14 @@ interface RoutingIdentity {
   backend: string | null;
 }
 
+interface RoutingStudio {
+  id: string;
+  name: string;
+  branch: string | null;
+  status: string;
+  agentId: string | null;
+}
+
 interface RoutingRoute {
   id: string;
   identityId: string;
@@ -43,6 +52,7 @@ interface RoutingRoute {
   platform: string;
   platformAccountId: string | null;
   chatId: string | null;
+  studioId: string | null;
   isActive: boolean;
   metadata: Record<string, unknown>;
   createdAt: string;
@@ -61,6 +71,7 @@ interface RoutingResponse {
     unassignedReminderCount: number;
   };
   identities: RoutingIdentity[];
+  studios: RoutingStudio[];
   routes: RoutingRoute[];
 }
 
@@ -145,6 +156,12 @@ export default function RoutingPage() {
 
   const routes = data?.routes || [];
   const identities = data?.identities || [];
+  const studios = data?.studios || [];
+  const studioMap = useMemo(() => {
+    const m = new Map<string, RoutingStudio>();
+    for (const s of studios) m.set(s.id, s);
+    return m;
+  }, [studios]);
   const summary = data?.summary || {
     totalRoutes: 0, activeRoutes: 0, agentsWithRoutes: 0, platformsCovered: 0, unassignedReminderCount: 0,
   };
@@ -399,6 +416,12 @@ export default function RoutingPage() {
                           <span className="text-sm text-gray-500 truncate">
                             {formatScopeLabel(route.platformAccountId, route.chatId)}
                           </span>
+                          {route.studioId && studioMap.get(route.studioId) && (
+                            <span className="flex items-center gap-1 text-[11px] text-gray-400">
+                              <GitBranch className="h-3 w-3" />
+                              {studioMap.get(route.studioId)!.name}
+                            </span>
+                          )}
                         </div>
 
                         <div className="flex items-center gap-2 shrink-0">

--- a/packages/web/src/lib/utils.ts
+++ b/packages/web/src/lib/utils.ts
@@ -4,3 +4,26 @@ import { twMerge } from 'tailwind-merge';
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+/**
+ * Deterministic gradient color for SB avatars.
+ * Always key on agentId (the stable handle) for consistency across pages.
+ */
+const SB_GRADIENTS = [
+  'from-rose-500 to-pink-600',
+  'from-sky-500 to-blue-600',
+  'from-emerald-500 to-teal-600',
+  'from-amber-500 to-orange-600',
+  'from-violet-500 to-purple-600',
+  'from-cyan-500 to-teal-600',
+  'from-indigo-500 to-blue-600',
+  'from-fuchsia-500 to-pink-600',
+];
+
+export function getAgentGradient(agentId: string): string {
+  let hash = 0;
+  for (let i = 0; i < agentId.length; i++) {
+    hash = agentId.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  return SB_GRADIENTS[Math.abs(hash) % SB_GRADIENTS.length];
+}

--- a/supabase/migrations/20260225000000_add_studio_id_to_channel_routes.sql
+++ b/supabase/migrations/20260225000000_add_studio_id_to_channel_routes.sql
@@ -1,0 +1,6 @@
+-- Add studio_id to channel_routes so routes can pin to a specific studio/worktree.
+-- When set, incoming messages on this route will be routed to sessions in the
+-- specified studio, preventing random assignment to whichever studio was most recent.
+ALTER TABLE channel_routes ADD COLUMN studio_id uuid REFERENCES studios(id) ON DELETE SET NULL;
+
+COMMENT ON COLUMN channel_routes.studio_id IS 'Optional studio to pin this route to. When set, messages use this studio for session creation.';

--- a/supabase/migrations/20260225000000_add_studio_id_to_channel_routes.sql
+++ b/supabase/migrations/20260225000000_add_studio_id_to_channel_routes.sql
@@ -1,6 +1,6 @@
--- Add studio_id to channel_routes so routes can pin to a specific studio/worktree.
--- When set, incoming messages on this route will be routed to sessions in the
--- specified studio, preventing random assignment to whichever studio was most recent.
-ALTER TABLE channel_routes ADD COLUMN studio_id uuid REFERENCES studios(id) ON DELETE SET NULL;
+-- Add studio_hint to channel_routes so routes can pin to a studio by name.
+-- "main" routes to the main-branch studio. NULL means auto-resolve (nearest session).
+-- Using a text hint instead of a UUID FK avoids requiring a studio record to exist upfront.
+ALTER TABLE channel_routes ADD COLUMN studio_hint text;
 
-COMMENT ON COLUMN channel_routes.studio_id IS 'Optional studio to pin this route to. When set, messages use this studio for session creation.';
+COMMENT ON COLUMN channel_routes.studio_hint IS 'Optional studio hint (e.g. "main"). When set, messages use this hint for studio resolution.';

--- a/yarn.lock
+++ b/yarn.lock
@@ -13033,7 +13033,6 @@ __metadata:
   resolution: "systeminformation@npm:5.31.1"
   bin:
     systeminformation: lib/cli.js
-  checksum: 10/1fff0b2827f7de2ec5379385c9bb12896db92186ee1d721cb08791ae7277a02f39fb8f3060df47312b70fe88c5b91a70726e7265ca8e5bab1f87780fb2acb991
   conditions: (os=darwin | os=linux | os=win32 | os=freebsd | os=openbsd | os=netbsd | os=sunos | os=android)
   languageName: node
   linkType: hard


### PR DESCRIPTION
## Summary

Redesigns both the Routing and Reminders dashboard pages to use **SB as the primary grouping**, replacing flat tables/lists with a card-per-SB hierarchy.

### Routing page
- **SB cards**: gradient avatar, name, @handle, role, combined reminder count, single "Manage" link
- **Platform routes nested inside**: colored platform badges (Telegram blue, WhatsApp green, etc.) with scope labels
- **"All traffic"** instead of confusing "Any account / Any chat" placeholders
- **Compact stat row**: total routes, active, SBs, platforms
- **Unassigned reminders callout**: amber banner linking to /reminders when orphaned reminders exist

### Reminders page
- **Collapsible SB sections**: gradient avatar, name, active count badge, expand/collapse
- **Active-first sorting**: SB groups with active reminders sort to top; within each group, active > paused > completed
- **Unassigned group**: reminders without an identity_id group under "Unassigned" (sorted last)
- **Compact cards**: tighter spacing, line-clamped descriptions, relative timestamps
- **Filter pills**: rounded pills with tabular-nums counts
- **"Manage routing" link**: cross-links to the routing page

## Test plan
- [ ] Routing page: SBs with multiple platform routes show as one card with nested rows
- [ ] Routing page: enable/disable per route works within the card
- [ ] Routing page: "Add Route" form still works
- [ ] Reminders page: reminders grouped by SB with correct counts
- [ ] Reminders page: filter tabs apply within SB groups (empty groups hide)
- [ ] Reminders page: completed SB sections start collapsed
- [ ] Both pages: clean build, no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)