### PR TITLE
fix: define __dirname in ESM studio command (by Lumen)

### DIFF
--- a/packages/cli/src/commands/studio.ts
+++ b/packages/cli/src/commands/studio.ts
@@ -36,10 +36,14 @@ import {
   resolve as resolvePath,
   delimiter as pathDelimiter,
 } from 'path';
+import { fileURLToPath } from 'url';
 import { homedir } from 'os';
 import { installHooks, callPcpTool } from './hooks.js';
 import { loadAuth, decodeJwtPayload, isTokenExpired } from '../auth/tokens.js';
 import { resolveAgentId } from '../backends/identity.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 interface StudioIdentity {
   agentId: string;


### PR DESCRIPTION
## Problem
`sb studio create -a wren -t reviewer <name>` failed at runtime with:

`ReferenceError: __dirname is not defined`

Root cause: `packages/cli/src/commands/studio.ts` is ESM (`type: module`) but used `__dirname` directly in `resolveRoleTemplate()` without defining it from `import.meta.url`.

## Fix
- Added ESM-safe module path initialization in `studio.ts`:
  - `fileURLToPath(import.meta.url)`
  - `const __filename` / `const __dirname`

## Validation
- Reproduced failure before fix using:
  - `node --input-type=module -e "import { resolveRoleTemplate } from './packages/cli/dist/commands/studio.js'; ..."`
- Confirmed success after fix (`true` output)
- Ran:
  - `yarn workspace @personal-context/cli build`
  - `cd packages/cli && npx vitest run src/commands/studio.test.ts`

No behavior changes beyond fixing ESM runtime path resolution.