### PR TITLE
fix: honor heartbeat disable flags in dev direct (by Lumen)

### DIFF
--- a/packages/api/src/config/heartbeat-flags.test.ts
+++ b/packages/api/src/config/heartbeat-flags.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { getHeartbeatProcessingConfig } from './heartbeat-flags';
+
+describe('getHeartbeatProcessingConfig', () => {
+  it('defaults to enabled when heartbeat flags are unset', () => {
+    const result = getHeartbeatProcessingConfig({});
+    expect(result.enabled).toBe(true);
+  });
+
+  it.each([
+    { ENABLE_HEARTBEAT_SERVICE: 'false' },
+    { ENABLE_HEARTBEAT_SERVICE: 'FALSE' },
+    { ENABLE_HEARTBEAT_SERVICE: ' false ' },
+    { ENABLE_HEARTBEAT_SERVICE: '0' },
+    { ENABLE_HEARTBEATS: 'off' },
+    { ENABLE_REMINDERS: 'no' },
+  ])('disables heartbeat processing for false-like flag values: %o', (envVars) => {
+    const result = getHeartbeatProcessingConfig(envVars);
+    expect(result.enabled).toBe(false);
+  });
+
+  it('stays enabled for true-like values', () => {
+    const result = getHeartbeatProcessingConfig({
+      ENABLE_HEARTBEAT_SERVICE: 'true',
+      ENABLE_HEARTBEATS: '1',
+      ENABLE_REMINDERS: 'yes',
+    });
+    expect(result.enabled).toBe(true);
+  });
+});

--- a/packages/api/src/config/heartbeat-flags.ts
+++ b/packages/api/src/config/heartbeat-flags.ts
@@ -1,0 +1,31 @@
+export interface HeartbeatFlagValues {
+  ENABLE_HEARTBEAT_SERVICE: string | undefined;
+  ENABLE_HEARTBEATS: string | undefined;
+  ENABLE_REMINDERS: string | undefined;
+}
+
+const DISABLED_VALUES = new Set(['false', '0', 'off', 'no']);
+
+function isDisabled(value: string | undefined): boolean {
+  if (value === undefined) return false;
+  return DISABLED_VALUES.has(value.trim().toLowerCase());
+}
+
+export function getHeartbeatProcessingConfig(envSource: NodeJS.ProcessEnv = process.env): {
+  enabled: boolean;
+  flags: HeartbeatFlagValues;
+} {
+  const flags: HeartbeatFlagValues = {
+    ENABLE_HEARTBEAT_SERVICE: envSource.ENABLE_HEARTBEAT_SERVICE,
+    ENABLE_HEARTBEATS: envSource.ENABLE_HEARTBEATS,
+    ENABLE_REMINDERS: envSource.ENABLE_REMINDERS,
+  };
+
+  return {
+    flags,
+    enabled:
+      !isDisabled(flags.ENABLE_HEARTBEAT_SERVICE) &&
+      !isDisabled(flags.ENABLE_HEARTBEATS) &&
+      !isDisabled(flags.ENABLE_REMINDERS),
+  };
+}

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -14,6 +14,7 @@ import { getAuthorizationService } from '../services/authorization';
 import { getOAuthService } from '../services/oauth';
 import { logger } from '../utils/logger';
 import { env, isDevelopment } from '../config/env';
+import { getHeartbeatProcessingConfig } from '../config/heartbeat-flags';
 import { runWithRequestContext } from '../utils/request-context';
 import { getDataComposer } from '../data/composer';
 
