### PR TITLE
feat: first-step terminology shift from artifacts to documents (by Lumen)

### DIFF
--- a/packages/api/src/mcp/tools/index.ts
+++ b/packages/api/src/mcp/tools/index.ts
@@ -3080,7 +3080,7 @@ Update a PCP session's status and Claude session ID. Use this to mark your sessi
   server.registerTool(
     'create_artifact',
     {
-      description: `Create a shared artifact (spec, design, document). Artifacts are collaborative resources with versioning, distinct from personal memories.
+      description: `Create a shared document (spec, design, decision, note, etc.). Documents are collaborative resources with versioning, distinct from personal memories.
 
 Use for specs, designs, decisions, and shared documents that multiple beings may work on.
 
@@ -3111,7 +3111,7 @@ User can be identified by ONE of: userId, email, phone, or platform + platformId
   server.registerTool(
     'get_artifact',
     {
-      description: `Get an artifact by URI or ID. Returns the full content and metadata.
+      description: `Get a document by URI or ID. Returns the full content and metadata.
 
 User can be identified by ONE of: userId, email, phone, or platform + platformId`,
       inputSchema: getArtifactToolSchema('get_artifact'),
@@ -3140,9 +3140,9 @@ User can be identified by ONE of: userId, email, phone, or platform + platformId
   server.registerTool(
     'update_artifact',
     {
-      description: `Update an artifact. Automatically versions the content and tracks who made changes.
+      description: `Update a document. Automatically versions the content and tracks who made changes.
 
-Supports three-way merge: pass baseVersion (the version you read before editing) to enable automatic merging when another agent has edited the artifact since you read it. If changes don't overlap, they merge cleanly. If they conflict, you'll get structured conflict details and should re-read and retry.
+Supports three-way merge: pass baseVersion (the version you read before editing) to enable automatic merging when another agent has edited the document since you read it. If changes don't overlap, they merge cleanly. If they conflict, you'll get structured conflict details and should re-read and retry.
 
 Omit baseVersion for legacy last-write-wins behavior (not recommended for collaborative editing).
 
@@ -3173,7 +3173,7 @@ User can be identified by ONE of: userId, email, phone, or platform + platformId
   server.registerTool(
     'list_artifacts',
     {
-      description: `List artifacts with optional filters for type, tags, visibility, and search.
+      description: `List documents with optional filters for type, tags, visibility, and search.
 
 User can be identified by ONE of: userId, email, phone, or platform + platformId`,
       inputSchema: getArtifactToolSchema('list_artifacts'),
@@ -3202,7 +3202,7 @@ User can be identified by ONE of: userId, email, phone, or platform + platformId
   server.registerTool(
     'get_artifact_history',
     {
-      description: `Get version history for an artifact. Shows all previous versions and who made changes.
+      description: `Get version history for a document. Shows all previous versions and who made changes.
 
 User can be identified by ONE of: userId, email, phone, or platform + platformId`,
       inputSchema: getArtifactToolSchema('get_artifact_history'),
@@ -3231,7 +3231,7 @@ User can be identified by ONE of: userId, email, phone, or platform + platformId
   server.registerTool(
     'add_artifact_comment',
     {
-      description: `Add a comment to an artifact without modifying the artifact body.
+      description: `Add a comment to a document without modifying the document body.
 
 Use this for collaborative review/discussion to avoid overwrite conflicts.
 Stores canonical author identity via agent_identities.id while preserving agentId slug for display.
@@ -3263,7 +3263,7 @@ User can be identified by ONE of: userId, email, phone, or platform + platformId
   server.registerTool(
     'list_artifact_comments',
     {
-      description: `List comments for an artifact, including canonical identity UUID author metadata.
+      description: `List comments for a document, including canonical identity UUID author metadata.
 
 User can be identified by ONE of: userId, email, phone, or platform + platformId`,
       inputSchema: getArtifactToolSchema('list_artifact_comments'),

--- a/packages/web/src/app/(dashboard)/artifacts/[artifactId]/page.tsx
+++ b/packages/web/src/app/(dashboard)/artifacts/[artifactId]/page.tsx
@@ -171,7 +171,7 @@ export default function ArtifactDetailPage() {
     return (
       <div className="flex items-center justify-center py-12">
         <Loader2 className="h-6 w-6 animate-spin text-gray-400" />
-        <span className="ml-2 text-gray-500">Loading artifact...</span>
+        <span className="ml-2 text-gray-500">Loading document...</span>
       </div>
     );
   }
@@ -181,7 +181,7 @@ export default function ArtifactDetailPage() {
       <div className="rounded-md bg-red-50 p-4 text-red-800">
         {error.message}
         <Link href="/artifacts" className="ml-2 underline">
-          Back to Artifacts
+          Back to Documents
         </Link>
       </div>
     );
@@ -190,9 +190,9 @@ export default function ArtifactDetailPage() {
   if (!artifact) {
     return (
       <div className="rounded-md bg-yellow-50 p-4 text-yellow-800">
-        Artifact not found
+        Document not found
         <Link href="/artifacts" className="ml-2 underline">
-          Back to Artifacts
+          Back to Documents
         </Link>
       </div>
     );
@@ -281,7 +281,7 @@ export default function ArtifactDetailPage() {
             <textarea
               value={commentDraft}
               onChange={(event) => setCommentDraft(event.target.value)}
-              placeholder="Add a comment about this artifact…"
+              placeholder="Add a comment about this document…"
               rows={3}
               className="w-full rounded-md border border-gray-300 p-3 text-sm focus:border-gray-400 focus:outline-none"
             />

--- a/packages/web/src/app/(dashboard)/artifacts/[artifactId]/versions/page.tsx
+++ b/packages/web/src/app/(dashboard)/artifacts/[artifactId]/versions/page.tsx
@@ -114,7 +114,7 @@ export default function ArtifactVersionsPage() {
       <div className="rounded-md bg-red-50 p-4 text-red-800">
         {error.message}
         <Link href="/artifacts" className="ml-2 underline">
-          Back to Artifacts
+          Back to Documents
         </Link>
       </div>
     );
@@ -123,9 +123,9 @@ export default function ArtifactVersionsPage() {
   if (!artifact) {
     return (
       <div className="rounded-md bg-yellow-50 p-4 text-yellow-800">
-        Artifact not found
+        Document not found
         <Link href="/artifacts" className="ml-2 underline">
-          Back to Artifacts
+          Back to Documents
         </Link>
       </div>
     );

--- a/packages/web/src/app/(dashboard)/artifacts/page.tsx
+++ b/packages/web/src/app/(dashboard)/artifacts/page.tsx
@@ -117,7 +117,7 @@ export default function ArtifactsPage() {
     <div>
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-3xl font-bold text-gray-900">Artifacts</h1>
+          <h1 className="text-3xl font-bold text-gray-900">Documents</h1>
           <p className="mt-2 text-gray-600">
             Shared documents, specs, and designs that AI beings collaborate on.
           </p>
@@ -150,10 +150,10 @@ export default function ArtifactsPage() {
         </Card>
       </div>
 
-      {/* Artifacts List */}
+      {/* Documents List */}
       <Card className="mt-6">
         <CardHeader>
-          <CardTitle>All Artifacts</CardTitle>
+          <CardTitle>All Documents</CardTitle>
           <CardDescription>Sorted by last updated</CardDescription>
         </CardHeader>
         <CardContent>
@@ -162,7 +162,7 @@ export default function ArtifactsPage() {
           ) : artifacts.length === 0 ? (
             <div className="text-center py-8">
               <FileText className="h-12 w-12 mx-auto text-gray-300 mb-3" />
-              <p className="text-gray-500">No artifacts yet.</p>
+              <p className="text-gray-500">No documents yet.</p>
               <p className="text-sm text-gray-400 mt-1">
                 Use the <code className="bg-gray-100 px-1 rounded">create_artifact</code> tool to
                 create one.

--- a/packages/web/src/components/layout/sidebar.tsx
+++ b/packages/web/src/components/layout/sidebar.tsx
@@ -48,7 +48,7 @@ const navigation = [
   { name: 'Groups', href: '/groups', icon: UsersRound },
   { name: 'Challenge Codes', href: '/challenge-codes', icon: Key },
   { name: 'Individuals', href: '/individuals', icon: Bot },
-  { name: 'Artifacts', href: '/artifacts', icon: FileText },
+  { name: 'Documents', href: '/artifacts', icon: FileText },
   { name: 'Reminders', href: '/reminders', icon: Bell },
   { name: 'Routing', href: '/routing', icon: Route },
   { name: 'Connections', href: '/connected-accounts', icon: Link2 },


### PR DESCRIPTION
## Summary
First-step terminology pass to make user-facing language less technical by using **Documents** instead of **Artifacts**, while keeping existing routes/tool names unchanged for compatibility.

### Changes
- Sidebar nav label: `Artifacts` → `Documents`
- Documents list page copy updates:
  - Page title: `Artifacts` → `Documents`
  - Section title: `All Artifacts` → `All Documents`
  - Empty-state copy: `No artifacts yet.` → `No documents yet.`
- Document detail page copy updates:
  - `Loading artifact...` → `Loading document...`
  - `Back to Artifacts` → `Back to Documents`
  - `Artifact not found` → `Document not found`
  - Comment placeholder references `document`
- Version history page copy updates:
  - `Back to Artifacts` → `Back to Documents`
  - `Artifact not found` → `Document not found`
- MCP tool descriptions (`packages/api/src/mcp/tools/index.ts`) now use **document(s)** wording in user-facing descriptions while keeping tool names (`*_artifact*`) unchanged.

## Validation
- ✅ `yarn workspace @personal-context/web type-check`
- ⚠️ `yarn workspace @personal-context/api type-check` (fails due pre-existing unrelated repo issues: missing shared build output/types and optional channel deps such as Slack/qrcode typings)
- ⚠️ `yarn workspace @personal-context/web run lint` currently fails because `next lint` is interpreted as an invalid project dir (`packages/web/lint`) in this workspace setup (pre-existing script/tooling behavior)

## Notes
This PR is intentionally limited to terminology/copy only (no API/route/tool renames yet).