### PR TITLE
fix: stop forcing backend model defaults in SessionService (by Lumen)

### DIFF
--- a/packages/api/src/config/env.ts
+++ b/packages/api/src/config/env.ts
@@ -145,9 +145,6 @@ const envSchema = z.object({
   LOG_LEVEL: z.enum(['error', 'warn', 'info', 'debug']).default('info'),
   SENTRY_DSN: optionalUrl,
 
-  // Agent Configuration
-  DEFAULT_MODEL: z.string().default('sonnet'),
-
   // Discord Bot
   DISCORD_BOT_TOKEN: optionalString,
   DISCORD_APPLICATION_ID: optionalString,

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -43,8 +43,6 @@ import { env } from './config/env';
 
 // Server configuration
 interface ServerConfig {
-  /** Model to use (default: sonnet) */
-  model?: string;
   /** Working directory for Claude Code */
   workingDirectory?: string;
   /** Path to MCP config file */
@@ -100,13 +98,11 @@ async function startServer(config: ServerConfig = {}): Promise<void> {
   // Resolve configuration
   const workingDirectory = config.workingDirectory || path.resolve(__dirname, '../../..');
   const mcpConfigPath = config.mcpConfigPath || path.resolve(workingDirectory, '.mcp.json');
-  const model = config.model || env.DEFAULT_MODEL || 'sonnet';
   const agentId = process.env.AGENT_ID || 'myra';
 
   logger.info('Configuration:', {
     workingDirectory,
     mcpConfigPath,
-    model,
     agentId,
     telegramPollingInterval: config.telegramPollingInterval || 1000,
   });
@@ -121,7 +117,6 @@ async function startServer(config: ServerConfig = {}): Promise<void> {
   const sessionServiceConfig: Partial<SessionServiceConfig> = {
     defaultWorkingDirectory: workingDirectory,
     mcpConfigPath,
-    defaultModel: model,
     compactionThreshold: config.compactionThreshold || 150000,
     responseHandler: async (responses) => routeResponses(responses),
   };
@@ -772,7 +767,6 @@ process.on('unhandledRejection', (reason) => {
 
 // Start the server
 startServer({
-  model: env.DEFAULT_MODEL || 'sonnet',
   workingDirectory: process.env.PCP_WORKING_DIR || path.resolve(__dirname, '../../..'),
   mcpConfigPath: process.env.MCP_CONFIG_PATH,
 }).catch((error) => {

--- a/packages/api/src/services/sessions/session-codex.integration.test.ts
+++ b/packages/api/src/services/sessions/session-codex.integration.test.ts
@@ -118,7 +118,6 @@ describe('SessionService Codex backend integration', () => {
       {
         defaultWorkingDirectory: process.cwd(),
         mcpConfigPath: '',
-        defaultModel: 'sonnet',
       },
       codexRunner
     );

--- a/packages/api/src/services/sessions/session-service.test.ts
+++ b/packages/api/src/services/sessions/session-service.test.ts
@@ -173,7 +173,6 @@ describe('SessionService', () => {
       {
         defaultWorkingDirectory: '/test',
         mcpConfigPath: '/test/.mcp.json',
-        defaultModel: 'sonnet',
         compactionThreshold: 150000,
       },
       mockCodexRunner
@@ -501,6 +500,8 @@ describe('SessionService', () => {
       expect(result.success).toBe(true);
       expect(mockCodexRunner.run).toHaveBeenCalledTimes(1);
       expect(mockClaudeRunner.run).not.toHaveBeenCalled();
+      const codexCallArgs = vi.mocked(mockCodexRunner.run).mock.calls[0][1];
+      expect(codexCallArgs.config).not.toHaveProperty('model');
       expect(mockRepository.update).toHaveBeenCalledWith(
         'codex-session',
         expect.objectContaining({ backend: 'codex-cli' })
@@ -817,7 +818,6 @@ describe('SessionService', () => {
         {
           defaultWorkingDirectory: '/test',
           mcpConfigPath: '/test/.mcp.json',
-          defaultModel: 'sonnet',
           compactionThreshold: 150000,
           responseHandler: mockResponseHandler,
         }
@@ -858,7 +858,6 @@ describe('SessionService', () => {
         {
           defaultWorkingDirectory: '/test',
           mcpConfigPath: '/test/.mcp.json',
-          defaultModel: 'sonnet',
           compactionThreshold: 150000,
           responseHandler: mockResponseHandler,
         }
@@ -1016,7 +1015,6 @@ describe('SessionService', () => {
         {
           defaultWorkingDirectory: '/test',
           mcpConfigPath: '/test/.mcp.json',
-          defaultModel: 'sonnet',
           compactionThreshold: 150000,
         },
         mockCodexRunner
@@ -1063,7 +1061,6 @@ describe('SessionService', () => {
         {
           defaultWorkingDirectory: '/test',
           mcpConfigPath: '/test/.mcp.json',
-          defaultModel: 'sonnet',
           compactionThreshold: 150000,
         },
         mockCodexRunner
@@ -1108,7 +1105,6 @@ describe('SessionService', () => {
         {
           defaultWorkingDirectory: '/test',
           mcpConfigPath: '/test/.mcp.json',
-          defaultModel: 'sonnet',
           compactionThreshold: 150000,
         },
         mockCodexRunner

--- a/packages/api/src/services/sessions/session-service.ts
+++ b/packages/api/src/services/sessions/session-service.ts
@@ -43,8 +43,10 @@ export interface SessionServiceConfig {
   defaultWorkingDirectory: string;
   /** Path to MCP config file */
   mcpConfigPath: string;
-  /** Default model to use */
-  defaultModel: string;
+  /** Optional explicit model override for Claude backend */
+  defaultModel?: string;
+  /** Optional explicit model override for Codex backend */
+  defaultCodexModel?: string;
   /** Token threshold for triggering compaction */
   compactionThreshold: number;
   /** Callback to route responses from async operations (compaction, etc.) */
@@ -54,7 +56,6 @@ export interface SessionServiceConfig {
 const DEFAULT_CONFIG: SessionServiceConfig = {
   defaultWorkingDirectory: process.cwd(),
   mcpConfigPath: '',
-  defaultModel: 'sonnet',
   compactionThreshold: 150000, // ~150k tokens
 };
 
@@ -327,10 +328,17 @@ export class SessionService implements ISessionService {
       session.identityId
     );
 
+    // 4. Select runtime backend and model
+    const resolvedBackend = this.resolveRuntimeBackend(
+      session.backend,
+      injectedContext.agent.backend
+    );
+    const runtimeModel =
+      resolvedBackend === 'codex-cli' ? this.config.defaultCodexModel : this.config.defaultModel;
+
     const runnerConfig: ClaudeRunnerConfig = {
       workingDirectory: resolvedWorkingDirectory,
       mcpConfigPath: this.config.mcpConfigPath,
-      model: this.config.defaultModel,
       appendSystemPrompt: buildIdentityPrompt(
         agentId,
         injectedContext.agent.name,
@@ -338,14 +346,11 @@ export class SessionService implements ISessionService {
         injectedContext.user.timezone,
         injectedContext.agent.heartbeat
       ),
+      ...(runtimeModel ? { model: runtimeModel } : {}),
       ...(pcpAccessToken ? { pcpAccessToken } : {}),
     };
 
-    // 4. Select runtime backend and run
-    const resolvedBackend = this.resolveRuntimeBackend(
-      session.backend,
-      injectedContext.agent.backend
-    );
+    // 5. Run with selected backend
     const runner = resolvedBackend === 'codex-cli' ? this.codexRunner : this.claudeRunner;
 
     const result = await runner.run(formattedMessage, {
@@ -354,14 +359,14 @@ export class SessionService implements ISessionService {
       config: runnerConfig,
     });
 
-    // 5. Log tool calls to activity stream (fire-and-forget, don't block response)
+    // 6. Log tool calls to activity stream (fire-and-forget, don't block response)
     if (result.toolCalls && result.toolCalls.length > 0) {
       this.logToolCalls(userId, agentId, session.id, result.toolCalls, request).catch((err) => {
         logger.warn('Failed to log tool calls to activity stream', { error: err });
       });
     }
 
-    // 6. Update session with new Claude session ID, usage, and message count
+    // 7. Update session with new Claude session ID, usage, and message count
     if (result.claudeSessionId !== session.claudeSessionId) {
       await this.repository.update(session.id, {
         claudeSessionId: result.claudeSessionId,
@@ -834,10 +839,15 @@ This session will continue with a fresh context after compaction. Your identity,
         session.identityId
       );
 
+      const runtimeBackend = this.resolveRuntimeBackend(session.backend, context.agent.backend);
+      const runtimeModel =
+        runtimeBackend === 'codex-cli'
+          ? this.config.defaultCodexModel
+          : this.config.defaultModel;
+
       const runnerConfig: ClaudeRunnerConfig = {
         workingDirectory: compactionWorkingDirectory,
         mcpConfigPath: this.config.mcpConfigPath,
-        model: this.config.defaultModel,
         appendSystemPrompt: buildIdentityPrompt(
           session.agentId,
           context.agent.name,
@@ -845,10 +855,10 @@ This session will continue with a fresh context after compaction. Your identity,
           fullContext.user.timezone,
           context.agent.heartbeat
         ),
+        ...(runtimeModel ? { model: runtimeModel } : {}),
         ...(compactionToken ? { pcpAccessToken: compactionToken } : {}),
       };
 
-      const runtimeBackend = this.resolveRuntimeBackend(session.backend, context.agent.backend);
       const runner = runtimeBackend === 'codex-cli' ? this.codexRunner : this.claudeRunner;
 
       // Phase 1: Send compaction prompt — agent saves context, notifies users, ends session

--- a/packages/api/src/services/sessions/types.ts
+++ b/packages/api/src/services/sessions/types.ts
@@ -378,7 +378,7 @@ export interface IContextBuilder {
 export interface ClaudeRunnerConfig {
   workingDirectory: string;
   mcpConfigPath: string;
-  model: string;
+  model?: string;
   systemPrompt?: string;
   appendSystemPrompt?: string;
   pcpAccessToken?: string;


### PR DESCRIPTION
## Summary
This removes forced default model selection from the SessionService runtime path.

- Removes server/env wiring for `DEFAULT_MODEL` and `DEFAULT_CODEX_MODEL`
- Makes SessionService model overrides optional instead of required
- Omits model flag entirely unless an explicit override is provided
- Lets each backend (Claude/Codex) use its native default model by default

## Why
Triggers to Lumen were failing after successful delivery because Codex runs inherited a forced `sonnet` model and exited with a backend model compatibility error. This avoids cross-backend model mismatch until we build a proper model router/allowlist system.

## Validation
- `npx vitest run packages/api/src/services/sessions/session-service.test.ts packages/api/src/services/sessions/codex-runner.test.ts`
  - ✅ 39 tests passed

## Notes
Workspace-level type-check still reports pre-existing unrelated issues (shared build artifacts + qrcode typings).