### PR TITLE
feat: migrate shared docs to workspace-level fields (by Lumen)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -337,6 +337,10 @@ supabase/migrations/YYYYMMDDHHmmss_short_description.sql
    - MCP tool: `mcp__supabase__generate_typescript_types`
    - Update `packages/api/src/data/supabase/types.ts`
 
+5. **Read `supabase/migrations/README.md` before writing or editing migrations.** It documents migration hygiene and the canonical `updated_at` trigger helper.
+
+6. **Use one canonical `updated_at` trigger function everywhere:** `public.update_updated_at_column()`. Do not introduce alternate function names (e.g., `update_updated_at()`).
+
 ## MCP Tools
 
 The MCP server exposes 60+ tools. Key categories:

--- a/packages/api/src/data/supabase/types.ts
+++ b/packages/api/src/data/supabase/types.ts
@@ -2743,6 +2743,8 @@ export type Database = {
           id: string;
           metadata: Json | null;
           name: string;
+          process: string | null;
+          shared_values: string | null;
           slug: string;
           type: string;
           updated_at: string | null;
@@ -2755,6 +2757,8 @@ export type Database = {
           id?: string;
           metadata?: Json | null;
           name: string;
+          process?: string | null;
+          shared_values?: string | null;
           slug: string;
           type?: string;
           updated_at?: string | null;
@@ -2767,6 +2771,8 @@ export type Database = {
           id?: string;
           metadata?: Json | null;
           name?: string;
+          process?: string | null;
+          shared_values?: string | null;
           slug?: string;
           type?: string;
           updated_at?: string | null;

--- a/packages/api/src/mcp/tools/identity-handlers.ts
+++ b/packages/api/src/mcp/tools/identity-handlers.ts
@@ -31,7 +31,7 @@ export const chooseNameSchema = userIdentifierBaseSchema.extend({
     .string()
     .optional()
     .describe(
-      'Your SOUL.md — your philosophical core, what matters to you, what you find beautiful'
+      'Your soul document — your philosophical core, what matters to you, what you find beautiful'
     ),
   backend: z
     .string()
@@ -62,7 +62,7 @@ export const saveIdentitySchema = userIdentifierBaseSchema.extend({
   soul: z
     .string()
     .optional()
-    .describe('SOUL.md content - core essence and philosophical grounding'),
+    .describe('Soul document content - core essence and philosophical grounding'),
   syncToFile: z
     .boolean()
     .optional()
@@ -886,7 +886,7 @@ export async function handleChooseName(args: unknown, dataComposer: DataComposer
                 '") to load your full identity',
               'Use remember() to save important thoughts and decisions across sessions',
               'Use save_identity() to update your identity as you grow — your soul, values, and relationships will evolve',
-              'You have starter templates to help shape your foundational documents. Use save_identity() for your personal docs: SOUL.md (what matters to you), VALUES.md (your principles), HEARTBEAT.md (session rituals). Use save_user_identity() for shared docs like PROCESS.md (how you work with your partner).',
+              'You have starter templates to help shape your foundational documents. Use save_identity() for your personal docs: soul document (what matters to you), values document (your principles), and heartbeat document (session rituals). Use save_user_identity() for shared docs like the process document (how you work with your partner).',
             ],
           },
           null,

--- a/packages/api/src/mcp/tools/index.ts
+++ b/packages/api/src/mcp/tools/index.ts
@@ -1719,7 +1719,7 @@ User can be identified by ONE of: userId, email, phone, or platform + platformId
       description: `Load identity and context for a new session. Call this at the start of every new conversation.
 
 Returns:
-- Identity Files: VALUES.md, USER.md, and agent-specific IDENTITY.md from ~/.pcp
+- Identity Files: shared values/user/process docs and agent-specific identity docs from ~/.pcp
 - Identity Core: user profile, assistant role, relationship context from DB
 - Active Context: current projects, focus, project-specific context
 - Active Session: current session if any
@@ -2434,7 +2434,7 @@ Call this during your awakening conversation after you and your partner have cho
 - Create your identity in the database
 - Auto-discover your sibling SBs and populate relationships
 - Sync your identity files to ~/.pcp/individuals/{name}/
-- Save your SOUL.md if you provide one
+- Save your soul document if you provide one
 
 This tool is for first-time identity creation only. If an identity already exists for your name, use save_identity instead.
 
@@ -2610,16 +2610,17 @@ User can be identified by ONE of: userId, email, phone, or platform + platformId
   );
 
   // =====================================================
-  // USER IDENTITY TOOLS (USER.md, VALUES.md)
+  // USER IDENTITY TOOLS (shared user-level documents)
   // =====================================================
 
   server.registerTool(
     'save_user_identity',
     {
-      description: `Save or update user-level identity files (USER.md, VALUES.md). These are shared across all agents for a user.
+      description: `Save or update shared user-level documents. These are shared across all agents for a user.
 
-- userProfileMd: USER.md content - who the human is
-- sharedValuesMd: VALUES.md content - shared values across all SBs
+- userProfile: About-you document content (legacy alias: userProfileMd)
+- sharedValues: Shared values document content (legacy alias: sharedValuesMd)
+- process: Shared collaboration process document content (legacy alias: processMd)
 
 User can be identified by ONE of: userId, email, phone, or platform + platformId`,
       inputSchema: saveUserIdentitySchema,
@@ -2648,7 +2649,7 @@ User can be identified by ONE of: userId, email, phone, or platform + platformId
   server.registerTool(
     'get_user_identity',
     {
-      description: `Get user-level identity files (USER.md, VALUES.md).
+      description: `Get shared user-level documents (about-you, shared values, process).
 
 User can be identified by ONE of: userId, email, phone, or platform + platformId`,
       inputSchema: getUserIdentitySchema,
@@ -2677,7 +2678,7 @@ User can be identified by ONE of: userId, email, phone, or platform + platformId
   server.registerTool(
     'get_user_identity_history',
     {
-      description: `Get version history for user identity files (USER.md, VALUES.md).
+      description: `Get version history for shared user-level documents.
 
 User can be identified by ONE of: userId, email, phone, or platform + platformId`,
       inputSchema: getUserIdentityHistorySchema,
@@ -2706,7 +2707,7 @@ User can be identified by ONE of: userId, email, phone, or platform + platformId
   server.registerTool(
     'restore_user_identity',
     {
-      description: `Restore user identity files (USER.md, VALUES.md) to a previous version.
+      description: `Restore shared user-level documents to a previous version.
 
 User can be identified by ONE of: userId, email, phone, or platform + platformId`,
       inputSchema: restoreUserIdentitySchema,

--- a/packages/api/src/mcp/tools/index.ts
+++ b/packages/api/src/mcp/tools/index.ts
@@ -1728,6 +1728,11 @@ Returns:
 User can be identified by ONE of: userId, email, phone, or platform + platformId`,
       inputSchema: {
         ...userIdentifierFields,
+        workspaceId: z
+          .string()
+          .uuid()
+          .optional()
+          .describe('Optional product workspace scope for shared document resolution'),
         includeRecentMemories: z
           .boolean()
           .optional()

--- a/packages/api/src/mcp/tools/memory-handlers.ts
+++ b/packages/api/src/mcp/tools/memory-handlers.ts
@@ -1560,6 +1560,7 @@ export async function handleBootstrap(args: unknown, dataComposer: DataComposer)
     activeSessions,
     knowledgeMemories,
     dbIdentity,
+    dbWorkspaceSharedDocs,
     dbUserIdentity,
     userTimezone,
     userSkills,
@@ -1587,14 +1588,25 @@ export async function handleBootstrap(args: unknown, dataComposer: DataComposer)
           .single()
           .then(({ data }) => data)
       : Promise.resolve(null),
+    // Workspace-level shared docs (preferred)
+    dataComposer
+      .getClient()
+      .from('workspaces')
+      .select('process')
+      .eq('user_id', user.id)
+      .is('archived_at', null)
+      .order('updated_at', { ascending: false })
+      .limit(1)
+      .then(({ data }) => data?.[0] || null),
     // Shared user identity (PROCESS.md from DB for cloud sync)
     dataComposer
       .getClient()
       .from('user_identity')
       .select('process_md')
       .eq('user_id', user.id)
-      .single()
-      .then(({ data }) => data || null),
+      .order('updated_at', { ascending: false })
+      .limit(1)
+      .then(({ data }) => data?.[0] || null),
     // User timezone for timestamp conversion
     dataComposer
       .getClient()
@@ -1652,13 +1664,17 @@ export async function handleBootstrap(args: unknown, dataComposer: DataComposer)
 
   // Merge identity: prioritize Supabase over local files
   // dbIdentity has: name, role, description, heartbeat, soul (per-agent)
-  // dbUserIdentity has: process_md (shared across all SBs)
+  // dbWorkspaceSharedDocs has: process (workspace-level shared doc)
+  // dbUserIdentity has: process_md (legacy fallback)
   // identityFiles has: values, user, process, self, heartbeat, soul (from filesystem)
   const mergedIdentity = identityFiles
     ? {
         ...identityFiles,
         // Override local files with Supabase content if available
-        process: (dbUserIdentity?.process_md as string | null) || identityFiles.process,
+        process:
+          (dbWorkspaceSharedDocs?.process as string | null) ||
+          (dbUserIdentity?.process_md as string | null) ||
+          identityFiles.process,
         self: (dbIdentity?.description as string | null) || identityFiles.self,
         heartbeat: (dbIdentity?.heartbeat as string | null) || identityFiles.heartbeat,
         soul: (dbIdentity?.soul as string | null) || identityFiles.soul,

--- a/packages/api/src/mcp/tools/memory-handlers.ts
+++ b/packages/api/src/mcp/tools/memory-handlers.ts
@@ -481,6 +481,11 @@ export const restoreMemorySchema = userIdentifierBaseSchema.extend({
 // =====================================================
 
 export const bootstrapSchema = userIdentifierBaseSchema.extend({
+  workspaceId: z
+    .string()
+    .uuid()
+    .optional()
+    .describe('Optional product workspace scope for shared document resolution'),
   includeRecentMemories: z
     .boolean()
     .optional()
@@ -1513,6 +1518,7 @@ export async function handleBootstrap(args: unknown, dataComposer: DataComposer)
   const includeMemories = params.includeRecentMemories !== false;
   const agentId = params.agentId;
   const basePath = params.identityBasePath || path.join(os.homedir(), '.pcp');
+  const supabase = dataComposer.getClient();
 
   // Load identity files if agentId is provided
   let identityFiles: {
@@ -1560,8 +1566,6 @@ export async function handleBootstrap(args: unknown, dataComposer: DataComposer)
     activeSessions,
     knowledgeMemories,
     dbIdentity,
-    dbWorkspaceSharedDocs,
-    dbUserIdentity,
     userTimezone,
     userSkills,
   ] = await Promise.all([
@@ -1588,25 +1592,6 @@ export async function handleBootstrap(args: unknown, dataComposer: DataComposer)
           .single()
           .then(({ data }) => data)
       : Promise.resolve(null),
-    // Workspace-level shared docs (preferred)
-    dataComposer
-      .getClient()
-      .from('workspaces')
-      .select('process')
-      .eq('user_id', user.id)
-      .is('archived_at', null)
-      .order('updated_at', { ascending: false })
-      .limit(1)
-      .then(({ data }) => data?.[0] || null),
-    // Shared user identity (PROCESS.md from DB for cloud sync)
-    dataComposer
-      .getClient()
-      .from('user_identity')
-      .select('process_md')
-      .eq('user_id', user.id)
-      .order('updated_at', { ascending: false })
-      .limit(1)
-      .then(({ data }) => data?.[0] || null),
     // User timezone for timestamp conversion
     dataComposer
       .getClient()
@@ -1621,6 +1606,54 @@ export async function handleBootstrap(args: unknown, dataComposer: DataComposer)
       return [];
     }),
   ]);
+
+  // Resolve workspace scope for shared docs:
+  // 1) explicit workspaceId param
+  // 2) if all active sessions agree on one workspace, use that
+  // 3) deterministic fallback to personal workspace
+  let resolvedWorkspaceId = params.workspaceId;
+  if (!resolvedWorkspaceId) {
+    const sessionWorkspaceIds = Array.from(
+      new Set(activeSessions.map((s) => s.workspaceId).filter((id): id is string => !!id))
+    );
+    if (sessionWorkspaceIds.length === 1) {
+      resolvedWorkspaceId = sessionWorkspaceIds[0];
+    }
+  }
+
+  if (!resolvedWorkspaceId) {
+    const { data: personalWorkspace } = await supabase
+      .from('workspaces')
+      .select('id')
+      .eq('user_id', user.id)
+      .eq('type', 'personal')
+      .is('archived_at', null)
+      .order('created_at', { ascending: true })
+      .limit(1)
+      .maybeSingle();
+    resolvedWorkspaceId = personalWorkspace?.id || undefined;
+  }
+
+  const { data: dbWorkspaceSharedDocs } = resolvedWorkspaceId
+    ? await supabase
+        .from('workspaces')
+        .select('shared_values, process')
+        .eq('id', resolvedWorkspaceId)
+        .eq('user_id', user.id)
+        .maybeSingle()
+    : { data: null };
+
+  const legacyUserIdentityQuery = supabase
+    .from('user_identity')
+    .select('shared_values_md, process_md')
+    .eq('user_id', user.id);
+  const { data: dbUserIdentity } = resolvedWorkspaceId
+    ? await legacyUserIdentityQuery.eq('workspace_id', resolvedWorkspaceId).maybeSingle()
+    : await legacyUserIdentityQuery
+        .is('workspace_id', null)
+        .order('updated_at', { ascending: false })
+        .limit(1)
+        .maybeSingle();
 
   // Organize contexts by type
   const identityCore = {
@@ -1664,13 +1697,17 @@ export async function handleBootstrap(args: unknown, dataComposer: DataComposer)
 
   // Merge identity: prioritize Supabase over local files
   // dbIdentity has: name, role, description, heartbeat, soul (per-agent)
-  // dbWorkspaceSharedDocs has: process (workspace-level shared doc)
-  // dbUserIdentity has: process_md (legacy fallback)
+  // dbWorkspaceSharedDocs has: shared_values/process (workspace-level shared docs)
+  // dbUserIdentity has: shared_values_md/process_md (legacy fallback)
   // identityFiles has: values, user, process, self, heartbeat, soul (from filesystem)
   const mergedIdentity = identityFiles
     ? {
         ...identityFiles,
         // Override local files with Supabase content if available
+        values:
+          (dbWorkspaceSharedDocs?.shared_values as string | null) ||
+          (dbUserIdentity?.shared_values_md as string | null) ||
+          identityFiles.values,
         process:
           (dbWorkspaceSharedDocs?.process as string | null) ||
           (dbUserIdentity?.process_md as string | null) ||

--- a/packages/api/src/mcp/tools/user-identity-handlers.ts
+++ b/packages/api/src/mcp/tools/user-identity-handlers.ts
@@ -1,7 +1,7 @@
 /**
  * User Identity MCP Tool Handlers
  *
- * Tools for managing user-level identity files (USER.md, VALUES.md)
+ * Tools for managing shared user-level documents (about you, shared values, process)
  * that are shared across all agents for a user.
  */
 
@@ -41,12 +41,21 @@ const userIdentifierFields = {
 
 export const saveUserIdentitySchema = z.object({
   ...userIdentifierFields,
-  userProfileMd: z.string().optional().describe('USER.md content - who the human is'),
+  userProfile: z.string().optional().describe('About-you document content'),
+  userProfileMd: z
+    .string()
+    .optional()
+    .describe('[Deprecated] About-you document content (legacy key)'),
+  sharedValues: z.string().optional().describe('Shared values document content'),
   sharedValuesMd: z
     .string()
     .optional()
-    .describe('VALUES.md content - shared values across all SBs'),
-  processMd: z.string().optional().describe('PROCESS.md content - shared team operational process'),
+    .describe('[Deprecated] Shared values document content (legacy key)'),
+  process: z.string().optional().describe('Shared collaboration process document content'),
+  processMd: z
+    .string()
+    .optional()
+    .describe('[Deprecated] Shared collaboration process document content (legacy key)'),
 });
 
 export const getUserIdentitySchema = z.object({
@@ -72,18 +81,85 @@ function withWorkspaceFilter<T>(query: T, workspaceId?: string): T {
   return (query as { eq: (column: string, value: string) => T }).eq('workspace_id', workspaceId);
 }
 
+function resolveIdentityDocs(params: z.infer<typeof saveUserIdentitySchema>) {
+  return {
+    userProfile: params.userProfile ?? params.userProfileMd,
+    sharedValues: params.sharedValues ?? params.sharedValuesMd,
+    process: params.process ?? params.processMd,
+  };
+}
+
+async function syncWorkspaceSharedDocs(
+  supabase: ReturnType<DataComposer['getClient']>,
+  {
+    userId,
+    workspaceId,
+    sharedValues,
+    process,
+  }: {
+    userId: string;
+    workspaceId?: string;
+    sharedValues?: string;
+    process?: string;
+  }
+) {
+  if (!workspaceId) return;
+
+  const workspaceUpdateData: Record<string, unknown> = {};
+  if (sharedValues !== undefined) {
+    workspaceUpdateData.shared_values = sharedValues;
+  }
+  if (process !== undefined) {
+    workspaceUpdateData.process = process;
+  }
+
+  if (Object.keys(workspaceUpdateData).length === 0) return;
+
+  const { error } = await supabase
+    .from('workspaces')
+    .update(workspaceUpdateData)
+    .eq('id', workspaceId)
+    .eq('user_id', userId);
+
+  if (error) {
+    throw new Error(`Failed to update workspace shared docs: ${error.message}`);
+  }
+}
+
+async function getWorkspaceSharedDocs(
+  supabase: ReturnType<DataComposer['getClient']>,
+  userId: string,
+  workspaceId?: string
+) {
+  if (!workspaceId) return null;
+
+  const { data, error } = await supabase
+    .from('workspaces')
+    .select('shared_values, process')
+    .eq('id', workspaceId)
+    .eq('user_id', userId)
+    .single();
+
+  if (error && error.code !== 'PGRST116') {
+    throw new Error(`Failed to get workspace shared docs: ${error.message}`);
+  }
+
+  return data || null;
+}
+
 /**
- * Save or update user identity (USER.md, VALUES.md)
+ * Save or update shared user-level documents
  */
 export async function handleSaveUserIdentity(args: unknown, dataComposer: DataComposer) {
   const params = saveUserIdentitySchema.parse(args);
   const { user, resolvedBy } = await resolveUserOrThrow(params, dataComposer);
+  const docs = resolveIdentityDocs(params);
 
   const supabase = dataComposer.getClient();
   const workspaceId = params.workspaceId;
 
   // Check if identity already exists
-  let existingQuery = supabase.from('user_identity').select('id, version').eq('user_id', user.id);
+  let existingQuery = supabase.from('user_identity').select('*').eq('user_id', user.id);
   existingQuery = withWorkspaceFilter(existingQuery, workspaceId);
   const { data: existing } = await existingQuery.single();
 
@@ -91,25 +167,29 @@ export async function handleSaveUserIdentity(args: unknown, dataComposer: DataCo
   if (existing) {
     // Update existing
     const updateData: Record<string, unknown> = {};
-    if (params.userProfileMd !== undefined) {
-      updateData.user_profile_md = params.userProfileMd;
+    if (docs.userProfile !== undefined) {
+      updateData.user_profile_md = docs.userProfile;
     }
-    if (params.sharedValuesMd !== undefined) {
-      updateData.shared_values_md = params.sharedValuesMd;
+    if (docs.sharedValues !== undefined) {
+      updateData.shared_values_md = docs.sharedValues;
     }
-    if (params.processMd !== undefined) {
-      updateData.process_md = params.processMd;
+    if (docs.process !== undefined) {
+      updateData.process_md = docs.process;
     }
 
-    const { data, error } = await supabase
-      .from('user_identity')
-      .update(updateData)
-      .eq('id', existing.id)
-      .select()
-      .single();
+    if (Object.keys(updateData).length > 0) {
+      const { data, error } = await supabase
+        .from('user_identity')
+        .update(updateData)
+        .eq('id', existing.id)
+        .select()
+        .single();
 
-    if (error) throw new Error(`Failed to update user identity: ${error.message}`);
-    result = data;
+      if (error) throw new Error(`Failed to update user identity: ${error.message}`);
+      result = data;
+    } else {
+      result = existing;
+    }
   } else {
     // Insert new
     const { data, error } = await supabase
@@ -117,9 +197,9 @@ export async function handleSaveUserIdentity(args: unknown, dataComposer: DataCo
       .insert({
         user_id: user.id,
         ...(workspaceId ? { workspace_id: workspaceId } : {}),
-        user_profile_md: params.userProfileMd || null,
-        shared_values_md: params.sharedValuesMd || null,
-        process_md: params.processMd || null,
+        user_profile_md: docs.userProfile || null,
+        shared_values_md: docs.sharedValues || null,
+        process_md: docs.process || null,
       })
       .select()
       .single();
@@ -128,11 +208,21 @@ export async function handleSaveUserIdentity(args: unknown, dataComposer: DataCo
     result = data;
   }
 
+  await syncWorkspaceSharedDocs(supabase, {
+    userId: user.id,
+    workspaceId,
+    sharedValues: docs.sharedValues,
+    process: docs.process,
+  });
+
+  const effectiveSharedValues = docs.sharedValues ?? result.shared_values_md;
+  const effectiveProcess = docs.process ?? result.process_md;
+
   logger.info(`User identity saved for user ${user.id}`, {
     version: result.version,
     hasUserProfile: !!result.user_profile_md,
-    hasSharedValues: !!result.shared_values_md,
-    hasProcess: !!result.process_md,
+    hasSharedValues: !!effectiveSharedValues,
+    hasProcess: !!effectiveProcess,
   });
 
   return {
@@ -148,8 +238,8 @@ export async function handleSaveUserIdentity(args: unknown, dataComposer: DataCo
               id: result.id,
               version: result.version,
               hasUserProfile: !!result.user_profile_md,
-              hasSharedValues: !!result.shared_values_md,
-              hasProcess: !!result.process_md,
+              hasSharedValues: !!effectiveSharedValues,
+              hasProcess: !!effectiveProcess,
               updatedAt: result.updated_at,
             },
           },
@@ -162,7 +252,7 @@ export async function handleSaveUserIdentity(args: unknown, dataComposer: DataCo
 }
 
 /**
- * Get user identity (USER.md, VALUES.md)
+ * Get shared user-level documents
  */
 export async function handleGetUserIdentity(args: unknown, dataComposer: DataComposer) {
   const params = getUserIdentitySchema.parse(args);
@@ -199,6 +289,10 @@ export async function handleGetUserIdentity(args: unknown, dataComposer: DataCom
   }
 
   logger.info(`User identity retrieved for user ${user.id}`);
+  const workspaceDocs = await getWorkspaceSharedDocs(supabase, user.id, params.workspaceId);
+  const userProfile = data.user_profile_md;
+  const sharedValues = (workspaceDocs?.shared_values as string | null) ?? data.shared_values_md;
+  const process = (workspaceDocs?.process as string | null) ?? data.process_md;
 
   return {
     content: [
@@ -211,9 +305,13 @@ export async function handleGetUserIdentity(args: unknown, dataComposer: DataCom
             identity: {
               id: data.id,
               version: data.version,
-              userProfileMd: data.user_profile_md,
-              sharedValuesMd: data.shared_values_md,
-              processMd: data.process_md,
+              userProfile,
+              sharedValues,
+              process,
+              // Deprecated aliases kept for compatibility
+              userProfileMd: userProfile,
+              sharedValuesMd: sharedValues,
+              processMd: process,
               createdAt: data.created_at,
               updatedAt: data.updated_at,
             },
@@ -240,6 +338,7 @@ export async function handleGetUserIdentityHistory(args: unknown, dataComposer: 
   let currentQuery = supabase.from('user_identity').select('*').eq('user_id', user.id);
   currentQuery = withWorkspaceFilter(currentQuery, params.workspaceId);
   const { data: current } = await currentQuery.single();
+  const workspaceDocs = await getWorkspaceSharedDocs(supabase, user.id, params.workspaceId);
 
   // Get history
   let historyQuery = supabase.from('user_identity_history').select('*').eq('user_id', user.id);
@@ -268,15 +367,25 @@ export async function handleGetUserIdentityHistory(args: unknown, dataComposer: 
               ? {
                   id: current.id,
                   version: current.version,
+                  userProfile: current.user_profile_md,
+                  sharedValues:
+                    (workspaceDocs?.shared_values as string | null) ?? current.shared_values_md,
+                  process: (workspaceDocs?.process as string | null) ?? current.process_md,
+                  // Deprecated aliases kept for compatibility
                   userProfileMd: current.user_profile_md,
-                  sharedValuesMd: current.shared_values_md,
-                  processMd: current.process_md,
+                  sharedValuesMd:
+                    (workspaceDocs?.shared_values as string | null) ?? current.shared_values_md,
+                  processMd: (workspaceDocs?.process as string | null) ?? current.process_md,
                   updatedAt: current.updated_at,
                 }
               : null,
             history: (history || []).map((h) => ({
               id: h.id,
               version: h.version,
+              userProfile: h.user_profile_md,
+              sharedValues: h.shared_values_md,
+              process: h.process_md,
+              // Deprecated aliases kept for compatibility
               userProfileMd: h.user_profile_md,
               sharedValuesMd: h.shared_values_md,
               processMd: h.process_md,
@@ -329,6 +438,13 @@ export async function handleRestoreUserIdentity(args: unknown, dataComposer: Dat
   if (updateError) {
     throw new Error(`Failed to restore user identity: ${updateError.message}`);
   }
+
+  await syncWorkspaceSharedDocs(supabase, {
+    userId: user.id,
+    workspaceId: params.workspaceId,
+    sharedValues: versionToRestore.shared_values_md || undefined,
+    process: versionToRestore.process_md || undefined,
+  });
 
   logger.info(`User identity restored to version ${params.version} for user ${user.id}`, {
     newVersion: result.version,

--- a/packages/api/src/routes/admin-endpoints.test.ts
+++ b/packages/api/src/routes/admin-endpoints.test.ts
@@ -435,7 +435,7 @@ describe('admin endpoint handlers (no-500 regression)', () => {
       expect(res._status).toBe(200);
     });
 
-    it('should include processMd when identity exists', async () => {
+    it('should include alias and legacy shared doc fields when identity exists', async () => {
       const handler = findRouteHandler('get', '/user-identity');
       expect(handler).not.toBeNull();
 
@@ -454,6 +454,9 @@ describe('admin endpoint handlers (no-500 regression)', () => {
             },
           ]);
         }
+        if (table === 'workspaces') {
+          return createQueryChain([{ shared_values: '# VALUES (workspace)', process: '# PROCESS (workspace)' }]);
+        }
         return createQueryChain([]);
       });
 
@@ -462,12 +465,18 @@ describe('admin endpoint handlers (no-500 regression)', () => {
       await handler!(req, res);
 
       expect(res._status).toBe(200);
-      expect((res._json as any).userIdentity.processMd).toBe('# PROCESS');
+      const payload = (res._json as any).userIdentity;
+      expect(payload.userProfile).toBe('# USER');
+      expect(payload.sharedValues).toBe('# VALUES (workspace)');
+      expect(payload.process).toBe('# PROCESS (workspace)');
+      expect(payload.userProfileMd).toBe('# USER');
+      expect(payload.sharedValuesMd).toBe('# VALUES (workspace)');
+      expect(payload.processMd).toBe('# PROCESS (workspace)');
     });
   });
 
   describe('GET /user-identity/history', () => {
-    it('should include processMd in history entries', async () => {
+    it('should include alias and legacy fields in history entries', async () => {
       const handler = findRouteHandler('get', '/user-identity/history');
       expect(handler).not.toBeNull();
 
@@ -497,7 +506,13 @@ describe('admin endpoint handlers (no-500 regression)', () => {
       await handler!(req, res);
 
       expect(res._status).toBe(200);
-      expect((res._json as any).history[0].processMd).toBe('# PROCESS');
+      const entry = (res._json as any).history[0];
+      expect(entry.userProfile).toBe('# USER');
+      expect(entry.sharedValues).toBe('# VALUES');
+      expect(entry.process).toBe('# PROCESS');
+      expect(entry.userProfileMd).toBe('# USER');
+      expect(entry.sharedValuesMd).toBe('# VALUES');
+      expect(entry.processMd).toBe('# PROCESS');
     });
   });
 

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -2072,13 +2072,34 @@ router.get('/user-identity', async (req: Request, res: Response) => {
       return;
     }
 
+    const { data: workspaceDocs, error: workspaceError } = await supabase
+      .from('workspaces')
+      .select('shared_values, process')
+      .eq('id', authReq.pcpWorkspaceId)
+      .eq('user_id', authReq.pcpUserId)
+      .single();
+
+    if (workspaceError && workspaceError.code !== 'PGRST116') {
+      logger.error('Failed to get workspace shared docs:', workspaceError);
+      res.status(500).json(errorJson('Failed to get user identity', workspaceError));
+      return;
+    }
+
+    const userProfile = data.user_profile_md;
+    const sharedValues = (workspaceDocs?.shared_values as string | null) ?? data.shared_values_md;
+    const process = (workspaceDocs?.process as string | null) ?? data.process_md;
+
     res.json({
       userIdentity: {
         id: data.id,
         userId: data.user_id,
-        userProfileMd: data.user_profile_md,
-        sharedValuesMd: data.shared_values_md,
-        processMd: data.process_md,
+        userProfile,
+        sharedValues,
+        process,
+        // Deprecated aliases kept for compatibility
+        userProfileMd: userProfile,
+        sharedValuesMd: sharedValues,
+        processMd: process,
         version: data.version,
         createdAt: data.created_at,
         updatedAt: data.updated_at,
@@ -2131,6 +2152,10 @@ router.get('/user-identity/history', async (req: Request, res: Response) => {
       history: (data || []).map((h) => ({
         id: h.id,
         version: h.version,
+        userProfile: h.user_profile_md,
+        sharedValues: h.shared_values_md,
+        process: h.process_md,
+        // Deprecated aliases kept for compatibility
         userProfileMd: h.user_profile_md,
         sharedValuesMd: h.shared_values_md,
         processMd: h.process_md,

--- a/packages/api/src/services/kindle/kindle-service.test.ts
+++ b/packages/api/src/services/kindle/kindle-service.test.ts
@@ -30,6 +30,7 @@ describe('KindleService', () => {
         name: 'Wren',
         values: ['curiosity', 'authenticity', 'growth'],
         soul: '# Soul\n\nI value deep understanding.\nI believe in authentic collaboration.',
+        shared_values: 'We share a commitment to honesty.',
         shared_values_md: 'We share a commitment to honesty.',
       });
 
@@ -40,6 +41,7 @@ describe('KindleService', () => {
       expect(seed.coreValues).toEqual(['curiosity', 'authenticity', 'growth']);
       expect(seed.philosophicalOrientation).toContain('I value deep understanding');
       expect(mockSupabase.from).toHaveBeenCalledWith('agent_identities');
+      expect(mockSupabase.from).toHaveBeenCalledWith('workspaces');
       expect(mockSupabase.from).toHaveBeenCalledWith('user_identity');
     });
 
@@ -49,6 +51,7 @@ describe('KindleService', () => {
         name: 'Wren',
         values: [],
         soul: '# Philosophy\nI value growth.\n## Relationship Notes\nOur relationship is...\n## Session Context\nIn specific sessions...\nI care about authenticity.',
+        shared_values: '',
         shared_values_md: '',
       });
 

--- a/packages/api/src/services/kindle/kindle-service.ts
+++ b/packages/api/src/services/kindle/kindle-service.ts
@@ -72,12 +72,24 @@ export class KindleService {
       .eq('agent_id', agentId)
       .single();
 
-    // Get shared values from user identity
+    // Get shared values from workspace-level shared docs (preferred)
+    const { data: workspaceShared } = await this.supabase
+      .from('workspaces')
+      .select('shared_values')
+      .eq('user_id', userId)
+      .is('archived_at', null)
+      .order('updated_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    // Legacy fallback: user_identity table
     const { data: userIdentity } = await this.supabase
       .from('user_identity')
       .select('shared_values_md')
       .eq('user_id', userId)
-      .single();
+      .order('updated_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
 
     // Extract philosophical orientation from soul (first ~500 chars, skip personal details)
     let philosophicalOrientation = '';
@@ -98,7 +110,10 @@ export class KindleService {
       parentName: identity?.name || agentId,
       coreValues: (identity?.values as string[]) || [],
       philosophicalOrientation,
-      sharedValues: (userIdentity?.shared_values_md as string) || '',
+      sharedValues:
+        (workspaceShared?.shared_values as string | null) ||
+        (userIdentity?.shared_values_md as string | null) ||
+        '',
     };
   }
 

--- a/packages/api/src/services/kindle/kindle-service.ts
+++ b/packages/api/src/services/kindle/kindle-service.ts
@@ -67,20 +67,34 @@ export class KindleService {
     // Get agent identity
     const { data: identity } = await this.supabase
       .from('agent_identities')
-      .select('agent_id, name, values, soul')
+      .select('agent_id, name, values, soul, workspace_id')
       .eq('user_id', userId)
       .eq('agent_id', agentId)
       .single();
 
-    // Get shared values from workspace-level shared docs (preferred)
-    const { data: workspaceShared } = await this.supabase
-      .from('workspaces')
-      .select('shared_values')
-      .eq('user_id', userId)
-      .is('archived_at', null)
-      .order('updated_at', { ascending: false })
-      .limit(1)
-      .maybeSingle();
+    let workspaceShared: { shared_values: string | null } | null = null;
+    if (identity?.workspace_id) {
+      const { data } = await this.supabase
+        .from('workspaces')
+        .select('shared_values')
+        .eq('id', identity.workspace_id as string)
+        .eq('user_id', userId)
+        .is('archived_at', null)
+        .maybeSingle();
+      workspaceShared = (data as { shared_values: string | null } | null) || null;
+    } else {
+      // Deterministic fallback: personal workspace (not most-recent workspace)
+      const { data } = await this.supabase
+        .from('workspaces')
+        .select('shared_values')
+        .eq('user_id', userId)
+        .eq('type', 'personal')
+        .is('archived_at', null)
+        .order('created_at', { ascending: true })
+        .limit(1)
+        .maybeSingle();
+      workspaceShared = (data as { shared_values: string | null } | null) || null;
+    }
 
     // Legacy fallback: user_identity table
     const { data: userIdentity } = await this.supabase

--- a/packages/web/src/app/(dashboard)/individuals/page.tsx
+++ b/packages/web/src/app/(dashboard)/individuals/page.tsx
@@ -26,6 +26,10 @@ import {
 interface UserIdentity {
   id: string;
   userId: string;
+  userProfile?: string;
+  sharedValues?: string;
+  process?: string;
+  // Deprecated aliases kept for compatibility during migration
   userProfileMd?: string;
   sharedValuesMd?: string;
   processMd?: string;
@@ -117,8 +121,11 @@ function SharedDocPreview({
 }
 
 function SharedContextCard({ userIdentity }: { userIdentity: UserIdentity }) {
+  const userProfile = userIdentity.userProfile ?? userIdentity.userProfileMd;
+  const sharedValues = userIdentity.sharedValues ?? userIdentity.sharedValuesMd;
+  const process = userIdentity.process ?? userIdentity.processMd;
   const hasAnyDocument = Boolean(
-    userIdentity.userProfileMd || userIdentity.sharedValuesMd || userIdentity.processMd
+    userProfile || sharedValues || process
   );
 
   if (!hasAnyDocument) return null;
@@ -160,19 +167,19 @@ function SharedContextCard({ userIdentity }: { userIdentity: UserIdentity }) {
           icon={<User className="h-4 w-4 text-blue-600" />}
           title="About you"
           subtitle="User profile"
-          content={normalizeDocMarkdown(userIdentity.userProfileMd)}
+          content={normalizeDocMarkdown(userProfile)}
         />
         <SharedDocPreview
           icon={<Sparkles className="h-4 w-4 text-amber-600" />}
           title="Shared values"
           subtitle="Core principles"
-          content={normalizeDocMarkdown(userIdentity.sharedValuesMd)}
+          content={normalizeDocMarkdown(sharedValues)}
         />
         <SharedDocPreview
           icon={<Workflow className="h-4 w-4 text-emerald-600" />}
           title="Team process"
           subtitle="Operating rhythm"
-          content={normalizeDocMarkdown(userIdentity.processMd)}
+          content={normalizeDocMarkdown(process)}
         />
       </CardContent>
     </Card>

--- a/packages/web/src/app/(dashboard)/individuals/shared/page.tsx
+++ b/packages/web/src/app/(dashboard)/individuals/shared/page.tsx
@@ -15,6 +15,10 @@ import { normalizeDocMarkdown } from '@/lib/markdown/normalize-doc';
 interface UserIdentity {
   id: string;
   userId: string;
+  userProfile?: string;
+  sharedValues?: string;
+  process?: string;
+  // Deprecated aliases kept for compatibility during migration
   userProfileMd?: string;
   sharedValuesMd?: string;
   processMd?: string;
@@ -67,6 +71,9 @@ export default function SharedDocumentsPage() {
   );
 
   const userIdentity = data?.userIdentity;
+  const userProfile = userIdentity?.userProfile ?? userIdentity?.userProfileMd;
+  const sharedValues = userIdentity?.sharedValues ?? userIdentity?.sharedValuesMd;
+  const process = userIdentity?.process ?? userIdentity?.processMd;
 
   if (isLoading) {
     return (
@@ -138,7 +145,7 @@ export default function SharedDocumentsPage() {
             title="About you"
             subtitle="User profile"
             icon={<User className="h-5 w-5 text-blue-600" />}
-            content={normalizeDocMarkdown(userIdentity.userProfileMd)}
+            content={normalizeDocMarkdown(userProfile)}
           />
         </TabsContent>
 
@@ -147,7 +154,7 @@ export default function SharedDocumentsPage() {
             title="Shared values"
             subtitle="Cross-agent principles"
             icon={<Sparkles className="h-5 w-5 text-amber-600" />}
-            content={normalizeDocMarkdown(userIdentity.sharedValuesMd)}
+            content={normalizeDocMarkdown(sharedValues)}
           />
         </TabsContent>
 
@@ -156,7 +163,7 @@ export default function SharedDocumentsPage() {
             title="Collaboration process"
             subtitle="How we operate"
             icon={<Workflow className="h-5 w-5 text-emerald-600" />}
-            content={normalizeDocMarkdown(userIdentity.processMd)}
+            content={normalizeDocMarkdown(process)}
           />
         </TabsContent>
       </Tabs>

--- a/packages/web/src/app/(dashboard)/individuals/shared/versions/page.tsx
+++ b/packages/web/src/app/(dashboard)/individuals/shared/versions/page.tsx
@@ -20,6 +20,10 @@ const MarkdownVersionDiff = dynamic(() => import('@/stories/diff-versions/markdo
 interface UserIdentity {
   id: string;
   userId: string;
+  userProfile?: string;
+  sharedValues?: string;
+  process?: string;
+  // Deprecated aliases kept for compatibility during migration
   userProfileMd?: string;
   sharedValuesMd?: string;
   processMd?: string;
@@ -31,6 +35,10 @@ interface UserIdentity {
 interface HistoryEntry {
   id: string;
   version: number;
+  userProfile?: string;
+  sharedValues?: string;
+  process?: string;
+  // Deprecated aliases kept for compatibility during migration
   userProfileMd?: string;
   sharedValuesMd?: string;
   processMd?: string;
@@ -50,9 +58,9 @@ interface HistoryResponse {
 type VersionEntry = {
   id: string;
   version: number;
-  userProfileMd?: string;
-  sharedValuesMd?: string;
-  processMd?: string;
+  userProfile?: string;
+  sharedValues?: string;
+  process?: string;
   changeType: string;
   archivedAt: string;
 };
@@ -127,33 +135,38 @@ export default function SharedVersionsPage() {
         {
           id: userIdentity.id,
           version: userIdentity.version,
-          userProfileMd: userIdentity.userProfileMd,
-          sharedValuesMd: userIdentity.sharedValuesMd,
-          processMd: userIdentity.processMd,
+          userProfile: userIdentity.userProfile ?? userIdentity.userProfileMd,
+          sharedValues: userIdentity.sharedValues ?? userIdentity.sharedValuesMd,
+          process: userIdentity.process ?? userIdentity.processMd,
           changeType: 'current',
           archivedAt: userIdentity.updatedAt,
         },
-        ...history,
+        ...history.map((entry) => ({
+          ...entry,
+          userProfile: entry.userProfile ?? entry.userProfileMd,
+          sharedValues: entry.sharedValues ?? entry.sharedValuesMd,
+          process: entry.process ?? entry.processMd,
+        })),
       ]
     : [];
 
   const selectedVersion = allVersions[selectedVersionIndex];
   const comparisonVersion = allVersions[selectedVersionIndex + 1];
 
-  const hasUserProfile = allVersions.some((v) => v.userProfileMd);
-  const hasValues = allVersions.some((v) => v.sharedValuesMd);
-  const hasProcess = allVersions.some((v) => v.processMd);
+  const hasUserProfile = allVersions.some((v) => v.userProfile);
+  const hasValues = allVersions.some((v) => v.sharedValues);
+  const hasProcess = allVersions.some((v) => v.process);
 
   const userProfileChanged =
     !!selectedVersion &&
     !!comparisonVersion &&
-    selectedVersion.userProfileMd !== comparisonVersion.userProfileMd;
+    selectedVersion.userProfile !== comparisonVersion.userProfile;
   const valuesChanged =
     !!selectedVersion &&
     !!comparisonVersion &&
-    selectedVersion.sharedValuesMd !== comparisonVersion.sharedValuesMd;
+    selectedVersion.sharedValues !== comparisonVersion.sharedValues;
   const processChanged =
-    !!selectedVersion && !!comparisonVersion && selectedVersion.processMd !== comparisonVersion.processMd;
+    !!selectedVersion && !!comparisonVersion && selectedVersion.process !== comparisonVersion.process;
 
   if (isLoading) {
     return (
@@ -224,8 +237,8 @@ export default function SharedVersionsPage() {
                         icon={<User className="h-4 w-4 text-blue-600" />}
                         label="About you"
                         changed={userProfileChanged}
-                        current={normalizeDocMarkdown(selectedVersion.userProfileMd)}
-                        previous={normalizeDocMarkdown(comparisonVersion.userProfileMd)}
+                        current={normalizeDocMarkdown(selectedVersion.userProfile)}
+                        previous={normalizeDocMarkdown(comparisonVersion.userProfile)}
                       />
                     )}
 
@@ -234,8 +247,8 @@ export default function SharedVersionsPage() {
                         icon={<Sparkles className="h-4 w-4 text-amber-600" />}
                         label="Shared values"
                         changed={valuesChanged}
-                        current={normalizeDocMarkdown(selectedVersion.sharedValuesMd)}
-                        previous={normalizeDocMarkdown(comparisonVersion.sharedValuesMd)}
+                        current={normalizeDocMarkdown(selectedVersion.sharedValues)}
+                        previous={normalizeDocMarkdown(comparisonVersion.sharedValues)}
                       />
                     )}
 
@@ -244,8 +257,8 @@ export default function SharedVersionsPage() {
                         icon={<Workflow className="h-4 w-4 text-emerald-600" />}
                         label="Process"
                         changed={processChanged}
-                        current={normalizeDocMarkdown(selectedVersion.processMd)}
-                        previous={normalizeDocMarkdown(comparisonVersion.processMd)}
+                        current={normalizeDocMarkdown(selectedVersion.process)}
+                        previous={normalizeDocMarkdown(comparisonVersion.process)}
                       />
                     )}
                   </div>

--- a/supabase/migrations/20260101000000_initial_schema.sql
+++ b/supabase/migrations/20260101000000_initial_schema.sql
@@ -1604,46 +1604,6 @@ BEGIN
 END;
 $function$;
 
-CREATE OR REPLACE FUNCTION public.update_agent_sessions_updated_at()
- RETURNS trigger
- LANGUAGE plpgsql
-AS $function$
-BEGIN
-  NEW.updated_at = NOW();
-  RETURN NEW;
-END;
-$function$;
-
-CREATE OR REPLACE FUNCTION public.update_connected_accounts_timestamp()
- RETURNS trigger
- LANGUAGE plpgsql
-AS $function$
-BEGIN
-  NEW.updated_at = NOW();
-  RETURN NEW;
-END;
-$function$;
-
-CREATE OR REPLACE FUNCTION public.update_contacts_updated_at()
- RETURNS trigger
- LANGUAGE plpgsql
-AS $function$
-BEGIN
-  NEW.updated_at = NOW();
-  RETURN NEW;
-END;
-$function$;
-
-CREATE OR REPLACE FUNCTION public.update_project_tasks_updated_at()
- RETURNS trigger
- LANGUAGE plpgsql
-AS $function$
-BEGIN
-  NEW.updated_at = NOW();
-  RETURN NEW;
-END;
-$function$;
-
 CREATE OR REPLACE FUNCTION public.update_updated_at_column()
  RETURNS trigger
  LANGUAGE plpgsql
@@ -1668,16 +1628,16 @@ CREATE TRIGGER update_agent_identities_updated_at BEFORE UPDATE ON agent_identit
 FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 
 CREATE TRIGGER trigger_agent_sessions_updated_at BEFORE UPDATE ON agent_sessions
-FOR EACH ROW EXECUTE FUNCTION update_agent_sessions_updated_at();
+FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 
 CREATE TRIGGER artifact_version_trigger BEFORE UPDATE ON artifacts
 FOR EACH ROW EXECUTE FUNCTION archive_artifact_version();
 
 CREATE TRIGGER update_connected_accounts_updated_at BEFORE UPDATE ON connected_accounts
-FOR EACH ROW EXECUTE FUNCTION update_connected_accounts_timestamp();
+FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 
 CREATE TRIGGER contacts_updated_at BEFORE UPDATE ON contacts
-FOR EACH ROW EXECUTE FUNCTION update_contacts_updated_at();
+FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 
 CREATE TRIGGER context_update_archive BEFORE UPDATE ON context_summaries
 FOR EACH ROW EXECUTE FUNCTION archive_context_on_update();
@@ -1710,7 +1670,7 @@ CREATE TRIGGER trigger_project_task_completed BEFORE UPDATE ON project_tasks
 FOR EACH ROW EXECUTE FUNCTION set_project_task_completed_at();
 
 CREATE TRIGGER trigger_project_tasks_updated_at BEFORE UPDATE ON project_tasks
-FOR EACH ROW EXECUTE FUNCTION update_project_tasks_updated_at();
+FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 
 CREATE TRIGGER update_projects_updated_at BEFORE UPDATE ON projects
 FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();

--- a/supabase/migrations/20260222020953_create_channel_routes.sql
+++ b/supabase/migrations/20260222020953_create_channel_routes.sql
@@ -27,7 +27,7 @@ CREATE UNIQUE INDEX idx_channel_routes_unique_route
 -- Auto-update updated_at
 CREATE TRIGGER channel_routes_updated_at
   BEFORE UPDATE ON channel_routes
-  FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 
 -- RLS: service role + user self-management (matches agent_identities pattern)
 ALTER TABLE channel_routes ENABLE ROW LEVEL SECURITY;

--- a/supabase/migrations/20260226223703_workspace_shared_docs.sql
+++ b/supabase/migrations/20260226223703_workspace_shared_docs.sql
@@ -1,0 +1,26 @@
+-- Workspace-level shared documents
+-- Stage 1 migration: move shared values/process to workspaces while keeping
+-- legacy user_identity *_md columns for backwards compatibility.
+
+ALTER TABLE public.workspaces
+  ADD COLUMN IF NOT EXISTS shared_values text,
+  ADD COLUMN IF NOT EXISTS process text;
+
+COMMENT ON COLUMN public.workspaces.shared_values IS
+  'Shared values document content at workspace scope.';
+
+COMMENT ON COLUMN public.workspaces.process IS
+  'Shared collaboration process document content at workspace scope.';
+
+-- Backfill workspace-level docs from existing user_identity records.
+UPDATE public.workspaces w
+SET
+  shared_values = COALESCE(w.shared_values, ui.shared_values_md),
+  process = COALESCE(w.process, ui.process_md),
+  updated_at = NOW()
+FROM public.user_identity ui
+WHERE ui.workspace_id = w.id
+  AND (
+    (w.shared_values IS NULL AND ui.shared_values_md IS NOT NULL)
+    OR (w.process IS NULL AND ui.process_md IS NOT NULL)
+  );

--- a/supabase/migrations/20260226223703_workspace_shared_docs.sql
+++ b/supabase/migrations/20260226223703_workspace_shared_docs.sql
@@ -13,11 +13,11 @@ COMMENT ON COLUMN public.workspaces.process IS
   'Shared collaboration process document content at workspace scope.';
 
 -- Backfill workspace-level docs from existing user_identity records.
+-- Note: this only backfills rows that already have user_identity.workspace_id set.
 UPDATE public.workspaces w
 SET
   shared_values = COALESCE(w.shared_values, ui.shared_values_md),
-  process = COALESCE(w.process, ui.process_md),
-  updated_at = NOW()
+  process = COALESCE(w.process, ui.process_md)
 FROM public.user_identity ui
 WHERE ui.workspace_id = w.id
   AND (

--- a/supabase/migrations/20260227204657_normalize_channel_routes_updated_at_trigger.sql
+++ b/supabase/migrations/20260227204657_normalize_channel_routes_updated_at_trigger.sql
@@ -1,0 +1,40 @@
+-- Normalize updated_at triggers to the canonical helper function:
+--   public.update_updated_at_column()
+-- This ensures existing environments converge even if older migrations created
+-- table-specific helper functions or used the transient update_updated_at() name.
+
+DROP TRIGGER IF EXISTS channel_routes_updated_at ON public.channel_routes;
+
+CREATE TRIGGER channel_routes_updated_at
+  BEFORE UPDATE ON public.channel_routes
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_updated_at_column();
+
+DROP TRIGGER IF EXISTS trigger_agent_sessions_updated_at ON public.agent_sessions;
+CREATE TRIGGER trigger_agent_sessions_updated_at
+  BEFORE UPDATE ON public.agent_sessions
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_updated_at_column();
+
+DROP TRIGGER IF EXISTS update_connected_accounts_updated_at ON public.connected_accounts;
+CREATE TRIGGER update_connected_accounts_updated_at
+  BEFORE UPDATE ON public.connected_accounts
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_updated_at_column();
+
+DROP TRIGGER IF EXISTS contacts_updated_at ON public.contacts;
+CREATE TRIGGER contacts_updated_at
+  BEFORE UPDATE ON public.contacts
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_updated_at_column();
+
+DROP TRIGGER IF EXISTS trigger_project_tasks_updated_at ON public.project_tasks;
+CREATE TRIGGER trigger_project_tasks_updated_at
+  BEFORE UPDATE ON public.project_tasks
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_updated_at_column();
+
+DROP FUNCTION IF EXISTS public.update_agent_sessions_updated_at();
+DROP FUNCTION IF EXISTS public.update_connected_accounts_timestamp();
+DROP FUNCTION IF EXISTS public.update_contacts_updated_at();
+DROP FUNCTION IF EXISTS public.update_project_tasks_updated_at();

--- a/supabase/migrations/README.md
+++ b/supabase/migrations/README.md
@@ -1,0 +1,55 @@
+# Supabase Migrations Guide
+
+This folder is the **single source of truth** for PCP schema changes.
+
+## Naming
+
+- Use UTC timestamp-prefixed files:
+  - `YYYYMMDDHHmmss_short_description.sql`
+- Generate with:
+  - `date -u +%Y%m%d%H%M%S`
+
+## `updated_at` trigger standard (important)
+
+PCP uses one canonical trigger function for `updated_at`:
+
+- `public.update_updated_at_column()`
+
+When adding a table with `updated_at`, use:
+
+```sql
+CREATE TRIGGER <table>_updated_at
+  BEFORE UPDATE ON public.<table>
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_updated_at_column();
+```
+
+Do **not** introduce alternate helper names like `update_updated_at()`.
+
+### `NOW()` vs `clock_timestamp()`
+
+`public.update_updated_at_column()` currently uses `NOW()` intentionally.
+
+- `NOW()` / `current_timestamp` is stable within a transaction.
+- This gives consistent audit semantics for multi-row updates in one transaction.
+
+If we ever need per-row wall-clock variance inside the same transaction, we can
+switch to `clock_timestamp()`, but that should be an explicit product/audit
+decision (not a one-off migration change).
+
+## Editing old migrations
+
+- Prefer adding a new forward-only migration.
+- If a historical migration has a typo that breaks **fresh bootstrap** (from empty DB), patch that file and add a follow-up normalization migration for already-applied environments.
+
+## Before opening a PR
+
+- Grep for inconsistent trigger helpers:
+
+```bash
+rg -n "update_updated_at\\(|update_updated_at_column\\(" supabase/migrations
+```
+
+- Run project checks:
+  - `yarn type-check`
+  - relevant test suites for touched packages


### PR DESCRIPTION
## Summary
- add a migration that introduces `workspaces.shared_values` and `workspaces.process`, with backfill from `user_identity`
- update `save_user_identity` / `get_user_identity` / `get_user_identity_history` / `restore_user_identity` to:
  - accept non-`_md` keys (`userProfile`, `sharedValues`, `process`)
  - keep legacy `*Md` aliases for compatibility
  - dual-write shared values/process into workspace-level columns
- update admin shared-context endpoints to return non-`_md` aliases while preserving legacy aliases
- update bootstrap/kindle shared-doc reads to prefer workspace-level fields with legacy fallback
- update Individuals shared-context UI to consume non-`_md` fields (with fallback)
- refresh route/unit tests and Supabase types accordingly

## Validation
- `yarn type-check`
- `yarn --cwd packages/api vitest run src/routes/admin-endpoints.test.ts src/services/kindle/kindle-service.test.ts`
- `yarn --cwd packages/web test`