### PR TITLE
feat(api): GeminiRunner backend for Aster (by Wren)

### DIFF
--- a/packages/api/src/services/sessions/gemini-runner.ts
+++ b/packages/api/src/services/sessions/gemini-runner.ts
@@ -6,8 +6,8 @@
  *   - Message via -p flag (not stdin)
  *   - JSON output via -o stream-json
  *   - Auto-approve via --yolo
- *   - Resume via -r (index-based, not UUID — session continuity is best-effort)
- *   - System prompt via --policy or prepended to message
+ *   - Resume via -r <uuid> (Gemini emits session_id in the init event)
+ *   - System prompt via --policy
  */
 
 import { spawn, type ChildProcess } from 'child_process';
@@ -48,15 +48,12 @@ export class GeminiRunner implements IClaudeRunner {
       config: ClaudeRunnerConfig;
     }
   ): Promise<ClaudeRunnerResult> {
-    const { injectedContext, config } = options;
+    const { claudeSessionId, injectedContext, config } = options;
+    const isResume = !!claudeSessionId;
 
-    // Gemini uses index-based session resume (-r), not UUID-based.
-    // For now, always start fresh sessions — resume support is best-effort.
-    const sessionId = randomUUID();
-
-    // Build the message with injected context (prepended, like Codex runner)
+    // Build the message with injected context on first turn (same as Claude/Codex)
     let fullMessage = message;
-    if (injectedContext) {
+    if (injectedContext && !isResume) {
       const contextBlock = formatInjectedContext(injectedContext);
       fullMessage = `${contextBlock}\n\n---\n\n${message}`;
     }
@@ -67,9 +64,10 @@ export class GeminiRunner implements IClaudeRunner {
     );
 
     try {
-      const args = this.buildArgs(fullMessage, config, policyPath);
+      const args = this.buildArgs(fullMessage, config, policyPath, claudeSessionId);
       logger.info('Spawning Gemini CLI', {
-        sessionId,
+        isResume,
+        claudeSessionId: claudeSessionId || '(new)',
         workingDirectory: config.workingDirectory,
         messageLength: fullMessage.length,
         hasPcpAccessToken: !!config.pcpAccessToken,
@@ -77,9 +75,12 @@ export class GeminiRunner implements IClaudeRunner {
 
       const result = await this.spawnProcess(args, config);
 
+      // Use session ID from Gemini's init event, fall back to the one we passed in
+      const resolvedSessionId = result.sessionId || claudeSessionId || randomUUID();
+
       return {
         success: true,
-        claudeSessionId: sessionId,
+        claudeSessionId: resolvedSessionId,
         responses: result.responses,
         usage: result.usage,
         finalTextResponse: result.finalTextResponse,
@@ -87,12 +88,12 @@ export class GeminiRunner implements IClaudeRunner {
       };
     } catch (error) {
       logger.error('Gemini process failed', {
-        sessionId,
+        claudeSessionId,
         error: error instanceof Error ? error.message : String(error),
       });
       return {
         success: false,
-        claudeSessionId: sessionId,
+        claudeSessionId: claudeSessionId || randomUUID(),
         responses: [],
         error: error instanceof Error ? error.message : 'Unknown error',
       };
@@ -101,8 +102,17 @@ export class GeminiRunner implements IClaudeRunner {
     }
   }
 
-  private buildArgs(message: string, config: ClaudeRunnerConfig, policyPath?: string): string[] {
+  private buildArgs(
+    message: string,
+    config: ClaudeRunnerConfig,
+    policyPath?: string,
+    resumeSessionId?: string
+  ): string[] {
     const args: string[] = ['-p', message, '-o', 'stream-json', '--yolo'];
+
+    if (resumeSessionId) {
+      args.push('-r', resumeSessionId);
+    }
 
     if (config.model) {
       args.push('-m', config.model);
@@ -123,6 +133,7 @@ export class GeminiRunner implements IClaudeRunner {
     usage?: GeminiUsageStats;
     finalTextResponse?: string;
     toolCalls: ToolCall[];
+    sessionId?: string;
   }> {
     return new Promise((resolve, reject) => {
       // Strip CLAUDECODE to prevent env leaking into subprocess
@@ -144,6 +155,7 @@ export class GeminiRunner implements IClaudeRunner {
       const toolCalls: ToolCall[] = [];
       let usage: GeminiUsageStats | undefined;
       let finalTextResponse: string | undefined;
+      let resolvedSessionId: string | undefined;
       let settled = false;
       let lastActivityAt = Date.now();
 
@@ -166,6 +178,7 @@ export class GeminiRunner implements IClaudeRunner {
               usage,
               toolCalls,
               finalTextResponse: finalTextResponse || `[Process timed out after ${idleSecs}s idle]`,
+              sessionId: resolvedSessionId,
             });
           }
         }, IDLE_TIMEOUT_MS);
@@ -185,6 +198,7 @@ export class GeminiRunner implements IClaudeRunner {
             usage,
             toolCalls,
             finalTextResponse: finalTextResponse || '[Process hit hard timeout]',
+            sessionId: resolvedSessionId,
           });
         }
       }, PROCESS_TIMEOUT_MS);
@@ -206,6 +220,11 @@ export class GeminiRunner implements IClaudeRunner {
             const parsed = JSON.parse(line);
             this.handleStreamEvent(parsed, responses);
             this.captureToolCall(parsed, toolCalls);
+
+            // Capture session_id from init event (Gemini emits this on every session)
+            if (parsed.type === 'init' && typeof parsed.session_id === 'string') {
+              resolvedSessionId = parsed.session_id;
+            }
 
             // Capture usage stats
             if (parsed.usageMetadata || parsed.usage) {
@@ -315,7 +334,7 @@ export class GeminiRunner implements IClaudeRunner {
           }
         }
 
-        resolve({ responses, usage, toolCalls, finalTextResponse });
+        resolve({ responses, usage, toolCalls, finalTextResponse, sessionId: resolvedSessionId });
       });
     });
   }

--- a/packages/api/src/services/sessions/gemini-runner.ts
+++ b/packages/api/src/services/sessions/gemini-runner.ts
@@ -139,6 +139,7 @@ export class GeminiRunner implements IClaudeRunner {
       });
 
       let stderr = '';
