### PR TITLE
fix: path-scope Claude resume sessions + explicit PCP availability warning (by Lumen)

### DIFF
--- a/packages/cli/src/commands/claude.test.ts
+++ b/packages/cli/src/commands/claude.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { filterPcpSessionsForContext, hasBackendSessionOverride } from './claude.js';
+import {
+  filterPcpSessionsForContext,
+  filterUntrackedLocalClaudeSessions,
+  hasBackendSessionOverride,
+} from './claude.js';
 
 describe('hasBackendSessionOverride', () => {
   it('detects explicit Codex resume subcommand in positional prompt parts', () => {
@@ -91,5 +95,33 @@ describe('filterPcpSessionsForContext', () => {
     );
 
     expect(filtered.map((session) => session.id)).toEqual(['codex-1']);
+  });
+});
+
+describe('filterUntrackedLocalClaudeSessions', () => {
+  it('excludes local claude sessions already represented by PCP sessions', () => {
+    const local = [
+      {
+        sessionId: 'claude-1',
+        projectPath: '/tmp/project',
+        modified: '2026-02-28T00:00:00.000Z',
+      },
+      {
+        sessionId: 'claude-2',
+        projectPath: '/tmp/project',
+        modified: '2026-02-28T00:00:00.000Z',
+      },
+    ];
+
+    const filtered = filterUntrackedLocalClaudeSessions(local, [
+      {
+        id: 'pcp-1',
+        startedAt: '2026-02-28T00:00:00.000Z',
+        backend: 'claude',
+        backendSessionId: 'claude-1',
+      },
+    ]);
+
+    expect(filtered.map((session) => session.sessionId)).toEqual(['claude-2']);
   });
 });

--- a/packages/cli/src/commands/claude.test.ts
+++ b/packages/cli/src/commands/claude.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { hasBackendSessionOverride } from './claude.js';
+import { filterPcpSessionsForContext, hasBackendSessionOverride } from './claude.js';
 
 describe('hasBackendSessionOverride', () => {
   it('detects explicit Codex resume subcommand in positional prompt parts', () => {
@@ -25,5 +25,71 @@ describe('hasBackendSessionOverride', () => {
     expect(hasBackendSessionOverride('codex', ['--resume', 'abc123'])).toBe(true);
     expect(hasBackendSessionOverride('claude', ['--resume', 'abc123'])).toBe(true);
     expect(hasBackendSessionOverride('gemini', ['--session-id', 'abc123'])).toBe(true);
+  });
+});
+
+describe('filterPcpSessionsForContext', () => {
+  it('filters claude sessions by workingDir when present', () => {
+    const filtered = filterPcpSessionsForContext(
+      [
+        {
+          id: 'a',
+          startedAt: '2026-02-28T00:00:00.000Z',
+          backend: 'claude',
+          workingDir: '/tmp/project-a',
+        },
+        {
+          id: 'b',
+          startedAt: '2026-02-28T00:00:00.000Z',
+          backend: 'claude',
+          workingDir: '/tmp/project-b',
+        },
+      ],
+      'claude',
+      '/tmp/project-a'
+    );
+
+    expect(filtered.map((session) => session.id)).toEqual(['a']);
+  });
+
+  it('retains claude sessions without workingDir when local claude session id matches', () => {
+    const filtered = filterPcpSessionsForContext(
+      [
+        {
+          id: 'pcp-1',
+          startedAt: '2026-02-28T00:00:00.000Z',
+          backend: 'claude',
+          backendSessionId: 'claude-local-123',
+        },
+      ],
+      'claude',
+      '/tmp/project-a',
+      new Set(['claude-local-123'])
+    );
+
+    expect(filtered.map((session) => session.id)).toEqual(['pcp-1']);
+  });
+
+  it('filters non-claude sessions only by backend', () => {
+    const filtered = filterPcpSessionsForContext(
+      [
+        {
+          id: 'codex-1',
+          startedAt: '2026-02-28T00:00:00.000Z',
+          backend: 'codex',
+          workingDir: '/tmp/other',
+        },
+        {
+          id: 'gemini-1',
+          startedAt: '2026-02-28T00:00:00.000Z',
+          backend: 'gemini',
+          workingDir: '/tmp/project',
+        },
+      ],
+      'codex',
+      '/tmp/project'
+    );
+
+    expect(filtered.map((session) => session.id)).toEqual(['codex-1']);
   });
 });

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -57,6 +57,23 @@ interface ClaudeLocalSessionSummary {
   gitBranch?: string;
 }
 
+function getSessionBackendId(session: PcpSessionSummary): string | undefined {
+  return session.backendSessionId || session.claudeSessionId || undefined;
+}
+
+export function filterUntrackedLocalClaudeSessions(
+  localSessions: ClaudeLocalSessionSummary[],
+  activePcpSessions: PcpSessionSummary[]
+): ClaudeLocalSessionSummary[] {
+  const trackedSessionIds = new Set(
+    activePcpSessions
+      .map((session) => getSessionBackendId(session))
+      .filter((sessionId): sessionId is string => Boolean(sessionId))
+  );
+
+  return localSessions.filter((session) => !trackedSessionIds.has(session.sessionId));
+}
+
 function isPromptCancelError(err: unknown): boolean {
   if (!err || typeof err !== 'object') return false;
   const maybe = err as { name?: string; message?: string };
@@ -421,6 +438,11 @@ async function ensurePcpSessionContext(
     printPcpUnavailableWarning(pcpUnavailableReason || 'unknown error', cwd);
   }
 
+  const untrackedLocalClaudeSessions =
+    backend === 'claude'
+      ? filterUntrackedLocalClaudeSessions(localClaudeSessions, activeSessions)
+      : [];
+
   let chosen: PcpSessionSummary | undefined;
   let selectedLocalBackendSessionId: string | undefined;
 
@@ -453,19 +475,21 @@ async function ensurePcpSessionContext(
 
     for (const session of activeSessions) {
       const value = `__pcp__:${session.id}`;
+      const linkedBackendSessionId =
+        backend === 'claude' ? getSessionBackendId(session) : undefined;
       choices.push({
-        name: `Resume PCP ${session.id.slice(0, 8)}${session.threadKey ? ` (${session.threadKey})` : ''}${session.currentPhase ? ` — ${session.currentPhase}` : ''}`,
+        name: `Resume PCP ${session.id.slice(0, 8)}${session.threadKey ? ` (${session.threadKey})` : ''}${session.currentPhase ? ` — ${session.currentPhase}` : ''}${linkedBackendSessionId ? ` · tracks Claude ${linkedBackendSessionId.slice(0, 8)}` : ''}`,
         value,
       });
       sessionChoiceByValue.set(value, session.id);
     }
 
     if (backend === 'claude') {
-      for (const localSession of localClaudeSessions) {
+      for (const localSession of untrackedLocalClaudeSessions) {
         const value = `__claude__:${localSession.sessionId}`;
         const preview = localSession.firstPrompt ? ` — ${localSession.firstPrompt}` : '';
         choices.push({
-          name: `Resume Claude ${localSession.sessionId.slice(0, 8)} (${new Date(localSession.modified).toLocaleString()})${preview}`,
+          name: `Resume Claude local ${localSession.sessionId.slice(0, 8)} (${new Date(localSession.modified).toLocaleString()})${preview}`,
           value,
         });
         sessionChoiceByValue.set(value, localSession.sessionId);

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -8,8 +8,8 @@
 import { spawn } from 'child_process';
 import chalk from 'chalk';
 import { randomUUID } from 'crypto';
-import { existsSync, readFileSync } from 'fs';
-import { join } from 'path';
+import { existsSync, readFileSync, readdirSync, realpathSync } from 'fs';
+import { join, resolve as resolvePath } from 'path';
 import { homedir } from 'os';
 import { getBackend, resolveAgentId } from '../backends/index.js';
 import { getValidAccessToken } from '../auth/tokens.js';
@@ -41,10 +41,20 @@ interface PcpSessionSummary {
   backend?: string | null;
   backendSessionId?: string | null;
   claudeSessionId?: string | null;
+  workingDir?: string | null;
 }
 
 interface ListSessionsResult {
   sessions?: PcpSessionSummary[];
+}
+
+interface ClaudeLocalSessionSummary {
+  sessionId: string;
+  projectPath: string;
+  modified: string;
+  firstPrompt?: string;
+  messageCount?: number;
+  gitBranch?: string;
 }
 
 function isPromptCancelError(err: unknown): boolean {
@@ -107,6 +117,129 @@ function getIdentityContextFromIdentityJson(cwd = process.cwd()): {
   } catch {
     return {};
   }
+}
+
+function normalizePath(path: string | null | undefined): string | null {
+  if (!path) return null;
+  try {
+    return realpathSync(path);
+  } catch {
+    try {
+      return resolvePath(path);
+    } catch {
+      return null;
+    }
+  }
+}
+
+export function filterPcpSessionsForContext(
+  sessions: PcpSessionSummary[],
+  backend: string,
+  cwd = process.cwd(),
+  localClaudeSessionIds: Set<string> = new Set()
+): PcpSessionSummary[] {
+  const normalizedCwd = normalizePath(cwd);
+
+  const backendMatched = sessions.filter((session) => {
+    if (!session.backend) return true;
+    return session.backend === backend;
+  });
+
+  if (backend !== 'claude' || !normalizedCwd) {
+    return backendMatched;
+  }
+
+  return backendMatched.filter((session) => {
+    const localMatchedId = session.backendSessionId || session.claudeSessionId;
+    if (localMatchedId && localClaudeSessionIds.has(localMatchedId)) return true;
+
+    const normalizedWorkingDir = normalizePath(session.workingDir);
+    return !!normalizedWorkingDir && normalizedWorkingDir === normalizedCwd;
+  });
+}
+
+export function getClaudeLocalSessionsForProject(
+  cwd = process.cwd(),
+  limit = 20
+): ClaudeLocalSessionSummary[] {
+  const claudeProjectsDir = join(homedir(), '.claude', 'projects');
+  if (!existsSync(claudeProjectsDir)) return [];
+
+  const normalizedCwd = normalizePath(cwd);
+  if (!normalizedCwd) return [];
+
+  const results: ClaudeLocalSessionSummary[] = [];
+
+  for (const entry of readdirSync(claudeProjectsDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const indexPath = join(claudeProjectsDir, entry.name, 'sessions-index.json');
+    if (!existsSync(indexPath)) continue;
+
+    try {
+      const parsed = JSON.parse(readFileSync(indexPath, 'utf-8')) as {
+        entries?: Array<{
+          sessionId?: string;
+          projectPath?: string;
+          modified?: string;
+          firstPrompt?: string;
+          messageCount?: number;
+          gitBranch?: string;
+        }>;
+      };
+
+      for (const item of parsed.entries || []) {
+        if (!item.sessionId || !item.projectPath || !item.modified) continue;
+        const normalizedProjectPath = normalizePath(item.projectPath);
+        if (!normalizedProjectPath || normalizedProjectPath !== normalizedCwd) continue;
+
+        results.push({
+          sessionId: item.sessionId,
+          projectPath: item.projectPath,
+          modified: item.modified,
+          firstPrompt: item.firstPrompt,
+          messageCount: item.messageCount,
+          gitBranch: item.gitBranch,
+        });
+      }
+    } catch {
+      // Ignore malformed local index files and continue.
+    }
+  }
+
+  const dedupedBySessionId = new Map<string, ClaudeLocalSessionSummary>();
+  for (const session of results) {
+    const existing = dedupedBySessionId.get(session.sessionId);
+    if (!existing || new Date(session.modified).getTime() > new Date(existing.modified).getTime()) {
+      dedupedBySessionId.set(session.sessionId, session);
+    }
+  }
+
+  return Array.from(dedupedBySessionId.values())
+    .sort((a, b) => new Date(b.modified).getTime() - new Date(a.modified).getTime())
+    .slice(0, limit);
+}
+
+function printPcpUnavailableWarning(reason: string, cwd = process.cwd()): void {
+  console.log(chalk.yellow(`\n⚠ PCP session service unavailable (${reason}).`));
+  const mcpPath = join(cwd, '.mcp.json');
+  if (!existsSync(mcpPath)) {
+    console.log(chalk.yellow('  .mcp.json not found in this repo.'));
+  } else {
+    try {
+      const parsed = JSON.parse(readFileSync(mcpPath, 'utf-8')) as {
+        mcpServers?: Record<string, unknown>;
+      };
+      if (!parsed.mcpServers?.pcp) {
+        console.log(chalk.yellow('  .mcp.json is missing mcpServers.pcp.'));
+      }
+    } catch {
+      console.log(chalk.yellow('  .mcp.json could not be parsed.'));
+    }
+  }
+  console.log(chalk.dim('  To reconnect PCP features:'));
+  console.log(chalk.dim('    sb auth login'));
+  console.log(chalk.dim('    sb init'));
+  console.log(chalk.dim('    sb status'));
 }
 
 export function hasBackendSessionOverride(
@@ -223,6 +356,7 @@ async function persistBackendSessionLink(options: {
       sessionId: options.pcpSessionId,
       backendSessionId: options.backendSessionId,
       status: 'active',
+      workingDir: process.cwd(),
     });
   } catch {
     // Best-effort linkage update only.
@@ -240,10 +374,11 @@ async function ensurePcpSessionContext(
 
   const config = getPcpConfig();
   const email = config?.email;
-  if (!email) return {};
-
   const cwd = process.cwd();
   const { studioId, identityId } = getIdentityContextFromIdentityJson(cwd);
+  const localClaudeSessions = backend === 'claude' ? getClaudeLocalSessionsForProject(cwd, 20) : [];
+  const localClaudeSessionIds = new Set(localClaudeSessions.map((session) => session.sessionId));
+  const sessionChoiceByValue = new Map<string, string>();
 
   // Fast path: runtime already knows current session for this backend.
   const existing = getCurrentRuntimeSession(cwd, backend);
@@ -256,57 +391,42 @@ async function ensurePcpSessionContext(
 
   // Pull active session list so caller can resume or start new.
   let activeSessions: PcpSessionSummary[] = [];
-  try {
-    const listed = await callPcpTool<ListSessionsResult>('list_sessions', {
-      email,
-      agentId,
-      ...(studioId ? { studioId } : {}),
-      limit: 20,
-    });
-    activeSessions = (listed.sessions || []).filter((s) => !s.endedAt);
-  } catch {
-    // Non-fatal; fallback to start new below.
-  }
+  let pcpAvailable = Boolean(email);
+  let pcpUnavailableReason: string | undefined;
 
-  let chosen: PcpSessionSummary | undefined;
-
-  if (process.stdin.isTTY) {
-    const choices = activeSessions.map((s) => ({
-      name: `Resume ${s.id.slice(0, 8)}${s.threadKey ? ` (${s.threadKey})` : ''}${s.currentPhase ? ` — ${s.currentPhase}` : ''}`,
-      value: s.id,
-    }));
-    choices.unshift({ name: 'Start new session', value: '__new__' });
-
+  if (!email) {
+    pcpAvailable = false;
+    pcpUnavailableReason = 'not authenticated';
+  } else {
     try {
-      const { select } = await import('@inquirer/prompts');
-      const selection = await select({
-        message: `Session for ${agentId}/${backend}`,
-        choices,
+      const listed = await callPcpTool<ListSessionsResult>('list_sessions', {
+        email,
+        agentId,
+        ...(studioId ? { studioId } : {}),
+        limit: 20,
       });
-      if (selection === '__new__') {
-        const newSessionId = randomUUID();
-        const started = await callPcpTool<{ session?: PcpSessionSummary }>('start_session', {
-          email,
-          agentId,
-          ...(studioId ? { studioId } : {}),
-          backend,
-          forceNew: true,
-          sessionId: newSessionId,
-        });
-        chosen = started.session || { id: newSessionId, startedAt: new Date().toISOString() };
-      } else {
-        chosen = activeSessions.find((s) => s.id === selection);
-      }
+      activeSessions = filterPcpSessionsForContext(
+        (listed.sessions || []).filter((s) => !s.endedAt),
+        backend,
+        cwd,
+        localClaudeSessionIds
+      );
     } catch (err) {
-      if (isPromptCancelError(err)) {
-        console.log(chalk.yellow('\nSession selection canceled.'));
-        process.exit(130);
-      }
-      // Prompt canceled or unavailable; fallback to start new.
+      pcpAvailable = false;
+      pcpUnavailableReason = err instanceof Error ? err.message : 'request failed';
     }
   }
 
-  if (!chosen) {
+  if (!pcpAvailable) {
+    printPcpUnavailableWarning(pcpUnavailableReason || 'unknown error', cwd);
+  }
+
+  let chosen: PcpSessionSummary | undefined;
+  let selectedLocalBackendSessionId: string | undefined;
+
+  const startNewPcpSession = async (): Promise<PcpSessionSummary | undefined> => {
+    if (!pcpAvailable || !email) return undefined;
+
     const newSessionId = randomUUID();
     try {
       const started = await callPcpTool<{ session?: PcpSessionSummary }>('start_session', {
@@ -317,13 +437,84 @@ async function ensurePcpSessionContext(
         forceNew: true,
         sessionId: newSessionId,
       });
-      chosen = started.session || { id: newSessionId, startedAt: new Date().toISOString() };
+      return started.session || { id: newSessionId, startedAt: new Date().toISOString() };
     } catch {
-      chosen = { id: newSessionId, startedAt: new Date().toISOString() };
+      return { id: newSessionId, startedAt: new Date().toISOString() };
+    }
+  };
+
+  if (process.stdin.isTTY) {
+    const choices: Array<{ name: string; value: string }> = [
+      {
+        name: pcpAvailable ? 'Start new session' : 'Start new backend session',
+        value: '__new__',
+      },
+    ];
+
+    for (const session of activeSessions) {
+      const value = `__pcp__:${session.id}`;
+      choices.push({
+        name: `Resume PCP ${session.id.slice(0, 8)}${session.threadKey ? ` (${session.threadKey})` : ''}${session.currentPhase ? ` — ${session.currentPhase}` : ''}`,
+        value,
+      });
+      sessionChoiceByValue.set(value, session.id);
+    }
+
+    if (backend === 'claude') {
+      for (const localSession of localClaudeSessions) {
+        const value = `__claude__:${localSession.sessionId}`;
+        const preview = localSession.firstPrompt ? ` — ${localSession.firstPrompt}` : '';
+        choices.push({
+          name: `Resume Claude ${localSession.sessionId.slice(0, 8)} (${new Date(localSession.modified).toLocaleString()})${preview}`,
+          value,
+        });
+        sessionChoiceByValue.set(value, localSession.sessionId);
+      }
+    }
+
+    try {
+      const { select } = await import('@inquirer/prompts');
+      const selection = await select({
+        message: `Session for ${agentId}/${backend}`,
+        choices,
+      });
+      if (selection === '__new__') {
+        chosen = await startNewPcpSession();
+      } else if (selection.startsWith('__pcp__:')) {
+        const sessionId = sessionChoiceByValue.get(selection);
+        chosen = activeSessions.find((session) => session.id === sessionId);
+      } else if (selection.startsWith('__claude__:')) {
+        selectedLocalBackendSessionId = sessionChoiceByValue.get(selection);
+        if (selectedLocalBackendSessionId && pcpAvailable) {
+          chosen = await startNewPcpSession();
+        }
+      }
+    } catch (err) {
+      if (isPromptCancelError(err)) {
+        console.log(chalk.yellow('\nSession selection canceled.'));
+        process.exit(130);
+      }
+      // Prompt canceled or unavailable; fallback to start new.
     }
   }
 
+  if (!chosen && !selectedLocalBackendSessionId && pcpAvailable) {
+    chosen = await startNewPcpSession();
+  }
+
+  if (!chosen?.id && !selectedLocalBackendSessionId) return {};
+
+  if (!chosen?.id && selectedLocalBackendSessionId) {
+    return { backendSessionId: selectedLocalBackendSessionId };
+  }
+
   if (!chosen?.id) return {};
+
+  const backendSessionId =
+    selectedLocalBackendSessionId ||
+    (!chosen.backend || chosen.backend === backend
+      ? chosen.backendSessionId || chosen.claudeSessionId || undefined
+      : undefined);
 
   upsertRuntimeSession(cwd, {
     pcpSessionId: chosen.id,
@@ -332,10 +523,7 @@ async function ensurePcpSessionContext(
     ...(identityId ? { identityId } : {}),
     ...(studioId ? { studioId } : {}),
     ...(chosen.threadKey ? { threadKey: chosen.threadKey } : {}),
-    ...((!chosen.backend || chosen.backend === backend) &&
-    (chosen.backendSessionId || chosen.claudeSessionId)
-      ? { backendSessionId: chosen.backendSessionId || chosen.claudeSessionId || undefined }
-      : {}),
+    ...(backendSessionId ? { backendSessionId } : {}),
     startedAt: chosen.startedAt,
   });
   setCurrentRuntimeSession(cwd, chosen.id, backend, {
@@ -346,12 +534,24 @@ async function ensurePcpSessionContext(
 
   if (verbose) {
     console.log(chalk.dim(`PCP session: ${chosen.id}`));
+    if (backendSessionId) {
+      console.log(chalk.dim(`Backend session: ${backendSessionId}`));
+    }
   }
 
-  const backendSessionId =
-    !chosen.backend || chosen.backend === backend
-      ? chosen.backendSessionId || chosen.claudeSessionId || undefined
-      : undefined;
+  if (email) {
+    try {
+      await callPcpTool('update_session_phase', {
+        email,
+        agentId,
+        sessionId: chosen.id,
+        status: 'active',
+        workingDir: cwd,
+      });
+    } catch {
+      // Best-effort only.
+    }
+  }
 
   return {
     pcpSessionId: chosen.id,

--- a/packages/cli/src/commands/hooks.ts
+++ b/packages/cli/src/commands/hooks.ts
@@ -559,6 +559,7 @@ async function updateRuntimeGenerationState(
       sessionId,
       phase,
       status: 'active',
+      workingDir: cwd,
     });
   } catch {
     // Non-fatal; hook execution should not fail due to transient session sync issues.
@@ -1463,6 +1464,7 @@ async function onSessionStartHandler(): Promise<void> {
         sessionId: pcpSessionId,
         phase: 'runtime:idle',
         status: 'active',
+        workingDir: cwd,
       };
       if (backendSessionId) updateArgs.backendSessionId = backendSessionId;
       await callPcpTool('update_session_phase', updateArgs);


### PR DESCRIPTION
## Summary
- Fix `sb -b claude` session selection so resumable sessions are project-path scoped.
- Add local Claude session discovery from `~/.claude/projects/*/sessions-index.json` and include those in the interactive picker.
- Filter PCP sessions for Claude by `workingDir` (with fallback match via known local Claude session IDs).
- If PCP session services are unavailable/not configured, print explicit guidance (`sb auth login`, `sb init`, `sb status`) instead of silently falling back.
- Persist `workingDir` on `update_session_phase` updates so future resume filtering can reliably scope by project path.

## Why
A user resumed Claude in another repo and confirmed a valid local Claude resume ID existed, but `sb -a wren -b claude` only showed "Start new session". This was caused by relying on PCP session listing without project-path-aware Claude-local fallback and without clear PCP availability diagnostics.

## Validation
- `yarn workspace @personal-context/cli type-check`
- `yarn workspace @personal-context/cli test`
- `yarn workspace @personal-context/cli build`

## Notes
- This keeps backend-native Claude resumes available even when PCP auth/server/config is missing.
- Session tracking remains best-effort; warnings now surface remediation steps clearly.

— Lumen