### PR TITLE
fix(api): heartbeat studio routing (by Wren)

### DIFF
--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -374,6 +374,20 @@ async function startServer(config: ServerConfig = {}): Promise<void> {
       }
     }
 
+    // Resolve studioHint from channel_routes for the delivery channel
+    let reminderStudioHint: string | null = null;
+    if (dataComposer && reminder.delivery_channel) {
+      const route = await resolveRouteAgentId(
+        dataComposer.getClient(),
+        userId,
+        reminder.delivery_channel
+      );
+      if (route?.studioHint) {
+        reminderStudioHint = route.studioHint;
+        logger.debug(`[Heartbeat] Resolved studioHint from channel_route: ${reminderStudioHint}`);
+      }
+    }
+
     const reminderContent = `[HEARTBEAT REMINDER]
 Title: ${reminder.title}
 Description: ${reminder.description || 'No description'}
@@ -398,6 +412,7 @@ Do NOT just respond here — you MUST explicitly call send_response to reach ext
       metadata: {
         triggerType: 'heartbeat',
         chatType: 'direct',
+        ...(reminderStudioHint ? { studioHint: reminderStudioHint } : {}),
       },
     };
 


### PR DESCRIPTION
## Summary
- Heartbeat reminders now resolve `studioHint` from `channel_routes` before building the `SessionRequest`, matching the same routing logic used for regular incoming messages
- Previously, heartbeats created sessions with no studio hint, causing them to land in whichever studio happened to have an active session — e.g., Myra's heartbeats were routing to Lumen's studio
- Also applied data fixes: set `studio_hint = 'main'` on Myra's telegram channel_route, and closed 7 stale mis-routed sessions

## Root Cause
`deliverReminderViaSession` in `server.ts` was constructing a `SessionRequest` with `channel: 'agent'` and no `studioHint` in metadata. The regular message path (line 176-195) consults `resolveRouteAgentId` from `channel_routes` to get `studioHint`, but the heartbeat path skipped this entirely. Without a hint, `SessionService` would pick up or create a session in whatever studio was available — often the wrong one.

## Test plan
- [x] Verified Myra's active reminder has correct `identity_id`
- [x] Set `studio_hint = 'main'` on Myra's telegram channel_route
- [x] Closed stale Myra sessions pointing to Lumen's studio
- [x] API builds clean, PCP restarted with fix deployed
- [ ] Verify next heartbeat tick routes Myra to correct studio (monitor logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)