### PR TITLE
feat: map backend-native Codex/Gemini sessions in sb picker (by Lumen)

### DIFF
--- a/packages/cli/src/backends/adapters.test.ts
+++ b/packages/cli/src/backends/adapters.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { CodexAdapter } from './codex.js';
+import { GeminiAdapter } from './gemini.js';
+
+describe('backend adapters session resume wiring', () => {
+  it('passes backendSessionId through codex resume subcommand', () => {
+    const adapter = new CodexAdapter();
+    const prepared = adapter.prepare({
+      agentId: 'lumen',
+      model: undefined,
+      promptParts: ['continue', 'work'],
+      passthroughArgs: [],
+      backendSessionId: 'codex-session-123',
+    });
+
+    try {
+      expect(prepared.args).toContain('resume');
+      expect(prepared.args).toContain('codex-session-123');
+    } finally {
+      prepared.cleanup();
+    }
+  });
+
+  it('passes backendSessionId through gemini --resume flag', () => {
+    const adapter = new GeminiAdapter();
+    const prepared = adapter.prepare({
+      agentId: 'aster',
+      model: undefined,
+      promptParts: [],
+      passthroughArgs: [],
+      backendSessionId: 'gemini-session-456',
+    });
+
+    try {
+      const resumeFlagIndex = prepared.args.indexOf('--resume');
+      expect(resumeFlagIndex).toBeGreaterThanOrEqual(0);
+      expect(prepared.args[resumeFlagIndex + 1]).toBe('gemini-session-456');
+    } finally {
+      prepared.cleanup();
+    }
+  });
+});

--- a/packages/cli/src/backends/codex.ts
+++ b/packages/cli/src/backends/codex.ts
@@ -27,6 +27,11 @@ export class CodexAdapter implements BackendAdapter {
       args.push('--model', config.model);
     }
 
+    // Resume a specific backend-native Codex session when available.
+    if (config.backendSessionId) {
+      args.push('resume', config.backendSessionId);
+    }
+
     // Passthrough flags
     args.push(...config.passthroughArgs);
 

--- a/packages/cli/src/backends/gemini.ts
+++ b/packages/cli/src/backends/gemini.ts
@@ -30,6 +30,11 @@ export class GeminiAdapter implements BackendAdapter {
       args.push('-p');
     }
 
+    // Resume a specific backend-native Gemini session when available.
+    if (config.backendSessionId) {
+      args.push('--resume', config.backendSessionId);
+    }
+
     // Passthrough flags
     args.push(...config.passthroughArgs);
 

--- a/packages/cli/src/commands/claude.test.ts
+++ b/packages/cli/src/commands/claude.test.ts
@@ -96,6 +96,29 @@ describe('filterPcpSessionsForContext', () => {
 
     expect(filtered.map((session) => session.id)).toEqual(['codex-1']);
   });
