### PR TITLE
feat: add DB-backed conversation user mapping fallback (by Lumen)

### DIFF
--- a/packages/api/src/channels/gateway.test.ts
+++ b/packages/api/src/channels/gateway.test.ts
@@ -581,11 +581,15 @@ describe('Activity Stream Integration', () => {
   let mockDataComposer: any;
 
   let mockFindByPlatformId: Mock;
+  let mockFindConversationByPlatformId: Mock;
+  let mockUpsertConversationByPlatformId: Mock;
 
   beforeEach(() => {
     vi.useFakeTimers();
     mockLogMessage = vi.fn().mockResolvedValue({ id: 'activity-123' });
     mockFindByPlatformId = vi.fn().mockResolvedValue(null);
+    mockFindConversationByPlatformId = vi.fn().mockResolvedValue(null);
+    mockUpsertConversationByPlatformId = vi.fn().mockResolvedValue({ id: 'conversation-123' });
     mockDataComposer = {
       repositories: {
         activityStream: {
@@ -593,6 +597,10 @@ describe('Activity Stream Integration', () => {
         },
         users: {
           findByPlatformId: mockFindByPlatformId,
+        },
+        conversations: {
+          findConversationByPlatformId: mockFindConversationByPlatformId,
+          upsertConversationByPlatformId: mockUpsertConversationByPlatformId,
         },
       },
     };
@@ -770,6 +778,22 @@ describe('Activity Stream Integration', () => {
         isDm: true,
       });
     });
+
+    it('should persist conversationId to userId mapping in DB for cache-miss recovery', async () => {
+      const handler = vi.fn().mockResolvedValue(undefined);
+      gateway.setMessageHandler(handler);
+
+      const forwardToHandler = (gateway as any).forwardToHandler.bind(gateway);
+      await forwardToHandler('telegram', 'chat123', { id: 'sender456' }, 'Hello', {
+        userId: 'user-uuid-123',
+      });
+
+      expect(mockUpsertConversationByPlatformId).toHaveBeenCalledWith({
+        user_id: 'user-uuid-123',
+        platform: 'telegram',
+        platform_conversation_id: 'chat123',
+      });
+    });
   });
 
   describe('Outgoing Messages', () => {
@@ -820,6 +844,30 @@ describe('Activity Stream Integration', () => {
 
       // No incoming message was processed for this chat, so no userId in map
       expect(mockLogMessage).not.toHaveBeenCalled();
+    });
+
+    it('should recover userId from DB when conversationUserMap cache misses', async () => {
+      mockFindConversationByPlatformId.mockResolvedValueOnce({
+        user_id: 'db-user-uuid',
+      });
+
+      (gateway as any).telegramListener = {
+        sendMessage: vi.fn().mockResolvedValue(undefined),
+      };
+
+      const sendTelegramMessage = (gateway as any).sendTelegramMessage.bind(gateway);
+      await sendTelegramMessage('chat-db-fallback', 'Recovered mapping reply');
+
+      expect(mockFindConversationByPlatformId).toHaveBeenCalledWith('telegram', 'chat-db-fallback');
+      expect(mockLogMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: 'db-user-uuid',
+          direction: 'out',
+          content: 'Recovered mapping reply',
+          platform: 'telegram',
+          platformChatId: 'chat-db-fallback',
+        })
+      );
     });
   });
 });

--- a/packages/api/src/channels/gateway.ts
+++ b/packages/api/src/channels/gateway.ts
@@ -25,6 +25,7 @@ import { env } from '../config/env';
 import { InboundMediaPipeline } from './media-pipeline';
 import { TextToSpeechService } from './text-to-speech';
 import telegramifyMarkdown from 'telegramify-markdown';
+import type { Platform } from '@shared/types/common';
 
 // Supported messaging channels
 export type GatewayChannel = 'telegram' | 'whatsapp' | 'discord' | 'slack';