+      let stdoutRemainder = '';
       const responses: ChannelResponse[] = [];
       const toolCalls: ToolCall[] = [];
       let usage: GeminiUsageStats | undefined;
@@ -193,9 +194,14 @@ export class GeminiRunner implements IClaudeRunner {
         resetIdleTimer();
         const chunk = data.toString();
 
-        // Parse streaming JSON lines
-        const lines = chunk.split('\n').filter((line: string) => line.trim());
+        // Buffer-aware line splitting: a single chunk may contain a partial
+        // JSON line at the end. We carry the remainder over to the next chunk.
+        const combined = `${stdoutRemainder}${chunk}`;
+        const lines = combined.split('\n');
+        stdoutRemainder = lines.pop() ?? '';
+
         for (const line of lines) {
+          if (!line.trim()) continue;
           try {
             const parsed = JSON.parse(line);
             this.handleStreamEvent(parsed, responses);
@@ -277,6 +283,29 @@ export class GeminiRunner implements IClaudeRunner {
         clearTimeout(idleTimer);
         if (settled) return;
         settled = true;
+
+        // Flush any remaining buffered output
+        if (stdoutRemainder.trim()) {
+          try {
+            const parsed = JSON.parse(stdoutRemainder);
+            this.handleStreamEvent(parsed, responses);
+            this.captureToolCall(parsed, toolCalls);
+            if (parsed.usageMetadata || parsed.usage) {
+              const u = parsed.usageMetadata || parsed.usage;
+              usage = {
+                contextTokens: u.totalTokenCount || u.context_tokens || 0,
+                inputTokens: u.promptTokenCount || u.input_tokens || 0,
+                outputTokens: u.candidatesTokenCount || u.output_tokens || 0,
+              };
+            }
+            if (parsed.type === 'result' && parsed.result) {
+              finalTextResponse =
+                typeof parsed.result === 'string' ? parsed.result : JSON.stringify(parsed.result);
+            }
+          } catch {
+            // Non-JSON remainder — ignore
+          }
+        }
 
         if (code !== 0) {
           logger.warn('Gemini CLI exited with non-zero code', { code, stderr });

--- a/packages/api/src/services/sessions/gemini-runner.ts
+++ b/packages/api/src/services/sessions/gemini-runner.ts
@@ -1,0 +1,380 @@
+/**
+ * Gemini Runner
+ *
+ * Spawns Gemini CLI in non-interactive (headless) JSON mode.
+ * Models after ClaudeRunner but adapts for Gemini CLI conventions:
+ *   - Message via -p flag (not stdin)
+ *   - JSON output via -o stream-json
+ *   - Auto-approve via --yolo
+ *   - Resume via -r (index-based, not UUID — session continuity is best-effort)
+ *   - System prompt via --policy or prepended to message
+ */
+
+import { spawn, type ChildProcess } from 'child_process';
+import { randomUUID } from 'crypto';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import type {
+  InjectedContext,
+  ClaudeRunnerConfig,
+  ClaudeRunnerResult,
+  ChannelResponse,
+  ChannelType,
+  IClaudeRunner,
+  ToolCall,
+} from './types.js';
+import { formatInjectedContext } from './context-builder.js';
+import { logger } from '../../utils/logger.js';
+
+/** Maximum time (ms) to wait for a Gemini CLI subprocess before killing it */
+const PROCESS_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
+
+/** Idle timeout: no output for this long = stuck */
+const IDLE_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+
+interface GeminiUsageStats {
+  contextTokens: number;
+  inputTokens: number;
+  outputTokens: number;
+}
+
+export class GeminiRunner implements IClaudeRunner {
+  async run(
+    message: string,
+    options: {
+      claudeSessionId?: string;
+      injectedContext?: InjectedContext;
+      config: ClaudeRunnerConfig;
+    }
+  ): Promise<ClaudeRunnerResult> {
+    const { injectedContext, config } = options;
+
+    // Gemini uses index-based session resume (-r), not UUID-based.
+    // For now, always start fresh sessions — resume support is best-effort.
+    const sessionId = randomUUID();
+
+    // Build the message with injected context (prepended, like Codex runner)
+    let fullMessage = message;
+    if (injectedContext) {
+      const contextBlock = formatInjectedContext(injectedContext);
+      fullMessage = `${contextBlock}\n\n---\n\n${message}`;
+    }
+
+    // Optionally write system prompt to a temp policy file
+    const { policyPath, cleanup } = this.createPolicyTempFile(
+      config.appendSystemPrompt || config.systemPrompt || ''
+    );
+
+    try {
+      const args = this.buildArgs(fullMessage, config, policyPath);
+      logger.info('Spawning Gemini CLI', {
+        sessionId,
+        workingDirectory: config.workingDirectory,
+        messageLength: fullMessage.length,
+        hasPcpAccessToken: !!config.pcpAccessToken,
+      });
+
+      const result = await this.spawnProcess(args, config);
+
+      return {
+        success: true,
+        claudeSessionId: sessionId,
+        responses: result.responses,
+        usage: result.usage,
+        finalTextResponse: result.finalTextResponse,
+        toolCalls: result.toolCalls,
+      };
+    } catch (error) {
+      logger.error('Gemini process failed', {
+        sessionId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return {
+        success: false,
+        claudeSessionId: sessionId,
+        responses: [],
+        error: error instanceof Error ? error.message : 'Unknown error',
+      };
+    } finally {
+      cleanup();
+    }
+  }
+
+  private buildArgs(message: string, config: ClaudeRunnerConfig, policyPath?: string): string[] {
+    const args: string[] = ['-p', message, '-o', 'stream-json', '--yolo'];
+
+    if (config.model) {
+      args.push('-m', config.model);
+    }
+
+    if (policyPath) {
+      args.push('--policy', policyPath);
+    }
+
+    return args;
+  }
+
+  private async spawnProcess(
+    args: string[],
+    config: ClaudeRunnerConfig
+  ): Promise<{
+    responses: ChannelResponse[];
+    usage?: GeminiUsageStats;
+    finalTextResponse?: string;
+    toolCalls: ToolCall[];
+  }> {
+    return new Promise((resolve, reject) => {
+      // Strip CLAUDECODE to prevent env leaking into subprocess
+      const { CLAUDECODE, ...cleanEnv } = process.env;
+      const proc = spawn('gemini', args, {
+        cwd: config.workingDirectory,
+        env: {
+          ...cleanEnv,
+          HOME: process.env.HOME,
+          PATH: process.env.PATH,
+          ...(config.pcpAccessToken ? { PCP_ACCESS_TOKEN: config.pcpAccessToken } : {}),
+        },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+
+      let stderr = '';
+      const responses: ChannelResponse[] = [];
+      const toolCalls: ToolCall[] = [];
+      let usage: GeminiUsageStats | undefined;
+      let finalTextResponse: string | undefined;
+      let settled = false;
+      let lastActivityAt = Date.now();
+
+      // Activity-based timeout
+      let idleTimer: NodeJS.Timeout;
+      const resetIdleTimer = () => {
+        clearTimeout(idleTimer);
+        idleTimer = setTimeout(() => {
+          if (!settled) {
+            const idleSecs = Math.round((Date.now() - lastActivityAt) / 1000);
+            logger.error('Gemini CLI process idle too long, killing', {
+              idleSeconds: idleSecs,
+              hasResponses: responses.length > 0,
+              hasFinalText: !!finalTextResponse,
+            });
+            this.killProcess(proc);
+            settled = true;
+            resolve({
+              responses,
+              usage,
+              toolCalls,
+              finalTextResponse: finalTextResponse || `[Process timed out after ${idleSecs}s idle]`,
+            });
+          }
+        }, IDLE_TIMEOUT_MS);
+      };
+      resetIdleTimer();
+
+      // Hard ceiling timeout
+      const timeout = setTimeout(() => {
+        if (!settled) {
+          logger.error('Gemini CLI process hit hard timeout, killing', {
+            timeoutMs: PROCESS_TIMEOUT_MS,
+          });
+          this.killProcess(proc);
+          settled = true;
+          resolve({
+            responses,
+            usage,
+            toolCalls,
+            finalTextResponse: finalTextResponse || '[Process hit hard timeout]',
+          });
+        }
+      }, PROCESS_TIMEOUT_MS);
+
+      proc.stdout.on('data', (data) => {
+        lastActivityAt = Date.now();
+        resetIdleTimer();
+        const chunk = data.toString();
+
+        // Parse streaming JSON lines
+        const lines = chunk.split('\n').filter((line: string) => line.trim());
+        for (const line of lines) {
+          try {
+            const parsed = JSON.parse(line);
+            this.handleStreamEvent(parsed, responses);
+            this.captureToolCall(parsed, toolCalls);
+
+            // Capture usage stats
+            if (parsed.usageMetadata || parsed.usage) {
+              const u = parsed.usageMetadata || parsed.usage;
+              usage = {
+                contextTokens: u.totalTokenCount || u.context_tokens || 0,
+                inputTokens: u.promptTokenCount || u.input_tokens || 0,
+                outputTokens: u.candidatesTokenCount || u.output_tokens || 0,
+              };
+            }
+
+            // Capture final text from various Gemini output formats
+            if (parsed.type === 'result' && parsed.result) {
+              finalTextResponse =
+                typeof parsed.result === 'string' ? parsed.result : JSON.stringify(parsed.result);
+            }
+
+            // Gemini stream-json may emit text content differently
+            if (parsed.type === 'assistant' && parsed.message?.content) {
+              const content = parsed.message.content as Array<{ type: string; text?: string }>;
+              const textContent = content
+                .filter((c: { type: string }) => c.type === 'text')
+                .map((c: { text?: string }) => c.text || '')
+                .join('');
+              if (textContent) {
+                finalTextResponse = textContent;
+              }
+            }
+
+            // Also handle plain text events
+            if (parsed.type === 'text' && typeof parsed.text === 'string') {
+              finalTextResponse = (finalTextResponse || '') + parsed.text;
+            }
+
+            // Handle modelResponse format (Gemini-specific)
+            if (parsed.type === 'modelResponse' && parsed.text) {
+              finalTextResponse = parsed.text;
+            }
+          } catch {
+            // Not JSON — could be plain text output
+            // Accumulate as potential response text
+            const trimmed = line.trim();
+            if (
+              trimmed &&
+              !trimmed.startsWith('YOLO') &&
+              !trimmed.startsWith('[ERROR]') &&
+              !trimmed.startsWith('Loaded') &&
+              !trimmed.startsWith('Found') &&
+              !trimmed.startsWith('Server') &&
+              !trimmed.startsWith('MCP')
+            ) {
+              finalTextResponse = (finalTextResponse || '') + trimmed + '\n';
+            }
+          }
+        }
+      });
+
+      proc.stderr.on('data', (data) => {
+        lastActivityAt = Date.now();
+        resetIdleTimer();
+        stderr += data.toString();
+      });
+
+      proc.on('error', (error) => {
+        clearTimeout(timeout);
+        clearTimeout(idleTimer);
+        if (!settled) {
+          settled = true;
+          reject(new Error(`Failed to spawn Gemini: ${error.message}`));
+        }
+      });
+
+      proc.on('close', (code) => {
+        clearTimeout(timeout);
+        clearTimeout(idleTimer);
+        if (settled) return;
+        settled = true;
+
+        if (code !== 0) {
+          logger.warn('Gemini CLI exited with non-zero code', { code, stderr });
+          if (responses.length === 0 && !finalTextResponse) {
+            reject(new Error(`Gemini exited with code ${code}: ${stderr}`));
+            return;
+          }
+        }
+
+        resolve({ responses, usage, toolCalls, finalTextResponse });
+      });
+    });
+  }
+
+  /**
+   * Kill a Gemini CLI subprocess gracefully, with escalation to SIGKILL.
+   */
+  private killProcess(proc: ChildProcess): void {
+    try {
+      proc.kill('SIGTERM');
+      setTimeout(() => {
+        try {
+          if (!proc.killed) {
+            proc.kill('SIGKILL');
+          }
+        } catch {
+          // Process already dead
+        }
+      }, 5000);
+    } catch {
+      // Process already dead
+    }
+  }
+
+  /**
+   * Capture tool_use events for activity stream logging.
+   */
+  private captureToolCall(event: Record<string, unknown>, toolCalls: ToolCall[]): void {
+    // Handle both Claude-style and Gemini-style tool call events
+    if (event.type === 'tool_use' || event.type === 'toolCall') {
+      toolCalls.push({
+        toolUseId: (event.id as string) || (event.toolCallId as string) || '',
+        toolName: (event.name as string) || (event.toolName as string) || '',
+        input:
+          (event.input as Record<string, unknown>) || (event.args as Record<string, unknown>) || {},
+      });
+    }
+  }
+
+  /**
+   * Handle a streaming JSON event — capture send_response tool calls.
+   */
+  private handleStreamEvent(event: Record<string, unknown>, responses: ChannelResponse[]): void {
+    // Look for send_response tool calls (same MCP tool as Claude/Codex)
+    const toolName = (event.name as string) || (event.toolName as string);
+    const isToolUse = event.type === 'tool_use' || event.type === 'toolCall';
+
+    if (isToolUse && toolName === 'mcp__pcp__send_response') {
+      const input =
+        (event.input as Record<string, unknown>) || (event.args as Record<string, unknown>) || {};
+      const channel = (input.channel as ChannelType) || 'telegram';
+      const response: ChannelResponse = {
+        channel,
+        conversationId: (input.conversationId as string) || '',
+        content: (input.content as string) || '',
+        format: input.format as 'text' | 'markdown' | 'code' | 'json' | undefined,
+        replyToMessageId: input.replyToMessageId as string | undefined,
+        metadata: input.metadata as Record<string, unknown> | undefined,
+      };
+      responses.push(response);
+      logger.debug('Captured send_response call from Gemini', { response });
+    }
+  }
+
+  /**
+   * Write system prompt / identity to a temp policy file for Gemini CLI.
+   */
+  private createPolicyTempFile(content: string): {
+    policyPath: string | undefined;
+    cleanup: () => void;
+  } {
+    if (!content) {
+      return { policyPath: undefined, cleanup: () => {} };
+    }
+
+    const dir = mkdtempSync(join(tmpdir(), 'gemini-policy-'));
+    const policyPath = join(dir, 'identity-policy.md');
+    writeFileSync(policyPath, content, 'utf-8');
+
+    return {
+      policyPath,
+      cleanup: () => {
+        try {
+          rmSync(dir, { recursive: true, force: true });
+        } catch {
+          // Best effort cleanup
+        }
+      },
+    };
+  }
+}

--- a/packages/api/src/services/sessions/index.ts
+++ b/packages/api/src/services/sessions/index.ts
@@ -18,9 +18,10 @@ export { SessionRepository } from './session-repository.js';
 // Context builder
 export { ContextBuilder, formatInjectedContext } from './context-builder.js';
 
-// Claude runner
+// Backend runners
 export { ClaudeRunner, buildIdentityPrompt } from './claude-runner.js';
 export { CodexRunner } from './codex-runner.js';
+export { GeminiRunner } from './gemini-runner.js';
 
 // Types
 export type {

--- a/packages/api/src/services/sessions/session-service.ts
+++ b/packages/api/src/services/sessions/session-service.ts
@@ -368,15 +368,9 @@ export class SessionService implements ISessionService {
           ? this.geminiRunner
           : this.claudeRunner;
 
-    // Gemini is stateless: it cannot resume prior sessions, so we always inject
-    // full context on every turn. Claude/Codex only inject on the first turn
-    // (subsequent turns use --resume with the existing session ID).
-    const isStatelessBackend = resolvedBackend === 'gemini';
-    const shouldInjectContext = isStatelessBackend || !session.claudeSessionId;
-
     const result = await runner.run(formattedMessage, {
       claudeSessionId: session.claudeSessionId || undefined,
-      injectedContext: shouldInjectContext ? injectedContext : undefined,
+      injectedContext: session.claudeSessionId ? undefined : injectedContext,
       config: runnerConfig,
     });
 
@@ -408,9 +402,8 @@ export class SessionService implements ISessionService {
         outputTokens: result.usage.outputTokens,
       });
 
-      // 6. Check if compaction is needed (skip for stateless backends — they don't
-      // accumulate conversation context across turns, so there's nothing to compact)
-      if (!isStatelessBackend && result.usage.contextTokens >= this.config.compactionThreshold) {
+      // 6. Check if compaction is needed
+      if (result.usage.contextTokens >= this.config.compactionThreshold) {
         logger.info('Session approaching context limit, triggering compaction', {
           sessionId: session.id,
           contextTokens: result.usage.contextTokens,

--- a/packages/api/src/services/sessions/session-service.ts
+++ b/packages/api/src/services/sessions/session-service.ts
@@ -31,6 +31,7 @@ import { SessionRepository } from './session-repository.js';
 import { ContextBuilder } from './context-builder.js';
 import { ClaudeRunner, buildIdentityPrompt } from './claude-runner.js';
 import { CodexRunner } from './codex-runner.js';
+import { GeminiRunner } from './gemini-runner.js';
 import { ActivityStreamRepository } from '../../data/repositories/activity-stream.repository.js';
 import { resolveIdentityId } from '../../auth/resolve-identity.js';
 import { logger } from '../../utils/logger.js';
@@ -47,6 +48,8 @@ export interface SessionServiceConfig {
   defaultModel?: string;
   /** Optional explicit model override for Codex backend */
   defaultCodexModel?: string;
+  /** Optional explicit model override for Gemini backend */
+  defaultGeminiModel?: string;
   /** Token threshold for triggering compaction */
   compactionThreshold: number;
   /** Callback to route responses from async operations (compaction, etc.) */
@@ -102,6 +105,7 @@ export class SessionService implements ISessionService {
   private contextBuilder: IContextBuilder;
   private claudeRunner: IClaudeRunner;
   private codexRunner: IClaudeRunner;
+  private geminiRunner: IClaudeRunner;
   private activityStream: IActivityStream;
   private config: SessionServiceConfig;
   private supabase: SupabaseClient<Database> | null;
@@ -133,12 +137,14 @@ export class SessionService implements ISessionService {
     activityStream: IActivityStream,
     config: Partial<SessionServiceConfig> = {},
     codexRunner?: IClaudeRunner,
-    supabase?: SupabaseClient<Database>
+    supabase?: SupabaseClient<Database>,
+    geminiRunner?: IClaudeRunner
   ) {
     this.repository = repository;
     this.contextBuilder = contextBuilder;
     this.claudeRunner = claudeRunner;
     this.codexRunner = codexRunner || claudeRunner;
+    this.geminiRunner = geminiRunner || claudeRunner;
     this.activityStream = activityStream;
     this.config = { ...DEFAULT_CONFIG, ...config };
     this.supabase = supabase || null;
@@ -334,7 +340,11 @@ export class SessionService implements ISessionService {
       injectedContext.agent.backend
     );
     const runtimeModel =
-      resolvedBackend === 'codex-cli' ? this.config.defaultCodexModel : this.config.defaultModel;
+      resolvedBackend === 'codex-cli'
+        ? this.config.defaultCodexModel
+        : resolvedBackend === 'gemini'
+          ? this.config.defaultGeminiModel
+          : this.config.defaultModel;
 
     const runnerConfig: ClaudeRunnerConfig = {
       workingDirectory: resolvedWorkingDirectory,
@@ -351,7 +361,12 @@ export class SessionService implements ISessionService {
     };
 
     // 5. Run with selected backend
-    const runner = resolvedBackend === 'codex-cli' ? this.codexRunner : this.claudeRunner;
+    const runner =
+      resolvedBackend === 'codex-cli'
+        ? this.codexRunner
+        : resolvedBackend === 'gemini'
+          ? this.geminiRunner
+          : this.claudeRunner;
 
     const result = await runner.run(formattedMessage, {
       claudeSessionId: session.claudeSessionId || undefined,
@@ -867,7 +882,9 @@ This session will continue with a fresh context after compaction. Your identity,
       const runtimeModel =
         runtimeBackend === 'codex-cli'
           ? this.config.defaultCodexModel
-          : this.config.defaultModel;
+          : runtimeBackend === 'gemini'
+            ? this.config.defaultGeminiModel
+            : this.config.defaultModel;
 
       const runnerConfig: ClaudeRunnerConfig = {
         workingDirectory: compactionWorkingDirectory,
@@ -883,7 +900,12 @@ This session will continue with a fresh context after compaction. Your identity,
         ...(compactionToken ? { pcpAccessToken: compactionToken } : {}),
       };
 
-      const runner = runtimeBackend === 'codex-cli' ? this.codexRunner : this.claudeRunner;
+      const runner =
+        runtimeBackend === 'codex-cli'
+          ? this.codexRunner
+          : runtimeBackend === 'gemini'
+            ? this.geminiRunner
+            : this.claudeRunner;
 
       // Phase 1: Send compaction prompt — agent saves context, notifies users, ends session
       const result = await runner.run(compactionPrompt, {
@@ -920,16 +942,11 @@ This session will continue with a fresh context after compaction. Your identity,
   /**
    * Normalize backend value to runtime backend IDs used by sessions.
    */
-  private normalizeBackend(raw: string | null | undefined): 'claude-code' | 'codex-cli' {
+  private normalizeBackend(raw: string | null | undefined): 'claude-code' | 'codex-cli' | 'gemini' {
     const value = (raw || '').toLowerCase().trim();
     if (value === 'codex' || value === 'codex-cli') return 'codex-cli';
+    if (value === 'gemini' || value === 'gemini-cli') return 'gemini';
     if (value === 'claude' || value === 'claude-code' || value === '') return 'claude-code';
-    if (value === 'gemini') {
-      logger.warn(
-        'Gemini backend configured but not yet supported in SessionService, falling back to claude-code'
-      );
-      return 'claude-code';
-    }
     logger.warn('Unknown backend configured, falling back to claude-code', { raw });
     return 'claude-code';
   }
@@ -940,7 +957,7 @@ This session will continue with a fresh context after compaction. Your identity,
   private async resolveAgentBackend(
     userId: string,
     agentId: string
-  ): Promise<'claude-code' | 'codex-cli'> {
+  ): Promise<'claude-code' | 'codex-cli' | 'gemini'> {
     try {
       const identityBackend = await this.contextBuilder.getAgentBackend(userId, agentId);
       return this.normalizeBackend(identityBackend);
@@ -960,7 +977,7 @@ This session will continue with a fresh context after compaction. Your identity,
   private resolveRuntimeBackend(
     sessionBackend: string | null | undefined,
     identityBackend: string | null | undefined
-  ): 'claude-code' | 'codex-cli' {
+  ): 'claude-code' | 'codex-cli' | 'gemini' {
     if (sessionBackend) return this.normalizeBackend(sessionBackend);
     return this.normalizeBackend(identityBackend);
   }
@@ -1161,6 +1178,7 @@ export function createSessionService(
     new ActivityStreamRepository(supabase),
     config,
     new CodexRunner(),
-    supabase
+    supabase,
+    new GeminiRunner()
   );
 }

--- a/packages/api/src/services/sessions/session-service.ts
+++ b/packages/api/src/services/sessions/session-service.ts
@@ -368,9 +368,15 @@ export class SessionService implements ISessionService {
           ? this.geminiRunner
           : this.claudeRunner;
 
+    // Gemini is stateless: it cannot resume prior sessions, so we always inject
+    // full context on every turn. Claude/Codex only inject on the first turn
+    // (subsequent turns use --resume with the existing session ID).
+    const isStatelessBackend = resolvedBackend === 'gemini';
+    const shouldInjectContext = isStatelessBackend || !session.claudeSessionId;
+
     const result = await runner.run(formattedMessage, {
       claudeSessionId: session.claudeSessionId || undefined,
-      injectedContext: session.claudeSessionId ? undefined : injectedContext,
+      injectedContext: shouldInjectContext ? injectedContext : undefined,
       config: runnerConfig,
     });
 
@@ -402,8 +408,9 @@ export class SessionService implements ISessionService {
         outputTokens: result.usage.outputTokens,
       });
 
-      // 6. Check if compaction is needed
-      if (result.usage.contextTokens >= this.config.compactionThreshold) {
+      // 6. Check if compaction is needed (skip for stateless backends — they don't
+      // accumulate conversation context across turns, so there's nothing to compact)
+      if (!isStatelessBackend && result.usage.contextTokens >= this.config.compactionThreshold) {
         logger.info('Session approaching context limit, triggering compaction', {
           sessionId: session.id,
           contextTokens: result.usage.contextTokens,


### PR DESCRIPTION
## Summary
- Adds `GeminiRunner` as a third backend alongside `ClaudeRunner` and `CodexRunner`
- Spawns `gemini -p <msg> -o stream-json --yolo` for headless Gemini CLI execution
- Updates `normalizeBackend()` to recognize 'gemini' as a first-class runtime (previously hardcoded fallback to claude-code)
- Wires GeminiRunner into SessionService factory, runner selection, and compaction paths
- Data fix: Set `backend = 'gemini'` on Aster's `agent_identities` record (was NULL)

## Bug
When Aster was triggered via `send_to_inbox` + `trigger_agent`, the system spawned Claude instead of Gemini because:
1. Aster's `backend` was NULL in `agent_identities` → defaulted to claude-code
2. Even with 'gemini' set, `normalizeBackend()` had a hardcoded fallback: `if (value === 'gemini') return 'claude-code'`

## Test plan
- [x] API builds clean
- [x] 872/873 tests pass (1 pre-existing failure in discord-listener)
- [ ] Trigger Aster and verify `backend:gemini` in status line
- [ ] Verify Gemini CLI produces parseable stream-json output

🤖 Generated with [Claude Code](https://claude.com/claude-code)