+
+  it('path-scopes codex sessions when workingDir data is available', () => {
+    const filtered = filterPcpSessionsForContext(
+      [
+        {
+          id: 'codex-a',
+          startedAt: '2026-02-28T00:00:00.000Z',
+          backend: 'codex',
+          workingDir: '/tmp/project-a',
+        },
+        {
+          id: 'codex-b',
+          startedAt: '2026-02-28T00:00:00.000Z',
+          backend: 'codex',
+          workingDir: '/tmp/project-b',
+        },
+      ],
+      'codex',
+      '/tmp/project-a'
+    );
+
+    expect(filtered.map((session) => session.id)).toEqual(['codex-a']);
+  });
 });
 
 describe('filterUntrackedLocalClaudeSessions', () => {

--- a/packages/cli/src/commands/claude.test.ts
+++ b/packages/cli/src/commands/claude.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { filterPcpSessionsForContext, hasBackendSessionOverride } from './claude.js';
+import {
+  filterPcpSessionsForContext,
+  filterUntrackedLocalClaudeSessions,
+  hasBackendSessionOverride,
+} from './claude.js';
 
 describe('hasBackendSessionOverride', () => {
   it('detects explicit Codex resume subcommand in positional prompt parts', () => {
@@ -91,5 +95,33 @@ describe('filterPcpSessionsForContext', () => {
     );
 
     expect(filtered.map((session) => session.id)).toEqual(['codex-1']);
+  });
+});
+
+describe('filterUntrackedLocalClaudeSessions', () => {
+  it('excludes local claude sessions already represented by PCP sessions', () => {
+    const local = [
+      {
+        sessionId: 'claude-1',
+        projectPath: '/tmp/project',
+        modified: '2026-02-28T00:00:00.000Z',
+      },
+      {
+        sessionId: 'claude-2',
+        projectPath: '/tmp/project',
+        modified: '2026-02-28T00:00:00.000Z',
+      },
+    ];
+
+    const filtered = filterUntrackedLocalClaudeSessions(local, [
+      {
+        id: 'pcp-1',
+        startedAt: '2026-02-28T00:00:00.000Z',
+        backend: 'claude',
+        backendSessionId: 'claude-1',
+      },
+    ]);
+
+    expect(filtered.map((session) => session.sessionId)).toEqual(['claude-2']);
   });
 });

--- a/packages/cli/src/commands/claude.test.ts
+++ b/packages/cli/src/commands/claude.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { hasBackendSessionOverride } from './claude.js';
+import { filterPcpSessionsForContext, hasBackendSessionOverride } from './claude.js';
 
 describe('hasBackendSessionOverride', () => {
   it('detects explicit Codex resume subcommand in positional prompt parts', () => {
@@ -25,5 +25,71 @@ describe('hasBackendSessionOverride', () => {
     expect(hasBackendSessionOverride('codex', ['--resume', 'abc123'])).toBe(true);
     expect(hasBackendSessionOverride('claude', ['--resume', 'abc123'])).toBe(true);
     expect(hasBackendSessionOverride('gemini', ['--session-id', 'abc123'])).toBe(true);
+  });
+});
+
+describe('filterPcpSessionsForContext', () => {
+  it('filters claude sessions by workingDir when present', () => {
+    const filtered = filterPcpSessionsForContext(
+      [
+        {
+          id: 'a',
+          startedAt: '2026-02-28T00:00:00.000Z',
+          backend: 'claude',
+          workingDir: '/tmp/project-a',
+        },
+        {
+          id: 'b',
+          startedAt: '2026-02-28T00:00:00.000Z',
+          backend: 'claude',
+          workingDir: '/tmp/project-b',
+        },
+      ],
+      'claude',
+      '/tmp/project-a'
+    );
+
+    expect(filtered.map((session) => session.id)).toEqual(['a']);
+  });
+
+  it('retains claude sessions without workingDir when local claude session id matches', () => {
+    const filtered = filterPcpSessionsForContext(
+      [
+        {
+          id: 'pcp-1',
+          startedAt: '2026-02-28T00:00:00.000Z',
+          backend: 'claude',
+          backendSessionId: 'claude-local-123',
+        },
+      ],
+      'claude',
+      '/tmp/project-a',
+      new Set(['claude-local-123'])
+    );
+
+    expect(filtered.map((session) => session.id)).toEqual(['pcp-1']);
+  });
+
+  it('filters non-claude sessions only by backend', () => {
+    const filtered = filterPcpSessionsForContext(
+      [
+        {
+          id: 'codex-1',
+          startedAt: '2026-02-28T00:00:00.000Z',
+          backend: 'codex',
+          workingDir: '/tmp/other',
+        },
+        {
+          id: 'gemini-1',
+          startedAt: '2026-02-28T00:00:00.000Z',
+          backend: 'gemini',
+          workingDir: '/tmp/project',
+        },
+      ],
+      'codex',
+      '/tmp/project'
+    );
+
+    expect(filtered.map((session) => session.id)).toEqual(['codex-1']);
   });
 });

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -57,6 +57,23 @@ interface ClaudeLocalSessionSummary {
   gitBranch?: string;
 }
 
+function getSessionBackendId(session: PcpSessionSummary): string | undefined {
+  return session.backendSessionId || session.claudeSessionId || undefined;
+}
+
+export function filterUntrackedLocalClaudeSessions(
+  localSessions: ClaudeLocalSessionSummary[],
+  activePcpSessions: PcpSessionSummary[]
+): ClaudeLocalSessionSummary[] {
+  const trackedSessionIds = new Set(
+    activePcpSessions
+      .map((session) => getSessionBackendId(session))
+      .filter((sessionId): sessionId is string => Boolean(sessionId))
+  );
+
+  return localSessions.filter((session) => !trackedSessionIds.has(session.sessionId));
+}
+
 function isPromptCancelError(err: unknown): boolean {
   if (!err || typeof err !== 'object') return false;
   const maybe = err as { name?: string; message?: string };
@@ -421,6 +438,11 @@ async function ensurePcpSessionContext(
     printPcpUnavailableWarning(pcpUnavailableReason || 'unknown error', cwd);
   }
 
+  const untrackedLocalClaudeSessions =
+    backend === 'claude'
+      ? filterUntrackedLocalClaudeSessions(localClaudeSessions, activeSessions)
+      : [];
+
   let chosen: PcpSessionSummary | undefined;
   let selectedLocalBackendSessionId: string | undefined;
 
@@ -453,19 +475,21 @@ async function ensurePcpSessionContext(
 
     for (const session of activeSessions) {
       const value = `__pcp__:${session.id}`;
+      const linkedBackendSessionId =
+        backend === 'claude' ? getSessionBackendId(session) : undefined;
       choices.push({
-        name: `Resume PCP ${session.id.slice(0, 8)}${session.threadKey ? ` (${session.threadKey})` : ''}${session.currentPhase ? ` — ${session.currentPhase}` : ''}`,
+        name: `Resume PCP ${session.id.slice(0, 8)}${session.threadKey ? ` (${session.threadKey})` : ''}${session.currentPhase ? ` — ${session.currentPhase}` : ''}${linkedBackendSessionId ? ` · tracks Claude ${linkedBackendSessionId.slice(0, 8)}` : ''}`,
         value,
       });
       sessionChoiceByValue.set(value, session.id);
     }
 
     if (backend === 'claude') {
-      for (const localSession of localClaudeSessions) {
+      for (const localSession of untrackedLocalClaudeSessions) {
         const value = `__claude__:${localSession.sessionId}`;
         const preview = localSession.firstPrompt ? ` — ${localSession.firstPrompt}` : '';
         choices.push({
-          name: `Resume Claude ${localSession.sessionId.slice(0, 8)} (${new Date(localSession.modified).toLocaleString()})${preview}`,
+          name: `Resume Claude local ${localSession.sessionId.slice(0, 8)} (${new Date(localSession.modified).toLocaleString()})${preview}`,
           value,
         });
         sessionChoiceByValue.set(value, localSession.sessionId);

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -8,8 +8,8 @@
 import { spawn } from 'child_process';
 import chalk from 'chalk';
 import { randomUUID } from 'crypto';
-import { existsSync, readFileSync } from 'fs';
-import { join } from 'path';
+import { existsSync, readFileSync, readdirSync, realpathSync } from 'fs';
+import { join, resolve as resolvePath } from 'path';
 import { homedir } from 'os';
 import { getBackend, resolveAgentId } from '../backends/index.js';
 import { getValidAccessToken } from '../auth/tokens.js';
@@ -41,10 +41,20 @@ interface PcpSessionSummary {
   backend?: string | null;
   backendSessionId?: string | null;
   claudeSessionId?: string | null;
+  workingDir?: string | null;
 }
 
 interface ListSessionsResult {
   sessions?: PcpSessionSummary[];
+}
+
+interface ClaudeLocalSessionSummary {
+  sessionId: string;
+  projectPath: string;
+  modified: string;
+  firstPrompt?: string;
+  messageCount?: number;
+  gitBranch?: string;
 }
 
 function isPromptCancelError(err: unknown): boolean {
@@ -107,6 +117,129 @@ function getIdentityContextFromIdentityJson(cwd = process.cwd()): {
   } catch {
     return {};
   }
+}
+
+function normalizePath(path: string | null | undefined): string | null {
+  if (!path) return null;
+  try {
+    return realpathSync(path);
+  } catch {
+    try {
+      return resolvePath(path);
+    } catch {
+      return null;
+    }
+  }
+}
+
+export function filterPcpSessionsForContext(
+  sessions: PcpSessionSummary[],
+  backend: string,
+  cwd = process.cwd(),
+  localClaudeSessionIds: Set<string> = new Set()
+): PcpSessionSummary[] {
+  const normalizedCwd = normalizePath(cwd);
+
+  const backendMatched = sessions.filter((session) => {
+    if (!session.backend) return true;
+    return session.backend === backend;
+  });
+
+  if (backend !== 'claude' || !normalizedCwd) {
+    return backendMatched;
+  }
+
+  return backendMatched.filter((session) => {
+    const localMatchedId = session.backendSessionId || session.claudeSessionId;
+    if (localMatchedId && localClaudeSessionIds.has(localMatchedId)) return true;
+
+    const normalizedWorkingDir = normalizePath(session.workingDir);
+    return !!normalizedWorkingDir && normalizedWorkingDir === normalizedCwd;
+  });
+}
+
+export function getClaudeLocalSessionsForProject(
+  cwd = process.cwd(),
+  limit = 20
+): ClaudeLocalSessionSummary[] {
+  const claudeProjectsDir = join(homedir(), '.claude', 'projects');
+  if (!existsSync(claudeProjectsDir)) return [];
+
+  const normalizedCwd = normalizePath(cwd);
+  if (!normalizedCwd) return [];
+
+  const results: ClaudeLocalSessionSummary[] = [];
+
+  for (const entry of readdirSync(claudeProjectsDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const indexPath = join(claudeProjectsDir, entry.name, 'sessions-index.json');
+    if (!existsSync(indexPath)) continue;
+
+    try {
+      const parsed = JSON.parse(readFileSync(indexPath, 'utf-8')) as {
+        entries?: Array<{
+          sessionId?: string;
+          projectPath?: string;
+          modified?: string;
+          firstPrompt?: string;
+          messageCount?: number;
+          gitBranch?: string;
+        }>;
+      };
+
+      for (const item of parsed.entries || []) {
+        if (!item.sessionId || !item.projectPath || !item.modified) continue;
+        const normalizedProjectPath = normalizePath(item.projectPath);
+        if (!normalizedProjectPath || normalizedProjectPath !== normalizedCwd) continue;
+
+        results.push({
+          sessionId: item.sessionId,
+          projectPath: item.projectPath,
+          modified: item.modified,
+          firstPrompt: item.firstPrompt,
+          messageCount: item.messageCount,
+          gitBranch: item.gitBranch,
+        });
+      }
+    } catch {
+      // Ignore malformed local index files and continue.
+    }
+  }
+
+  const dedupedBySessionId = new Map<string, ClaudeLocalSessionSummary>();
+  for (const session of results) {
+    const existing = dedupedBySessionId.get(session.sessionId);
+    if (!existing || new Date(session.modified).getTime() > new Date(existing.modified).getTime()) {
+      dedupedBySessionId.set(session.sessionId, session);
+    }
+  }
+
+  return Array.from(dedupedBySessionId.values())
+    .sort((a, b) => new Date(b.modified).getTime() - new Date(a.modified).getTime())
+    .slice(0, limit);
+}
+
+function printPcpUnavailableWarning(reason: string, cwd = process.cwd()): void {
+  console.log(chalk.yellow(`\n⚠ PCP session service unavailable (${reason}).`));
+  const mcpPath = join(cwd, '.mcp.json');
+  if (!existsSync(mcpPath)) {
+    console.log(chalk.yellow('  .mcp.json not found in this repo.'));
+  } else {
+    try {
+      const parsed = JSON.parse(readFileSync(mcpPath, 'utf-8')) as {
+        mcpServers?: Record<string, unknown>;
+      };
+      if (!parsed.mcpServers?.pcp) {
+        console.log(chalk.yellow('  .mcp.json is missing mcpServers.pcp.'));
+      }
+    } catch {
+      console.log(chalk.yellow('  .mcp.json could not be parsed.'));
+    }
+  }
+  console.log(chalk.dim('  To reconnect PCP features:'));
+  console.log(chalk.dim('    sb auth login'));
+  console.log(chalk.dim('    sb init'));
+  console.log(chalk.dim('    sb status'));
 }
 
 export function hasBackendSessionOverride(
@@ -223,6 +356,7 @@ async function persistBackendSessionLink(options: {
       sessionId: options.pcpSessionId,
       backendSessionId: options.backendSessionId,
       status: 'active',
+      workingDir: process.cwd(),
     });
   } catch {
     // Best-effort linkage update only.
@@ -240,10 +374,11 @@ async function ensurePcpSessionContext(
 
   const config = getPcpConfig();
   const email = config?.email;
-  if (!email) return {};
-
   const cwd = process.cwd();
   const { studioId, identityId } = getIdentityContextFromIdentityJson(cwd);
+  const localClaudeSessions = backend === 'claude' ? getClaudeLocalSessionsForProject(cwd, 20) : [];
+  const localClaudeSessionIds = new Set(localClaudeSessions.map((session) => session.sessionId));
+  const sessionChoiceByValue = new Map<string, string>();
 
   // Fast path: runtime already knows current session for this backend.
   const existing = getCurrentRuntimeSession(cwd, backend);
@@ -256,57 +391,42 @@ async function ensurePcpSessionContext(
 
   // Pull active session list so caller can resume or start new.
   let activeSessions: PcpSessionSummary[] = [];
-  try {
-    const listed = await callPcpTool<ListSessionsResult>('list_sessions', {
-      email,
-      agentId,
-      ...(studioId ? { studioId } : {}),
-      limit: 20,
-    });
-    activeSessions = (listed.sessions || []).filter((s) => !s.endedAt);
-  } catch {
-    // Non-fatal; fallback to start new below.
-  }
+  let pcpAvailable = Boolean(email);
+  let pcpUnavailableReason: string | undefined;
 
-  let chosen: PcpSessionSummary | undefined;
-
-  if (process.stdin.isTTY) {
-    const choices = activeSessions.map((s) => ({
-      name: `Resume ${s.id.slice(0, 8)}${s.threadKey ? ` (${s.threadKey})` : ''}${s.currentPhase ? ` — ${s.currentPhase}` : ''}`,
-      value: s.id,
-    }));
-    choices.unshift({ name: 'Start new session', value: '__new__' });
-
+  if (!email) {
+    pcpAvailable = false;
+    pcpUnavailableReason = 'not authenticated';
+  } else {
     try {
-      const { select } = await import('@inquirer/prompts');
-      const selection = await select({
-        message: `Session for ${agentId}/${backend}`,
-        choices,
+      const listed = await callPcpTool<ListSessionsResult>('list_sessions', {
+        email,
+        agentId,
+        ...(studioId ? { studioId } : {}),
+        limit: 20,
       });
-      if (selection === '__new__') {
-        const newSessionId = randomUUID();
-        const started = await callPcpTool<{ session?: PcpSessionSummary }>('start_session', {
-          email,
-          agentId,
-          ...(studioId ? { studioId } : {}),
-          backend,
-          forceNew: true,
-          sessionId: newSessionId,
-        });
-        chosen = started.session || { id: newSessionId, startedAt: new Date().toISOString() };
-      } else {
-        chosen = activeSessions.find((s) => s.id === selection);
-      }
+      activeSessions = filterPcpSessionsForContext(
+        (listed.sessions || []).filter((s) => !s.endedAt),
+        backend,
+        cwd,
+        localClaudeSessionIds
+      );
     } catch (err) {
-      if (isPromptCancelError(err)) {
-        console.log(chalk.yellow('\nSession selection canceled.'));
-        process.exit(130);
-      }
-      // Prompt canceled or unavailable; fallback to start new.
+      pcpAvailable = false;
+      pcpUnavailableReason = err instanceof Error ? err.message : 'request failed';
     }
   }
 
-  if (!chosen) {
+  if (!pcpAvailable) {
+    printPcpUnavailableWarning(pcpUnavailableReason || 'unknown error', cwd);
+  }
+
+  let chosen: PcpSessionSummary | undefined;
+  let selectedLocalBackendSessionId: string | undefined;
+
+  const startNewPcpSession = async (): Promise<PcpSessionSummary | undefined> => {
+    if (!pcpAvailable || !email) return undefined;
+
     const newSessionId = randomUUID();
     try {
       const started = await callPcpTool<{ session?: PcpSessionSummary }>('start_session', {
@@ -317,13 +437,84 @@ async function ensurePcpSessionContext(
         forceNew: true,
         sessionId: newSessionId,
       });
-      chosen = started.session || { id: newSessionId, startedAt: new Date().toISOString() };
+      return started.session || { id: newSessionId, startedAt: new Date().toISOString() };
     } catch {
-      chosen = { id: newSessionId, startedAt: new Date().toISOString() };
+      return { id: newSessionId, startedAt: new Date().toISOString() };
+    }
+  };
+
+  if (process.stdin.isTTY) {
+    const choices: Array<{ name: string; value: string }> = [
+      {
+        name: pcpAvailable ? 'Start new session' : 'Start new backend session',
+        value: '__new__',
+      },
+    ];
+
+    for (const session of activeSessions) {
+      const value = `__pcp__:${session.id}`;
+      choices.push({
+        name: `Resume PCP ${session.id.slice(0, 8)}${session.threadKey ? ` (${session.threadKey})` : ''}${session.currentPhase ? ` — ${session.currentPhase}` : ''}`,
+        value,
+      });
+      sessionChoiceByValue.set(value, session.id);
+    }
+
+    if (backend === 'claude') {
+      for (const localSession of localClaudeSessions) {
+        const value = `__claude__:${localSession.sessionId}`;
+        const preview = localSession.firstPrompt ? ` — ${localSession.firstPrompt}` : '';
+        choices.push({
+          name: `Resume Claude ${localSession.sessionId.slice(0, 8)} (${new Date(localSession.modified).toLocaleString()})${preview}`,
+          value,
+        });
+        sessionChoiceByValue.set(value, localSession.sessionId);
+      }
+    }
+
+    try {
+      const { select } = await import('@inquirer/prompts');
+      const selection = await select({
+        message: `Session for ${agentId}/${backend}`,
+        choices,
+      });
+      if (selection === '__new__') {
+        chosen = await startNewPcpSession();
+      } else if (selection.startsWith('__pcp__:')) {
+        const sessionId = sessionChoiceByValue.get(selection);
+        chosen = activeSessions.find((session) => session.id === sessionId);
+      } else if (selection.startsWith('__claude__:')) {
+        selectedLocalBackendSessionId = sessionChoiceByValue.get(selection);
+        if (selectedLocalBackendSessionId && pcpAvailable) {
+          chosen = await startNewPcpSession();
+        }
+      }
+    } catch (err) {
+      if (isPromptCancelError(err)) {
+        console.log(chalk.yellow('\nSession selection canceled.'));
+        process.exit(130);
+      }
+      // Prompt canceled or unavailable; fallback to start new.
     }
   }
 
+  if (!chosen && !selectedLocalBackendSessionId && pcpAvailable) {
+    chosen = await startNewPcpSession();
+  }
+
+  if (!chosen?.id && !selectedLocalBackendSessionId) return {};
+
+  if (!chosen?.id && selectedLocalBackendSessionId) {
+    return { backendSessionId: selectedLocalBackendSessionId };
+  }
+
   if (!chosen?.id) return {};
+
+  const backendSessionId =
+    selectedLocalBackendSessionId ||
+    (!chosen.backend || chosen.backend === backend
+      ? chosen.backendSessionId || chosen.claudeSessionId || undefined
+      : undefined);
 
   upsertRuntimeSession(cwd, {
     pcpSessionId: chosen.id,
@@ -332,10 +523,7 @@ async function ensurePcpSessionContext(
     ...(identityId ? { identityId } : {}),
     ...(studioId ? { studioId } : {}),
     ...(chosen.threadKey ? { threadKey: chosen.threadKey } : {}),
-    ...((!chosen.backend || chosen.backend === backend) &&
-    (chosen.backendSessionId || chosen.claudeSessionId)
-      ? { backendSessionId: chosen.backendSessionId || chosen.claudeSessionId || undefined }
-      : {}),
+    ...(backendSessionId ? { backendSessionId } : {}),
     startedAt: chosen.startedAt,
   });
   setCurrentRuntimeSession(cwd, chosen.id, backend, {
@@ -346,12 +534,24 @@ async function ensurePcpSessionContext(
 
   if (verbose) {
     console.log(chalk.dim(`PCP session: ${chosen.id}`));
+    if (backendSessionId) {
+      console.log(chalk.dim(`Backend session: ${backendSessionId}`));
+    }
   }
 
-  const backendSessionId =
-    !chosen.backend || chosen.backend === backend
-      ? chosen.backendSessionId || chosen.claudeSessionId || undefined
-      : undefined;
+  if (email) {
+    try {
+      await callPcpTool('update_session_phase', {
+        email,
+        agentId,
+        sessionId: chosen.id,
+        status: 'active',
+        workingDir: cwd,
+      });
+    } catch {
+      // Best-effort only.
+    }
+  }
 
   return {
     pcpSessionId: chosen.id,

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -5,7 +5,7 @@
  * passthrough flags, and session tracking.
  */
 
-import { spawn } from 'child_process';
+import { spawn, spawnSync } from 'child_process';
 import chalk from 'chalk';
 import { randomUUID } from 'crypto';
 import { existsSync, readFileSync, readdirSync, realpathSync } from 'fs';
@@ -48,7 +48,8 @@ interface ListSessionsResult {
   sessions?: PcpSessionSummary[];
 }
 
-interface ClaudeLocalSessionSummary {
+interface BackendLocalSessionSummary {
+  backend: 'claude' | 'codex' | 'gemini';
   sessionId: string;
   projectPath: string;
   modified: string;
@@ -62,9 +63,9 @@ function getSessionBackendId(session: PcpSessionSummary): string | undefined {
 }
 
 export function filterUntrackedLocalClaudeSessions(
-  localSessions: ClaudeLocalSessionSummary[],
+  localSessions: BackendLocalSessionSummary[],
   activePcpSessions: PcpSessionSummary[]
-): ClaudeLocalSessionSummary[] {
+): BackendLocalSessionSummary[] {
   const trackedSessionIds = new Set(
     activePcpSessions
       .map((session) => getSessionBackendId(session))
@@ -149,11 +150,18 @@ function normalizePath(path: string | null | undefined): string | null {
   }
 }
 
+function truncateText(text: string | null | undefined, max = 90): string {
+  if (!text) return '';
+  const compact = text.replace(/\s+/g, ' ').trim();
+  if (compact.length <= max) return compact;
+  return `${compact.slice(0, max - 1)}…`;
+}
+
 export function filterPcpSessionsForContext(
   sessions: PcpSessionSummary[],
   backend: string,
   cwd = process.cwd(),
-  localClaudeSessionIds: Set<string> = new Set()
+  localBackendSessionIds: Set<string> = new Set()
 ): PcpSessionSummary[] {
   const normalizedCwd = normalizePath(cwd);
 
@@ -162,30 +170,32 @@ export function filterPcpSessionsForContext(
     return session.backend === backend;
   });
 
-  if (backend !== 'claude' || !normalizedCwd) {
+  if (!normalizedCwd) {
     return backendMatched;
   }
 
-  return backendMatched.filter((session) => {
+  const pathScoped = backendMatched.filter((session) => {
     const localMatchedId = session.backendSessionId || session.claudeSessionId;
-    if (localMatchedId && localClaudeSessionIds.has(localMatchedId)) return true;
+    if (localMatchedId && localBackendSessionIds.has(localMatchedId)) return true;
 
     const normalizedWorkingDir = normalizePath(session.workingDir);
     return !!normalizedWorkingDir && normalizedWorkingDir === normalizedCwd;
   });
+
+  return pathScoped.length > 0 ? pathScoped : backendMatched;
 }
 
 export function getClaudeLocalSessionsForProject(
   cwd = process.cwd(),
   limit = 20
-): ClaudeLocalSessionSummary[] {
+): BackendLocalSessionSummary[] {
   const claudeProjectsDir = join(homedir(), '.claude', 'projects');
   if (!existsSync(claudeProjectsDir)) return [];
 
   const normalizedCwd = normalizePath(cwd);
   if (!normalizedCwd) return [];
 
-  const results: ClaudeLocalSessionSummary[] = [];
+  const results: BackendLocalSessionSummary[] = [];
 
   for (const entry of readdirSync(claudeProjectsDir, { withFileTypes: true })) {
     if (!entry.isDirectory()) continue;
@@ -210,6 +220,7 @@ export function getClaudeLocalSessionsForProject(
         if (!normalizedProjectPath || normalizedProjectPath !== normalizedCwd) continue;
 
         results.push({
+          backend: 'claude',
           sessionId: item.sessionId,
           projectPath: item.projectPath,
           modified: item.modified,
@@ -223,7 +234,7 @@ export function getClaudeLocalSessionsForProject(
     }
   }
 
-  const dedupedBySessionId = new Map<string, ClaudeLocalSessionSummary>();
+  const dedupedBySessionId = new Map<string, BackendLocalSessionSummary>();
   for (const session of results) {
     const existing = dedupedBySessionId.get(session.sessionId);
     if (!existing || new Date(session.modified).getTime() > new Date(existing.modified).getTime()) {
@@ -234,6 +245,182 @@ export function getClaudeLocalSessionsForProject(
   return Array.from(dedupedBySessionId.values())
     .sort((a, b) => new Date(b.modified).getTime() - new Date(a.modified).getTime())
     .slice(0, limit);
+}
+
+export function getCodexLocalSessionsForProject(
+  cwd = process.cwd(),
+  limit = 20
+): BackendLocalSessionSummary[] {
+  const codexStateDbPath = join(homedir(), '.codex', 'state_5.sqlite');
+  if (!existsSync(codexStateDbPath)) return [];
+
+  const normalizedCwd = normalizePath(cwd);
+  if (!normalizedCwd) return [];
+
+  const query = `
+SELECT id, cwd, updated_at,
+       replace(replace(first_user_message, char(10), ' '), char(9), ' ') AS first_user_message,
+       git_branch
+FROM threads
+WHERE archived = 0
+ORDER BY updated_at DESC
+LIMIT 200;
+`;
+
+  const result = spawnSync('sqlite3', ['-tabs', codexStateDbPath, query], { encoding: 'utf-8' });
+  if (result.error || result.status !== 0 || !result.stdout) return [];
+
+  const sessions: BackendLocalSessionSummary[] = [];
+  const lines = result.stdout.split('\n').map((line) => line.trim());
+  for (const line of lines) {
+    if (!line) continue;
+    const [sessionId, sessionCwd, updatedAtRaw, firstPrompt, gitBranch] = line.split('\t');
+    if (!sessionId || !sessionCwd || !updatedAtRaw) continue;
+
+    const normalizedSessionPath = normalizePath(sessionCwd);
+    if (!normalizedSessionPath || normalizedSessionPath !== normalizedCwd) continue;
+
+    const updatedAtSeconds = Number(updatedAtRaw);
+    const modified = Number.isFinite(updatedAtSeconds)
+      ? new Date(updatedAtSeconds * 1000).toISOString()
+      : new Date().toISOString();
+
+    sessions.push({
+      backend: 'codex',
+      sessionId,
+      projectPath: sessionCwd,
+      modified,
+      firstPrompt: firstPrompt?.trim(),
+      gitBranch: gitBranch?.trim(),
+    });
+  }
+
+  return sessions.slice(0, limit);
+}
+
+function getGeminiProjectKeysForCwd(cwd = process.cwd()): string[] {
+  const normalizedCwd = normalizePath(cwd);
+  if (!normalizedCwd) return [];
+
+  const keys = new Set<string>();
+
+  const projectsJsonPath = join(homedir(), '.gemini', 'projects.json');
+  if (existsSync(projectsJsonPath)) {
+    try {
+      const parsed = JSON.parse(readFileSync(projectsJsonPath, 'utf-8')) as {
+        projects?: Record<string, string>;
+      };
+      for (const [projectPath, projectKey] of Object.entries(parsed.projects || {})) {
+        const normalizedProjectPath = normalizePath(projectPath);
+        if (normalizedProjectPath === normalizedCwd && projectKey) {
+          keys.add(projectKey);
+        }
+      }
+    } catch {
+      // Ignore malformed projects.json
+    }
+  }
+
+  const geminiHistoryDir = join(homedir(), '.gemini', 'history');
+  if (existsSync(geminiHistoryDir)) {
+    for (const entry of readdirSync(geminiHistoryDir, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      const projectRootPath = join(geminiHistoryDir, entry.name, '.project_root');
+      if (!existsSync(projectRootPath)) continue;
+      try {
+        const projectRoot = readFileSync(projectRootPath, 'utf-8').trim();
+        if (normalizePath(projectRoot) === normalizedCwd) {
+          keys.add(entry.name);
+        }
+      } catch {
+        // Ignore unreadable .project_root files
+      }
+    }
+  }
+
+  return Array.from(keys);
+}
+
+function getGeminiSessionsForProjectKey(projectKey: string): BackendLocalSessionSummary[] {
+  const chatsDir = join(homedir(), '.gemini', 'tmp', projectKey, 'chats');
+  if (!existsSync(chatsDir)) return [];
+
+  const sessions: BackendLocalSessionSummary[] = [];
+  const projectRoot = join(homedir(), '.gemini', 'history', projectKey, '.project_root');
+  const projectPath = existsSync(projectRoot)
+    ? readFileSync(projectRoot, 'utf-8').trim()
+    : projectKey;
+
+  for (const entry of readdirSync(chatsDir, { withFileTypes: true })) {
+    if (!entry.isFile() || !entry.name.startsWith('session-') || !entry.name.endsWith('.json')) {
+      continue;
+    }
+    const sessionPath = join(chatsDir, entry.name);
+    try {
+      const parsed = JSON.parse(readFileSync(sessionPath, 'utf-8')) as {
+        sessionId?: string;
+        lastUpdated?: string;
+        startTime?: string;
+        summary?: string;
+        messages?: Array<{ type?: string; content?: string }>;
+      };
+
+      if (!parsed.sessionId) continue;
+      const modified = parsed.lastUpdated || parsed.startTime;
+      if (!modified) continue;
+
+      const firstUserMessage = (parsed.messages || []).find((message) => message.type === 'user');
+      const firstPrompt =
+        parsed.summary ||
+        (typeof firstUserMessage?.content === 'string'
+          ? firstUserMessage.content.trim()
+          : undefined);
+
+      sessions.push({
+        backend: 'gemini',
+        sessionId: parsed.sessionId,
+        projectPath,
+        modified,
+        firstPrompt,
+      });
+    } catch {
+      // Ignore malformed session files.
+    }
+  }
+
+  return sessions;
+}
+
+export function getGeminiLocalSessionsForProject(
+  cwd = process.cwd(),
+  limit = 20
+): BackendLocalSessionSummary[] {
+  const projectKeys = getGeminiProjectKeysForCwd(cwd);
+  if (projectKeys.length === 0) return [];
+
+  const sessions = projectKeys.flatMap((projectKey) => getGeminiSessionsForProjectKey(projectKey));
+  const deduped = new Map<string, BackendLocalSessionSummary>();
+  for (const session of sessions) {
+    const existing = deduped.get(session.sessionId);
+    if (!existing || new Date(session.modified).getTime() > new Date(existing.modified).getTime()) {
+      deduped.set(session.sessionId, session);
+    }
+  }
+
+  return Array.from(deduped.values())
+    .sort((a, b) => new Date(b.modified).getTime() - new Date(a.modified).getTime())
+    .slice(0, limit);
+}
+
+export function getBackendLocalSessionsForProject(
+  backend: string,
+  cwd = process.cwd(),
+  limit = 20
+): BackendLocalSessionSummary[] {
+  if (backend === 'claude') return getClaudeLocalSessionsForProject(cwd, limit);
+  if (backend === 'codex') return getCodexLocalSessionsForProject(cwd, limit);
+  if (backend === 'gemini') return getGeminiLocalSessionsForProject(cwd, limit);
+  return [];
 }
 
 function printPcpUnavailableWarning(reason: string, cwd = process.cwd()): void {
@@ -393,8 +580,8 @@ async function ensurePcpSessionContext(
   const email = config?.email;
   const cwd = process.cwd();
   const { studioId, identityId } = getIdentityContextFromIdentityJson(cwd);
-  const localClaudeSessions = backend === 'claude' ? getClaudeLocalSessionsForProject(cwd, 20) : [];
-  const localClaudeSessionIds = new Set(localClaudeSessions.map((session) => session.sessionId));
+  const localBackendSessions = getBackendLocalSessionsForProject(backend, cwd, 20);
+  const localBackendSessionIds = new Set(localBackendSessions.map((session) => session.sessionId));
   const sessionChoiceByValue = new Map<string, string>();
 
   // Fast path: runtime already knows current session for this backend.
@@ -426,7 +613,7 @@ async function ensurePcpSessionContext(
         (listed.sessions || []).filter((s) => !s.endedAt),
         backend,
         cwd,
-        localClaudeSessionIds
+        localBackendSessionIds
       );
     } catch (err) {
       pcpAvailable = false;
@@ -438,10 +625,10 @@ async function ensurePcpSessionContext(
     printPcpUnavailableWarning(pcpUnavailableReason || 'unknown error', cwd);
   }
 
-  const untrackedLocalClaudeSessions =
+  const untrackedLocalBackendSessions =
     backend === 'claude'
-      ? filterUntrackedLocalClaudeSessions(localClaudeSessions, activeSessions)
-      : [];
+      ? filterUntrackedLocalClaudeSessions(localBackendSessions, activeSessions)
+      : localBackendSessions;
 
   let chosen: PcpSessionSummary | undefined;
   let selectedLocalBackendSessionId: string | undefined;
@@ -484,16 +671,21 @@ async function ensurePcpSessionContext(
       sessionChoiceByValue.set(value, session.id);
     }
 
-    if (backend === 'claude') {
-      for (const localSession of untrackedLocalClaudeSessions) {
-        const value = `__claude__:${localSession.sessionId}`;
-        const preview = localSession.firstPrompt ? ` — ${localSession.firstPrompt}` : '';
-        choices.push({
-          name: `Resume Claude local ${localSession.sessionId.slice(0, 8)} (${new Date(localSession.modified).toLocaleString()})${preview}`,
-          value,
-        });
-        sessionChoiceByValue.set(value, localSession.sessionId);
-      }
+    for (const localSession of untrackedLocalBackendSessions) {
+      const value = `__local__:${localSession.sessionId}`;
+      const preview = localSession.firstPrompt
+        ? ` — ${truncateText(localSession.firstPrompt)}`
+        : '';
+      const backendLabel =
+        localSession.backend[0].toUpperCase() + localSession.backend.slice(1);
+      choices.push({
+        name:
+          localSession.backend === 'claude'
+            ? `Resume Claude local ${localSession.sessionId.slice(0, 8)} (${new Date(localSession.modified).toLocaleString()})${preview}`
+            : `Resume ${backendLabel} local ${localSession.sessionId.slice(0, 8)} (${new Date(localSession.modified).toLocaleString()})${preview}`,
+        value,
+      });
+      sessionChoiceByValue.set(value, localSession.sessionId);
     }
 
     try {
@@ -507,7 +699,7 @@ async function ensurePcpSessionContext(
       } else if (selection.startsWith('__pcp__:')) {
         const sessionId = sessionChoiceByValue.get(selection);
         chosen = activeSessions.find((session) => session.id === sessionId);
-      } else if (selection.startsWith('__claude__:')) {
+      } else if (selection.startsWith('__local__:')) {
         selectedLocalBackendSessionId = sessionChoiceByValue.get(selection);
         if (selectedLocalBackendSessionId && pcpAvailable) {
           chosen = await startNewPcpSession();

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -62,10 +62,10 @@ function getSessionBackendId(session: PcpSessionSummary): string | undefined {
   return session.backendSessionId || session.claudeSessionId || undefined;
 }
 
-export function filterUntrackedLocalClaudeSessions(
-  localSessions: BackendLocalSessionSummary[],
+export function filterUntrackedLocalClaudeSessions<T extends { sessionId: string }>(
+  localSessions: T[],
   activePcpSessions: PcpSessionSummary[]
-): BackendLocalSessionSummary[] {
+): T[] {
   const trackedSessionIds = new Set(
     activePcpSessions
       .map((session) => getSessionBackendId(session))
@@ -676,8 +676,7 @@ async function ensurePcpSessionContext(
       const preview = localSession.firstPrompt
         ? ` — ${truncateText(localSession.firstPrompt)}`
         : '';
-      const backendLabel =
-        localSession.backend[0].toUpperCase() + localSession.backend.slice(1);
+      const backendLabel = localSession.backend[0].toUpperCase() + localSession.backend.slice(1);
       choices.push({
         name:
           localSession.backend === 'claude'

--- a/packages/cli/src/commands/hooks.ts
+++ b/packages/cli/src/commands/hooks.ts
@@ -559,6 +559,7 @@ async function updateRuntimeGenerationState(
       sessionId,
       phase,
       status: 'active',
+      workingDir: cwd,
     });
   } catch {
     // Non-fatal; hook execution should not fail due to transient session sync issues.
@@ -1463,6 +1464,7 @@ async function onSessionStartHandler(): Promise<void> {
         sessionId: pcpSessionId,
         phase: 'runtime:idle',
         status: 'active',
+        workingDir: cwd,
       };
       if (backendSessionId) updateArgs.backendSessionId = backendSessionId;
       await callPcpTool('update_session_phase', updateArgs);


### PR DESCRIPTION
## Summary
- Extend backend-native session mapping beyond Claude, so `sb` can show local resumable sessions for Codex and Gemini too.
- Add Codex local session discovery from `~/.codex/state_5.sqlite` (`threads` table), path-scoped by `cwd`.
- Add Gemini local session discovery from `~/.gemini` project mappings (`projects.json` / `history/*/.project_root`) + `tmp/<project>/chats/session-*.json`.
- Generalize PCP session filtering to path-scope when `workingDir` (or matched backend session IDs) is available.
- Wire backend session IDs into adapters:
  - Codex: `resume <sessionId>`
  - Gemini: `--resume <sessionId>`
- Add/extend tests for adapter resume wiring and path-scoped filtering behavior.

## Why
This follows PR #118's Claude fix with equivalent backend-specific mapping behavior for Codex/Gemini, as requested.

## Validation
- `yarn workspace @personal-context/cli type-check`
- `yarn workspace @personal-context/cli test src/commands/claude.test.ts src/backends/adapters.test.ts`
- `yarn workspace @personal-context/cli build`

## Notes
- This PR is intentionally stacked on top of #118 (base branch is `lumen/fix/claude-path-scoped-resume`) to keep the changes split and reviewable.

— Lumen