### PR TITLE
fix: add workspace studio success feedback (by lumen)

### DIFF
--- a/packages/web/src/components/layout/sidebar.tsx
+++ b/packages/web/src/components/layout/sidebar.tsx
@@ -106,6 +106,7 @@ export function Sidebar() {
   const [inviteEmail, setInviteEmail] = useState('');
   const [inviteRole, setInviteRole] = useState<'owner' | 'admin' | 'member' | 'viewer'>('member');
   const [workspaceError, setWorkspaceError] = useState<string | null>(null);
+  const [workspaceSuccess, setWorkspaceSuccess] = useState<string | null>(null);
   const [isMounted, setIsMounted] = useState(false);
   const [accountMenuOpen, setAccountMenuOpen] = useState(false);
   const accountMenuRef = useRef<HTMLDivElement | null>(null);
@@ -167,11 +168,13 @@ export function Sidebar() {
       setNewWorkspaceName('');
       setNewWorkspaceDescription('');
       setWorkspaceError(null);
+      setWorkspaceSuccess(`Created workspace "${data.workspace.name}".`);
       queryClient.invalidateQueries({ queryKey: ['workspaces'] });
       queryClient.invalidateQueries({ queryKey: ['workspace-members', createdWorkspaceId] });
       router.refresh();
     },
     onError: (error) => {
+      setWorkspaceSuccess(null);
       setWorkspaceError(error.message || 'Failed to create workspace');
     },
   });
@@ -189,9 +192,11 @@ export function Sidebar() {
       onSuccess: (_, variables) => {
         setInviteEmail('');
         setWorkspaceError(null);
+        setWorkspaceSuccess('Collaborator invited successfully.');
         queryClient.invalidateQueries({ queryKey: ['workspace-members', variables.workspaceId] });
       },
       onError: (error) => {
+        setWorkspaceSuccess(null);
         setWorkspaceError(error.message || 'Failed to invite collaborator');
       },
     }
@@ -251,10 +256,12 @@ export function Sidebar() {
   const handleCreateWorkspace = () => {
     const trimmedWorkspaceName = newWorkspaceName.trim();
     if (!trimmedWorkspaceName) {
+      setWorkspaceSuccess(null);
       setWorkspaceError('Workspace name is required');
       return;
     }
 
+    setWorkspaceSuccess(null);
     setWorkspaceError(null);
     createWorkspaceMutation.mutate({
       name: trimmedWorkspaceName,
@@ -266,15 +273,18 @@ export function Sidebar() {
   const handleInviteWorkspaceMember = () => {
     const trimmedInviteEmail = inviteEmail.trim();
     if (!trimmedInviteEmail || !trimmedInviteEmail.includes('@')) {
+      setWorkspaceSuccess(null);
       setWorkspaceError('Valid collaborator email is required');
       return;
     }
 
     if (!inviteTargetWorkspaceId) {
+      setWorkspaceSuccess(null);
       setWorkspaceError('Select a workspace before inviting');
       return;
     }
 
+    setWorkspaceSuccess(null);
     setWorkspaceError(null);
     inviteWorkspaceMemberMutation.mutate({
       workspaceId: inviteTargetWorkspaceId,
@@ -526,6 +536,11 @@ export function Sidebar() {
             {workspaceError && (
               <p className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
                 {workspaceError}
+              </p>
+            )}
+            {workspaceSuccess && (
+              <p className="rounded-md border border-green-200 bg-green-50 px-3 py-2 text-sm text-green-700">
+                {workspaceSuccess}
               </p>
             )}
           </DialogContent>


### PR DESCRIPTION
## Summary
- add explicit success feedback in Workspace Studio after creating a workspace
- add explicit success feedback after inviting a collaborator
- clear stale success/error state when new create/invite actions start so messages stay accurate

## Files
- `packages/web/src/components/layout/sidebar.tsx`

## Validation
- `yarn workspace @personal-context/web type-check`
- `yarn workspace @personal-context/web test` (27 passing)

## Why
Creating a workspace currently has no visible success acknowledgement, which makes the action feel ambiguous. This adds clear in-modal feedback for successful operations while preserving current error handling.