### PR TITLE
feat(api): per-chat reminder route resolution (by Wren)

### DIFF
--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -374,17 +374,25 @@ async function startServer(config: ServerConfig = {}): Promise<void> {
       }
     }
 
-    // Resolve studioHint from channel_routes for the delivery channel
+    // Resolve studioHint from channel_routes for the delivery channel + target
+    // delivery_target is the chat/conversation ID (e.g., Telegram chat ID)
+    // This enables per-chat routing for multi-user scenarios
     let reminderStudioHint: string | null = null;
     if (dataComposer && reminder.delivery_channel) {
       const route = await resolveRouteAgentId(
         dataComposer.getClient(),
         userId,
-        reminder.delivery_channel
+        reminder.delivery_channel,
+        undefined, // platformAccountId — not stored on reminders yet
+        reminder.delivery_target || undefined
       );
       if (route?.studioHint) {
         reminderStudioHint = route.studioHint;
-        logger.debug(`[Heartbeat] Resolved studioHint from channel_route: ${reminderStudioHint}`);
+        logger.debug(`[Heartbeat] Resolved studioHint from channel_route`, {
+          studioHint: reminderStudioHint,
+          deliveryChannel: reminder.delivery_channel,
+          deliveryTarget: reminder.delivery_target,
+        });
       }
     }
 


### PR DESCRIPTION
## Summary
- Threads `delivery_target` (chat/conversation ID) through to `resolveRouteAgentId` as the `chatId` parameter during heartbeat reminder delivery
- Enables the full specificity cascade for reminders: exact (platform + account + chat) > account default > platform default
- Critical for multi-user: without this, all reminders on a platform resolve to the same route, meaning multiple people can't have different SBs on the same channel

## Context
Follow-up to PR #108 (studioHint routing). Lumen flagged in review that `delivery_target` wasn't being threaded through. This is a multi-user blocker — a single platform-level route means only one user can be served per channel.

## Changes
- `server.ts`: Pass `reminder.delivery_target` as `chatId` to `resolveRouteAgentId` (alongside the existing `delivery_channel` as `platform`)
- Enhanced debug logging with delivery channel + target context

## Test plan
- [x] API builds clean
- [x] 872/873 API tests pass (1 pre-existing failure in discord-listener from separate PR)
- [ ] Verify with chat-specific channel_route that reminders resolve to correct agent/studio

🤖 Generated with [Claude Code](https://claude.com/claude-code)