@@ -124,7 +125,7 @@ export class ChannelGateway extends EventEmitter {
   private autoVoiceReplyOnAudio = process.env.TELEGRAM_AUTO_VOICE_REPLY === 'true';
   private includeTextAfterVoiceReply = process.env.TELEGRAM_VOICE_INCLUDE_TEXT !== 'false';
   private pendingVoiceReplyConversations: Set<string> = new Set();
-  private conversationUserMap = new Map<string, string>(); // conversationId -> userId
+  private conversationUserMap = new Map<string, string>(); // channel:conversationId -> userId
 
   constructor(config: ChannelGatewayConfig = {}) {
     super();
@@ -308,6 +309,70 @@ export class ChannelGateway extends EventEmitter {
    */
   private getBufferKey(channel: GatewayChannel, conversationId: string): string {
     return `${channel}:${conversationId}`;
+  }
+
+  private toPersistentConversationPlatform(channel: GatewayChannel): Platform | null {
+    // conversations.platform currently supports telegram/whatsapp/discord/api
+    if (channel === 'telegram' || channel === 'whatsapp' || channel === 'discord') {
+      return channel;
+    }
+    return null;
+  }
+
+  private async resolveUserIdForConversation(
+    channel: GatewayChannel,
+    conversationId: string
+  ): Promise<string | undefined> {
+    const key = this.getBufferKey(channel, conversationId);
+    const cachedUserId = this.conversationUserMap.get(key);
+    if (cachedUserId) return cachedUserId;
+
+    const platform = this.toPersistentConversationPlatform(channel);
+    if (!platform || !this.dataComposer) return undefined;
+
+    try {
+      const conversation =
+        await this.dataComposer.repositories.conversations.findConversationByPlatformId(
+          platform,
+          conversationId
+        );
+      const userId = conversation?.user_id;
+      if (!userId) return undefined;
+
+      this.conversationUserMap.set(key, userId);
+      return userId;
+    } catch (error) {
+      logger.warn('Failed to resolve conversation user from DB', {
+        channel,
+        conversationId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return undefined;
+    }
+  }
+
+  private persistConversationUserMapping(
+    channel: GatewayChannel,
+    conversationId: string,
+    userId: string
+  ): void {
+    const platform = this.toPersistentConversationPlatform(channel);
+    if (!platform || !this.dataComposer) return;
+
+    void this.dataComposer.repositories.conversations
+      .upsertConversationByPlatformId({
+        user_id: userId,
+        platform,
+        platform_conversation_id: conversationId,
+      })
+      .catch((error) => {
+        logger.warn('Failed to persist conversation user mapping', {
+          channel,
+          conversationId,
+          userId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
   }
 
   /**
@@ -510,7 +575,8 @@ export class ChannelGateway extends EventEmitter {
       }
     }
     if (userId) {
-      this.conversationUserMap.set(conversationId, userId);
+      this.conversationUserMap.set(this.getBufferKey(channel, conversationId), userId);
+      this.persistConversationUserMapping(channel, conversationId, userId);
     }
 
     if (
@@ -632,7 +698,7 @@ export class ChannelGateway extends EventEmitter {
         await this.whatsappListener.sendMessage(conversationId, content);
         // Log outgoing WhatsApp message to activity stream
         {
-          const userId = this.conversationUserMap.get(conversationId);
+          const userId = await this.resolveUserIdForConversation('whatsapp', conversationId);
           if (this.dataComposer && userId) {
             try {
               await this.dataComposer.repositories.activityStream.logMessage({
@@ -661,7 +727,7 @@ export class ChannelGateway extends EventEmitter {
         await this.discordListener.sendMessage(conversationId, content);
         // Log outgoing Discord message to activity stream
         {
-          const userId = this.conversationUserMap.get(conversationId);
+          const userId = await this.resolveUserIdForConversation('discord', conversationId);
           if (this.dataComposer && userId) {
             try {
               await this.dataComposer.repositories.activityStream.logMessage({
@@ -690,7 +756,7 @@ export class ChannelGateway extends EventEmitter {
         await this.slackListener.sendMessage(conversationId, content);
         // Log outgoing Slack message to activity stream
         {
-          const userId = this.conversationUserMap.get(conversationId);
+          const userId = await this.resolveUserIdForConversation('slack', conversationId);
           if (this.dataComposer && userId) {
             try {
               await this.dataComposer.repositories.activityStream.logMessage({
@@ -838,7 +904,7 @@ export class ChannelGateway extends EventEmitter {
 
   private async logOutgoingTelegram(conversationId: string, content: string): Promise<void> {
     // Log outgoing message to activity stream
-    const userId = this.conversationUserMap.get(conversationId);
+    const userId = await this.resolveUserIdForConversation('telegram', conversationId);
     if (this.dataComposer && userId) {
       try {
         await this.dataComposer.repositories.activityStream.logMessage({

--- a/packages/api/src/data/repositories/conversations.repository.ts
+++ b/packages/api/src/data/repositories/conversations.repository.ts
@@ -29,6 +29,25 @@ export class ConversationsRepository extends BaseRepository {
     }
   }
 
+  async upsertConversationByPlatformId(
+    conversationData: CreateConversationDTO
+  ): Promise<Conversation> {
+    try {
+      const { data, error } = await this.client
+        .from('conversations')
+        .upsert(conversationData, {
+          onConflict: 'platform,platform_conversation_id',
+        })
+        .select()
+        .single();
+
+      if (error) throw error;
+      return data;
+    } catch (error) {
+      this.handleError(error, 'upsertConversationByPlatformId');
+    }
+  }
+
   async findConversationById(id: string, userId: string): Promise<Conversation | null> {
     try {
       const { data, error } = await this.client


### PR DESCRIPTION
## Summary
Adds durable conversation-to-user mapping for channel routing robustness.

## What changed
- Added `upsertConversationByPlatformId(...)` to `ConversationsRepository`.
- Updated `ChannelGateway` to:
  - cache user mapping by `channel:conversationId` (avoids cross-channel collisions)
  - persist mapping on inbound (`platform + conversationId -> userId`) using non-blocking DB upsert
  - resolve userId from DB on outbound cache miss before activity logging
- Added tests to verify:
  - mapping is persisted on inbound
  - outbound logging recovers userId via DB lookup when cache misses

## Notes
- Persistence currently uses `conversations` table for `telegram/whatsapp/discord` (existing DB platform constraint).
- Slack continues to use cache-only path for now.

## Tests
- `npx vitest run packages/api/src/channels/gateway.test.ts`