### PR TITLE
fix: enforce workspace scoping across dashboard admin endpoints (by lumen)

### DIFF
--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -2005,8 +2005,9 @@ router.get('/reminders', async (req: Request, res: Response) => {
 
     const { data, error } = await supabase
       .from('scheduled_reminders')
-      .select('*, users(email, first_name), agent_identities(agent_id, name)')
+      .select('*, users(email, first_name), agent_identities!inner(agent_id, name, workspace_id)')
       .eq('user_id', authReq.pcpUserId)
+      .eq('agent_identities.workspace_id', authReq.pcpWorkspaceId)
       .order('next_run_at', { ascending: true })
       .limit(100);
 
@@ -2318,13 +2319,31 @@ router.get('/individuals/:agentId/memories/timeline', async (req: Request, res: 
 
     const supabase = createClient(env.SUPABASE_URL, env.SUPABASE_SECRET_KEY);
     const timeline: TimelineEntry[] = [];
+    const { data: identity } = await supabase
+      .from('agent_identities')
+      .select('id')
+      .eq('user_id', authReq.pcpUserId)
+      .eq('workspace_id', authReq.pcpWorkspaceId)
+      .eq('agent_id', agentId)
+      .maybeSingle();
+
+    if (!identity) {
+      res.json({
+        agentId,
+        timeline: [],
+        total: 0,
+        limit,
+        offset,
+      });
+      return;
+    }
 
     // 1. Get current memories (created events)
     const { data: memories, error: memoriesError } = await supabase
       .from('memories')
       .select('*')
       .eq('user_id', authReq.pcpUserId)
-      .eq('agent_id', agentId)
+      .eq('identity_id', identity.id)
       .order('created_at', { ascending: false });
 
     if (memoriesError) {
@@ -2361,12 +2380,22 @@ router.get('/individuals/:agentId/memories/timeline', async (req: Request, res: 
       const agentMemoryIds = new Set(memories?.map((m) => m.id) || []);
 
       for (const h of history) {
+        const metadata = h.metadata as Record<string, unknown> | null;
         // Include if it's a deleted memory that belonged to this agent
         // or if it's an update to an existing agent memory
         const isAgentMemory = agentMemoryIds.has(h.memory_id);
-        const hasAgentMetadata = (h.metadata as Record<string, unknown>)?.agentId === agentId;
+        const metadataIdentityId =
+          (metadata?.identityId as string | undefined) ||
+          (metadata?.identity_id as string | undefined);
+        const metadataWorkspaceId =
+          (metadata?.workspaceId as string | undefined) ||
+          (metadata?.workspace_id as string | undefined);
+        const metadataAgentId = metadata?.agentId as string | undefined;
+        const hasScopedMetadata =
+          metadataIdentityId === identity.id ||
+          (metadataAgentId === agentId && metadataWorkspaceId === authReq.pcpWorkspaceId);
 
-        if (isAgentMemory || hasAgentMetadata) {
+        if (isAgentMemory || hasScopedMetadata) {
           timeline.push({
             id: `memory-${h.change_type}-${h.id}`,
             type: h.change_type === 'delete' ? 'memory_deleted' : 'memory_updated',
@@ -2389,6 +2418,8 @@ router.get('/individuals/:agentId/memories/timeline', async (req: Request, res: 
       .from('sessions')
       .select('id')
       .eq('user_id', authReq.pcpUserId)
+      .eq('workspace_id', authReq.pcpWorkspaceId)
+      .eq('identity_id', identity.id)
       .eq('agent_id', agentId);
 
     if (sessionsError) {
@@ -2447,9 +2478,30 @@ router.get(
   '/individuals/:agentId/memories/:memoryId/history',
   async (req: Request, res: Response) => {
     try {
-      const { memoryId } = req.params;
+      const { agentId, memoryId } = req.params;
       const supabase = createClient(env.SUPABASE_URL, env.SUPABASE_SECRET_KEY);
       const authReq = req as AdminAuthRequest;
+
+      const { data: identity } = await supabase
+        .from('agent_identities')
+        .select('id')
+        .eq('user_id', authReq.pcpUserId)
+        .eq('workspace_id', authReq.pcpWorkspaceId)
+        .eq('agent_id', agentId)
+        .maybeSingle();
+
+      if (!identity) {
+        res.status(404).json({ error: 'Identity not found in active workspace' });
+        return;
+      }
+
+      const { data: scopedMemory } = await supabase
+        .from('memories')
+        .select('id')
+        .eq('id', memoryId)
+        .eq('user_id', authReq.pcpUserId)
+        .eq('identity_id', identity.id)
+        .maybeSingle();
 
       // Get memory history
       const { data, error } = await supabase
@@ -2465,9 +2517,25 @@ router.get(
         return;
       }
 
+      const scopedHistory = (data || []).filter((h) => {
+        if (scopedMemory) return true;
+        const metadata = h.metadata as Record<string, unknown> | null;
+        const metadataIdentityId =
+          (metadata?.identityId as string | undefined) ||
+          (metadata?.identity_id as string | undefined);
+        const metadataWorkspaceId =
+          (metadata?.workspaceId as string | undefined) ||
+          (metadata?.workspace_id as string | undefined);
+        const metadataAgentId = metadata?.agentId as string | undefined;
+        return (
+          metadataIdentityId === identity.id ||
+          (metadataAgentId === agentId && metadataWorkspaceId === authReq.pcpWorkspaceId)
+        );
+      });
+
       res.json({
         memoryId,
-        history: (data || []).map((h) => ({
+        history: scopedHistory.map((h) => ({
           id: h.id,
           version: h.version,
           content: h.content,
@@ -2510,6 +2578,41 @@ router.get('/individuals/:agentId/inbox', async (req: Request, res: Response) =>
       env.SUPABASE_SECRET_KEY
     );
 
+    const { data: identityRows, error: identityError } = await supabase
+      .from('agent_identities')
+      .select('id')
+      .eq('user_id', authReq.pcpUserId)
+      .eq('workspace_id', authReq.pcpWorkspaceId)
+      .eq('agent_id', agentId);
+
+    if (identityError) {
+      logger.error('Failed to resolve inbox identities for workspace scope:', identityError);
+      res.status(500).json(errorJson('Failed to fetch inbox', identityError));
+      return;
+    }
+
+    const scopedIdentityIds = (identityRows || []).map((row) => row.id);
+    if (scopedIdentityIds.length === 0) {
+      res.json({
+        agentId,
+        stats: {
+          totalMessages: 0,
+          unreadCount: 0,
+          threadCount: 0,
+          flatCount: 0,
+        },
+        threads: [],
+        flatMessages: [],
+        pagination: {
+          limit,
+          offset,
+          totalThreads: 0,
+          hasMore: false,
+        },
+      });
+      return;
+    }
+
     // Fetch messages where this agent is either the sender or recipient
     // to provide a complete inbox view (like email: sent + received)
     const receivedQuery = supabase
@@ -2517,6 +2620,7 @@ router.get('/individuals/:agentId/inbox', async (req: Request, res: Response) =>
       .select('*')
       .eq('recipient_user_id', authReq.pcpUserId)
       .eq('recipient_agent_id', agentId)
+      .in('recipient_identity_id', scopedIdentityIds)
       .order('created_at', { ascending: false })
       .limit(500);
 
@@ -2525,6 +2629,7 @@ router.get('/individuals/:agentId/inbox', async (req: Request, res: Response) =>
       .select('*')
       .eq('recipient_user_id', authReq.pcpUserId)
       .eq('sender_agent_id', agentId)
+      .in('sender_identity_id', scopedIdentityIds)
       .order('created_at', { ascending: false })
       .limit(500);
 
@@ -2582,6 +2687,12 @@ router.get('/individuals/:agentId/inbox', async (req: Request, res: Response) =>
       const threadResult = await threadQuery;
       if (!threadResult.error && threadResult.data) {
         for (const m of threadResult.data) {
+          const hasScopedIdentity =
+            (m.recipient_identity_id && scopedIdentityIds.includes(m.recipient_identity_id)) ||
+            (m.sender_identity_id && scopedIdentityIds.includes(m.sender_identity_id));
+          if (!hasScopedIdentity) {
+            continue;
+          }
           if (!seenIds.has(m.id)) {
             seenIds.add(m.id);
             allMessages.push(m);
@@ -3514,6 +3625,7 @@ router.get('/sessions', async (req: Request, res: Response) => {
       .from('sessions')
       .select('*')
       .eq('user_id', authReq.pcpUserId)
+      .eq('workspace_id', authReq.pcpWorkspaceId)
       .order('updated_at', { ascending: false })
       .limit(100);
 
@@ -3542,6 +3654,7 @@ router.get('/sessions', async (req: Request, res: Response) => {
         .from('agent_identities')
         .select('agent_id, name, role')
         .eq('user_id', authReq.pcpUserId)
+        .eq('workspace_id', authReq.pcpWorkspaceId)
         .in('agent_id', uniqueAgentIds);
 
       for (const identity of identities || []) {
@@ -3746,17 +3859,38 @@ router.get('/studios', async (req: Request, res: Response) => {
       .from('agent_identities')
       .select('id, agent_id, name, role, backend')
       .eq('user_id', authReq.pcpUserId)
+      .eq('workspace_id', authReq.pcpWorkspaceId)
       .order('name', { ascending: true });
 
     // 2. Fetch all non-cleaned studios for this user
-    const { data: studios } = await supabase
-      .from('studios')
-      .select(
-        'id, agent_id, branch, base_branch, purpose, work_type, worktree_path, slug, status, updated_at, created_at'
-      )
-      .eq('user_id', authReq.pcpUserId)
-      .neq('status', 'cleaned')
-      .order('updated_at', { ascending: false });
+    const identityIds = (identities || []).map((i) => i.id).filter(Boolean);
+    let studios: Array<{
+      id: string;
+      agent_id: string | null;
+      branch: string;
+      base_branch: string | null;
+      purpose: string | null;
+      work_type: string | null;
+      worktree_path: string;
+      slug: string | null;
+      status: string;
+      updated_at: string | null;
+      created_at: string | null;
+    }> | null = [];
+
+    if (identityIds.length > 0) {
+      const { data: scopedStudios } = await supabase
+        .from('studios')
+        .select(
+          'id, agent_id, branch, base_branch, purpose, work_type, worktree_path, slug, status, updated_at, created_at'
+        )
+        .eq('user_id', authReq.pcpUserId)
+        .in('identity_id', identityIds)
+        .neq('status', 'cleaned')
+        .order('updated_at', { ascending: false });
+
+      studios = scopedStudios;
+    }
 
     // 3. Fetch latest active session per agent (for status/phase)
     const agentIds = (identities || []).map((i) => i.agent_id).filter(Boolean);
@@ -3770,6 +3904,7 @@ router.get('/studios', async (req: Request, res: Response) => {
         .from('sessions')
         .select('agent_id, current_phase, status, updated_at')
         .eq('user_id', authReq.pcpUserId)
+        .eq('workspace_id', authReq.pcpWorkspaceId)
         .in('agent_id', agentIds)
         .is('ended_at', null)
         .order('updated_at', { ascending: false });
@@ -3862,6 +3997,7 @@ router.get('/sessions/:id/logs', async (req: Request, res: Response) => {
       )
       .eq('id', sessionId)
       .eq('user_id', authReq.pcpUserId)
+      .eq('workspace_id', authReq.pcpWorkspaceId)
       .single();
 
     if (sessionError || !session) {

--- a/packages/web/src/app/(dashboard)/individuals/page.tsx
+++ b/packages/web/src/app/(dashboard)/individuals/page.tsx
@@ -124,9 +124,7 @@ function SharedContextCard({ userIdentity }: { userIdentity: UserIdentity }) {
   const userProfile = userIdentity.userProfile ?? userIdentity.userProfileMd;
   const sharedValues = userIdentity.sharedValues ?? userIdentity.sharedValuesMd;
   const process = userIdentity.process ?? userIdentity.processMd;
-  const hasAnyDocument = Boolean(
-    userProfile || sharedValues || process
-  );
+  const hasAnyDocument = Boolean(userProfile || sharedValues || process);
 
   if (!hasAnyDocument) return null;
 
@@ -207,7 +205,9 @@ function AgentSummaryCard({
       <div className="flex h-full flex-col md:flex-row">
         <div className="shrink-0 border-r border-gray-100 bg-gray-50/50 p-5 md:w-64">
           <div className="mb-4 flex items-start justify-between">
-            <div className={clsx('rounded-full p-2.5', isActive ? 'bg-green-100' : 'bg-purple-100')}>
+            <div
+              className={clsx('rounded-full p-2.5', isActive ? 'bg-green-100' : 'bg-purple-100')}
+            >
               {isActive ? (
                 <Activity className="h-5 w-5 text-green-600" />
               ) : (
@@ -216,7 +216,10 @@ function AgentSummaryCard({
             </div>
             <div className="flex gap-1">
               {identity.hasHeartbeat && (
-                <div title="Has operational guide" className="rounded-md bg-blue-50 p-1.5 text-blue-500">
+                <div
+                  title="Has operational guide"
+                  className="rounded-md bg-blue-50 p-1.5 text-blue-500"
+                >
                   <Zap className="h-3.5 w-3.5 fill-current" />
                 </div>
               )}
@@ -236,12 +239,18 @@ function AgentSummaryCard({
               </Badge>
             )}
             {isPaused && (
-              <Badge variant="outline" className="w-full justify-center border-amber-200 bg-amber-50 py-1 text-amber-700">
+              <Badge
+                variant="outline"
+                className="w-full justify-center border-amber-200 bg-amber-50 py-1 text-amber-700"
+              >
                 Paused
               </Badge>
             )}
             {!isActive && !isPaused && (
-              <Badge variant="secondary" className="w-full justify-center bg-gray-100 py-1 font-normal text-gray-500">
+              <Badge
+                variant="secondary"
+                className="w-full justify-center bg-gray-100 py-1 font-normal text-gray-500"
+              >
                 Idle
               </Badge>
             )}
@@ -256,7 +265,9 @@ function AgentSummaryCard({
                 {identity.hasSoul ? 'Constitution' : 'Overview'}
               </span>
             </div>
-            <p className="mb-4 line-clamp-3 text-sm leading-relaxed text-gray-700">{primaryContent}</p>
+            <p className="mb-4 line-clamp-3 text-sm leading-relaxed text-gray-700">
+              {primaryContent}
+            </p>
 
             {currentFocus && (
               <div className="rounded-md border border-yellow-100 bg-yellow-50/50 p-3">
@@ -327,10 +338,8 @@ function AgentSummaryCard({
 }
 
 export default function IndividualsPage() {
-  const { data: userIdentityData, isLoading: userIdentityLoading } = useApiQuery<UserIdentityResponse>(
-    ['user-identity'],
-    '/api/admin/user-identity'
-  );
+  const { data: userIdentityData, isLoading: userIdentityLoading } =
+    useApiQuery<UserIdentityResponse>(['user-identity'], '/api/admin/user-identity');
 
   const {
     data: individualsData,
@@ -393,7 +402,10 @@ export default function IndividualsPage() {
           {isLoading ? (
             <div className="space-y-4">
               {[1, 2, 3].map((i) => (
-                <div key={i} className="flex h-48 animate-pulse rounded-lg border border-gray-200 bg-white">
+                <div
+                  key={i}
+                  className="flex h-48 animate-pulse rounded-lg border border-gray-200 bg-white"
+                >
                   <div className="w-64 border-r border-gray-100 bg-gray-50" />
                   <div className="flex-1 space-y-4 p-6">
                     <div className="h-4 w-3/4 rounded bg-gray-100" />
@@ -407,7 +419,10 @@ export default function IndividualsPage() {
               <CardContent className="py-12 text-center text-gray-500">
                 <p>No individuals found.</p>
                 <p className="mt-2 text-sm">
-                  Use the <code>save_identity</code> tool to create one.
+                  Run <code>sb awaken</code> to create one (recommended).
+                </p>
+                <p className="mt-1 text-sm">
+                  You can also use the <code>save_identity</code> tool directly.
                 </p>
               </CardContent>
             </Card>

--- a/packages/web/src/components/layout/sidebar.tsx
+++ b/packages/web/src/components/layout/sidebar.tsx
@@ -13,7 +13,6 @@ import {
   Link2,
   FileText,
   Puzzle,
-  MessageSquare,
   Plus,
   UserPlus,
   Building2,
@@ -42,7 +41,6 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 
 const navigation = [
   { name: 'Dashboard', href: '/', icon: Home },
-  { name: 'Chat', href: '/chat', icon: MessageSquare },
   { name: 'Sessions', href: '/sessions', icon: Activity },
   { name: 'Trusted Users', href: '/trusted-users', icon: Users },
   { name: 'Groups', href: '/groups', icon: UsersRound },

--- a/packages/web/src/components/layout/sidebar.tsx
+++ b/packages/web/src/components/layout/sidebar.tsx
@@ -106,6 +106,7 @@ export function Sidebar() {
   const [inviteEmail, setInviteEmail] = useState('');
   const [inviteRole, setInviteRole] = useState<'owner' | 'admin' | 'member' | 'viewer'>('member');
   const [workspaceError, setWorkspaceError] = useState<string | null>(null);
+  const [workspaceSuccess, setWorkspaceSuccess] = useState<string | null>(null);
   const [isMounted, setIsMounted] = useState(false);
   const [accountMenuOpen, setAccountMenuOpen] = useState(false);
   const accountMenuRef = useRef<HTMLDivElement | null>(null);
@@ -167,11 +168,13 @@ export function Sidebar() {
       setNewWorkspaceName('');
       setNewWorkspaceDescription('');
       setWorkspaceError(null);
+      setWorkspaceSuccess(`Created workspace "${data.workspace.name}".`);
       queryClient.invalidateQueries({ queryKey: ['workspaces'] });
       queryClient.invalidateQueries({ queryKey: ['workspace-members', createdWorkspaceId] });
       router.refresh();
     },
     onError: (error) => {
+      setWorkspaceSuccess(null);
       setWorkspaceError(error.message || 'Failed to create workspace');
     },
   });
@@ -189,9 +192,11 @@ export function Sidebar() {
       onSuccess: (_, variables) => {
         setInviteEmail('');
         setWorkspaceError(null);
+        setWorkspaceSuccess('Collaborator invited successfully.');
         queryClient.invalidateQueries({ queryKey: ['workspace-members', variables.workspaceId] });
       },
       onError: (error) => {
+        setWorkspaceSuccess(null);
         setWorkspaceError(error.message || 'Failed to invite collaborator');
       },
     }
@@ -251,10 +256,12 @@ export function Sidebar() {
   const handleCreateWorkspace = () => {
     const trimmedWorkspaceName = newWorkspaceName.trim();
     if (!trimmedWorkspaceName) {
+      setWorkspaceSuccess(null);
       setWorkspaceError('Workspace name is required');
       return;
     }
 
+    setWorkspaceSuccess(null);
     setWorkspaceError(null);
     createWorkspaceMutation.mutate({
       name: trimmedWorkspaceName,
@@ -266,15 +273,18 @@ export function Sidebar() {
   const handleInviteWorkspaceMember = () => {
     const trimmedInviteEmail = inviteEmail.trim();
     if (!trimmedInviteEmail || !trimmedInviteEmail.includes('@')) {
+      setWorkspaceSuccess(null);
       setWorkspaceError('Valid collaborator email is required');
       return;
     }
 
     if (!inviteTargetWorkspaceId) {
+      setWorkspaceSuccess(null);
       setWorkspaceError('Select a workspace before inviting');
       return;
     }
 
+    setWorkspaceSuccess(null);
     setWorkspaceError(null);
     inviteWorkspaceMemberMutation.mutate({
       workspaceId: inviteTargetWorkspaceId,
@@ -526,6 +536,11 @@ export function Sidebar() {
             {workspaceError && (
               <p className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
                 {workspaceError}
+              </p>
+            )}
+            {workspaceSuccess && (
+              <p className="rounded-md border border-green-200 bg-green-50 px-3 py-2 text-sm text-green-700">
+                {workspaceSuccess}
               </p>
             )}
           </DialogContent>


### PR DESCRIPTION
## Summary
Follow-up to #116: enforce active workspace scoping across dashboard/admin data paths and polish related UI copy/navigation.

### API scoping fixes
- Scope `GET /api/admin/sessions` by `workspace_id`
- Scope identity lookup inside sessions endpoint by `workspace_id`
- Scope `GET /api/admin/studios` identities + latest-session query by `workspace_id`
- Scope studios query to identities in active workspace
- Scope `GET /api/admin/sessions/:id/logs` by `workspace_id`
- Scope `GET /api/admin/reminders` via `agent_identities.workspace_id`
- Scope individuals memory timeline/history by active workspace identity
- Scope individuals inbox by active workspace identities

### Web polish
- Individuals empty state now recommends `sb awaken` (with `save_identity` as secondary option)
- Hide Chat in sidebar navigation for now

## Files
- `packages/api/src/routes/admin.ts`
- `packages/web/src/app/(dashboard)/individuals/page.tsx`
- `packages/web/src/components/layout/sidebar.tsx`

## Validation
- `yarn workspace @personal-context/api type-check`
- `yarn workspace @personal-context/web type-check`
- `yarn workspace @personal-context/web test`
- `yarn workspace @personal-context/api test` *(1 unrelated pre-existing failure in `src/channels/discord-listener.test.ts`)*

## Why
Dashboard views were still leaking cross-workspace data in several endpoints. This aligns admin/dashboard behavior with the selected active workspace.