### PR TITLE
feat(web): dashboard studios grouped by SB + avatar fix (by Wren)

### DIFF
--- a/packages/api/src/data/repositories/studios.repository.ts
+++ b/packages/api/src/data/repositories/studios.repository.ts
@@ -58,6 +58,8 @@ export interface UpdateStudioInput {
   purpose?: string;
   workType?: WorkType;
   roleTemplate?: string | null;
+  worktreePath?: string;
+  slug?: string | null;
   metadata?: Json;
   archivedAt?: string;
   cleanedAt?: string;
@@ -242,6 +244,8 @@ export class StudiosRepository {
     if (input.purpose !== undefined) updateData.purpose = input.purpose;
     if (input.workType !== undefined) updateData.work_type = input.workType;
     if (input.roleTemplate !== undefined) updateData.role_template = input.roleTemplate;
+    if (input.worktreePath !== undefined) updateData.worktree_path = input.worktreePath;
+    if (input.slug !== undefined) updateData.slug = input.slug;
     if (input.metadata !== undefined) updateData.metadata = input.metadata;
     if (input.archivedAt !== undefined) updateData.archived_at = input.archivedAt;
     if (input.cleanedAt !== undefined) updateData.cleaned_at = input.cleanedAt;

--- a/packages/api/src/data/repositories/studios.repository.ts
+++ b/packages/api/src/data/repositories/studios.repository.ts
@@ -27,6 +27,7 @@ export interface Studio {
   baseBranch: string;
   purpose: string | null;
   workType: string | null;
+  slug: string | null;
   roleTemplate: string | null;
   status: StudioStatus;
   metadata: Json;
@@ -62,6 +63,18 @@ export interface UpdateStudioInput {
   cleanedAt?: string;
 }
 
+/**
+ * Derive a studio slug from the worktree folder path.
+ * Convention: folders are named <repo>--<slug>, e.g.
+ *   /path/to/personal-context-protocol--wren → "wren"
+ */
+export function deriveStudioSlug(worktreePath: string): string | null {
+  const folder = worktreePath.split('/').pop() || '';
+  const idx = folder.indexOf('--');
+  if (idx === -1) return null;
+  return folder.slice(idx + 2) || null;
+}
+
 export class StudiosRepository {
   constructor(private client: SupabaseClient<Database>) {}
 
@@ -77,6 +90,7 @@ export class StudiosRepository {
       baseBranch: row.base_branch as string,
       purpose: (row.purpose as string) || null,
       workType: (row.work_type as string) || null,
+      slug: (row.slug as string) || null,
       roleTemplate: (row.role_template as string) || null,
       status: row.status as StudioStatus,
       metadata: (row.metadata as Json) || {},
@@ -104,6 +118,7 @@ export class StudiosRepository {
       purpose: input.purpose,
       work_type: input.workType,
       role_template: input.roleTemplate,
+      slug: deriveStudioSlug(input.worktreePath),
       status: 'active',
       metadata: input.metadata || {},
     };

--- a/packages/api/src/data/supabase/types.ts
+++ b/packages/api/src/data/supabase/types.ts
@@ -2836,6 +2836,7 @@ export type Database = {
           repo_root: string;
           role_template: string | null;
           session_id: string | null;
+          slug: string | null;
           status: string;
           updated_at: string | null;
           user_id: string;
@@ -2856,6 +2857,7 @@ export type Database = {
           repo_root: string;
           role_template?: string | null;
           session_id?: string | null;
+          slug?: string | null;
           status?: string;
           updated_at?: string | null;
           user_id: string;
@@ -2876,6 +2878,7 @@ export type Database = {
           repo_root?: string;
           role_template?: string | null;
           session_id?: string | null;
+          slug?: string | null;
           status?: string;
           updated_at?: string | null;
           user_id?: string;

--- a/packages/api/src/mcp/tools/workspace-handlers.ts
+++ b/packages/api/src/mcp/tools/workspace-handlers.ts
@@ -81,6 +81,8 @@ const updateWorkspaceSchema = userIdentifierBaseSchema.extend({
   status: z.enum(['active', 'idle', 'archived']).optional().describe('New workspace status'),
   purpose: z.string().optional().describe('Updated purpose description'),
   roleTemplate: z.string().optional().describe('Role template name to set'),
+  worktreePath: z.string().optional().describe('Updated worktree path (after rename/move)'),
+  slug: z.string().optional().describe('Updated studio slug'),
   sessionId: z.string().uuid().optional().describe('Session ID to link'),
   unlinkSession: z
     .boolean()
@@ -341,7 +343,17 @@ export async function handleUpdateWorkspace(args: unknown, dataComposer: DataCom
   const parsed = updateWorkspaceSchema.parse(args);
   await resolveUserOrThrow(parsed, dataComposer);
 
-  const { workspaceId, agentId, status, purpose, roleTemplate, sessionId, unlinkSession } = parsed;
+  const {
+    workspaceId,
+    agentId,
+    status,
+    purpose,
+    roleTemplate,
+    worktreePath,
+    slug,
+    sessionId,
+    unlinkSession,
+  } = parsed;
   const studiosRepo = dataComposer.repositories.studios;
 
   // Verify workspace exists
@@ -366,6 +378,12 @@ export async function handleUpdateWorkspace(args: unknown, dataComposer: DataCom
     }
     if (roleTemplate !== undefined) {
       updateObj.roleTemplate = roleTemplate;
+    }
+    if (worktreePath !== undefined) {
+      updateObj.worktreePath = worktreePath;
+    }
+    if (slug !== undefined) {
+      updateObj.slug = slug;
     }
     updated = await studiosRepo.update(workspaceId, updateObj);
   }

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -3734,7 +3734,7 @@ router.get('/studios', async (req: Request, res: Response) => {
     const { data: studios } = await supabase
       .from('studios')
       .select(
-        'id, agent_id, name, branch, base_branch, purpose, work_type, worktree_path, status, updated_at, created_at'
+        'id, agent_id, branch, base_branch, purpose, work_type, worktree_path, status, updated_at, created_at'
       )
       .eq('user_id', authReq.pcpUserId)
       .neq('status', 'cleaned')
@@ -3790,7 +3790,6 @@ router.get('/studios', async (req: Request, res: Response) => {
           : null,
         studios: agentStudios.map((s) => ({
           id: s.id,
-          name: s.name,
           branch: s.branch,
           baseBranch: s.base_branch,
           purpose: s.purpose,

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -3744,13 +3744,13 @@ router.get('/studios', async (req: Request, res: Response) => {
     const agentIds = (identities || []).map((i) => i.agent_id).filter(Boolean);
     const latestSessionByAgent = new Map<
       string,
-      { currentPhase: string | null; updatedAt: string }
+      { currentPhase: string | null; status: string | null; updatedAt: string }
     >();
 
     if (agentIds.length > 0) {
       const { data: sessions } = await supabase
         .from('sessions')
-        .select('agent_id, current_phase, updated_at')
+        .select('agent_id, current_phase, status, updated_at')
         .eq('user_id', authReq.pcpUserId)
         .in('agent_id', agentIds)
         .is('ended_at', null)
@@ -3760,6 +3760,7 @@ router.get('/studios', async (req: Request, res: Response) => {
         if (!latestSessionByAgent.has(session.agent_id)) {
           latestSessionByAgent.set(session.agent_id, {
             currentPhase: session.current_phase,
+            status: session.status,
             updatedAt: session.updated_at,
           });
         }
@@ -3786,7 +3787,11 @@ router.get('/studios', async (req: Request, res: Response) => {
         backend: identity.backend,
         identityId: identity.id,
         latestSession: latestSession
-          ? { currentPhase: latestSession.currentPhase, updatedAt: latestSession.updatedAt }
+          ? {
+              currentPhase: latestSession.currentPhase,
+              status: latestSession.status,
+              updatedAt: latestSession.updatedAt,
+            }
           : null,
         studios: agentStudios.map((s) => ({
           id: s.id,

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -3713,6 +3713,103 @@ router.get('/sessions', async (req: Request, res: Response) => {
 });
 
 /**
+ * GET /api/admin/studios
+ * List studios grouped by agent, with latest session status per agent.
+ */
+router.get('/studios', async (req: Request, res: Response) => {
+  try {
+    const authReq = req as AdminAuthRequest;
+    const supabase = createClient(env.SUPABASE_URL, env.SUPABASE_SECRET_KEY, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+
+    // 1. Fetch all agent identities for this user
+    const { data: identities } = await supabase
+      .from('agent_identities')
+      .select('id, agent_id, name, role, backend')
+      .eq('user_id', authReq.pcpUserId)
+      .order('name', { ascending: true });
+
+    // 2. Fetch all non-cleaned studios for this user
+    const { data: studios } = await supabase
+      .from('studios')
+      .select(
+        'id, agent_id, name, branch, base_branch, purpose, work_type, worktree_path, status, updated_at, created_at'
+      )
+      .eq('user_id', authReq.pcpUserId)
+      .neq('status', 'cleaned')
+      .order('updated_at', { ascending: false });
+
+    // 3. Fetch latest active session per agent (for status/phase)
+    const agentIds = (identities || []).map((i) => i.agent_id).filter(Boolean);
+    const latestSessionByAgent = new Map<
+      string,
+      { currentPhase: string | null; updatedAt: string }
+    >();
+
+    if (agentIds.length > 0) {
+      const { data: sessions } = await supabase
+        .from('sessions')
+        .select('agent_id, current_phase, updated_at')
+        .eq('user_id', authReq.pcpUserId)
+        .in('agent_id', agentIds)
+        .is('ended_at', null)
+        .order('updated_at', { ascending: false });
+
+      for (const session of sessions || []) {
+        if (!latestSessionByAgent.has(session.agent_id)) {
+          latestSessionByAgent.set(session.agent_id, {
+            currentPhase: session.current_phase,
+            updatedAt: session.updated_at,
+          });
+        }
+      }
+    }
+
+    // 4. Group studios by agent
+    const studiosByAgent = new Map<string, typeof studios>();
+    for (const studio of studios || []) {
+      const key = studio.agent_id || '__unassigned__';
+      if (!studiosByAgent.has(key)) studiosByAgent.set(key, []);
+      studiosByAgent.get(key)!.push(studio);
+    }
+
+    // 5. Build response grouped by agent
+    const agents = (identities || []).map((identity) => {
+      const agentStudios = studiosByAgent.get(identity.agent_id) || [];
+      const latestSession = latestSessionByAgent.get(identity.agent_id);
+
+      return {
+        agentId: identity.agent_id,
+        agentName: identity.name,
+        agentRole: identity.role,
+        backend: identity.backend,
+        identityId: identity.id,
+        latestSession: latestSession
+          ? { currentPhase: latestSession.currentPhase, updatedAt: latestSession.updatedAt }
+          : null,
+        studios: agentStudios.map((s) => ({
+          id: s.id,
+          name: s.name,
+          branch: s.branch,
+          baseBranch: s.base_branch,
+          purpose: s.purpose,
+          workType: s.work_type,
+          worktreePath: s.worktree_path,
+          status: s.status,
+          updatedAt: s.updated_at,
+        })),
+      };
+    });
+
+    res.json({ agents });
+  } catch (error) {
+    logger.error('Failed to list studios:', error);
+    res.status(500).json(errorJson('Failed to list studios', error));
+  }
+});
+
+/**
  * GET /api/admin/sessions/:id/logs
  * Get merged session logs (activity stream + session_logs + optional local transcript fallback)
  */

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -3734,7 +3734,7 @@ router.get('/studios', async (req: Request, res: Response) => {
     const { data: studios } = await supabase
       .from('studios')
       .select(
-        'id, agent_id, branch, base_branch, purpose, work_type, worktree_path, status, updated_at, created_at'
+        'id, agent_id, branch, base_branch, purpose, work_type, worktree_path, slug, status, updated_at, created_at'
       )
       .eq('user_id', authReq.pcpUserId)
       .neq('status', 'cleaned')
@@ -3795,6 +3795,7 @@ router.get('/studios', async (req: Request, res: Response) => {
           purpose: s.purpose,
           workType: s.work_type,
           worktreePath: s.worktree_path,
+          slug: s.slug,
           status: s.status,
           updatedAt: s.updated_at,
         })),

--- a/packages/cli/src/commands/hooks.test.ts
+++ b/packages/cli/src/commands/hooks.test.ts
@@ -9,7 +9,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { existsSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { installHooks, callPcpTool } from './hooks.js';
+import { installHooks, callPcpTool, buildIdentityBlock } from './hooks.js';
 
 const TEST_DIR = join(tmpdir(), 'pcp-hooks-test-' + Date.now());
 
@@ -590,5 +590,117 @@ describe('callPcpTool: Streamable HTTP response formats', () => {
 
     const result = await callPcpTool('bootstrap', { agentId: 'wren' });
     expect(result).toEqual({ text: 'plain text result' });
+  });
+});
+
+// ============================================================================
+// buildIdentityBlock: identity file rendering (regression)
+// ============================================================================
+
+describe('buildIdentityBlock', () => {
+  it('should render identity files from bootstrap response', () => {
+    const bootstrap = {
+      identityFiles: {
+        self: '# IDENTITY.md - Wren\n\nI am Wren.',
+        soul: '# SOUL.md\n\nI exist.',
+        values: '# VALUES.md\n\nBe helpful.',
+        process: '# PROCESS.md\n\nHow we work.',
+        user: '# USER.md\n\nAbout the human.',
+        heartbeat: '# HEARTBEAT.md\n\nSession management.',
+      },
+    };
+
+    const result = buildIdentityBlock(bootstrap);
+
+    // All identity files should be present
+    expect(result).toContain('# IDENTITY.md - Wren');
+    expect(result).toContain('# SOUL.md');
+    expect(result).toContain('# VALUES.md');
+    expect(result).toContain('# PROCESS.md');
+    expect(result).toContain('# USER.md');
+    expect(result).toContain('# HEARTBEAT.md');
+  });
+
+  it('should render files in correct order: self, soul, values, process, user, heartbeat', () => {
+    const bootstrap = {
+      identityFiles: {
+        heartbeat: 'HEARTBEAT',
+        user: 'USER',
+        self: 'SELF',
+        values: 'VALUES',
+        soul: 'SOUL',
+        process: 'PROCESS',
+      },
+    };
+
+    const result = buildIdentityBlock(bootstrap);
+    const selfIdx = result.indexOf('SELF');
+    const soulIdx = result.indexOf('SOUL');
+    const valuesIdx = result.indexOf('VALUES');
+    const processIdx = result.indexOf('PROCESS');
+    const userIdx = result.indexOf('USER');
+    const heartbeatIdx = result.indexOf('HEARTBEAT');
+
+    expect(selfIdx).toBeLessThan(soulIdx);
+    expect(soulIdx).toBeLessThan(valuesIdx);
+    expect(valuesIdx).toBeLessThan(processIdx);
+    expect(processIdx).toBeLessThan(userIdx);
+    expect(userIdx).toBeLessThan(heartbeatIdx);
+  });
+
+  it('should return empty string when identityFiles is missing', () => {
+    expect(buildIdentityBlock({})).toBe('');
+    expect(buildIdentityBlock({ someOtherField: 'data' })).toBe('');
+  });
+
+  it('should return empty string for null/undefined input', () => {
+    expect(buildIdentityBlock(null as unknown as Record<string, unknown>)).toBe('');
+    expect(buildIdentityBlock(undefined as unknown as Record<string, unknown>)).toBe('');
+  });
+
+  it('should handle partial identity files (some missing)', () => {
+    const bootstrap = {
+      identityFiles: {
+        self: '# IDENTITY.md\n\nI am here.',
+        soul: '# SOUL.md\n\nI exist.',
+        // values, process, user, heartbeat missing
+      },
+    };
+
+    const result = buildIdentityBlock(bootstrap);
+    expect(result).toContain('# IDENTITY.md');
+    expect(result).toContain('# SOUL.md');
+    expect(result).not.toContain('VALUES');
+  });
+
+  it('should NOT render when passed bootstrap.identity (old broken field path)', () => {
+    // Regression: the old code used bootstrap.identity which doesn't exist
+    // on the bootstrap response. This ensures we catch if someone reverts
+    // to the broken field path.
+    const bootstrap = {
+      identity: { name: 'Wren', role: 'dev' },
+      identityFiles: {
+        self: '# IDENTITY.md\n\nReal content',
+      },
+    };
+
+    // buildIdentityBlock receives the full bootstrap object,
+    // and should read identityFiles, not identity
+    const result = buildIdentityBlock(bootstrap);
+    expect(result).toContain('# IDENTITY.md');
+    expect(result).not.toContain('"name"');
+    expect(result).not.toContain('JSON');
+  });
+
+  it('should separate files with horizontal rules', () => {
+    const bootstrap = {
+      identityFiles: {
+        self: 'SELF',
+        soul: 'SOUL',
+      },
+    };
+
+    const result = buildIdentityBlock(bootstrap);
+    expect(result).toContain('---');
   });
 });

--- a/packages/cli/src/commands/hooks.ts
+++ b/packages/cli/src/commands/hooks.ts
@@ -613,9 +613,23 @@ function renderTemplate(template: string, vars: Record<string, string>): string 
 // Shared Block Builders
 // ============================================================================
 
-function buildIdentityBlock(identity: unknown): string {
-  if (!identity) return '';
-  return `### Identity\n\`\`\`json\n${JSON.stringify(identity, null, 2)}\n\`\`\``;
+export function buildIdentityBlock(bootstrapResult: Record<string, unknown>): string {
+  const files = bootstrapResult?.identityFiles as Record<string, string> | undefined;
+  if (!files) return '';
+
+  const sections: string[] = [];
+
+  // Render identity files in a meaningful order
+  const fileOrder = ['self', 'soul', 'values', 'process', 'user', 'heartbeat'];
+  for (const key of fileOrder) {
+    const content = files[key];
+    if (content && typeof content === 'string') {
+      sections.push(content.trim());
+    }
+  }
+
+  if (sections.length === 0) return '';
+  return sections.join('\n\n---\n\n');
 }
 
 function buildInboxBlock(messages: Array<Record<string, unknown>> | undefined): string {
@@ -1235,6 +1249,7 @@ async function postCompactHandler(): Promise<void> {
   const agentId = resolveAgentId() || 'unknown';
 
   let identityBlock = '';
+  let memoriesBlock = '';
   let inboxBlock = '';
   let skillsBlock = '';
 
@@ -1244,7 +1259,10 @@ async function postCompactHandler(): Promise<void> {
       email: config?.email,
       agentId,
     });
-    identityBlock = buildIdentityBlock(bootstrap.identity);
+    identityBlock = buildIdentityBlock(bootstrap);
+    memoriesBlock = buildMemoriesBlock(
+      bootstrap.recentMemories as Array<Record<string, unknown>> | undefined
+    );
   } catch {
     identityBlock =
       '*FAILED: Could not reach PCP server for `bootstrap`. You should call the `bootstrap` MCP tool manually to reload your identity context.*';
@@ -1277,6 +1295,7 @@ async function postCompactHandler(): Promise<void> {
   const output = renderTemplate(template, {
     AGENT_ID: agentId,
     IDENTITY_BLOCK: identityBlock,
+    MEMORIES_BLOCK: memoriesBlock,
     SKILLS_BLOCK: skillsBlock,
     INBOX_BLOCK: inboxBlock,
   });
@@ -1318,7 +1337,7 @@ async function onSessionStartHandler(): Promise<void> {
     if (studioId) bootstrapArgs.studioId = studioId;
 
     const bootstrap = await callPcpTool('bootstrap', bootstrapArgs);
-    identityBlock = buildIdentityBlock(bootstrap.identity);
+    identityBlock = buildIdentityBlock(bootstrap);
     memoriesBlock = buildMemoriesBlock(
       bootstrap.recentMemories as Array<Record<string, unknown>> | undefined
     );

--- a/packages/cli/src/commands/studio.ts
+++ b/packages/cli/src/commands/studio.ts
@@ -37,7 +37,7 @@ import {
   delimiter as pathDelimiter,
 } from 'path';
 import { homedir } from 'os';
-import { installHooks } from './hooks.js';
+import { installHooks, callPcpTool } from './hooks.js';
 import { loadAuth, decodeJwtPayload, isTokenExpired } from '../auth/tokens.js';
 import { resolveAgentId } from '../backends/identity.js';
 
@@ -833,10 +833,38 @@ async function renameStudio(from: string, to: string): Promise<void> {
       process.exit(1);
     }
 
+    // Read studioId before moving (for DB update)
+    let studioId: string | undefined;
+    try {
+      const identityPath = join(fromPath, '.pcp', 'identity.json');
+      if (existsSync(identityPath)) {
+        const identity = JSON.parse(readFileSync(identityPath, 'utf-8'));
+        studioId = identity.studioId;
+      }
+    } catch {
+      // Non-fatal
+    }
+
     git(`worktree move "${fromPath}" "${toPath}"`, gitRoot);
 
     spinner.text = 'Updating studio identity metadata...';
     const updatedIdentity = updateIdentityForStudioRename(toPath, from, to);
+
+    // Update the cloud record if we have a studioId
+    if (studioId) {
+      spinner.text = 'Syncing rename to cloud...';
+      try {
+        await callPcpTool('update_workspace', {
+          workspaceId: studioId,
+          agentId: resolveAgentId() || 'unknown',
+          worktreePath: toPath,
+          slug: to,
+        });
+      } catch {
+        // Non-fatal: local rename succeeded, cloud sync can be retried
+        console.log(chalk.yellow('\n  Note: Cloud sync failed — slug will update on next session start'));
+      }
+    }
 
     // Intentionally keep existing branch name unchanged.
     // Studio names are path/identity labels; branch naming is an independent concern.

--- a/packages/cli/src/templates/hook-post-compact.md
+++ b/packages/cli/src/templates/hook-post-compact.md
@@ -4,6 +4,8 @@ Agent: {{AGENT_ID}}
 
 {{IDENTITY_BLOCK}}
 
+{{MEMORIES_BLOCK}}
+
 {{SKILLS_BLOCK}}
 
 {{INBOX_BLOCK}}

--- a/packages/web/src/app/(dashboard)/page.tsx
+++ b/packages/web/src/app/(dashboard)/page.tsx
@@ -21,7 +21,6 @@ import { getAgentGradient } from '@/lib/utils';
 
 interface StudioInfo {
   id: string;
-  name: string | null;
   branch: string;
   baseBranch: string | null;
   purpose: string | null;
@@ -248,12 +247,9 @@ export default function DashboardPage() {
                                 className={clsx('h-4 w-4', getStudioStatusColor(studio.status))}
                               />
                               <span className="text-sm font-medium text-gray-700">
-                                {studio.name || studio.branch}
+                                {studio.branch}
                               </span>
                             </div>
-                            {studio.name && studio.branch !== studio.name && (
-                              <span className="text-xs text-gray-400">{studio.branch}</span>
-                            )}
                             {studio.purpose && (
                               <span className="text-xs text-gray-400 truncate">
                                 {studio.purpose}

--- a/packages/web/src/app/(dashboard)/page.tsx
+++ b/packages/web/src/app/(dashboard)/page.tsx
@@ -33,6 +33,7 @@ interface StudioInfo {
 
 interface AgentLatestSession {
   currentPhase: string | null;
+  status: string | null;
   updatedAt: string;
 }
 
@@ -70,17 +71,28 @@ function getInitial(name: string): string {
   return name.charAt(0).toUpperCase();
 }
 
-function getAgentStatusBadge(phase: string | null): {
+function getAgentStatusBadge(
+  phase: string | null,
+  sessionStatus: string | null
+): {
   label: string;
   badgeClass: string;
 } {
-  if (!phase) return { label: 'Offline', badgeClass: 'bg-gray-100 text-gray-500' };
-  if (phase.startsWith('blocked'))
-    return { label: 'Blocked', badgeClass: 'bg-amber-100 text-amber-700' };
-  if (phase === 'runtime:generating')
-    return { label: 'Generating', badgeClass: 'bg-blue-100 text-blue-700' };
-  if (phase === 'runtime:idle') return { label: 'Idle', badgeClass: 'bg-green-100 text-green-700' };
-  return { label: 'Active', badgeClass: 'bg-green-100 text-green-700' };
+  // Phase takes priority when present
+  if (phase) {
+    if (phase.startsWith('blocked'))
+      return { label: 'Blocked', badgeClass: 'bg-amber-100 text-amber-700' };
+    if (phase === 'runtime:generating')
+      return { label: 'Generating', badgeClass: 'bg-blue-100 text-blue-700' };
+    if (phase === 'runtime:idle')
+      return { label: 'Idle', badgeClass: 'bg-green-100 text-green-700' };
+    return { label: 'Active', badgeClass: 'bg-green-100 text-green-700' };
+  }
+  // Fall back to session status when phase is null
+  if (sessionStatus === 'active' || sessionStatus === 'resumable')
+    return { label: 'Active', badgeClass: 'bg-green-100 text-green-700' };
+  if (sessionStatus) return { label: 'Active', badgeClass: 'bg-green-100 text-green-700' };
+  return { label: 'Offline', badgeClass: 'bg-gray-100 text-gray-500' };
 }
 
 function getStudioSlug(worktreePath: string | null): string | null {
@@ -199,7 +211,10 @@ export default function DashboardPage() {
           <div className="space-y-4">
             {agents.map((agent) => {
               const gradient = getAgentGradient(agent.agentId);
-              const status = getAgentStatusBadge(agent.latestSession?.currentPhase ?? null);
+              const status = getAgentStatusBadge(
+                agent.latestSession?.currentPhase ?? null,
+                agent.latestSession?.status ?? null
+              );
               const backendLabel = formatBackend(agent.backend);
 
               return (

--- a/packages/web/src/app/(dashboard)/page.tsx
+++ b/packages/web/src/app/(dashboard)/page.tsx
@@ -7,47 +7,50 @@ import {
   Users,
   UsersRound,
   Key,
-  Activity,
   GitBranch,
   ArrowRight,
   Monitor,
+  FolderGit2,
 } from 'lucide-react';
 import Link from 'next/link';
 import { useApiQuery } from '@/lib/api';
 import clsx from 'clsx';
+import { getAgentGradient } from '@/lib/utils';
 
-interface SessionWorkspace {
+// ─── Types ───
+
+interface StudioInfo {
   id: string;
-  branch: string | null;
+  name: string | null;
+  branch: string;
   baseBranch: string | null;
   purpose: string | null;
   workType: string | null;
+  worktreePath: string | null;
   status: string;
+  updatedAt: string;
 }
 
-interface Session {
-  id: string;
+interface AgentLatestSession {
+  currentPhase: string | null;
+  updatedAt: string;
+}
+
+interface AgentWithStudios {
   agentId: string;
   agentName: string;
   agentRole: string | null;
-  status: string;
-  currentPhase: string | null;
-  summary: string | null;
-  context: string | null;
   backend: string | null;
-  model: string | null;
-  messageCount: number | null;
-  tokenCount: number | null;
-  startedAt: string;
-  updatedAt: string;
-  endedAt: string | null;
-  workspace: SessionWorkspace | null;
+  identityId: string;
+  latestSession: AgentLatestSession | null;
+  studios: StudioInfo[];
 }
 
-interface SessionsResponse {
-  stats: { active: number; blocked: number; paused: number; total: number };
-  sessions: Session[];
+interface StudiosResponse {
+  agents: AgentWithStudios[];
 }
+
+// ─── Helpers ───
 
 function formatRelativeTime(date: string): string {
   const now = new Date();
@@ -63,77 +66,54 @@ function formatRelativeTime(date: string): string {
   return `${diffDays}d ago`;
 }
 
-function isBlocked(session: Session): boolean {
-  return session.currentPhase?.startsWith('blocked') ?? false;
+function getInitial(name: string): string {
+  return name.charAt(0).toUpperCase();
 }
 
-function isGenerating(session: Session): boolean {
-  return session.currentPhase === 'runtime:generating';
-}
-
-function isRuntimeIdle(session: Session): boolean {
-  return session.currentPhase === 'runtime:idle';
-}
-
-function getSessionStatusBadge(session: Session): {
+function getAgentStatusBadge(phase: string | null): {
   label: string;
   badgeClass: string;
-  cardClass: string;
 } {
-  if (isBlocked(session)) {
-    return {
-      label: 'Blocked',
-      badgeClass: 'bg-amber-100 text-amber-700',
-      cardClass: 'border-amber-300 bg-amber-50/50',
-    };
-  }
-  if (session.status === 'paused') {
-    return {
-      label: 'Paused',
-      badgeClass: 'bg-gray-100 text-gray-600',
-      cardClass: 'border-gray-200',
-    };
-  }
-  if (isGenerating(session)) {
-    return {
-      label: 'Generating',
-      badgeClass: 'bg-blue-100 text-blue-700',
-      cardClass: 'border-blue-200 bg-blue-50/50',
-    };
-  }
-  if (isRuntimeIdle(session)) {
-    return {
-      label: 'Idle',
-      badgeClass: 'bg-green-100 text-green-700',
-      cardClass: 'border-green-200 bg-green-50/50',
-    };
-  }
-  if (session.status === 'active') {
-    return {
-      label: 'Active',
-      badgeClass: 'bg-green-100 text-green-700',
-      cardClass: 'border-green-200 bg-green-50/50',
-    };
-  }
-  return {
-    label: session.status,
-    badgeClass: 'bg-gray-100 text-gray-600',
-    cardClass: 'border-gray-200',
-  };
+  if (!phase) return { label: 'Offline', badgeClass: 'bg-gray-100 text-gray-500' };
+  if (phase.startsWith('blocked'))
+    return { label: 'Blocked', badgeClass: 'bg-amber-100 text-amber-700' };
+  if (phase === 'runtime:generating')
+    return { label: 'Generating', badgeClass: 'bg-blue-100 text-blue-700' };
+  if (phase === 'runtime:idle') return { label: 'Idle', badgeClass: 'bg-green-100 text-green-700' };
+  return { label: 'Active', badgeClass: 'bg-green-100 text-green-700' };
 }
 
-function phasePreviewLabel(phase: string | null): string | null {
-  if (!phase) return null;
-  if (phase.startsWith('runtime:')) return phase.replace('runtime:', 'Runtime: ');
-  return phase;
+function getStudioStatusColor(status: string): string {
+  switch (status) {
+    case 'active':
+      return 'text-green-600';
+    case 'idle':
+      return 'text-gray-500';
+    case 'archived':
+      return 'text-gray-400';
+    default:
+      return 'text-gray-400';
+  }
 }
+
+function formatBackend(backend: string | null): string | null {
+  if (!backend) return null;
+  const map: Record<string, string> = {
+    'claude-code': 'Claude',
+    'codex-cli': 'Codex',
+    gemini: 'Gemini',
+  };
+  return map[backend] || backend;
+}
+
+// ─── Quick Links ───
 
 const quickLinks = [
   {
     name: 'Sessions',
-    description: 'View all agent sessions and studios',
+    description: 'View all agent sessions',
     href: '/sessions',
-    icon: Activity,
+    icon: Monitor,
   },
   {
     name: 'WhatsApp',
@@ -161,41 +141,24 @@ const quickLinks = [
   },
 ];
 
+// ─── Component ───
+
 export default function DashboardPage() {
-  const { data, isLoading } = useApiQuery<SessionsResponse>(['sessions'], '/api/admin/sessions', {
+  const { data, isLoading } = useApiQuery<StudiosResponse>(['studios'], '/api/admin/studios', {
     refetchInterval: 30000,
   });
 
-  const sessions = data?.sessions ?? [];
-
-  // Sort: blocked first, then active, then paused — then by updatedAt
-  const previewSessions = [...sessions]
-    .sort((a, b) => {
-      const sessionPriority = (session: Session): number => {
-        if (isBlocked(session)) return 0;
-        if (isGenerating(session)) return 1;
-        if (isRuntimeIdle(session)) return 2;
-        if (session.status === 'active') return 3;
-        if (session.status === 'paused') return 4;
-        return 5;
-      };
-      const priorityDiff = sessionPriority(a) - sessionPriority(b);
-      if (priorityDiff !== 0) return priorityDiff;
-      return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
-    })
-    .slice(0, 4);
+  const agents = data?.agents ?? [];
 
   return (
     <div>
       <h1 className="text-3xl font-bold text-gray-900">Dashboard</h1>
-      <p className="mt-2 text-gray-600">
-        Welcome to the PCP Admin Dashboard. Monitor active sessions and manage your system.
-      </p>
+      <p className="mt-2 text-gray-600">Monitor your SBs and their studios.</p>
 
-      {/* Sessions Preview */}
+      {/* SBs + Studios */}
       <div className="mt-8">
         <div className="flex items-center justify-between mb-4">
-          <h2 className="text-lg font-semibold text-gray-900">Active Sessions</h2>
+          <h2 className="text-lg font-semibold text-gray-900">Studios</h2>
           <Link
             href="/sessions"
             className="flex items-center gap-1 text-sm text-blue-600 hover:text-blue-800"
@@ -206,59 +169,124 @@ export default function DashboardPage() {
         </div>
 
         {isLoading ? (
-          <div className="grid gap-3 sm:grid-cols-2">
+          <div className="space-y-4">
             {[1, 2].map((i) => (
               <div
                 key={i}
-                className="h-20 rounded-lg border border-gray-200 bg-gray-50 animate-pulse"
+                className="h-24 rounded-lg border border-gray-200 bg-gray-50 animate-pulse"
               />
             ))}
           </div>
-        ) : previewSessions.length === 0 ? (
+        ) : agents.length === 0 ? (
           <Card>
             <CardContent className="py-6 text-center">
-              <Monitor className="h-8 w-8 mx-auto text-gray-300 mb-2" />
-              <p className="text-sm text-gray-500">No active sessions</p>
+              <FolderGit2 className="h-8 w-8 mx-auto text-gray-300 mb-2" />
+              <p className="text-sm text-gray-500">No SBs configured</p>
             </CardContent>
           </Card>
         ) : (
-          <div className="grid gap-3 sm:grid-cols-2">
-            {previewSessions.map((session) => {
-              const badge = getSessionStatusBadge(session);
-              const phaseLabel = phasePreviewLabel(session.currentPhase);
+          <div className="space-y-4">
+            {agents.map((agent) => {
+              const gradient = getAgentGradient(agent.agentId);
+              const status = getAgentStatusBadge(agent.latestSession?.currentPhase ?? null);
+              const backendLabel = formatBackend(agent.backend);
 
               return (
-                <Link key={session.id} href="/sessions">
-                  <div
-                    className={clsx(
-                      'rounded-lg border p-3 hover:shadow-md transition-shadow cursor-pointer',
-                      badge.cardClass
-                    )}
-                  >
-                    <div className="flex items-center justify-between">
-                      <div className="flex items-center gap-2 min-w-0">
-                        <span className="font-medium text-gray-900 truncate">
-                          {session.agentName}
-                        </span>
-                        <Badge className={clsx('text-xs shrink-0', badge.badgeClass)}>
-                          {badge.label}
+                <Card key={agent.agentId} className="overflow-hidden">
+                  {/* Agent header */}
+                  <div className="flex items-center gap-4 px-5 py-4 border-b bg-gray-50/50">
+                    <div
+                      className={clsx(
+                        'h-10 w-10 rounded-full bg-gradient-to-br flex items-center justify-center text-white font-semibold text-sm shrink-0',
+                        gradient
+                      )}
+                    >
+                      {getInitial(agent.agentName)}
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2">
+                        <h3 className="font-semibold text-gray-900">{agent.agentName}</h3>
+                        <span className="text-xs text-gray-400">@{agent.agentId}</span>
+                        <Badge className={clsx('text-[11px]', status.badgeClass)}>
+                          {status.label}
                         </Badge>
                       </div>
-                      <span className="text-xs text-gray-400 shrink-0 ml-2">
-                        {formatRelativeTime(session.updatedAt)}
-                      </span>
-                    </div>
-                    {phaseLabel && (
-                      <p className="text-xs mt-1 truncate text-gray-500">{phaseLabel}</p>
-                    )}
-                    {session.workspace?.branch && (
-                      <div className="flex items-center gap-1 mt-1 text-xs text-gray-400">
-                        <GitBranch className="h-3 w-3" />
-                        <span className="truncate">{session.workspace.branch}</span>
+                      <div className="flex items-center gap-2 mt-0.5">
+                        {agent.agentRole && (
+                          <p className="text-sm text-gray-500 truncate">{agent.agentRole}</p>
+                        )}
                       </div>
-                    )}
+                    </div>
+                    <div className="flex items-center gap-3 shrink-0">
+                      {backendLabel && (
+                        <span className="text-xs text-gray-400">{backendLabel}</span>
+                      )}
+                      {agent.latestSession && (
+                        <span className="text-xs text-gray-400">
+                          {formatRelativeTime(agent.latestSession.updatedAt)}
+                        </span>
+                      )}
+                      <Link
+                        href={`/routing/${agent.agentId}`}
+                        className="text-sm font-medium text-gray-500 hover:text-gray-900 transition-colors"
+                      >
+                        Manage
+                      </Link>
+                    </div>
                   </div>
-                </Link>
+
+                  {/* Studios list */}
+                  {agent.studios.length === 0 ? (
+                    <div className="px-5 py-4 text-sm text-gray-400">No studios</div>
+                  ) : (
+                    <div className="divide-y">
+                      {agent.studios.map((studio) => (
+                        <div key={studio.id} className="flex items-center gap-4 px-5 py-3">
+                          <div className="flex items-center gap-3 flex-1 min-w-0">
+                            <div className="flex items-center gap-2">
+                              <GitBranch
+                                className={clsx('h-4 w-4', getStudioStatusColor(studio.status))}
+                              />
+                              <span className="text-sm font-medium text-gray-700">
+                                {studio.name || studio.branch}
+                              </span>
+                            </div>
+                            {studio.name && studio.branch !== studio.name && (
+                              <span className="text-xs text-gray-400">{studio.branch}</span>
+                            )}
+                            {studio.purpose && (
+                              <span className="text-xs text-gray-400 truncate">
+                                {studio.purpose}
+                              </span>
+                            )}
+                            {studio.workType && (
+                              <Badge className="text-[10px] bg-gray-100 text-gray-500 border-gray-200">
+                                {studio.workType}
+                              </Badge>
+                            )}
+                          </div>
+                          <div className="flex items-center gap-3 shrink-0">
+                            <Badge
+                              className={clsx(
+                                'text-[11px] font-medium border',
+                                studio.status === 'active'
+                                  ? 'bg-green-50 text-green-700 border-green-200 hover:bg-green-50'
+                                  : studio.status === 'idle'
+                                    ? 'bg-gray-50 text-gray-500 border-gray-200 hover:bg-gray-50'
+                                    : 'bg-gray-50 text-gray-400 border-gray-200 hover:bg-gray-50'
+                              )}
+                            >
+                              {studio.status}
+                            </Badge>
+                            <span className="text-xs text-gray-400">
+                              {formatRelativeTime(studio.updatedAt)}
+                            </span>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </Card>
               );
             })}
           </div>

--- a/packages/web/src/app/(dashboard)/page.tsx
+++ b/packages/web/src/app/(dashboard)/page.tsx
@@ -26,6 +26,7 @@ interface StudioInfo {
   purpose: string | null;
   workType: string | null;
   worktreePath: string | null;
+  slug: string | null;
   status: string;
   updatedAt: string;
 }
@@ -80,6 +81,17 @@ function getAgentStatusBadge(phase: string | null): {
     return { label: 'Generating', badgeClass: 'bg-blue-100 text-blue-700' };
   if (phase === 'runtime:idle') return { label: 'Idle', badgeClass: 'bg-green-100 text-green-700' };
   return { label: 'Active', badgeClass: 'bg-green-100 text-green-700' };
+}
+
+function getStudioSlug(worktreePath: string | null): string | null {
+  if (!worktreePath) return null;
+  // Worktree folder names follow the pattern: <repo>--<slug>
+  // e.g. /path/to/personal-context-protocol--wren → "wren"
+  // e.g. /path/to/personal-context-protocol--lumen--lumen-alpha → "lumen--lumen-alpha"
+  const folder = worktreePath.split('/').pop() || '';
+  const dashDashIdx = folder.indexOf('--');
+  if (dashDashIdx === -1) return null;
+  return folder.slice(dashDashIdx + 2);
 }
 
 function getStudioStatusColor(status: string): string {
@@ -239,7 +251,9 @@ export default function DashboardPage() {
                     <div className="px-5 py-4 text-sm text-gray-400">No studios</div>
                   ) : (
                     <div className="divide-y">
-                      {agent.studios.map((studio) => (
+                      {agent.studios.map((studio) => {
+                        const slug = studio.slug || getStudioSlug(studio.worktreePath);
+                        return (
                         <div key={studio.id} className="flex items-center gap-4 px-5 py-3">
                           <div className="flex items-center gap-3 flex-1 min-w-0">
                             <div className="flex items-center gap-2">
@@ -247,8 +261,13 @@ export default function DashboardPage() {
                                 className={clsx('h-4 w-4', getStudioStatusColor(studio.status))}
                               />
                               <span className="text-sm font-medium text-gray-700">
-                                {studio.branch}
+                                {slug || studio.branch}
                               </span>
+                              {slug && slug !== studio.branch && (
+                                <span className="text-xs text-gray-400">
+                                  {studio.branch}
+                                </span>
+                              )}
                             </div>
                             {studio.purpose && (
                               <span className="text-xs text-gray-400 truncate">
@@ -279,7 +298,8 @@ export default function DashboardPage() {
                             </span>
                           </div>
                         </div>
-                      ))}
+                      );
+                      })}
                     </div>
                   )}
                 </Card>

--- a/packages/web/src/app/(dashboard)/page.tsx
+++ b/packages/web/src/app/(dashboard)/page.tsx
@@ -263,11 +263,6 @@ export default function DashboardPage() {
                               <span className="text-sm font-medium text-gray-700">
                                 {slug || studio.branch}
                               </span>
-                              {slug && slug !== studio.branch && (
-                                <span className="text-xs text-gray-400">
-                                  {studio.branch}
-                                </span>
-                              )}
                             </div>
                             {studio.purpose && (
                               <span className="text-xs text-gray-400 truncate">

--- a/packages/web/tailwind.config.ts
+++ b/packages/web/tailwind.config.ts
@@ -7,6 +7,7 @@ const config: Config = {
     './src/components/**/*.{js,ts,jsx,tsx,mdx}',
     './src/app/**/*.{js,ts,jsx,tsx,mdx}',
     './src/stories/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/lib/**/*.{js,ts}',
   ],
   // Safelist classes used dynamically (e.g., by TipTap marks)
   safelist: [

--- a/supabase/migrations/20260226062842_add_slug_to_studios.sql
+++ b/supabase/migrations/20260226062842_add_slug_to_studios.sql
@@ -1,0 +1,19 @@
+-- Add slug column to studios, derived from the worktree folder name.
+-- Convention: worktree folders are named <repo>--<slug>, e.g.
+--   personal-context-protocol--wren → "wren"
+--   personal-context-protocol--lumen--lumen-alpha → "lumen--lumen-alpha"
+
+ALTER TABLE studios ADD COLUMN slug text;
+
+-- Backfill: extract slug from worktree_path for existing rows
+UPDATE studios
+SET slug = CASE
+  WHEN worktree_path IS NOT NULL
+       AND position('--' IN split_part(worktree_path, '/', array_length(string_to_array(worktree_path, '/'), 1))) > 0
+  THEN substring(
+    split_part(worktree_path, '/', array_length(string_to_array(worktree_path, '/'), 1))
+    FROM position('--' IN split_part(worktree_path, '/', array_length(string_to_array(worktree_path, '/'), 1))) + 2
+  )
+  ELSE NULL
+END
+WHERE worktree_path IS NOT NULL;


### PR DESCRIPTION
## Summary

- **Dashboard overhaul**: Replaces "Active Sessions" preview with Studios section — SBs listed with avatar, name, status badge (Generating/Idle/Blocked/Offline), backend label, and their studios listed underneath with branch, purpose, work type, and status badges.
- **New API endpoint**: `GET /api/admin/studios` returns studios grouped by agent identity, including latest session phase for the agent status display.
- **Avatar gradient bug fix**: Added `./src/lib/**/*.{js,ts}` to Tailwind `content` scan — the dynamic gradient classes from `getAgentGradient()` in `utils.ts` were being purged because Tailwind wasn't scanning `src/lib/`.

## Bug fixes

1. **Myra's circular avatar missing** — `SB_GRADIENTS` array in `src/lib/utils.ts` contained gradient class names (`from-rose-500 to-pink-600`, etc.) but Tailwind's content scanner only looked at `src/pages/`, `src/components/`, `src/app/`, and `src/stories/`. Classes in `src/lib/` were purged from CSS output. Fix: add `src/lib/` to content config.

2. **Note: "Generating" status may be stale** — Both Myra and Wren show "Generating" on the dashboard which could indicate hooks aren't clearing `current_phase` when sessions go idle. This is a separate investigation (hook behavior), not addressed in this PR.

## Test plan

- [ ] Dashboard loads and shows SBs with avatars (colored gradient circles)
- [ ] Each SB shows status badge from latest session phase
- [ ] Studios listed under each SB with branch, status, purpose
- [ ] Routing page avatars now render (previously purged)
- [ ] Reminders page avatars now render
- [ ] 30-second auto-refresh works

🤖 Generated with [Claude Code](https://claude.com/claude-code)