### PR TITLE
fix: enforce workspace scope resolution for artifact writes (by Lumen)

### DIFF
--- a/packages/api/src/mcp/server.ts
+++ b/packages/api/src/mcp/server.ts
@@ -85,6 +85,8 @@ export class MCPServer {
     userId: string,
     agentId: string
   ): Promise<string | null> {
+    // TODO(lumen): Deduplicate this with the artifact-handler variant in a
+    // shared helper that can choose ambiguous-workspace behavior (warn/throw).
     const { data, error } = await this.dataComposer
       .getClient()
       .from('agent_identities')

--- a/packages/api/src/mcp/server.ts
+++ b/packages/api/src/mcp/server.ts
@@ -31,6 +31,7 @@ import {
   type IncomingMessageHandler,
 } from '../channels/gateway';
 import { runWithRequestContext } from '../utils/request-context';
+import { resolveWorkspaceContextForRequest } from '../utils/workspace-scope';
 import { PcpAuthProvider } from './auth/pcp-auth-provider';
 
 export { setWhatsAppListener, getAgentGateway };
@@ -78,6 +79,77 @@ export class MCPServer {
     this.server = this.createMcpServerInstance();
 
     logger.info('MCP Server initialized');
+  }
+
+  private async deriveWorkspaceIdFromAgent(
+    userId: string,
+    agentId: string
+  ): Promise<string | null> {
+    const { data, error } = await this.dataComposer
+      .getClient()
+      .from('agent_identities')
+      .select('workspace_id')
+      .eq('user_id', userId)
+      .eq('agent_id', agentId);
+
+    if (error) {
+      logger.warn('Failed to derive workspace from agent identity in MCP request context', {
+        userId,
+        agentId,
+        error: error.message,
+      });
+      return null;
+    }
+
+    const workspaceIds = Array.from(
+      new Set(
+        (data || [])
+          .map((row) => row.workspace_id)
+          .filter((workspaceId): workspaceId is string => typeof workspaceId === 'string')
+      )
+    );
+
+    if (workspaceIds.length === 1) return workspaceIds[0];
+
+    if (workspaceIds.length > 1) {
+      logger.warn('Ambiguous workspace mapping for agent identity in MCP request context', {
+        userId,
+        agentId,
+        workspaceCount: workspaceIds.length,
+      });
+    }
+
+    return null;
+  }
+
+  private async resolveWorkspaceContextForMcpRequest(
+    req: express.Request,
+    userData: { userId: string; email: string; agentId?: string; identityId?: string }
+  ): Promise<{ workspaceId?: string; workspaceSource?: 'header' | 'derived' }> {
+    const requestedWorkspaceId = req.header('x-pcp-workspace-id')?.trim();
+
+    const resolution = await resolveWorkspaceContextForRequest({
+      requestedWorkspaceId,
+      validateRequestedWorkspaceId: requestedWorkspaceId
+        ? async (workspaceId: string) => {
+            const workspace = await this.dataComposer.repositories.workspaces.findById(
+              workspaceId,
+              userData.userId
+            );
+            return !!workspace;
+          }
+        : undefined,
+      deriveWorkspaceIdFromAgent: userData.agentId
+        ? () => this.deriveWorkspaceIdFromAgent(userData.userId, userData.agentId!)
+        : undefined,
+    });
+
+    if (!resolution) return {};
+
+    return {
+      workspaceId: resolution.workspaceId,
+      workspaceSource: resolution.source,
+    };
   }
 
   /**
@@ -202,6 +274,24 @@ export class MCPServer {
           }
         : {};
 
+      if (userData) {
+        try {
+          Object.assign(ctx, await this.resolveWorkspaceContextForMcpRequest(req, userData));
+        } catch (error) {
+          logger.warn('Rejected MCP request due to invalid workspace scope', {
+            userId: userData.userId,
+            agentId: userData.agentId,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          res.status(403).json({
+            jsonrpc: '2.0',
+            error: { code: -32003, message: 'Workspace not found or not accessible.' },
+            id: null,
+          });
+          return;
+        }
+      }
+
       await runWithRequestContext(ctx, async () => {
         let transport: StreamableHTTPServerTransport | undefined;
         let mcpServer: ReturnType<typeof this.createMcpServerInstance> | undefined;
@@ -239,11 +329,14 @@ export class MCPServer {
     // This stateless endpoint does not expose a standalone SSE stream.
     // Streamable HTTP clients may probe GET /mcp; return explicit 405 per spec.
     app.get('/mcp', (_req, res) => {
-      res.status(405).set('Allow', 'POST, DELETE').json({
-        jsonrpc: '2.0',
-        error: { code: -32000, message: 'Method not allowed.' },
-        id: null,
-      });
+      res
+        .status(405)
+        .set('Allow', 'POST, DELETE')
+        .json({
+          jsonrpc: '2.0',
+          error: { code: -32000, message: 'Method not allowed.' },
+          id: null,
+        });
     });
 
     // DELETE /mcp - No-op in stateless mode (no sessions to terminate)

--- a/packages/api/src/mcp/tools/artifact-handlers.test.ts
+++ b/packages/api/src/mcp/tools/artifact-handlers.test.ts
@@ -4,9 +4,14 @@
  * Covers three-way merge/CAS behavior plus comment + identity UUID flows.
  */
 
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { DataComposer } from '../../data/composer';
 import { createTableAwareSupabaseMock } from '../../test/table-aware-supabase-mock';
+import {
+  clearSessionContext,
+  runWithRequestContext,
+  setSessionContext,
+} from '../../utils/request-context';
 import {
   handleAddArtifactComment,
   handleCreateArtifact,
@@ -34,6 +39,10 @@ vi.mock('../../utils/logger', () => ({
     debug: vi.fn(),
   },
 }));
+
+afterEach(() => {
+  clearSessionContext();
+});
 
 function createMockSupabase(
   overrides: {
@@ -65,6 +74,12 @@ function createMockSupabase(
         select: vi.fn().mockReturnValue({
           eq: vi.fn().mockReturnValue({
             eq: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                maybeSingle: vi.fn().mockResolvedValue({
+                  data: null,
+                  error: null,
+                }),
+              }),
               maybeSingle: vi.fn().mockResolvedValue({
                 data: null,
                 error: null,
@@ -79,6 +94,12 @@ function createMockSupabase(
         select: vi.fn().mockReturnValue({
           eq: vi.fn().mockReturnValue({
             eq: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                single: vi.fn().mockResolvedValue({
+                  data: artifact,
+                  error: artifact ? null : { message: 'Not found' },
+                }),
+              }),
               single: vi.fn().mockResolvedValue({
                 data: artifact,
                 error: artifact ? null : { message: 'Not found' },
@@ -142,6 +163,10 @@ function createMockDataComposer(supabase: { from: ReturnType<typeof vi.fn> }) {
 describe('handleUpdateArtifact', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    setSessionContext({
+      userId: '00000000-0000-0000-0000-000000000001',
+      workspaceId: '11111111-1111-1111-1111-111111111111',
+    });
   });
 
   describe('without baseVersion (backward compatible)', () => {
@@ -409,6 +434,10 @@ describe('handleUpdateArtifact', () => {
 describe('artifact comment + identity UUID flows', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    setSessionContext({
+      userId: '00000000-0000-0000-0000-000000000001',
+      workspaceId: '11111111-1111-1111-1111-111111111111',
+    });
   });
 
   it('handleGetArtifact includes comments when includeComments=true', async () => {
@@ -555,6 +584,12 @@ describe('artifact comment + identity UUID flows', () => {
     const supabase = createTableAwareSupabaseMock({
       agent_identities: [
         {
+          then: {
+            data: [{ workspace_id: '11111111-1111-1111-1111-111111111111' }],
+            error: null,
+          },
+        },
+        {
           maybeSingle: [
             {
               data: { id: 'identity-1', agent_id: 'lumen', name: 'Lumen', backend: 'codex' },
@@ -622,7 +657,15 @@ describe('artifact comment + identity UUID flows', () => {
 
   it('handleCreateArtifact keeps slug behavior when identity row is missing', async () => {
     const supabase = createTableAwareSupabaseMock({
-      agent_identities: [{ maybeSingle: [{ data: null, error: null }] }],
+      agent_identities: [
+        {
+          then: {
+            data: [],
+            error: null,
+          },
+        },
+        { maybeSingle: [{ data: null, error: null }] },
+      ],
       artifacts: [
         { maybeSingle: [{ data: null, error: null }] },
         {
@@ -680,6 +723,359 @@ describe('artifact comment + identity UUID flows', () => {
     });
   });
 
+  it('handleCreateArtifact uses workspaceId from session context when args omit workspaceId', async () => {
+    setSessionContext({
+      userId: '00000000-0000-0000-0000-000000000001',
+      workspaceId: '22222222-2222-2222-2222-222222222222',
+    });
+
+    const supabase = createTableAwareSupabaseMock({
+      agent_identities: [{ maybeSingle: [{ data: null, error: null }] }],
+      artifacts: [
+        { maybeSingle: [{ data: null, error: null }] },
+        {
+          single: [
+            {
+              data: {
+                id: 'artifact-ctx-1',
+                uri: 'pcp://specs/context-workspace',
+                title: 'Context scoped spec',
+                artifact_type: 'spec',
+                version: 1,
+                created_at: '2026-02-28T00:00:00Z',
+              },
+              error: null,
+            },
+          ],
+        },
+      ],
+      artifact_history: [{ then: { data: null, error: null } }],
+    });
+
+    const result = await handleCreateArtifact(
+      {
+        userId: '00000000-0000-0000-0000-000000000001',
+        uri: 'pcp://specs/context-workspace',
+        title: 'Context scoped spec',
+        content: '# Context Workspace',
+        artifactType: 'spec',
+      },
+      createMockDataComposer(supabase)
+    );
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.success).toBe(true);
+
+    const artifactInsertBuilder = supabase.calls.find(
+      (c) =>
+        c.table === 'artifacts' &&
+        (c.builder.insert as ReturnType<typeof vi.fn>).mock.calls.length > 0
+    )?.builder;
+    const historyInsertBuilder = supabase.calls.find(
+      (c) => c.table === 'artifact_history'
+    )?.builder;
+
+    expect(
+      (artifactInsertBuilder?.insert as ReturnType<typeof vi.fn>).mock.calls[0][0]
+    ).toMatchObject({
+      workspace_id: '22222222-2222-2222-2222-222222222222',
+    });
+    expect(
+      (historyInsertBuilder?.insert as ReturnType<typeof vi.fn>).mock.calls[0][0]
+    ).toMatchObject({
+      workspace_id: '22222222-2222-2222-2222-222222222222',
+    });
+  });
+
+  it('handleCreateArtifact prioritizes header workspace over explicit workspace arg', async () => {
+    const supabase = createTableAwareSupabaseMock({
+      artifacts: [
+        { maybeSingle: [{ data: null, error: null }] },
+        {
+          single: [
+            {
+              data: {
+                id: 'artifact-header-1',
+                uri: 'pcp://specs/header-workspace',
+                title: 'Header scoped spec',
+                artifact_type: 'spec',
+                version: 1,
+                created_at: '2026-02-28T00:00:00Z',
+              },
+              error: null,
+            },
+          ],
+        },
+      ],
+      artifact_history: [{ then: { data: null, error: null } }],
+    });
+
+    await runWithRequestContext(
+      {
+        userId: '00000000-0000-0000-0000-000000000001',
+        workspaceId: '33333333-3333-3333-3333-333333333333',
+        workspaceSource: 'header',
+      },
+      async () => {
+        const result = await handleCreateArtifact(
+          {
+            userId: '00000000-0000-0000-0000-000000000001',
+            workspaceId: '44444444-4444-4444-4444-444444444444',
+            uri: 'pcp://specs/header-workspace',
+            title: 'Header scoped spec',
+            content: '# Header Workspace',
+            artifactType: 'spec',
+          },
+          createMockDataComposer(supabase)
+        );
+
+        const parsed = JSON.parse(result.content[0].text);
+        expect(parsed.success).toBe(true);
+      }
+    );
+
+    const artifactInsertBuilder = supabase.calls.find(
+      (c) =>
+        c.table === 'artifacts' &&
+        (c.builder.insert as ReturnType<typeof vi.fn>).mock.calls.length > 0
+    )?.builder;
+    const historyInsertBuilder = supabase.calls.find(
+      (c) => c.table === 'artifact_history'
+    )?.builder;
+
+    expect(
+      (artifactInsertBuilder?.insert as ReturnType<typeof vi.fn>).mock.calls[0][0]
+    ).toMatchObject({
+      workspace_id: '33333333-3333-3333-3333-333333333333',
+    });
+    expect(
+      (historyInsertBuilder?.insert as ReturnType<typeof vi.fn>).mock.calls[0][0]
+    ).toMatchObject({
+      workspace_id: '33333333-3333-3333-3333-333333333333',
+    });
+  });
+
+  it('handleCreateArtifact treats header workspace as first-class, ahead of agent-derived scope', async () => {
+    const supabase = createTableAwareSupabaseMock({
+      // Single identity lookup for resolveIdentityForAgent. If deriveWorkspaceIdFromAgent
+      // runs unexpectedly, this queue will underflow and fail the test.
+      agent_identities: [{ maybeSingle: [{ data: null, error: null }] }],
+      artifacts: [
+        { maybeSingle: [{ data: null, error: null }] },
+        {
+          single: [
+            {
+              data: {
+                id: 'artifact-header-first-1',
+                uri: 'pcp://specs/header-first',
+                title: 'Header first',
+                artifact_type: 'spec',
+                version: 1,
+                created_at: '2026-02-28T00:00:00Z',
+              },
+              error: null,
+            },
+          ],
+        },
+      ],
+      artifact_history: [{ then: { data: null, error: null } }],
+    });
+
+    await runWithRequestContext(
+      {
+        userId: '00000000-0000-0000-0000-000000000001',
+        workspaceId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+        workspaceSource: 'header',
+      },
+      async () => {
+        const result = await handleCreateArtifact(
+          {
+            userId: '00000000-0000-0000-0000-000000000001',
+            uri: 'pcp://specs/header-first',
+            title: 'Header first',
+            content: '# Header first',
+            artifactType: 'spec',
+            agentId: 'lumen',
+          },
+          createMockDataComposer(supabase)
+        );
+
+        const parsed = JSON.parse(result.content[0].text);
+        expect(parsed.success).toBe(true);
+      }
+    );
+
+    const artifactInsertBuilder = supabase.calls.find(
+      (c) =>
+        c.table === 'artifacts' &&
+        (c.builder.insert as ReturnType<typeof vi.fn>).mock.calls.length > 0
+    )?.builder;
+    expect(
+      (artifactInsertBuilder?.insert as ReturnType<typeof vi.fn>).mock.calls[0][0]
+    ).toMatchObject({
+      workspace_id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    });
+  });
+
+  it('handleCreateArtifact prefers agent-derived workspace over non-header request context fallback', async () => {
+    const supabase = createTableAwareSupabaseMock({
+      agent_identities: [
+        {
+          then: {
+            data: [{ workspace_id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb' }],
+            error: null,
+          },
+        },
+        {
+          maybeSingle: [
+            {
+              data: { id: 'identity-derive-2', agent_id: 'lumen', name: 'Lumen', backend: 'codex' },
+              error: null,
+            },
+          ],
+        },
+      ],
+      artifacts: [
+        { maybeSingle: [{ data: null, error: null }] },
+        {
+          single: [
+            {
+              data: {
+                id: 'artifact-derived-over-default-1',
+                uri: 'pcp://specs/derived-over-default',
+                title: 'Derived over default',
+                artifact_type: 'spec',
+                version: 1,
+                created_at: '2026-02-28T00:00:00Z',
+              },
+              error: null,
+            },
+          ],
+        },
+      ],
+      artifact_history: [{ then: { data: null, error: null } }],
+    });
+
+    await runWithRequestContext(
+      {
+        userId: '00000000-0000-0000-0000-000000000001',
+        workspaceId: 'cccccccc-cccc-cccc-cccc-cccccccccccc',
+        workspaceSource: 'default',
+      },
+      async () => {
+        const result = await handleCreateArtifact(
+          {
+            userId: '00000000-0000-0000-0000-000000000001',
+            uri: 'pcp://specs/derived-over-default',
+            title: 'Derived over default',
+            content: '# Derived over default',
+            artifactType: 'spec',
+            agentId: 'lumen',
+          },
+          createMockDataComposer(supabase)
+        );
+
+        const parsed = JSON.parse(result.content[0].text);
+        expect(parsed.success).toBe(true);
+      }
+    );
+
+    const artifactInsertBuilder = supabase.calls.find(
+      (c) =>
+        c.table === 'artifacts' &&
+        (c.builder.insert as ReturnType<typeof vi.fn>).mock.calls.length > 0
+    )?.builder;
+    expect(
+      (artifactInsertBuilder?.insert as ReturnType<typeof vi.fn>).mock.calls[0][0]
+    ).toMatchObject({
+      workspace_id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+      created_by_identity_id: 'identity-derive-2',
+    });
+  });
+
+  it('handleCreateArtifact derives workspace from agent identity when workspace is omitted', async () => {
+    const supabase = createTableAwareSupabaseMock({
+      agent_identities: [
+        {
+          then: {
+            data: [{ workspace_id: '55555555-5555-5555-5555-555555555555' }],
+            error: null,
+          },
+        },
+        {
+          maybeSingle: [
+            {
+              data: { id: 'identity-derive-1', agent_id: 'lumen', name: 'Lumen', backend: 'codex' },
+              error: null,
+            },
+          ],
+        },
+      ],
+      artifacts: [
+        { maybeSingle: [{ data: null, error: null }] },
+        {
+          single: [
+            {
+              data: {
+                id: 'artifact-derived-1',
+                uri: 'pcp://specs/derived-workspace',
+                title: 'Derived workspace spec',
+                artifact_type: 'spec',
+                version: 1,
+                created_at: '2026-02-28T00:00:00Z',
+              },
+              error: null,
+            },
+          ],
+        },
+      ],
+      artifact_history: [{ then: { data: null, error: null } }],
+    });
+
+    const result = await handleCreateArtifact(
+      {
+        userId: '00000000-0000-0000-0000-000000000001',
+        uri: 'pcp://specs/derived-workspace',
+        title: 'Derived workspace spec',
+        content: '# Derived Workspace',
+        artifactType: 'spec',
+        agentId: 'lumen',
+      },
+      createMockDataComposer(supabase)
+    );
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.success).toBe(true);
+
+    const artifactInsertBuilder = supabase.calls.find(
+      (c) =>
+        c.table === 'artifacts' &&
+        (c.builder.insert as ReturnType<typeof vi.fn>).mock.calls.length > 0
+    )?.builder;
+    expect(
+      (artifactInsertBuilder?.insert as ReturnType<typeof vi.fn>).mock.calls[0][0]
+    ).toMatchObject({
+      workspace_id: '55555555-5555-5555-5555-555555555555',
+      created_by_identity_id: 'identity-derive-1',
+    });
+  });
+
+  it('handleCreateArtifact rejects writes when workspace scope cannot be resolved', async () => {
+    clearSessionContext();
+    await expect(
+      handleCreateArtifact(
+        {
+          userId: '00000000-0000-0000-0000-000000000001',
+          uri: 'pcp://specs/no-workspace',
+          title: 'No workspace',
+          content: '# Missing workspace scope',
+          artifactType: 'spec',
+        },
+        createMockDataComposer({ from: vi.fn() })
+      )
+    ).rejects.toThrow('Artifact write requires workspace scope');
+  });
+
   it('handleAddArtifactComment resolves identity UUID and returns identity metadata', async () => {
     const supabase = createTableAwareSupabaseMock({
       artifacts: [
@@ -693,6 +1089,12 @@ describe('artifact comment + identity UUID flows', () => {
         },
       ],
       agent_identities: [
+        {
+          then: {
+            data: [{ workspace_id: '11111111-1111-1111-1111-111111111111' }],
+            error: null,
+          },
+        },
         {
           maybeSingle: [
             {

--- a/packages/api/src/mcp/tools/artifact-handlers.ts
+++ b/packages/api/src/mcp/tools/artifact-handlers.ts
@@ -17,6 +17,8 @@ import { resolveUserOrThrow, userIdentifierBaseSchema } from '../../services/use
 import { logger } from '../../utils/logger';
 import { getEffectiveAgentId } from '../../auth/enforce-identity';
 import type { Database, Json } from '../../data/supabase/types';
+import { mergeWithContext } from '../../utils/request-context';
+import { resolveWorkspaceScopeForWrite } from '../../utils/workspace-scope';
 
 // ============== Schemas ==============
 
@@ -116,7 +118,57 @@ const listArtifactCommentsSchema = workspaceScopedUserIdentifierSchema.extend({
 
 function withWorkspaceFilter<T>(query: T, workspaceId?: string): T {
   if (!workspaceId) return query;
-  return (query as { eq: (column: string, value: string) => T }).eq('workspace_id', workspaceId);
+  const queryWithEq = query as { eq?: (column: string, value: string) => T };
+  if (typeof queryWithEq.eq !== 'function') return query;
+  return queryWithEq.eq('workspace_id', workspaceId);
+}
+
+function parseWithContext<T extends z.ZodTypeAny>(schema: T, args: unknown): z.infer<T> {
+  const merged = mergeWithContext((args ?? {}) as Record<string, unknown>);
+  return schema.parse(merged);
+}
+
+function toArgsRecord(args: unknown): Record<string, unknown> {
+  if (!args || typeof args !== 'object') return {};
+  return args as Record<string, unknown>;
+}
+
+async function deriveWorkspaceIdFromAgent(
+  supabase: SupabaseClient<Database>,
+  userId: string,
+  agentId: string
+): Promise<string | null> {
+  const { data, error } = await supabase
+    .from('agent_identities')
+    .select('workspace_id')
+    .eq('user_id', userId)
+    .eq('agent_id', agentId);
+
+  if (error) {
+    logger.warn('Failed to derive workspace from agent identity', {
+      userId,
+      agentId,
+      error: error.message,
+    });
+    return null;
+  }
+
+  const workspaceIds = Array.from(
+    new Set(
+      (data || [])
+        .map((row) => row.workspace_id)
+        .filter((workspaceId): workspaceId is string => typeof workspaceId === 'string')
+    )
+  );
+
+  if (workspaceIds.length === 1) return workspaceIds[0];
+  if (workspaceIds.length > 1) {
+    throw new Error(
+      `Workspace is ambiguous for agent "${agentId}". Provide workspaceId or X-PCP-Workspace-Id.`
+    );
+  }
+
+  return null;
 }
 
 async function resolveIdentityForAgent(
@@ -203,7 +255,8 @@ function resolveArtifactForUser(
 
 export async function handleCreateArtifact(args: unknown, dataComposer: DataComposer) {
   const supabase = dataComposer.getClient();
-  const parsed = createArtifactSchema.parse(args);
+  const rawArgs = toArgsRecord(args);
+  const parsed = parseWithContext(createArtifactSchema, args);
   const resolved = await resolveUserOrThrow(parsed, dataComposer);
 
   const {
@@ -218,10 +271,23 @@ export async function handleCreateArtifact(args: unknown, dataComposer: DataComp
     workspaceId,
   } = parsed;
   const agentId = getEffectiveAgentId(parsed.agentId);
+  const workspaceResolution = await resolveWorkspaceScopeForWrite({
+    rawArgs,
+    explicitWorkspaceId: workspaceId,
+    agentId,
+    deriveWorkspaceIdFromAgent: (candidateAgentId) =>
+      deriveWorkspaceIdFromAgent(supabase, resolved.user.id, candidateAgentId),
+  });
+  if (!workspaceResolution) {
+    throw new Error(
+      'Artifact write requires workspace scope. Provide X-PCP-Workspace-Id, workspaceId, or a workspace-scoped agent identity.'
+    );
+  }
+  const workspaceScope = workspaceResolution.workspaceId;
   const authorIdentity = await resolveIdentityForAgent(
     supabase,
     resolved.user.id,
-    workspaceId,
+    workspaceScope,
     agentId
   );
 
@@ -231,7 +297,7 @@ export async function handleCreateArtifact(args: unknown, dataComposer: DataComp
     .select('id')
     .eq('user_id', resolved.user.id)
     .eq('uri', uri);
-  existingQuery = withWorkspaceFilter(existingQuery, workspaceId);
+  existingQuery = withWorkspaceFilter(existingQuery, workspaceScope);
   const { data: existing } = await existingQuery.maybeSingle();
 
   if (existing) {
@@ -243,7 +309,7 @@ export async function handleCreateArtifact(args: unknown, dataComposer: DataComp
     .insert({
       uri,
       user_id: resolved.user.id,
-      ...(workspaceId ? { workspace_id: workspaceId } : {}),
+      workspace_id: workspaceScope,
       created_by_identity_id: authorIdentity?.id || null,
       title,
       content,
@@ -265,7 +331,7 @@ export async function handleCreateArtifact(args: unknown, dataComposer: DataComp
   // Create initial history entry
   await supabase.from('artifact_history').insert({
     artifact_id: artifact.id,
-    ...(workspaceId ? { workspace_id: workspaceId } : {}),
+    workspace_id: workspaceScope,
     version: 1,
     title,
     content,
@@ -300,7 +366,7 @@ export async function handleCreateArtifact(args: unknown, dataComposer: DataComp
 
 export async function handleGetArtifact(args: unknown, dataComposer: DataComposer) {
   const supabase = dataComposer.getClient();
-  const parsed = getArtifactSchema.parse(args);
+  const parsed = parseWithContext(getArtifactSchema, args);
   const resolved = await resolveUserOrThrow(parsed, dataComposer);
 
   const { uri, artifactId, includeComments = false, commentLimit = 50, workspaceId } = parsed;
@@ -480,7 +546,8 @@ export async function handleGetArtifact(args: unknown, dataComposer: DataCompose
 
 export async function handleUpdateArtifact(args: unknown, dataComposer: DataComposer) {
   const supabase = dataComposer.getClient();
-  const parsed = updateArtifactSchema.parse(args);
+  const rawArgs = toArgsRecord(args);
+  const parsed = parseWithContext(updateArtifactSchema, args);
   const resolved = await resolveUserOrThrow(parsed, dataComposer);
 
   const {
@@ -495,15 +562,28 @@ export async function handleUpdateArtifact(args: unknown, dataComposer: DataComp
     workspaceId,
   } = parsed;
   const agentId = getEffectiveAgentId(parsed.agentId);
+  const workspaceResolution = await resolveWorkspaceScopeForWrite({
+    rawArgs,
+    explicitWorkspaceId: workspaceId,
+    agentId,
+    deriveWorkspaceIdFromAgent: (candidateAgentId) =>
+      deriveWorkspaceIdFromAgent(supabase, resolved.user.id, candidateAgentId),
+  });
+  if (!workspaceResolution) {
+    throw new Error(
+      'Artifact write requires workspace scope. Provide X-PCP-Workspace-Id, workspaceId, or a workspace-scoped agent identity.'
+    );
+  }
+  const workspaceScope = workspaceResolution.workspaceId;
   const editorIdentity = await resolveIdentityForAgent(
     supabase,
     resolved.user.id,
-    workspaceId,
+    workspaceScope,
     agentId
   );
 
   // First, get the current artifact
-  const query = resolveArtifactForUser(supabase, resolved.user.id, workspaceId, {
+  const query = resolveArtifactForUser(supabase, resolved.user.id, workspaceScope, {
     uri,
     artifactId,
   });
@@ -542,7 +622,7 @@ export async function handleUpdateArtifact(args: unknown, dataComposer: DataComp
       .select('content')
       .eq('artifact_id', current.id)
       .eq('version', baseVersion);
-    baseHistoryQuery = withWorkspaceFilter(baseHistoryQuery, workspaceId);
+    baseHistoryQuery = withWorkspaceFilter(baseHistoryQuery, workspaceScope);
     const { data: baseHistory, error: historyError } = await baseHistoryQuery.single();
 
     if (historyError || !baseHistory?.content) {
@@ -646,7 +726,7 @@ export async function handleUpdateArtifact(args: unknown, dataComposer: DataComp
     .update(updates)
     .eq('id', current.id)
     .eq('version', expectedVersion);
-  updateQuery = withWorkspaceFilter(updateQuery, workspaceId);
+  updateQuery = withWorkspaceFilter(updateQuery, workspaceScope);
   const { data: updated, error: updateError } = await updateQuery.select().maybeSingle();
 
   if (updateError) {
@@ -685,7 +765,7 @@ export async function handleUpdateArtifact(args: unknown, dataComposer: DataComp
 
   await supabase.from('artifact_history').insert({
     artifact_id: current.id,
-    ...(workspaceId ? { workspace_id: workspaceId } : {}),
+    workspace_id: workspaceScope,
     version: newVersion,
     title: updated.title,
     content: updated.content,
@@ -727,7 +807,7 @@ export async function handleUpdateArtifact(args: unknown, dataComposer: DataComp
 
 export async function handleListArtifacts(args: unknown, dataComposer: DataComposer) {
   const supabase = dataComposer.getClient();
-  const parsed = listArtifactsSchema.parse(args);
+  const parsed = parseWithContext(listArtifactsSchema, args);
   const resolved = await resolveUserOrThrow(parsed, dataComposer);
 
   const { artifactType, tags, visibility, search, limit = 20, workspaceId } = parsed;
@@ -784,7 +864,7 @@ export async function handleListArtifacts(args: unknown, dataComposer: DataCompo
 
 export async function handleGetArtifactHistory(args: unknown, dataComposer: DataComposer) {
   const supabase = dataComposer.getClient();
-  const parsed = getArtifactHistorySchema.parse(args);
+  const parsed = parseWithContext(getArtifactHistorySchema, args);
   const resolved = await resolveUserOrThrow(parsed, dataComposer);
 
   const { uri, artifactId, limit = 10, workspaceId } = parsed;
@@ -837,7 +917,8 @@ export async function handleGetArtifactHistory(args: unknown, dataComposer: Data
 
 export async function handleAddArtifactComment(args: unknown, dataComposer: DataComposer) {
   const supabase = dataComposer.getClient();
-  const parsed = addArtifactCommentSchema.parse(args);
+  const rawArgs = toArgsRecord(args);
+  const parsed = parseWithContext(addArtifactCommentSchema, args);
   const resolved = await resolveUserOrThrow(parsed, dataComposer);
 
   const { uri, artifactId, content, agentId, parentCommentId, metadata = {}, workspaceId } = parsed;
@@ -846,10 +927,25 @@ export async function handleAddArtifactComment(args: unknown, dataComposer: Data
     throw new Error('Comment content cannot be empty');
   }
 
+  const effectiveAgentId = getEffectiveAgentId(agentId);
+  const workspaceResolution = await resolveWorkspaceScopeForWrite({
+    rawArgs,
+    explicitWorkspaceId: workspaceId,
+    agentId: effectiveAgentId,
+    deriveWorkspaceIdFromAgent: (candidateAgentId) =>
+      deriveWorkspaceIdFromAgent(supabase, resolved.user.id, candidateAgentId),
+  });
+  if (!workspaceResolution) {
+    throw new Error(
+      'Artifact write requires workspace scope. Provide X-PCP-Workspace-Id, workspaceId, or a workspace-scoped agent identity.'
+    );
+  }
+  const workspaceScope = workspaceResolution.workspaceId;
+
   const { data: artifact, error: artifactError } = await resolveArtifactForUser(
     supabase,
     resolved.user.id,
-    workspaceId,
+    workspaceScope,
     { uri, artifactId }
   ).single();
 
@@ -864,7 +960,7 @@ export async function handleAddArtifactComment(args: unknown, dataComposer: Data
       .eq('id', parentCommentId)
       .eq('artifact_id', artifact.id)
       .eq('user_id', resolved.user.id);
-    parentQuery = withWorkspaceFilter(parentQuery, workspaceId);
+    parentQuery = withWorkspaceFilter(parentQuery, workspaceScope);
     const { data: parent, error: parentError } = await parentQuery.maybeSingle();
 
     if (parentError || !parent) {
@@ -875,8 +971,8 @@ export async function handleAddArtifactComment(args: unknown, dataComposer: Data
   const authorIdentity = await resolveIdentityForAgent(
     supabase,
     resolved.user.id,
-    workspaceId,
-    agentId
+    workspaceScope,
+    effectiveAgentId
   );
 
   const { data: created, error: createError } = await supabase
@@ -885,7 +981,7 @@ export async function handleAddArtifactComment(args: unknown, dataComposer: Data
       artifact_id: artifact.id,
       user_id: resolved.user.id,
       created_by_user_id: resolved.user.id,
-      ...(workspaceId ? { workspace_id: workspaceId } : {}),
+      workspace_id: workspaceScope,
       created_by_identity_id: authorIdentity?.id || null,
       parent_comment_id: parentCommentId || null,
       content: trimmed,
@@ -901,7 +997,7 @@ export async function handleAddArtifactComment(args: unknown, dataComposer: Data
   logger.info('Artifact comment added', {
     artifactId: artifact.id,
     commentId: created.id,
-    agentId: agentId || null,
+    agentId: effectiveAgentId || null,
     identityId: authorIdentity?.id || null,
   });
 
@@ -946,7 +1042,7 @@ export async function handleAddArtifactComment(args: unknown, dataComposer: Data
 
 export async function handleListArtifactComments(args: unknown, dataComposer: DataComposer) {
   const supabase = dataComposer.getClient();
-  const parsed = listArtifactCommentsSchema.parse(args);
+  const parsed = parseWithContext(listArtifactCommentsSchema, args);
   const resolved = await resolveUserOrThrow(parsed, dataComposer);
 
   const { uri, artifactId, limit = 100, workspaceId } = parsed;

--- a/packages/api/src/mcp/tools/artifact-handlers.ts
+++ b/packages/api/src/mcp/tools/artifact-handlers.ts
@@ -138,6 +138,9 @@ async function deriveWorkspaceIdFromAgent(
   userId: string,
   agentId: string
 ): Promise<string | null> {
+  // TODO(lumen): Deduplicate with MCPServer.deriveWorkspaceIdFromAgent in
+  // server.ts via a shared helper; keep strict throw-on-ambiguous behavior
+  // here for write-path safety.
   const { data, error } = await supabase
     .from('agent_identities')
     .select('workspace_id')

--- a/packages/api/src/routes/admin-auth.test.ts
+++ b/packages/api/src/routes/admin-auth.test.ts
@@ -322,6 +322,7 @@ describe('adminAuthMiddleware', () => {
         userId: 'user-ctx',
         email: 'ctx@example.com',
         workspaceId: 'workspace-1',
+        workspaceSource: 'default',
       });
     });
 

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -696,6 +696,7 @@ async function adminAuthMiddleware(req: Request, res: Response, next: NextFuncti
         userId: pcpUserId!,
         email: userEmail,
         workspaceId: activeWorkspaceId,
+        workspaceSource: requestedWorkspaceId ? 'header' : 'default',
       },
       () => next()
     );

--- a/packages/api/src/utils/request-context.ts
+++ b/packages/api/src/utils/request-context.ts
@@ -37,6 +37,8 @@ export interface RequestContextData {
   sessionId?: string;
   /** Active product workspace ID */
   workspaceId?: string;
+  /** How workspace scope was determined for this request/session */
+  workspaceSource?: 'header' | 'default' | 'derived' | 'session';
   /** Conversation ID for channel routing */
   conversationId?: string;
   /** Request timestamp */
@@ -70,6 +72,10 @@ export function runWithRequestContext<T>(
  * Persists until cleared or replaced.
  */
 export function setSessionContext(context: Omit<RequestContextData, 'timestamp'> | null): void {
+  if (context?.workspaceId && !context.workspaceSource) {
+    sessionContext = { ...context, workspaceSource: 'session' };
+    return;
+  }
   sessionContext = context;
 }
 

--- a/packages/api/src/utils/workspace-scope.test.ts
+++ b/packages/api/src/utils/workspace-scope.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { clearSessionContext, runWithRequestContext, setSessionContext } from './request-context';
+import {
+  resolveWorkspaceContextForRequest,
+  resolveWorkspaceScopeForWrite,
+} from './workspace-scope';
+
+afterEach(() => {
+  clearSessionContext();
+});
+
+describe('resolveWorkspaceScopeForWrite', () => {
+  it('uses header-derived request workspace first', async () => {
+    await runWithRequestContext(
+      {
+        userId: 'user-1',
+        workspaceId: 'ws-header',
+        workspaceSource: 'header',
+      },
+      async () => {
+        const derive = vi.fn().mockResolvedValue('ws-derived');
+        const result = await resolveWorkspaceScopeForWrite({
+          rawArgs: { workspaceId: 'ws-arg' },
+          explicitWorkspaceId: 'ws-explicit',
+          agentId: 'lumen',
+          deriveWorkspaceIdFromAgent: derive,
+        });
+
+        expect(result).toEqual({ workspaceId: 'ws-header', source: 'header' });
+        expect(derive).not.toHaveBeenCalled();
+      }
+    );
+  });
+
+  it('uses agent-derived workspace when no header workspace exists', async () => {
+    const derive = vi.fn().mockResolvedValue('ws-derived');
+    const result = await resolveWorkspaceScopeForWrite({
+      rawArgs: {},
+      agentId: 'lumen',
+      deriveWorkspaceIdFromAgent: derive,
+    });
+
+    expect(result).toEqual({ workspaceId: 'ws-derived', source: 'derived' });
+    expect(derive).toHaveBeenCalledWith('lumen');
+  });
+
+  it('falls back to merged request/session/arg workspace when derivation is unavailable', async () => {
+    setSessionContext({ userId: 'user-1', workspaceId: 'ws-session' });
+
+    const result = await resolveWorkspaceScopeForWrite({
+      rawArgs: {},
+    });
+
+    expect(result).toEqual({ workspaceId: 'ws-session', source: 'context' });
+  });
+
+  it('returns null when no workspace can be resolved', async () => {
+    const result = await resolveWorkspaceScopeForWrite({
+      rawArgs: {},
+    });
+
+    expect(result).toBeNull();
+  });
+});
+
+describe('resolveWorkspaceContextForRequest', () => {
+  it('returns header workspace when provided and valid', async () => {
+    const validate = vi.fn().mockResolvedValue(true);
+    const result = await resolveWorkspaceContextForRequest({
+      requestedWorkspaceId: 'ws-header',
+      validateRequestedWorkspaceId: validate,
+      deriveWorkspaceIdFromAgent: vi.fn().mockResolvedValue('ws-derived'),
+    });
+
+    expect(result).toEqual({ workspaceId: 'ws-header', source: 'header' });
+    expect(validate).toHaveBeenCalledWith('ws-header');
+  });
+
+  it('throws when requested header workspace is invalid', async () => {
+    await expect(
+      resolveWorkspaceContextForRequest({
+        requestedWorkspaceId: 'ws-bad',
+        validateRequestedWorkspaceId: vi.fn().mockResolvedValue(false),
+      })
+    ).rejects.toThrow('Workspace not found or not accessible');
+  });
+
+  it('falls back to derived workspace when header is absent', async () => {
+    const result = await resolveWorkspaceContextForRequest({
+      deriveWorkspaceIdFromAgent: vi.fn().mockResolvedValue('ws-derived'),
+    });
+
+    expect(result).toEqual({ workspaceId: 'ws-derived', source: 'derived' });
+  });
+});

--- a/packages/api/src/utils/workspace-scope.ts
+++ b/packages/api/src/utils/workspace-scope.ts
@@ -1,0 +1,93 @@
+import { getRequestContext, mergeWithContext } from './request-context';
+
+export type WorkspaceScopeSource = 'header' | 'derived' | 'context';
+
+export interface ResolvedWorkspaceScope {
+  workspaceId: string;
+  source: WorkspaceScopeSource;
+}
+
+export interface ResolveWorkspaceScopeForWriteParams {
+  rawArgs: Record<string, unknown>;
+  explicitWorkspaceId?: string;
+  agentId?: string;
+  deriveWorkspaceIdFromAgent?: (agentId: string) => Promise<string | null>;
+}
+
+export interface ResolveWorkspaceContextForRequestParams {
+  requestedWorkspaceId?: string;
+  validateRequestedWorkspaceId?: (workspaceId: string) => Promise<boolean>;
+  deriveWorkspaceIdFromAgent?: () => Promise<string | null>;
+}
+
+/**
+ * Resolve workspace scope for write operations with stable precedence:
+ * 1) Header-derived request context (authoritative)
+ * 2) Agent-derived workspace (injectable callback)
+ * 3) Merged request/session/args fallback
+ */
+export async function resolveWorkspaceScopeForWrite({
+  rawArgs,
+  explicitWorkspaceId,
+  agentId,
+  deriveWorkspaceIdFromAgent,
+}: ResolveWorkspaceScopeForWriteParams): Promise<ResolvedWorkspaceScope | null> {
+  const reqCtx = getRequestContext();
+  if (reqCtx?.workspaceSource === 'header' && reqCtx.workspaceId) {
+    return { workspaceId: reqCtx.workspaceId, source: 'header' };
+  }
+
+  if (reqCtx?.workspaceSource === 'derived' && reqCtx.workspaceId) {
+    return { workspaceId: reqCtx.workspaceId, source: 'derived' };
+  }
+
+  if (agentId && deriveWorkspaceIdFromAgent) {
+    const derived = await deriveWorkspaceIdFromAgent(agentId);
+    if (derived) {
+      return { workspaceId: derived, source: 'derived' };
+    }
+  }
+
+  const mergedWorkspaceId = mergeWithContext(rawArgs).workspaceId;
+  const fallbackWorkspaceId =
+    typeof mergedWorkspaceId === 'string' ? mergedWorkspaceId : explicitWorkspaceId;
+  if (fallbackWorkspaceId) {
+    return { workspaceId: fallbackWorkspaceId, source: 'context' };
+  }
+
+  return null;
+}
+
+/**
+ * Resolve workspace context at request entry (middleware/onion layer):
+ * 1) Header workspace when provided and authorized
+ * 2) Agent-derived workspace (injectable callback)
+ * 3) No workspace context (tool-level fallback may still apply)
+ */
+export async function resolveWorkspaceContextForRequest({
+  requestedWorkspaceId,
+  validateRequestedWorkspaceId,
+  deriveWorkspaceIdFromAgent,
+}: ResolveWorkspaceContextForRequestParams): Promise<{
+  workspaceId: string;
+  source: 'header' | 'derived';
+} | null> {
+  if (requestedWorkspaceId) {
+    if (validateRequestedWorkspaceId) {
+      const allowed = await validateRequestedWorkspaceId(requestedWorkspaceId);
+      if (!allowed) {
+        throw new Error(`Workspace not found or not accessible: ${requestedWorkspaceId}`);
+      }
+    }
+    return { workspaceId: requestedWorkspaceId, source: 'header' };
+  }
+
+  if (deriveWorkspaceIdFromAgent) {
+    const derived = await deriveWorkspaceIdFromAgent();
+    if (derived) {
+      return { workspaceId: derived, source: 'derived' };
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- centralize workspace scope resolution into an injectable utility (`workspace-scope.ts`) with explicit precedence:
  1. header-derived workspace (authoritative)
  2. agent-derived workspace
  3. request/session/context fallback
- wire request-context metadata to capture workspace source (`header`, `default`, `derived`, `session`)
- add request-level workspace derivation in MCP HTTP handling (header validation first, then agent-derived fallback)
- enforce non-null workspace scope for artifact write flows (`create`, `update`, `add_comment`) and fail fast when scope cannot be resolved

## Tests
- added `packages/api/src/utils/workspace-scope.test.ts`
- updated `packages/api/src/mcp/tools/artifact-handlers.test.ts`
- updated `packages/api/src/routes/admin-auth.test.ts`
- validated with:
  - `npx vitest run packages/api/src/utils/workspace-scope.test.ts packages/api/src/utils/request-context.test.ts packages/api/src/mcp/tools/artifact-handlers.test.ts packages/api/src/routes/admin-auth.test.ts`

## Note on backfill
- intentionally **not** shipping a migration for one-off backfill of legacy NULL `workspace_id` rows
- this PR only hardens request/tool resolution and prevents future unscoped writes