@@ -1376,10 +1377,7 @@ router.post('/whatsapp/logout', async (_req: Request, res: Response) => {
  */
 router.post('/heartbeat', async (req: Request, res: Response) => {
   try {
-    const heartbeatEnabled =
-      process.env.ENABLE_HEARTBEAT_SERVICE !== 'false' &&
-      process.env.ENABLE_HEARTBEATS !== 'false' &&
-      process.env.ENABLE_REMINDERS !== 'false';
+    const { enabled: heartbeatEnabled } = getHeartbeatProcessingConfig();
     const forceRun = req.query.force === 'true';
 
     if (!heartbeatEnabled && !forceRun) {
@@ -1514,10 +1512,7 @@ router.get('/routing', async (req: Request, res: Response) => {
       toRoutingRoute(route, reminderCountByIdentity, nextReminderByIdentity)
     );
 
-    const heartbeatProcessingEnabled =
-      process.env.ENABLE_HEARTBEAT_SERVICE !== 'false' &&
-      process.env.ENABLE_HEARTBEATS !== 'false' &&
-      process.env.ENABLE_REMINDERS !== 'false';
+    const { enabled: heartbeatProcessingEnabled } = getHeartbeatProcessingConfig();
 
     const uniqueAgents = new Set(routes.map((route) => route.agentId).filter(Boolean));
     const uniquePlatforms = new Set(routes.map((route) => route.platform));
@@ -1659,11 +1654,7 @@ router.get('/routing/agents/:agentId', async (req: Request, res: Response) => {
       .eq('agent_id', identity.agent_id)
       .in('status', ['active', 'idle'])
       .order('name', { ascending: true });
-
-    const heartbeatProcessingEnabled =
-      process.env.ENABLE_HEARTBEAT_SERVICE !== 'false' &&
-      process.env.ENABLE_HEARTBEATS !== 'false' &&
-      process.env.ENABLE_REMINDERS !== 'false';
+    const { enabled: heartbeatProcessingEnabled } = getHeartbeatProcessingConfig();
 
     res.json({
       heartbeatProcessingEnabled,

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -38,6 +38,7 @@ import { setResponseCallback, hasExplicitResponse } from './mcp/tools/response-h
 import { getAgentGateway, type AgentTriggerPayload } from './channels/agent-gateway';
 import { resolveRouteAgentId } from './services/routing/resolve-route';
 import { resolveAgentFromMention } from './services/routing/resolve-mention';
+import { getHeartbeatProcessingConfig } from './config/heartbeat-flags';
 import { logger } from './utils/logger';
 import { env } from './config/env';
 
@@ -343,15 +344,20 @@ async function startServer(config: ServerConfig = {}): Promise<void> {
   // 6. Initialize heartbeat service for scheduled reminders
   // Useful for secondary/local dev servers where we want API/MCP without
   // participating in global reminder delivery.
-  const heartbeatServiceEnabled =
-    process.env.ENABLE_HEARTBEAT_SERVICE !== 'false' &&
-    process.env.ENABLE_HEARTBEATS !== 'false' &&
-    process.env.ENABLE_REMINDERS !== 'false';
+  const {
+    enabled: heartbeatServiceEnabled,
+    flags: heartbeatServiceFlags,
+  } = getHeartbeatProcessingConfig();
   const enableLocalCron =
     process.env.ENABLE_LOCAL_CRON !== undefined
       ? process.env.ENABLE_LOCAL_CRON === 'true'
       : process.env.NODE_ENV !== 'production';
   const heartbeatInterval = process.env.HEARTBEAT_INTERVAL || '*/5 * * * *';
+
+  logger.info('Heartbeat service flags evaluated', {
+    heartbeatServiceEnabled,
+    ...heartbeatServiceFlags,
+  });
 
   /**
    * Deliver reminder via SessionService - same stateless flow as all other messages.

--- a/scripts/dev-direct.sh
+++ b/scripts/dev-direct.sh
@@ -12,6 +12,13 @@ while IFS='=' read -r key value; do
   printf 'export %s=%q\n' "${key}" "${value}" >>"${PRESERVED_ENV_FILE}"
 done < <(env)
 
+cleanup() {
+  if [[ -n "${PRESERVED_ENV_FILE:-}" ]]; then rm -f "${PRESERVED_ENV_FILE}" 2>/dev/null || true; fi
+  if [[ -n "${API_PID:-}" ]]; then kill "${API_PID}" 2>/dev/null || true; fi
+  if [[ -n "${WEB_PID:-}" ]]; then kill "${WEB_PID}" 2>/dev/null || true; fi
+}
+trap cleanup EXIT INT TERM
+
 load_env_file() {
   local file="$1"
   if [[ -f "${file}" ]]; then
@@ -29,7 +36,6 @@ load_env_file "${ROOT_DIR}/.env"
 # Restore original environment values from the caller (prefix assignments, exported vars).
 # shellcheck disable=SC1090
 source "${PRESERVED_ENV_FILE}"
-rm -f "${PRESERVED_ENV_FILE}"
 
 # Run API + web directly (no PM2), useful for parallel worktrees.
 BASE_PORT="${PCP_PORT_BASE:-3001}"
@@ -47,12 +53,6 @@ echo "  ENABLE_HEARTBEAT_SERVICE=${ENABLE_HEARTBEAT_SERVICE:-<unset>}"
 echo "  ENABLE_HEARTBEATS=${ENABLE_HEARTBEATS:-<unset>}"
 echo "  ENABLE_REMINDERS=${ENABLE_REMINDERS:-<unset>}"
 echo "  API_URL=${API_URL}"
-
-cleanup() {
-  if [[ -n "${API_PID:-}" ]]; then kill "${API_PID}" 2>/dev/null || true; fi
-  if [[ -n "${WEB_PID:-}" ]]; then kill "${WEB_PID}" 2>/dev/null || true; fi
-}
-trap cleanup EXIT INT TERM
 
 (
   PCP_PORT_BASE="${BASE_PORT}" \

--- a/scripts/dev-direct.sh
+++ b/scripts/dev-direct.sh
@@ -6,19 +6,30 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 export PROJECT_CWD="${ROOT_DIR}"
 export INIT_CWD="${ROOT_DIR}"
 
+# Preserve caller-provided env so explicit CLI overrides win over .env files.
+PRESERVED_ENV_FILE="$(mktemp)"
+while IFS='=' read -r key value; do
+  printf 'export %s=%q\n' "${key}" "${value}" >>"${PRESERVED_ENV_FILE}"
+done < <(env)
+
+load_env_file() {
+  local file="$1"
+  if [[ -f "${file}" ]]; then
+    set -a
+    # shellcheck disable=SC1090
+    source "${file}"
+    set +a
+  fi
+}
+
 # Load root env files so both API + web get a consistent local dev environment.
-if [[ -f "${ROOT_DIR}/.env.local" ]]; then
-  set -a
-  # shellcheck disable=SC1090
-  source "${ROOT_DIR}/.env.local"
-  set +a
-fi
-if [[ -f "${ROOT_DIR}/.env" ]]; then
-  set -a
-  # shellcheck disable=SC1090
-  source "${ROOT_DIR}/.env"
-  set +a
-fi
+load_env_file "${ROOT_DIR}/.env.local"
+load_env_file "${ROOT_DIR}/.env"
+
+# Restore original environment values from the caller (prefix assignments, exported vars).
+# shellcheck disable=SC1090
+source "${PRESERVED_ENV_FILE}"
+rm -f "${PRESERVED_ENV_FILE}"
 
 # Run API + web directly (no PM2), useful for parallel worktrees.
 BASE_PORT="${PCP_PORT_BASE:-3001}"
@@ -32,6 +43,9 @@ echo "  PCP_PORT_BASE=${BASE_PORT}"
 echo "  WEB_PORT=${WEB_PORT}"
 echo "  MYRA_HTTP_PORT=${MYRA_PORT}"
 echo "  ENABLE_TELEGRAM=${ENABLE_TELEGRAM}"
+echo "  ENABLE_HEARTBEAT_SERVICE=${ENABLE_HEARTBEAT_SERVICE:-<unset>}"
+echo "  ENABLE_HEARTBEATS=${ENABLE_HEARTBEATS:-<unset>}"
+echo "  ENABLE_REMINDERS=${ENABLE_REMINDERS:-<unset>}"
 echo "  API_URL=${API_URL}"
 
 cleanup() {


### PR DESCRIPTION
## Summary
- preserve caller-provided environment variables in `scripts/dev-direct.sh` so `.env`/`.env.local` cannot overwrite explicit CLI flag overrides
- centralize heartbeat enable/disable evaluation in `packages/api/src/config/heartbeat-flags.ts`
- support false-like values (`false`, `0`, `off`, `no`, case/whitespace insensitive) for heartbeat flags
- reuse the centralized heartbeat flag helper in server startup and admin routes
- log evaluated heartbeat flags at server startup for easier diagnosis

## Why
`ENABLE_HEARTBEAT_SERVICE=false yarn dev:direct` could still start heartbeat processing when `.env` or `.env.local` set heartbeat flags. The dev script sourced env files in a way that could clobber caller overrides.

## Validation
- `yarn type-check`
- `yarn test`
- `bash -n scripts/dev-direct.sh`

— Lumen