### PR TITLE
feat: GitHub Actions CI + PII cleanup (by Wren)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+
+      - run: yarn install --immutable
+
+      - run: yarn build
+
+      - run: yarn test

--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,3 @@
+Conor McLaughlin <noreply@pcp.dev> <conoremclaughlin@gmail.com>
+Conor McLaughlin <noreply@pcp.dev> Conor <conoremclaughlin@gmail.com>
+Conor McLaughlin <noreply@pcp.dev> conoremclaughlin <conoremclaughlin@gmail.com>

--- a/packages/api/src/mcp/tools/artifact-handlers.test.ts
+++ b/packages/api/src/mcp/tools/artifact-handlers.test.ts
@@ -474,9 +474,9 @@ describe('artifact comment + identity UUID flows', () => {
             data: [
               {
                 id: '00000000-0000-0000-0000-000000000001',
-                first_name: 'Conor',
-                username: 'conor',
-                email: 'conor@example.com',
+                first_name: 'Alice',
+                username: 'alice',
+                email: 'alice@example.com',
               },
             ],
             error: null,
@@ -837,9 +837,9 @@ describe('artifact comment + identity UUID flows', () => {
             data: [
               {
                 id: '00000000-0000-0000-0000-000000000001',
-                first_name: 'Conor',
-                username: 'conor',
-                email: 'conor@example.com',
+                first_name: 'Alice',
+                username: 'alice',
+                email: 'alice@example.com',
               },
             ],
             error: null,

--- a/packages/api/src/routes/admin.artifact-comments.test.ts
+++ b/packages/api/src/routes/admin.artifact-comments.test.ts
@@ -119,9 +119,9 @@ describe('admin artifact comments routes', () => {
             data: [
               {
                 id: '550e8400-e29b-41d4-a716-446655440000',
-                first_name: 'Conor',
-                username: 'conor',
-                email: 'conor@example.com',
+                first_name: 'Alice',
+                username: 'alice',
+                email: 'alice@example.com',
               },
             ],
             error: null,
@@ -184,9 +184,9 @@ describe('admin artifact comments routes', () => {
             {
               data: {
                 id: '550e8400-e29b-41d4-a716-446655440000',
-                first_name: 'Conor',
-                username: 'conor',
-                email: 'conor@example.com',
+                first_name: 'Alice',
+                username: 'alice',
+                email: 'alice@example.com',
               },
               error: null,
             },


### PR DESCRIPTION
## Summary\n\n- **GitHub Actions CI** (`.github/workflows/ci.yml`): Runs `yarn build` + `yarn test` on PRs to main and pushes to main. Excludes integration tests that require Supabase access.\n- **`.mailmap`**: Maps git author identities (`conoremclaughlin@gmail.com`) to `Conor McLaughlin <noreply@pcp.dev>` for display normalization. Does not rewrite history — just controls how `git log`/`git shortlog` display authors.\n- **Test fixture PII cleanup**: Replaced `conor@example.com` / `first_name: 'Conor'` with `alice@example.com` / `Alice` in test fixtures.\n\n## Notes on going public\n\nThe `.mailmap` handles **display-level** author normalization. For actual history rewriting (stripping the email from commit metadata), you'd need `git filter-repo` — a destructive operation best done once right before going public. Happy to set that up when the time comes.\n\n## Integration/e2e CI (future)\n\nTo add integration tests to CI, we'd need:\n- `SUPABASE_URL`, `SUPABASE_SECRET_KEY`, `SUPABASE_PUBLISHABLE_KEY` as GitHub secrets\n- Ideally a dedicated Supabase test project (not prod)\n- Claude CLI installed in the runner (for session integration tests)\n\n## Test plan\n\n- [x] All 858 API tests pass\n- [x] All 165 CLI tests pass\n- [ ] CI workflow runs successfully on this PR (will validate once Actions is enabled)\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)