### PR TITLE
feat: log backend CLI executions to activity stream (by Lumen)

### DIFF
--- a/packages/cli/src/backends/adapters.test.ts
+++ b/packages/cli/src/backends/adapters.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { CodexAdapter } from './codex.js';
+import { GeminiAdapter } from './gemini.js';
+
+describe('backend adapters session resume wiring', () => {
+  it('passes backendSessionId through codex resume subcommand', () => {
+    const adapter = new CodexAdapter();
+    const prepared = adapter.prepare({
+      agentId: 'lumen',
+      model: undefined,
+      promptParts: ['continue', 'work'],
+      passthroughArgs: [],
+      backendSessionId: 'codex-session-123',
+    });
+
+    try {
+      expect(prepared.args).toContain('resume');
+      expect(prepared.args).toContain('codex-session-123');
+    } finally {
+      prepared.cleanup();
+    }
+  });
+
+  it('passes backendSessionId through gemini --resume flag', () => {
+    const adapter = new GeminiAdapter();
+    const prepared = adapter.prepare({
+      agentId: 'aster',
+      model: undefined,
+      promptParts: [],
+      passthroughArgs: [],
+      backendSessionId: 'gemini-session-456',
+    });
+
+    try {
+      const resumeFlagIndex = prepared.args.indexOf('--resume');
+      expect(resumeFlagIndex).toBeGreaterThanOrEqual(0);
+      expect(prepared.args[resumeFlagIndex + 1]).toBe('gemini-session-456');
+    } finally {
+      prepared.cleanup();
+    }
+  });
+});

--- a/packages/cli/src/backends/codex.ts
+++ b/packages/cli/src/backends/codex.ts
@@ -27,6 +27,11 @@ export class CodexAdapter implements BackendAdapter {
       args.push('--model', config.model);
     }
 
+    // Resume a specific backend-native Codex session when available.
+    if (config.backendSessionId) {
+      args.push('resume', config.backendSessionId);
+    }
+
     // Passthrough flags
     args.push(...config.passthroughArgs);
 

--- a/packages/cli/src/backends/gemini.ts
+++ b/packages/cli/src/backends/gemini.ts
@@ -30,6 +30,11 @@ export class GeminiAdapter implements BackendAdapter {
       args.push('-p');
     }
 
+    // Resume a specific backend-native Gemini session when available.
+    if (config.backendSessionId) {
+      args.push('--resume', config.backendSessionId);
+    }
+
     // Passthrough flags
     args.push(...config.passthroughArgs);
 

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -18,6 +18,7 @@ import { join } from 'path';
 import { homedir } from 'os';
 import { resolveAgentId } from '../backends/identity.js';
 import { getCurrentRuntimeSession } from '../session/runtime.js';
+import { callPcpTool } from '../lib/pcp-mcp.js';
 
 interface PcpConfig {
   userId?: string;
@@ -63,21 +64,6 @@ function getPcpConfig(): PcpConfig | null {
   return null;
 }
 
-function getPcpServerUrl(): string {
-  return process.env.PCP_SERVER_URL || 'http://localhost:3001';
-}
-
-async function fetchPcp(path: string, options?: RequestInit): Promise<Response> {
-  const url = `${getPcpServerUrl()}${path}`;
-  return fetch(url, {
-    ...options,
-    headers: {
-      'Content-Type': 'application/json',
-      ...options?.headers,
-    },
-  });
-}
-
 // ============================================================================
 // Commands
 // ============================================================================
@@ -106,35 +92,21 @@ async function triggerAgent(
     const currentRuntime = getCurrentRuntimeSession(process.cwd());
     const threadKey = options.threadKey || currentRuntime?.threadKey;
 
-    const inboxResponse = await fetchPcp('/api/mcp/call', {
-      method: 'POST',
-      body: JSON.stringify({
-        tool: 'send_to_inbox',
-        args: {
-          email: config.email,
-          recipientAgentId: agentId,
-          senderAgentId: 'cli',
-          content: options.message || `CLI trigger at ${new Date().toISOString()}`,
-          messageType: 'message',
-          priority: options.priority || 'normal',
-          ...(threadKey ? { threadKey } : {}),
-          ...(options.recipientSessionId ? { recipientSessionId: options.recipientSessionId } : {}),
-          ...(options.studioId ? { recipientStudioId: options.studioId } : {}),
-          ...(options.studioHint ? { recipientStudioHint: options.studioHint } : {}),
-          trigger: true,
-          triggerType: 'message',
-          triggerSummary: options.message || 'CLI trigger',
-        },
-      }),
+    const result = await callPcpTool<TriggerResult>('send_to_inbox', {
+      email: config.email,
+      recipientAgentId: agentId,
+      senderAgentId: 'cli',
+      content: options.message || `CLI trigger at ${new Date().toISOString()}`,
+      messageType: 'message',
+      priority: options.priority || 'normal',
+      ...(threadKey ? { threadKey } : {}),
+      ...(options.recipientSessionId ? { recipientSessionId: options.recipientSessionId } : {}),
+      ...(options.studioId ? { recipientStudioId: options.studioId } : {}),
+      ...(options.studioHint ? { recipientStudioHint: options.studioHint } : {}),
+      trigger: true,
+      triggerType: 'message',
+      triggerSummary: options.message || 'CLI trigger',
     });
-
-    if (!inboxResponse.ok) {
-      const error = await inboxResponse.text();
-      spinner.fail(`Failed to trigger: ${error}`);
-      process.exit(1);
-    }
-
-    const result = (await inboxResponse.json()) as TriggerResult;
     spinner.succeed(`Triggered ${agentId}`);
 
     if (result.trigger?.triggered) {
@@ -160,42 +132,28 @@ async function statusCommand(agentId?: string): Promise<void> {
 
   for (const agent of agents) {
     try {
-      const response = await fetchPcp('/api/mcp/call', {
-        method: 'POST',
-        body: JSON.stringify({
-          tool: 'get_agent_status',
-          args: {
-            email: config.email,
-            agentId: agent,
-          },
-        }),
+      const result = await callPcpTool<AgentStatusResult>('get_agent_status', {
+        email: config.email,
+        agentId: agent,
       });
 
-      if (response.ok) {
-        const result = (await response.json()) as AgentStatusResult;
+      const statusIcon =
+        result.status === 'active'
+          ? chalk.green('●')
+          : result.status === 'recently_active'
+            ? chalk.yellow('●')
+            : chalk.dim('○');
 
-        const statusIcon =
-          result.status === 'active'
-            ? chalk.green('●')
-            : result.status === 'recently_active'
-              ? chalk.yellow('●')
-              : chalk.dim('○');
+      console.log(`  ${statusIcon} ${chalk.cyan(agent)}`);
+      console.log(chalk.dim(`      Status: ${result.status}`));
+      console.log(chalk.dim(`      Inbox:  ${result.inbox?.unreadCount || 0} unread`));
 
-        console.log(`  ${statusIcon} ${chalk.cyan(agent)}`);
-        console.log(chalk.dim(`      Status: ${result.status}`));
-        console.log(chalk.dim(`      Inbox:  ${result.inbox?.unreadCount || 0} unread`));
-
-        if (result.lastSession) {
-          const lastActive = new Date(result.lastSession.endedAt || result.lastSession.startedAt);
-          const ago = formatTimeAgo(lastActive);
-          console.log(chalk.dim(`      Last:   ${ago}`));
-        }
-        console.log('');
-      } else {
-        console.log(`  ${chalk.dim('○')} ${chalk.cyan(agent)}`);
-        console.log(chalk.dim('      Status: unknown'));
-        console.log('');
+      if (result.lastSession) {
+        const lastActive = new Date(result.lastSession.endedAt || result.lastSession.startedAt);
+        const ago = formatTimeAgo(lastActive);
+        console.log(chalk.dim(`      Last:   ${ago}`));
       }
+      console.log('');
     } catch {
       console.log(`  ${chalk.dim('○')} ${chalk.cyan(agent)}`);
       console.log(chalk.dim('      Status: unreachable'));
@@ -218,25 +176,12 @@ async function inboxCommand(agentId?: string): Promise<void> {
   }
 
   try {
-    const response = await fetchPcp('/api/mcp/call', {
-      method: 'POST',
-      body: JSON.stringify({
-        tool: 'get_inbox',
-        args: {
-          email: config.email,
-          agentId: agent,
-          status: 'all',
-          limit: 10,
-        },
-      }),
+    const result = await callPcpTool<InboxResult>('get_inbox', {
+      email: config.email,
+      agentId: agent,
+      status: 'all',
+      limit: 10,
     });
-
-    if (!response.ok) {
-      console.error(chalk.red(`Failed to fetch inbox: ${await response.text()}`));
-      process.exit(1);
-    }
-
-    const result = (await response.json()) as InboxResult;
 
     console.log(chalk.bold(`\nInbox for ${agent}:`));
     console.log(chalk.dim(`  ${result.unreadCount} unread\n`));

--- a/packages/cli/src/commands/awaken.ts
+++ b/packages/cli/src/commands/awaken.ts
@@ -21,6 +21,7 @@ import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { homedir, tmpdir } from 'os';
 import { getBackend, BACKEND_NAMES } from '../backends/index.js';
+import { callPcpTool } from '../lib/pcp-mcp.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -85,10 +86,6 @@ function getPcpConfig(): PcpConfig | null {
   return null;
 }
 
-function getPcpServerUrl(): string {
-  return process.env.PCP_SERVER_URL || 'http://localhost:3001';
-}
-
 /**
  * Fetch shared values and sibling identities from PCP cloud.
  * Returns null if the server is unreachable.
@@ -98,23 +95,16 @@ async function fetchFromCloud(config: PcpConfig): Promise<{
   siblings: BootstrapIdentity[];
 } | null> {
   try {
-    const url = `${getPcpServerUrl()}/api/mcp/call`;
-    const response = await fetch(url, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        tool: 'bootstrap',
-        args: {
-          email: config.email,
-          agentId: 'awakening', // temporary identity for bootstrap
-        },
-      }),
-      signal: AbortSignal.timeout(5000),
-    });
-
-    if (!response.ok) return null;
-
-    const result = (await response.json()) as BootstrapResponse;
+    const result = await callPcpTool<BootstrapResponse>(
+      'bootstrap',
+      {
+        email: config.email,
+        agentId: 'awakening', // temporary identity for bootstrap
+      },
+      {
+        timeoutMs: 5000,
+      }
+    );
 
     // Extract shared values from identity files
     const sharedValues = result.identityFiles?.values || '';

--- a/packages/cli/src/commands/claude.test.ts
+++ b/packages/cli/src/commands/claude.test.ts
@@ -96,6 +96,29 @@ describe('filterPcpSessionsForContext', () => {
 
     expect(filtered.map((session) => session.id)).toEqual(['codex-1']);
   });
+
+  it('path-scopes codex sessions when workingDir data is available', () => {
+    const filtered = filterPcpSessionsForContext(
+      [
+        {
+          id: 'codex-a',
+          startedAt: '2026-02-28T00:00:00.000Z',
+          backend: 'codex',
+          workingDir: '/tmp/project-a',
+        },
+        {
+          id: 'codex-b',
+          startedAt: '2026-02-28T00:00:00.000Z',
+          backend: 'codex',
+          workingDir: '/tmp/project-b',
+        },
+      ],
+      'codex',
+      '/tmp/project-a'
+    );
+
+    expect(filtered.map((session) => session.id)).toEqual(['codex-a']);
+  });
 });
 
 describe('filterUntrackedLocalClaudeSessions', () => {

--- a/packages/cli/src/commands/claude.test.ts
+++ b/packages/cli/src/commands/claude.test.ts
@@ -3,6 +3,7 @@ import {
   filterPcpSessionsForContext,
   filterUntrackedLocalClaudeSessions,
   hasBackendSessionOverride,
+  sanitizeBackendExecutionArgs,
 } from './claude.js';
 
 describe('hasBackendSessionOverride', () => {
@@ -146,5 +147,53 @@ describe('filterUntrackedLocalClaudeSessions', () => {
     ]);
 
     expect(filtered.map((session) => session.sessionId)).toEqual(['claude-2']);
+  });
+});
+
+describe('sanitizeBackendExecutionArgs', () => {
+  it('redacts claude system prompt and one-shot prompt text', () => {
+    const sanitized = sanitizeBackendExecutionArgs(
+      [
+        '-p',
+        '--append-system-prompt',
+        'identity text',
+        '--mcp-config',
+        '/tmp/.mcp.json',
+        'fix this bug',
+      ],
+      'claude'
+    );
+    expect(sanitized).toEqual([
+      '-p',
+      '--append-system-prompt',
+      '<redacted-system-prompt>',
+      '--mcp-config',
+      '/tmp/.mcp.json',
+      '<redacted-prompt>',
+    ]);
+  });
+
+  it('redacts trailing codex prompt parts when present', () => {
+    const sanitized = sanitizeBackendExecutionArgs(
+      [
+        '--config',
+        'model_instructions_file=/tmp/identity.md',
+        '--model',
+        'o3',
+        'please',
+        'summarize',
+      ],
+      'codex',
+      ['please', 'summarize']
+    );
+
+    expect(sanitized).toEqual([
+      '--config',
+      'model_instructions_file=/tmp/identity.md',
+      '--model',
+      'o3',
+      '<redacted-prompt-part>',
+      '<redacted-prompt-part>',
+    ]);
   });
 });

--- a/packages/cli/src/commands/claude.test.ts
+++ b/packages/cli/src/commands/claude.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  extractClaudeHistorySessionsForProject,
   filterPcpSessionsForContext,
   filterUntrackedLocalClaudeSessions,
   hasBackendSessionOverride,
@@ -205,5 +206,33 @@ describe('shouldAutoResumeRuntimeSession', () => {
     expect(shouldAutoResumeRuntimeSession({ pcpSessionId: 'pcp-1' }, true)).toBe(false);
     expect(shouldAutoResumeRuntimeSession(undefined, false)).toBe(false);
     expect(shouldAutoResumeRuntimeSession({ backendSessionId: 'b-1' }, false)).toBe(false);
+  });
+});
+
+describe('extractClaudeHistorySessionsForProject', () => {
+  it('parses local claude sessions from history.jsonl for the current project path', () => {
+    const jsonl = [
+      JSON.stringify({
+        sessionId: 'sess-clearpol-1',
+        project: '/Users/conormclaughlin/ws/clearpol-ai',
+        timestamp: 1772254853007,
+        display: 'Hi Wren',
+      }),
+      JSON.stringify({
+        sessionId: 'sess-other',
+        project: '/Users/conormclaughlin/ws/another-repo',
+        timestamp: 1772254853007,
+      }),
+    ].join('\n');
+
+    const parsed = extractClaudeHistorySessionsForProject(
+      jsonl,
+      '/Users/conormclaughlin/ws/clearpol-ai'
+    );
+
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].sessionId).toBe('sess-clearpol-1');
+    expect(parsed[0].backend).toBe('claude');
+    expect(parsed[0].firstPrompt).toBe('Hi Wren');
   });
 });

--- a/packages/cli/src/commands/claude.test.ts
+++ b/packages/cli/src/commands/claude.test.ts
@@ -4,6 +4,7 @@ import {
   filterUntrackedLocalClaudeSessions,
   hasBackendSessionOverride,
   sanitizeBackendExecutionArgs,
+  shouldAutoResumeRuntimeSession,
 } from './claude.js';
 
 describe('hasBackendSessionOverride', () => {
@@ -195,5 +196,14 @@ describe('sanitizeBackendExecutionArgs', () => {
       '<redacted-prompt-part>',
       '<redacted-prompt-part>',
     ]);
+  });
+});
+
+describe('shouldAutoResumeRuntimeSession', () => {
+  it('auto-resumes only for non-tty execution when runtime has a PCP session', () => {
+    expect(shouldAutoResumeRuntimeSession({ pcpSessionId: 'pcp-1' }, false)).toBe(true);
+    expect(shouldAutoResumeRuntimeSession({ pcpSessionId: 'pcp-1' }, true)).toBe(false);
+    expect(shouldAutoResumeRuntimeSession(undefined, false)).toBe(false);
+    expect(shouldAutoResumeRuntimeSession({ backendSessionId: 'b-1' }, false)).toBe(false);
   });
 });

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -58,6 +58,27 @@ interface BackendLocalSessionSummary {
   gitBranch?: string;
 }
 
+interface BackendExecutionLogContext {
+  pcpConfig: PcpConfig | null;
+  agentId: string;
+  backend: string;
+  binary: string;
+  args: string[];
+  promptParts?: string[];
+  pcpSessionId?: string;
+  backendSessionId?: string;
+  studioId?: string;
+  runtimeLinkId?: string;
+  cwd: string;
+  mode: 'prompt' | 'interactive';
+  retryAttempt: number;
+  maxAttempts: number;
+}
+
+type LogActivityResult = {
+  activity?: { id?: string };
+};
+
 function getSessionBackendId(session: PcpSessionSummary): string | undefined {
   return session.backendSessionId || session.claudeSessionId || undefined;
 }
@@ -155,6 +176,50 @@ function truncateText(text: string | null | undefined, max = 90): string {
   const compact = text.replace(/\s+/g, ' ').trim();
   if (compact.length <= max) return compact;
   return `${compact.slice(0, max - 1)}…`;
+}
+
+export function sanitizeBackendExecutionArgs(
+  args: string[],
+  backend: string,
+  promptParts: string[] = []
+): string[] {
+  const sanitized = [...args];
+
+  for (let i = 0; i < sanitized.length; i++) {
+    const arg = sanitized[i];
+    if (arg === '--append-system-prompt' && i + 1 < sanitized.length) {
+      sanitized[i + 1] = '<redacted-system-prompt>';
+      i += 1;
+      continue;
+    }
+
+    if (arg === '-p' && i + 1 < sanitized.length && !sanitized[i + 1].startsWith('-')) {
+      sanitized[i + 1] = '<redacted-prompt>';
+      i += 1;
+    }
+  }
+
+  if (sanitized.includes('-p') && sanitized.length > 0) {
+    const lastIndex = sanitized.length - 1;
+    if (!sanitized[lastIndex].startsWith('-')) {
+      sanitized[lastIndex] = '<redacted-prompt>';
+    }
+  }
+
+  // Codex one-shot prompts may be passed as positional args (no -p flag).
+  if (backend === 'codex' && promptParts.length > 0 && sanitized.length >= promptParts.length) {
+    const startIndex = sanitized.length - promptParts.length;
+    const trailingMatches = promptParts.every(
+      (part, index) => sanitized[startIndex + index] === part
+    );
+    if (trailingMatches) {
+      for (let i = startIndex; i < sanitized.length; i++) {
+        sanitized[i] = '<redacted-prompt-part>';
+      }
+    }
+  }
+
+  return sanitized;
 }
 
 export function filterPcpSessionsForContext(
@@ -492,6 +557,103 @@ async function callPcpTool<T = Record<string, unknown>>(tool: string, args: obje
   }
 
   return (await response.json()) as T;
+}
+
+function extractActivityIdFromLogResult(result: unknown): string | undefined {
+  if (!result || typeof result !== 'object') return undefined;
+  const maybe = result as LogActivityResult;
+  if (typeof maybe.activity?.id === 'string') return maybe.activity.id;
+  return undefined;
+}
+
+async function logBackendExecutionStart(
+  context: BackendExecutionLogContext
+): Promise<string | undefined> {
+  if (!context.pcpConfig?.email) return undefined;
+
+  try {
+    const argsSanitized = sanitizeBackendExecutionArgs(
+      context.args,
+      context.backend,
+      context.promptParts || []
+    );
+
+    const result = await callPcpTool<LogActivityResult>('log_activity', {
+      email: context.pcpConfig.email,
+      agentId: context.agentId,
+      type: 'tool_call',
+      subtype: `backend_cli:${context.backend}`,
+      status: 'running',
+      ...(context.pcpSessionId ? { sessionId: context.pcpSessionId } : {}),
+      ...(context.runtimeLinkId ? { correlationId: context.runtimeLinkId } : {}),
+      content: `Spawned backend CLI (${context.binary})`,
+      payload: {
+        kind: 'backend_cli_execution',
+        phase: 'start',
+        backend: context.backend,
+        binary: context.binary,
+        argsSanitized,
+        cwd: context.cwd,
+        studioId: context.studioId || null,
+        pcpSessionId: context.pcpSessionId || null,
+        backendSessionId: context.backendSessionId || null,
+        retryAttempt: context.retryAttempt,
+        maxAttempts: context.maxAttempts,
+      },
+    });
+
+    return extractActivityIdFromLogResult(result);
+  } catch {
+    return undefined;
+  }
+}
+
+async function logBackendExecutionResult(options: {
+  context: BackendExecutionLogContext;
+  parentActivityId?: string;
+  exitCode: number | null;
+  durationMs: number;
+  error?: string;
+  backendSessionId?: string;
+}): Promise<void> {
+  if (!options.context.pcpConfig?.email) return;
+
+  const status = options.exitCode === 0 && !options.error ? 'completed' : 'failed';
+
+  try {
+    await callPcpTool('log_activity', {
+      email: options.context.pcpConfig.email,
+      agentId: options.context.agentId,
+      type: 'tool_result',
+      subtype: `backend_cli:${options.context.backend}`,
+      status,
+      ...(options.context.pcpSessionId ? { sessionId: options.context.pcpSessionId } : {}),
+      ...(options.parentActivityId ? { parentId: options.parentActivityId } : {}),
+      ...(options.context.runtimeLinkId ? { correlationId: options.context.runtimeLinkId } : {}),
+      content:
+        status === 'completed'
+          ? `Backend CLI finished (${options.context.binary})`
+          : `Backend CLI failed (${options.context.binary})`,
+      payload: {
+        kind: 'backend_cli_execution',
+        phase: 'result',
+        backend: options.context.backend,
+        binary: options.context.binary,
+        cwd: options.context.cwd,
+        studioId: options.context.studioId || null,
+        pcpSessionId: options.context.pcpSessionId || null,
+        backendSessionId: options.backendSessionId || null,
+        retryAttempt: options.context.retryAttempt,
+        maxAttempts: options.context.maxAttempts,
+        retries: Math.max(options.context.retryAttempt - 1, 0),
+        exitCode: options.exitCode,
+        durationMs: options.durationMs,
+        error: options.error || null,
+      },
+    });
+  } catch {
+    // Best-effort telemetry only.
+  }
 }
 
 function extractBackendSessionIdFromEvent(event: Record<string, unknown>): string | undefined {
@@ -846,8 +1008,45 @@ export async function runClaude(
   }
 
   const pcpConfig = getPcpConfig();
+  const executionContext: BackendExecutionLogContext = {
+    pcpConfig,
+    agentId,
+    backend: options.backend,
+    binary: prepared.binary,
+    args: prepared.args,
+    promptParts,
+    pcpSessionId: sessionContext.pcpSessionId,
+    backendSessionId: sessionContext.backendSessionId,
+    studioId,
+    runtimeLinkId,
+    cwd: process.cwd(),
+    mode: 'prompt',
+    retryAttempt: 1,
+    maxAttempts: 1,
+  };
+  const executionStartedAt = Date.now();
+  const backendStartActivityId = await logBackendExecutionStart(executionContext);
   let capturedBackendSessionId = sessionContext.backendSessionId;
   let stdoutLineBuffer = '';
+  let cleanedUp = false;
+  let finalizedExecution = false;
+  const ensureCleanup = (): void => {
+    if (cleanedUp) return;
+    cleanedUp = true;
+    prepared.cleanup();
+  };
+  const finalizeExecution = async (exitCode: number | null, error?: string): Promise<void> => {
+    if (finalizedExecution) return;
+    finalizedExecution = true;
+    await logBackendExecutionResult({
+      context: executionContext,
+      parentActivityId: backendStartActivityId,
+      exitCode,
+      durationMs: Date.now() - executionStartedAt,
+      error,
+      backendSessionId: capturedBackendSessionId,
+    });
+  };
   const consumeOutputChunk = (chunkText: string): void => {
     stdoutLineBuffer += chunkText;
     const lines = stdoutLineBuffer.split('\n');
@@ -879,7 +1078,7 @@ export async function runClaude(
   });
 
   child.on('close', async (code) => {
-    prepared.cleanup();
+    ensureCleanup();
     if (stdoutLineBuffer.trim()) {
       const parsedSessionId = parseSessionIdFromJsonLine(stdoutLineBuffer.trim());
       if (parsedSessionId) capturedBackendSessionId = parsedSessionId;
@@ -895,8 +1094,15 @@ export async function runClaude(
       identityId,
       email: pcpConfig?.email,
     });
+    await finalizeExecution(code ?? null);
 
     if (code !== 0) process.exit(code || 1);
+  });
+
+  child.on('error', async (err) => {
+    ensureCleanup();
+    await finalizeExecution(null, err.message || 'spawn failed');
+    process.exit(1);
   });
 
   process.on('SIGINT', () => child.kill('SIGINT'));
@@ -964,6 +1170,44 @@ export async function runClaudeInteractive(
     console.log(chalk.dim(`Running: ${prepared.binary} ${prepared.args.join(' ')}`));
   }
 
+  const pcpConfig = getPcpConfig();
+  const executionContext: BackendExecutionLogContext = {
+    pcpConfig,
+    agentId,
+    backend: options.backend,
+    binary: prepared.binary,
+    args: prepared.args,
+    pcpSessionId: sessionContext.pcpSessionId,
+    backendSessionId: sessionContext.backendSessionId,
+    studioId,
+    runtimeLinkId,
+    cwd: process.cwd(),
+    mode: 'interactive',
+    retryAttempt: 1,
+    maxAttempts: 1,
+  };
+  const executionStartedAt = Date.now();
+  const backendStartActivityId = await logBackendExecutionStart(executionContext);
+  let cleanedUp = false;
+  let finalizedExecution = false;
+  const ensureCleanup = (): void => {
+    if (cleanedUp) return;
+    cleanedUp = true;
+    prepared.cleanup();
+  };
+  const finalizeExecution = async (exitCode: number | null, error?: string): Promise<void> => {
+    if (finalizedExecution) return;
+    finalizedExecution = true;
+    await logBackendExecutionResult({
+      context: executionContext,
+      parentActivityId: backendStartActivityId,
+      exitCode,
+      durationMs: Date.now() - executionStartedAt,
+      error,
+      backendSessionId: sessionContext.backendSessionId,
+    });
+  };
+
   const child = spawn(prepared.binary, prepared.args, {
     stdio: 'inherit',
     env: {
@@ -974,8 +1218,15 @@ export async function runClaudeInteractive(
     },
   });
 
-  child.on('close', (code) => {
-    prepared.cleanup();
+  child.on('close', async (code) => {
+    ensureCleanup();
+    await finalizeExecution(code ?? null);
     process.exit(code || 0);
+  });
+
+  child.on('error', async (err) => {
+    ensureCleanup();
+    await finalizeExecution(null, err.message || 'spawn failed');
+    process.exit(1);
   });
 }

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -58,6 +58,13 @@ interface BackendLocalSessionSummary {
   gitBranch?: string;
 }
 
+interface ClaudeHistoryLine {
+  display?: string;
+  timestamp?: number;
+  project?: string;
+  sessionId?: string;
+}
+
 interface BackendExecutionLogContext {
   pcpConfig: PcpConfig | null;
   agentId: string;
@@ -133,6 +140,52 @@ function isPromptCancelError(err: unknown): boolean {
 
 function getPcpServerUrl(): string {
   return process.env.PCP_SERVER_URL || 'http://localhost:3001';
+}
+
+function getPcpToolCallBaseUrls(): string[] {
+  const urls: string[] = [];
+  const add = (value: string | undefined): void => {
+    if (!value) return;
+    if (!urls.includes(value)) urls.push(value);
+  };
+
+  const configured = process.env.PCP_SERVER_URL;
+  const explicitToolUrl = process.env.PCP_TOOL_CALL_URL;
+  const envPortBase = process.env.PCP_PORT_BASE
+    ? Number.parseInt(process.env.PCP_PORT_BASE, 10)
+    : undefined;
+
+  add(explicitToolUrl);
+
+  if (envPortBase && Number.isFinite(envPortBase)) {
+    add(`http://localhost:${envPortBase + 1}`); // web proxy (serves /api/mcp/call)
+    add(`http://localhost:${envPortBase}`); // api/auth server
+  } else {
+    // Default local dev topology: API on 3001, web proxy on 3002.
+    add('http://localhost:3002');
+    add('http://localhost:3001');
+  }
+
+  add(configured);
+
+  // If explicitly pointed at localhost:3001, also try sibling web port 3002.
+  if (configured) {
+    try {
+      const parsed = new URL(configured);
+      if (parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1') {
+        const port = parsed.port ? Number.parseInt(parsed.port, 10) : undefined;
+        if (port && Number.isFinite(port)) {
+          const sibling = new URL(configured);
+          sibling.port = String(port + 1);
+          add(sibling.origin);
+        }
+      }
+    } catch {
+      // Ignore malformed URLs in env overrides.
+    }
+  }
+
+  return urls;
 }
 
 async function resolvePcpAuthEnv(verbose: boolean): Promise<Record<string, string>> {
@@ -321,6 +374,21 @@ export function getClaudeLocalSessionsForProject(
     }
   }
 
+  // Fallback path: some Claude installations persist session linkage in history.jsonl
+  // even when per-project sessions-index files are missing/out-of-date.
+  const historyPath = join(homedir(), '.claude', 'history.jsonl');
+  if (existsSync(historyPath)) {
+    try {
+      const historySessions = extractClaudeHistorySessionsForProject(
+        readFileSync(historyPath, 'utf-8'),
+        normalizedCwd
+      );
+      results.push(...historySessions);
+    } catch {
+      // Ignore unreadable history file.
+    }
+  }
+
   const dedupedBySessionId = new Map<string, BackendLocalSessionSummary>();
   for (const session of results) {
     const existing = dedupedBySessionId.get(session.sessionId);
@@ -332,6 +400,42 @@ export function getClaudeLocalSessionsForProject(
   return Array.from(dedupedBySessionId.values())
     .sort((a, b) => new Date(b.modified).getTime() - new Date(a.modified).getTime())
     .slice(0, limit);
+}
+
+export function extractClaudeHistorySessionsForProject(
+  historyJsonl: string,
+  normalizedCwd: string
+): BackendLocalSessionSummary[] {
+  const sessions: BackendLocalSessionSummary[] = [];
+  for (const line of historyJsonl.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    let parsed: ClaudeHistoryLine;
+    try {
+      parsed = JSON.parse(trimmed) as ClaudeHistoryLine;
+    } catch {
+      continue;
+    }
+
+    if (!parsed.sessionId || !parsed.project) continue;
+    const normalizedProjectPath = normalizePath(parsed.project);
+    if (!normalizedProjectPath || normalizedProjectPath !== normalizedCwd) continue;
+
+    const modified =
+      typeof parsed.timestamp === 'number' && Number.isFinite(parsed.timestamp)
+        ? new Date(parsed.timestamp).toISOString()
+        : new Date().toISOString();
+
+    sessions.push({
+      backend: 'claude',
+      sessionId: parsed.sessionId,
+      projectPath: parsed.project,
+      modified,
+      firstPrompt: parsed.display,
+    });
+  }
+
+  return sessions;
 }
 
 export function getCodexLocalSessionsForProject(
@@ -568,17 +672,39 @@ export function hasBackendSessionOverride(
 }
 
 async function callPcpTool<T = Record<string, unknown>>(tool: string, args: object): Promise<T> {
-  const response = await fetch(`${getPcpServerUrl()}/api/mcp/call`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ tool, args }),
-  });
+  const baseUrls = getPcpToolCallBaseUrls();
+  let lastError: Error | undefined;
+  const tried: string[] = [];
 
-  if (!response.ok) {
-    throw new Error(`PCP tool ${tool} failed: ${response.status} ${await response.text()}`);
+  for (const baseUrl of baseUrls) {
+    const endpoint = `${baseUrl}/api/mcp/call`;
+    tried.push(endpoint);
+    try {
+      const response = await fetch(endpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ tool, args }),
+      });
+
+      if (response.ok) {
+        return (await response.json()) as T;
+      }
+
+      // Common misconfiguration case: hitting API/auth origin instead of web proxy.
+      if (response.status === 404) {
+        lastError = new Error(`404 ${await response.text()}`);
+        continue;
+      }
+
+      lastError = new Error(`PCP tool ${tool} failed: ${response.status} ${await response.text()}`);
+    } catch (error) {
+      lastError = error instanceof Error ? error : new Error(String(error));
+    }
   }
 
-  return (await response.json()) as T;
+  throw new Error(
+    `PCP tool ${tool} failed after trying ${tried.length} endpoint(s): ${tried.join(', ')}${lastError ? ` — ${lastError.message}` : ''}`
+  );
 }
 
 function extractActivityIdFromLogResult(result: unknown): string | undefined {

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -675,24 +675,81 @@ async function callPcpTool<T = Record<string, unknown>>(tool: string, args: obje
   const baseUrls = getPcpToolCallBaseUrls();
   let lastError: Error | undefined;
   const tried: string[] = [];
+  let jsonRpcId = Date.now();
 
   for (const baseUrl of baseUrls) {
-    const endpoint = `${baseUrl}/api/mcp/call`;
-    tried.push(endpoint);
+    const mcpEndpoint = `${baseUrl}/mcp`;
+    const legacyEndpoint = `${baseUrl}/api/mcp/call`;
+    tried.push(mcpEndpoint);
+    tried.push(legacyEndpoint);
+
     try {
-      const response = await fetch(endpoint, {
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream',
+      };
+      const token = await getValidAccessToken(baseUrl);
+      if (token) headers.Authorization = `Bearer ${token}`;
+
+      const response = await fetch(mcpEndpoint, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ tool, args }),
+        headers,
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          method: 'tools/call',
+          params: { name: tool, arguments: args },
+          id: jsonRpcId++,
+        }),
       });
 
       if (response.ok) {
-        return (await response.json()) as T;
+        const contentType = response.headers.get('content-type') || '';
+        let payload: Record<string, unknown>;
+
+        if (contentType.includes('text/event-stream')) {
+          const text = await response.text();
+          const dataLines = text
+            .split('\n')
+            .filter((line) => line.startsWith('data: '))
+            .map((line) => line.slice(6));
+          const lastData = dataLines[dataLines.length - 1];
+          if (!lastData) throw new Error('PCP SSE response contained no data lines');
+          payload = JSON.parse(lastData) as Record<string, unknown>;
+        } else {
+          payload = (await response.json()) as Record<string, unknown>;
+        }
+
+        if (payload.error) {
+          const err = payload.error as { message?: string; code?: number };
+          throw new Error(`PCP tool error (${err.code}): ${err.message}`);
+        }
+
+        const result = payload.result as { content?: Array<{ text?: string }> } | undefined;
+        const mcpText = result?.content?.[0]?.text;
+        if (typeof mcpText === 'string') {
+          try {
+            return JSON.parse(mcpText) as T;
+          } catch {
+            return { text: mcpText } as unknown as T;
+          }
+        }
+
+        return (result as unknown as T) || (payload as unknown as T);
       }
 
-      // Common misconfiguration case: hitting API/auth origin instead of web proxy.
-      if (response.status === 404) {
-        lastError = new Error(`404 ${await response.text()}`);
+      // Legacy fallback endpoint (/api/mcp/call) for older server deployments.
+      if (response.status === 404 || response.status === 405) {
+        const legacyResponse = await fetch(legacyEndpoint, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ tool, args }),
+        });
+        if (legacyResponse.ok) {
+          return (await legacyResponse.json()) as T;
+        }
+        lastError = new Error(
+          `legacy fallback failed: ${legacyResponse.status} ${await legacyResponse.text()}`
+        );
         continue;
       }
 

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -13,6 +13,7 @@ import { join, resolve as resolvePath } from 'path';
 import { homedir } from 'os';
 import { getBackend, resolveAgentId } from '../backends/index.js';
 import { getValidAccessToken } from '../auth/tokens.js';
+import { callPcpTool, getPcpServerUrl } from '../lib/pcp-mcp.js';
 import {
   getCurrentRuntimeSession,
   setCurrentRuntimeSession,
@@ -136,56 +137,6 @@ function isPromptCancelError(err: unknown): boolean {
     name === 'AbortPromptError' ||
     /force closed|ctrl\+c|sigint|cancell?ed|aborted/i.test(message)
   );
-}
-
-function getPcpServerUrl(): string {
-  return process.env.PCP_SERVER_URL || 'http://localhost:3001';
-}
-
-function getPcpToolCallBaseUrls(): string[] {
-  const urls: string[] = [];
-  const add = (value: string | undefined): void => {
-    if (!value) return;
-    if (!urls.includes(value)) urls.push(value);
-  };
-
-  const configured = process.env.PCP_SERVER_URL;
-  const explicitToolUrl = process.env.PCP_TOOL_CALL_URL;
-  const envPortBase = process.env.PCP_PORT_BASE
-    ? Number.parseInt(process.env.PCP_PORT_BASE, 10)
-    : undefined;
-
-  add(explicitToolUrl);
-
-  if (envPortBase && Number.isFinite(envPortBase)) {
-    add(`http://localhost:${envPortBase + 1}`); // web proxy (serves /api/mcp/call)
-    add(`http://localhost:${envPortBase}`); // api/auth server
-  } else {
-    // Default local dev topology: API on 3001, web proxy on 3002.
-    add('http://localhost:3002');
-    add('http://localhost:3001');
-  }
-
-  add(configured);
-
-  // If explicitly pointed at localhost:3001, also try sibling web port 3002.
-  if (configured) {
-    try {
-      const parsed = new URL(configured);
-      if (parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1') {
-        const port = parsed.port ? Number.parseInt(parsed.port, 10) : undefined;
-        if (port && Number.isFinite(port)) {
-          const sibling = new URL(configured);
-          sibling.port = String(port + 1);
-          add(sibling.origin);
-        }
-      }
-    } catch {
-      // Ignore malformed URLs in env overrides.
-    }
-  }
-
-  return urls;
 }
 
 async function resolvePcpAuthEnv(verbose: boolean): Promise<Record<string, string>> {
@@ -669,99 +620,6 @@ export function hasBackendSessionOverride(
   }
 
   return has('--resume') || has('-r') || has('--session-id');
-}
-
-async function callPcpTool<T = Record<string, unknown>>(tool: string, args: object): Promise<T> {
-  const baseUrls = getPcpToolCallBaseUrls();
-  let lastError: Error | undefined;
-  const tried: string[] = [];
-  let jsonRpcId = Date.now();
-
-  for (const baseUrl of baseUrls) {
-    const mcpEndpoint = `${baseUrl}/mcp`;
-    const legacyEndpoint = `${baseUrl}/api/mcp/call`;
-    tried.push(mcpEndpoint);
-    tried.push(legacyEndpoint);
-
-    try {
-      const headers: Record<string, string> = {
-        'Content-Type': 'application/json',
-        Accept: 'application/json, text/event-stream',
-      };
-      const token = await getValidAccessToken(baseUrl);
-      if (token) headers.Authorization = `Bearer ${token}`;
-
-      const response = await fetch(mcpEndpoint, {
-        method: 'POST',
-        headers,
-        body: JSON.stringify({
-          jsonrpc: '2.0',
-          method: 'tools/call',
-          params: { name: tool, arguments: args },
-          id: jsonRpcId++,
-        }),
-      });
-
-      if (response.ok) {
-        const contentType = response.headers.get('content-type') || '';
-        let payload: Record<string, unknown>;
-
-        if (contentType.includes('text/event-stream')) {
-          const text = await response.text();
-          const dataLines = text
-            .split('\n')
-            .filter((line) => line.startsWith('data: '))
-            .map((line) => line.slice(6));
-          const lastData = dataLines[dataLines.length - 1];
-          if (!lastData) throw new Error('PCP SSE response contained no data lines');
-          payload = JSON.parse(lastData) as Record<string, unknown>;
-        } else {
-          payload = (await response.json()) as Record<string, unknown>;
-        }
-
-        if (payload.error) {
-          const err = payload.error as { message?: string; code?: number };
-          throw new Error(`PCP tool error (${err.code}): ${err.message}`);
-        }
-
-        const result = payload.result as { content?: Array<{ text?: string }> } | undefined;
-        const mcpText = result?.content?.[0]?.text;
-        if (typeof mcpText === 'string') {
-          try {
-            return JSON.parse(mcpText) as T;
-          } catch {
-            return { text: mcpText } as unknown as T;
-          }
-        }
-
-        return (result as unknown as T) || (payload as unknown as T);
-      }
-
-      // Legacy fallback endpoint (/api/mcp/call) for older server deployments.
-      if (response.status === 404 || response.status === 405) {
-        const legacyResponse = await fetch(legacyEndpoint, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ tool, args }),
-        });
-        if (legacyResponse.ok) {
-          return (await legacyResponse.json()) as T;
-        }
-        lastError = new Error(
-          `legacy fallback failed: ${legacyResponse.status} ${await legacyResponse.text()}`
-        );
-        continue;
-      }
-
-      lastError = new Error(`PCP tool ${tool} failed: ${response.status} ${await response.text()}`);
-    } catch (error) {
-      lastError = error instanceof Error ? error : new Error(String(error));
-    }
-  }
-
-  throw new Error(
-    `PCP tool ${tool} failed after trying ${tried.length} endpoint(s): ${tried.join(', ')}${lastError ? ` — ${lastError.message}` : ''}`
-  );
 }
 
 function extractActivityIdFromLogResult(result: unknown): string | undefined {

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -5,7 +5,7 @@
  * passthrough flags, and session tracking.
  */
 
-import { spawn } from 'child_process';
+import { spawn, spawnSync } from 'child_process';
 import chalk from 'chalk';
 import { randomUUID } from 'crypto';
 import { existsSync, readFileSync, readdirSync, realpathSync } from 'fs';
@@ -48,7 +48,8 @@ interface ListSessionsResult {
   sessions?: PcpSessionSummary[];
 }
 
-interface ClaudeLocalSessionSummary {
+interface BackendLocalSessionSummary {
+  backend: 'claude' | 'codex' | 'gemini';
   sessionId: string;
   projectPath: string;
   modified: string;
@@ -62,9 +63,9 @@ function getSessionBackendId(session: PcpSessionSummary): string | undefined {
 }
 
 export function filterUntrackedLocalClaudeSessions(
-  localSessions: ClaudeLocalSessionSummary[],
+  localSessions: BackendLocalSessionSummary[],
   activePcpSessions: PcpSessionSummary[]
-): ClaudeLocalSessionSummary[] {
+): BackendLocalSessionSummary[] {
   const trackedSessionIds = new Set(
     activePcpSessions
       .map((session) => getSessionBackendId(session))
@@ -149,11 +150,18 @@ function normalizePath(path: string | null | undefined): string | null {
   }
 }
 
+function truncateText(text: string | null | undefined, max = 90): string {
+  if (!text) return '';
+  const compact = text.replace(/\s+/g, ' ').trim();
+  if (compact.length <= max) return compact;
+  return `${compact.slice(0, max - 1)}…`;
+}
+
 export function filterPcpSessionsForContext(
   sessions: PcpSessionSummary[],
   backend: string,
   cwd = process.cwd(),
-  localClaudeSessionIds: Set<string> = new Set()
+  localBackendSessionIds: Set<string> = new Set()
 ): PcpSessionSummary[] {
   const normalizedCwd = normalizePath(cwd);
 
@@ -162,30 +170,32 @@ export function filterPcpSessionsForContext(
     return session.backend === backend;
   });
 
-  if (backend !== 'claude' || !normalizedCwd) {
+  if (!normalizedCwd) {
     return backendMatched;
   }
 
-  return backendMatched.filter((session) => {
+  const pathScoped = backendMatched.filter((session) => {
     const localMatchedId = session.backendSessionId || session.claudeSessionId;
-    if (localMatchedId && localClaudeSessionIds.has(localMatchedId)) return true;
+    if (localMatchedId && localBackendSessionIds.has(localMatchedId)) return true;
 
     const normalizedWorkingDir = normalizePath(session.workingDir);
     return !!normalizedWorkingDir && normalizedWorkingDir === normalizedCwd;
   });
+
+  return pathScoped.length > 0 ? pathScoped : backendMatched;
 }
 
 export function getClaudeLocalSessionsForProject(
   cwd = process.cwd(),
   limit = 20
-): ClaudeLocalSessionSummary[] {
+): BackendLocalSessionSummary[] {
   const claudeProjectsDir = join(homedir(), '.claude', 'projects');
   if (!existsSync(claudeProjectsDir)) return [];
 
   const normalizedCwd = normalizePath(cwd);
   if (!normalizedCwd) return [];
 
-  const results: ClaudeLocalSessionSummary[] = [];
+  const results: BackendLocalSessionSummary[] = [];
 
   for (const entry of readdirSync(claudeProjectsDir, { withFileTypes: true })) {
     if (!entry.isDirectory()) continue;
@@ -210,6 +220,7 @@ export function getClaudeLocalSessionsForProject(
         if (!normalizedProjectPath || normalizedProjectPath !== normalizedCwd) continue;
 
         results.push({
+          backend: 'claude',
           sessionId: item.sessionId,
           projectPath: item.projectPath,
           modified: item.modified,
@@ -223,7 +234,7 @@ export function getClaudeLocalSessionsForProject(
     }
   }
 
-  const dedupedBySessionId = new Map<string, ClaudeLocalSessionSummary>();
+  const dedupedBySessionId = new Map<string, BackendLocalSessionSummary>();
   for (const session of results) {
     const existing = dedupedBySessionId.get(session.sessionId);
     if (!existing || new Date(session.modified).getTime() > new Date(existing.modified).getTime()) {
@@ -234,6 +245,182 @@ export function getClaudeLocalSessionsForProject(
   return Array.from(dedupedBySessionId.values())
     .sort((a, b) => new Date(b.modified).getTime() - new Date(a.modified).getTime())
     .slice(0, limit);
+}
+
+export function getCodexLocalSessionsForProject(
+  cwd = process.cwd(),
+  limit = 20
+): BackendLocalSessionSummary[] {
+  const codexStateDbPath = join(homedir(), '.codex', 'state_5.sqlite');
+  if (!existsSync(codexStateDbPath)) return [];
+
+  const normalizedCwd = normalizePath(cwd);
+  if (!normalizedCwd) return [];
+
+  const query = `
+SELECT id, cwd, updated_at,
+       replace(replace(first_user_message, char(10), ' '), char(9), ' ') AS first_user_message,
+       git_branch
+FROM threads
+WHERE archived = 0
+ORDER BY updated_at DESC
+LIMIT 200;
+`;
+
+  const result = spawnSync('sqlite3', ['-tabs', codexStateDbPath, query], { encoding: 'utf-8' });
+  if (result.error || result.status !== 0 || !result.stdout) return [];
+
+  const sessions: BackendLocalSessionSummary[] = [];
+  const lines = result.stdout.split('\n').map((line) => line.trim());
+  for (const line of lines) {
+    if (!line) continue;
+    const [sessionId, sessionCwd, updatedAtRaw, firstPrompt, gitBranch] = line.split('\t');
+    if (!sessionId || !sessionCwd || !updatedAtRaw) continue;
+
+    const normalizedSessionPath = normalizePath(sessionCwd);
+    if (!normalizedSessionPath || normalizedSessionPath !== normalizedCwd) continue;
+
+    const updatedAtSeconds = Number(updatedAtRaw);
+    const modified = Number.isFinite(updatedAtSeconds)
+      ? new Date(updatedAtSeconds * 1000).toISOString()
+      : new Date().toISOString();
+
+    sessions.push({
+      backend: 'codex',
+      sessionId,
+      projectPath: sessionCwd,
+      modified,
+      firstPrompt: firstPrompt?.trim(),
+      gitBranch: gitBranch?.trim(),
+    });
+  }
+
+  return sessions.slice(0, limit);
+}
+
+function getGeminiProjectKeysForCwd(cwd = process.cwd()): string[] {
+  const normalizedCwd = normalizePath(cwd);
+  if (!normalizedCwd) return [];
+
+  const keys = new Set<string>();
+
+  const projectsJsonPath = join(homedir(), '.gemini', 'projects.json');
+  if (existsSync(projectsJsonPath)) {
+    try {
+      const parsed = JSON.parse(readFileSync(projectsJsonPath, 'utf-8')) as {
+        projects?: Record<string, string>;
+      };
+      for (const [projectPath, projectKey] of Object.entries(parsed.projects || {})) {
+        const normalizedProjectPath = normalizePath(projectPath);
+        if (normalizedProjectPath === normalizedCwd && projectKey) {
+          keys.add(projectKey);
+        }
+      }
+    } catch {
+      // Ignore malformed projects.json
+    }
+  }
+
+  const geminiHistoryDir = join(homedir(), '.gemini', 'history');
+  if (existsSync(geminiHistoryDir)) {
+    for (const entry of readdirSync(geminiHistoryDir, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      const projectRootPath = join(geminiHistoryDir, entry.name, '.project_root');
+      if (!existsSync(projectRootPath)) continue;
+      try {
+        const projectRoot = readFileSync(projectRootPath, 'utf-8').trim();
+        if (normalizePath(projectRoot) === normalizedCwd) {
+          keys.add(entry.name);
+        }
+      } catch {
+        // Ignore unreadable .project_root files
+      }
+    }
+  }
+
+  return Array.from(keys);
+}
+
+function getGeminiSessionsForProjectKey(projectKey: string): BackendLocalSessionSummary[] {
+  const chatsDir = join(homedir(), '.gemini', 'tmp', projectKey, 'chats');
+  if (!existsSync(chatsDir)) return [];
+
+  const sessions: BackendLocalSessionSummary[] = [];
+  const projectRoot = join(homedir(), '.gemini', 'history', projectKey, '.project_root');
+  const projectPath = existsSync(projectRoot)
+    ? readFileSync(projectRoot, 'utf-8').trim()
+    : projectKey;
+
+  for (const entry of readdirSync(chatsDir, { withFileTypes: true })) {
+    if (!entry.isFile() || !entry.name.startsWith('session-') || !entry.name.endsWith('.json')) {
+      continue;
+    }
+    const sessionPath = join(chatsDir, entry.name);
+    try {
+      const parsed = JSON.parse(readFileSync(sessionPath, 'utf-8')) as {
+        sessionId?: string;
+        lastUpdated?: string;
+        startTime?: string;
+        summary?: string;
+        messages?: Array<{ type?: string; content?: string }>;
+      };
+
+      if (!parsed.sessionId) continue;
+      const modified = parsed.lastUpdated || parsed.startTime;
+      if (!modified) continue;
+
+      const firstUserMessage = (parsed.messages || []).find((message) => message.type === 'user');
+      const firstPrompt =
+        parsed.summary ||
+        (typeof firstUserMessage?.content === 'string'
+          ? firstUserMessage.content.trim()
+          : undefined);
+
+      sessions.push({
+        backend: 'gemini',
+        sessionId: parsed.sessionId,
+        projectPath,
+        modified,
+        firstPrompt,
+      });
+    } catch {
+      // Ignore malformed session files.
+    }
+  }
+
+  return sessions;
+}
+
+export function getGeminiLocalSessionsForProject(
+  cwd = process.cwd(),
+  limit = 20
+): BackendLocalSessionSummary[] {
+  const projectKeys = getGeminiProjectKeysForCwd(cwd);
+  if (projectKeys.length === 0) return [];
+
+  const sessions = projectKeys.flatMap((projectKey) => getGeminiSessionsForProjectKey(projectKey));
+  const deduped = new Map<string, BackendLocalSessionSummary>();
+  for (const session of sessions) {
+    const existing = deduped.get(session.sessionId);
+    if (!existing || new Date(session.modified).getTime() > new Date(existing.modified).getTime()) {
+      deduped.set(session.sessionId, session);
+    }
+  }
+
+  return Array.from(deduped.values())
+    .sort((a, b) => new Date(b.modified).getTime() - new Date(a.modified).getTime())
+    .slice(0, limit);
+}
+
+export function getBackendLocalSessionsForProject(
+  backend: string,
+  cwd = process.cwd(),
+  limit = 20
+): BackendLocalSessionSummary[] {
+  if (backend === 'claude') return getClaudeLocalSessionsForProject(cwd, limit);
+  if (backend === 'codex') return getCodexLocalSessionsForProject(cwd, limit);
+  if (backend === 'gemini') return getGeminiLocalSessionsForProject(cwd, limit);
+  return [];
 }
 
 function printPcpUnavailableWarning(reason: string, cwd = process.cwd()): void {
@@ -393,8 +580,8 @@ async function ensurePcpSessionContext(
   const email = config?.email;
   const cwd = process.cwd();
   const { studioId, identityId } = getIdentityContextFromIdentityJson(cwd);
-  const localClaudeSessions = backend === 'claude' ? getClaudeLocalSessionsForProject(cwd, 20) : [];
-  const localClaudeSessionIds = new Set(localClaudeSessions.map((session) => session.sessionId));
+  const localBackendSessions = getBackendLocalSessionsForProject(backend, cwd, 20);
+  const localBackendSessionIds = new Set(localBackendSessions.map((session) => session.sessionId));
   const sessionChoiceByValue = new Map<string, string>();
 
   // Fast path: runtime already knows current session for this backend.
@@ -426,7 +613,7 @@ async function ensurePcpSessionContext(
         (listed.sessions || []).filter((s) => !s.endedAt),
         backend,
         cwd,
-        localClaudeSessionIds
+        localBackendSessionIds
       );
     } catch (err) {
       pcpAvailable = false;
@@ -438,10 +625,10 @@ async function ensurePcpSessionContext(
     printPcpUnavailableWarning(pcpUnavailableReason || 'unknown error', cwd);
   }
 
-  const untrackedLocalClaudeSessions =
+  const untrackedLocalBackendSessions =
     backend === 'claude'
-      ? filterUntrackedLocalClaudeSessions(localClaudeSessions, activeSessions)
-      : [];
+      ? filterUntrackedLocalClaudeSessions(localBackendSessions, activeSessions)
+      : localBackendSessions;
 
   let chosen: PcpSessionSummary | undefined;
   let selectedLocalBackendSessionId: string | undefined;
@@ -484,16 +671,21 @@ async function ensurePcpSessionContext(
       sessionChoiceByValue.set(value, session.id);
     }
 
-    if (backend === 'claude') {
-      for (const localSession of untrackedLocalClaudeSessions) {
-        const value = `__claude__:${localSession.sessionId}`;
-        const preview = localSession.firstPrompt ? ` — ${localSession.firstPrompt}` : '';
-        choices.push({
-          name: `Resume Claude local ${localSession.sessionId.slice(0, 8)} (${new Date(localSession.modified).toLocaleString()})${preview}`,
-          value,
-        });
-        sessionChoiceByValue.set(value, localSession.sessionId);
-      }
+    for (const localSession of untrackedLocalBackendSessions) {
+      const value = `__local__:${localSession.sessionId}`;
+      const preview = localSession.firstPrompt
+        ? ` — ${truncateText(localSession.firstPrompt)}`
+        : '';
+      const backendLabel =
+        localSession.backend[0].toUpperCase() + localSession.backend.slice(1);
+      choices.push({
+        name:
+          localSession.backend === 'claude'
+            ? `Resume Claude local ${localSession.sessionId.slice(0, 8)} (${new Date(localSession.modified).toLocaleString()})${preview}`
+            : `Resume ${backendLabel} local ${localSession.sessionId.slice(0, 8)} (${new Date(localSession.modified).toLocaleString()})${preview}`,
+        value,
+      });
+      sessionChoiceByValue.set(value, localSession.sessionId);
     }
 
     try {
@@ -507,7 +699,7 @@ async function ensurePcpSessionContext(
       } else if (selection.startsWith('__pcp__:')) {
         const sessionId = sessionChoiceByValue.get(selection);
         chosen = activeSessions.find((session) => session.id === sessionId);
-      } else if (selection.startsWith('__claude__:')) {
+      } else if (selection.startsWith('__local__:')) {
         selectedLocalBackendSessionId = sessionChoiceByValue.get(selection);
         if (selectedLocalBackendSessionId && pcpAvailable) {
           chosen = await startNewPcpSession();

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -62,10 +62,10 @@ function getSessionBackendId(session: PcpSessionSummary): string | undefined {
   return session.backendSessionId || session.claudeSessionId || undefined;
 }
 
-export function filterUntrackedLocalClaudeSessions(
-  localSessions: BackendLocalSessionSummary[],
+export function filterUntrackedLocalClaudeSessions<T extends { sessionId: string }>(
+  localSessions: T[],
   activePcpSessions: PcpSessionSummary[]
-): BackendLocalSessionSummary[] {
+): T[] {
   const trackedSessionIds = new Set(
     activePcpSessions
       .map((session) => getSessionBackendId(session))
@@ -676,8 +676,7 @@ async function ensurePcpSessionContext(
       const preview = localSession.firstPrompt
         ? ` — ${truncateText(localSession.firstPrompt)}`
         : '';
-      const backendLabel =
-        localSession.backend[0].toUpperCase() + localSession.backend.slice(1);
+      const backendLabel = localSession.backend[0].toUpperCase() + localSession.backend.slice(1);
       choices.push({
         name:
           localSession.backend === 'claude'

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -100,6 +100,21 @@ export function shouldAutoResumeRuntimeSession(
   existing: { pcpSessionId?: string; backendSessionId?: string } | undefined,
   isTty: boolean
 ): boolean {
+  // CRITICAL UX NOTE:
+  // - Interactive users (TTY=true) MUST see the session picker so they can explicitly choose
+  //   between:
+  //     1) starting a new session,
+  //     2) resuming a tracked PCP session, or
+  //     3) resuming a backend-local session.
+  // - Non-interactive contexts (TTY=false), like scripts/piped invocations, cannot render the
+  //   picker safely. Only in that case do we allow implicit runtime auto-resume.
+  //
+  // Regressions here are high-impact because they make session behavior feel "mysterious":
+  // users see an unexpected resume with no chance to choose.
+  //
+  // If you modify this function, manually verify both:
+  //   sb -a <agent> -b <backend>          # TTY: picker appears
+  //   echo "prompt" | sb -a <agent> ...   # non-TTY: no picker, deterministic auto behavior
   return Boolean(existing?.pcpSessionId && !isTty);
 }
 

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -96,6 +96,13 @@ export function filterUntrackedLocalClaudeSessions<T extends { sessionId: string
   return localSessions.filter((session) => !trackedSessionIds.has(session.sessionId));
 }
 
+export function shouldAutoResumeRuntimeSession(
+  existing: { pcpSessionId?: string; backendSessionId?: string } | undefined,
+  isTty: boolean
+): boolean {
+  return Boolean(existing?.pcpSessionId && !isTty);
+}
+
 function isPromptCancelError(err: unknown): boolean {
   if (!err || typeof err !== 'object') return false;
   const maybe = err as { name?: string; message?: string };
@@ -748,7 +755,7 @@ async function ensurePcpSessionContext(
 
   // Fast path: runtime already knows current session for this backend.
   const existing = getCurrentRuntimeSession(cwd, backend);
-  if (existing?.pcpSessionId) {
+  if (existing?.pcpSessionId && shouldAutoResumeRuntimeSession(existing, process.stdin.isTTY)) {
     return {
       pcpSessionId: existing.pcpSessionId,
       backendSessionId: existing.backendSessionId,

--- a/packages/cli/src/commands/session.ts
+++ b/packages/cli/src/commands/session.ts
@@ -15,6 +15,7 @@ import chalk from 'chalk';
 import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
+import { callPcpTool } from '../lib/pcp-mcp.js';
 
 interface PcpConfig {
   userId?: string;
@@ -52,21 +53,6 @@ function getPcpConfig(): PcpConfig | null {
   return null;
 }
 
-function getPcpServerUrl(): string {
-  return process.env.PCP_SERVER_URL || 'http://localhost:3001';
-}
-
-async function fetchPcp(path: string, options?: RequestInit): Promise<Response> {
-  const url = `${getPcpServerUrl()}${path}`;
-  return fetch(url, {
-    ...options,
-    headers: {
-      'Content-Type': 'application/json',
-      ...options?.headers,
-    },
-  });
-}
-
 // ============================================================================
 // Commands
 // ============================================================================
@@ -79,24 +65,11 @@ async function listCommand(options: { agent?: string; limit?: string }): Promise
   }
 
   try {
-    const response = await fetchPcp('/api/mcp/call', {
-      method: 'POST',
-      body: JSON.stringify({
-        tool: 'list_sessions',
-        args: {
-          email: config.email,
-          agentId: options.agent,
-          limit: parseInt(options.limit || '10', 10),
-        },
-      }),
+    const result = await callPcpTool<SessionListResult>('list_sessions', {
+      email: config.email,
+      agentId: options.agent,
+      limit: parseInt(options.limit || '10', 10),
     });
-
-    if (!response.ok) {
-      console.error(chalk.red(`Failed to list sessions: ${await response.text()}`));
-      process.exit(1);
-    }
-
-    const result = (await response.json()) as SessionListResult;
 
     console.log(chalk.bold('\nRecent Sessions:\n'));
 
@@ -146,23 +119,10 @@ async function showCommand(sessionId: string): Promise<void> {
   }
 
   try {
-    const response = await fetchPcp('/api/mcp/call', {
-      method: 'POST',
-      body: JSON.stringify({
-        tool: 'get_session',
-        args: {
-          email: config.email,
-          sessionId,
-        },
-      }),
+    const session = await callPcpTool<Session>('get_session', {
+      email: config.email,
+      sessionId,
     });
-
-    if (!response.ok) {
-      console.error(chalk.red(`Failed to get session: ${await response.text()}`));
-      process.exit(1);
-    }
-
-    const session = (await response.json()) as Session;
 
     console.log(chalk.bold(`\nSession: ${session.id}\n`));
     console.log(chalk.dim('  Agent:    ') + (session.agentId || 'unknown'));
@@ -209,23 +169,10 @@ async function resumeCommand(sessionId: string): Promise<void> {
 
   // Get session to find Claude session ID
   try {
-    const response = await fetchPcp('/api/mcp/call', {
-      method: 'POST',
-      body: JSON.stringify({
-        tool: 'get_session',
-        args: {
-          email: config.email,
-          sessionId,
-        },
-      }),
+    const session = await callPcpTool<Session>('get_session', {
+      email: config.email,
+      sessionId,
     });
-
-    if (!response.ok) {
-      console.error(chalk.red(`Failed to get session: ${await response.text()}`));
-      process.exit(1);
-    }
-
-    const session = (await response.json()) as Session;
 
     if (!session.claudeSessionId) {
       console.error(chalk.red('Session has no Claude session ID to resume'));
@@ -257,22 +204,10 @@ async function endCommand(sessionId?: string): Promise<void> {
   }
 
   try {
-    const response = await fetchPcp('/api/mcp/call', {
-      method: 'POST',
-      body: JSON.stringify({
-        tool: 'end_session',
-        args: {
-          email: config.email,
-          sessionId,
-        },
-      }),
+    await callPcpTool('end_session', {
+      email: config.email,
+      sessionId,
     });
-
-    if (!response.ok) {
-      console.error(chalk.red(`Failed to end session: ${await response.text()}`));
-      process.exit(1);
-    }
-
     console.log(chalk.green(`Session ${sessionId.substring(0, 8)} ended`));
   } catch (error) {
     console.error(chalk.red(`Failed to end session: ${error}`));

--- a/packages/cli/src/commands/workspace.ts
+++ b/packages/cli/src/commands/workspace.ts
@@ -11,6 +11,7 @@ import chalk from 'chalk';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
 import { homedir } from 'os';
 import { join } from 'path';
+import { callPcpTool } from '../lib/pcp-mcp.js';
 
 interface PcpConfig {
   userId?: string;
@@ -27,6 +28,30 @@ interface Workspace {
   role?: 'owner' | 'admin' | 'member' | 'viewer';
   description?: string | null;
   archivedAt?: string | null;
+}
+
+interface WorkspaceMember {
+  role?: string;
+  user?: {
+    email?: string | null;
+    firstName?: string | null;
+    username?: string | null;
+    lastLoginAt?: string | null;
+  };
+  userId?: string;
+  userWasCreated?: boolean;
+}
+
+interface AddWorkspaceMemberResult {
+  success?: boolean;
+  error?: string;
+  member?: WorkspaceMember;
+}
+
+interface GetWorkspaceResult {
+  workspace?: {
+    members?: WorkspaceMember[];
+  };
 }
 
 function getConfigPath(): string {
@@ -53,50 +78,6 @@ function savePcpConfig(config: PcpConfig): void {
   writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n');
 }
 
-function getPcpServerUrl(): string {
-  return process.env.PCP_SERVER_URL || 'http://localhost:3001';
-}
-
-async function fetchPcp(path: string, options?: RequestInit): Promise<Response> {
-  const url = `${getPcpServerUrl()}${path}`;
-  // Intentionally no Authorization header here:
-  // CLI workspace selection currently goes through MCP tool calls (`/api/mcp/call`)
-  // that resolve user context from explicit args (email/userId), matching other sb CLI commands.
-  return fetch(url, {
-    ...options,
-    headers: {
-      'Content-Type': 'application/json',
-      ...options?.headers,
-    },
-  });
-}
-
-function unwrapToolResult(payload: unknown): Record<string, unknown> {
-  if (!payload || typeof payload !== 'object') {
-    throw new Error('Invalid response payload');
-  }
-
-  const direct = payload as Record<string, unknown>;
-  if (Array.isArray(direct.workspaces)) {
-    return direct;
-  }
-
-  const mcpText =
-    (direct.result as { content?: Array<{ text?: string }> } | undefined)?.content?.[0]?.text ||
-    (direct.content as Array<{ text?: string }> | undefined)?.[0]?.text;
-
-  if (typeof mcpText === 'string') {
-    try {
-      const parsed = JSON.parse(mcpText) as Record<string, unknown>;
-      return parsed;
-    } catch {
-      // fall through
-    }
-  }
-
-  return direct;
-}
-
 async function listWorkspaces(options: {
   all?: boolean;
   type?: 'personal' | 'team';
@@ -108,26 +89,12 @@ async function listWorkspaces(options: {
     process.exit(1);
   }
 
-  const response = await fetchPcp('/api/mcp/call', {
-    method: 'POST',
-    body: JSON.stringify({
-      tool: 'list_workspaces',
-      args: {
-        email: config.email,
-        includeArchived: options.all === true,
-        type: options.type,
-        ensurePersonal: true,
-      },
-    }),
+  const parsed = await callPcpTool<{ workspaces?: Workspace[] }>('list_workspaces', {
+    email: config.email,
+    includeArchived: options.all === true,
+    type: options.type,
+    ensurePersonal: true,
   });
-
-  if (!response.ok) {
-    console.error(chalk.red(`Failed to list workspaces: ${await response.text()}`));
-    process.exit(1);
-  }
-
-  const raw = (await response.json()) as unknown;
-  const parsed = unwrapToolResult(raw);
   const workspaces = Array.isArray(parsed.workspaces) ? (parsed.workspaces as Workspace[]) : [];
 
   if (options.json) {
@@ -169,25 +136,11 @@ async function useWorkspace(workspaceRef: string): Promise<void> {
     process.exit(1);
   }
 
-  const response = await fetchPcp('/api/mcp/call', {
-    method: 'POST',
-    body: JSON.stringify({
-      tool: 'list_workspaces',
-      args: {
-        email: config.email,
-        includeArchived: false,
-        ensurePersonal: true,
-      },
-    }),
+  const parsed = await callPcpTool<{ workspaces?: Workspace[] }>('list_workspaces', {
+    email: config.email,
+    includeArchived: false,
+    ensurePersonal: true,
   });
-
-  if (!response.ok) {
-    console.error(chalk.red(`Failed to list workspaces: ${await response.text()}`));
-    process.exit(1);
-  }
-
-  const raw = (await response.json()) as unknown;
-  const parsed = unwrapToolResult(raw);
   const workspaces = Array.isArray(parsed.workspaces) ? (parsed.workspaces as Workspace[]) : [];
   const match = workspaces.find((w) => w.id === workspaceRef || w.slug === workspaceRef);
 
@@ -206,24 +159,11 @@ async function useWorkspace(workspaceRef: string): Promise<void> {
 }
 
 async function resolveWorkspaceByRef(workspaceRef: string, config: PcpConfig): Promise<Workspace> {
-  const response = await fetchPcp('/api/mcp/call', {
-    method: 'POST',
-    body: JSON.stringify({
-      tool: 'list_workspaces',
-      args: {
-        email: config.email,
-        includeArchived: false,
-        ensurePersonal: true,
-      },
-    }),
+  const parsed = await callPcpTool<{ workspaces?: Workspace[] }>('list_workspaces', {
+    email: config.email,
+    includeArchived: false,
+    ensurePersonal: true,
   });
-
-  if (!response.ok) {
-    throw new Error(`Failed to list workspaces: ${await response.text()}`);
-  }
-
-  const raw = (await response.json()) as unknown;
-  const parsed = unwrapToolResult(raw);
   const workspaces = Array.isArray(parsed.workspaces) ? (parsed.workspaces as Workspace[]) : [];
   const match = workspaces.find(
     (workspace) => workspace.id === workspaceRef || workspace.slug === workspaceRef
@@ -246,27 +186,13 @@ async function createWorkspace(
     process.exit(1);
   }
 
-  const response = await fetchPcp('/api/mcp/call', {
-    method: 'POST',
-    body: JSON.stringify({
-      tool: 'create_workspace',
-      args: {
-        email: config.email,
-        name,
-        type: options.type || 'team',
-        description: options.description,
-        slug: options.slug,
-      },
-    }),
+  const parsed = await callPcpTool<{ workspace?: Workspace }>('create_workspace', {
+    email: config.email,
+    name,
+    type: options.type || 'team',
+    description: options.description,
+    slug: options.slug,
   });
-
-  if (!response.ok) {
-    console.error(chalk.red(`Failed to create workspace: ${await response.text()}`));
-    process.exit(1);
-  }
-
-  const raw = (await response.json()) as unknown;
-  const parsed = unwrapToolResult(raw);
   const workspace = parsed.workspace as Workspace | undefined;
 
   if (!workspace?.id) {
@@ -307,35 +233,19 @@ async function inviteWorkspaceMember(
     process.exit(1);
   }
 
-  const response = await fetchPcp('/api/mcp/call', {
-    method: 'POST',
-    body: JSON.stringify({
-      tool: 'add_workspace_member',
-      args: {
-        email: config.email,
-        workspaceId: targetWorkspace.id,
-        inviteeEmail,
-        role: options.role || 'member',
-      },
-    }),
+  const parsed = await callPcpTool<AddWorkspaceMemberResult>('add_workspace_member', {
+    email: config.email,
+    workspaceId: targetWorkspace.id,
+    inviteeEmail,
+    role: options.role || 'member',
   });
-
-  if (!response.ok) {
-    console.error(chalk.red(`Failed to invite member: ${await response.text()}`));
-    process.exit(1);
-  }
-
-  const raw = (await response.json()) as unknown;
-  const parsed = unwrapToolResult(raw);
 
   if (parsed.success === false) {
     console.error(chalk.red(`Failed to invite member: ${String(parsed.error || 'unknown error')}`));
     process.exit(1);
   }
 
-  const member = parsed.member as
-    | { role?: string; user?: { email?: string | null }; userWasCreated?: boolean }
-    | undefined;
+  const member = parsed.member;
   console.log(
     chalk.green(
       `Added ${member?.user?.email || inviteeEmail} to ${targetWorkspace.name} as ${member?.role || options.role || 'member'}`
@@ -371,37 +281,12 @@ async function listWorkspaceMembers(workspaceRef?: string): Promise<void> {
     process.exit(1);
   }
 
-  const response = await fetchPcp('/api/mcp/call', {
-    method: 'POST',
-    body: JSON.stringify({
-      tool: 'get_workspace',
-      args: {
-        email: config.email,
-        workspaceId: targetWorkspace.id,
-        includeMembers: true,
-      },
-    }),
+  const parsed = await callPcpTool<GetWorkspaceResult>('get_workspace', {
+    email: config.email,
+    workspaceId: targetWorkspace.id,
+    includeMembers: true,
   });
-
-  if (!response.ok) {
-    console.error(chalk.red(`Failed to list workspace members: ${await response.text()}`));
-    process.exit(1);
-  }
-
-  const raw = (await response.json()) as unknown;
-  const parsed = unwrapToolResult(raw);
-  const members = Array.isArray((parsed.workspace as { members?: unknown[] } | undefined)?.members)
-    ? ((parsed.workspace as { members?: unknown[] }).members as Array<{
-        role?: string;
-        user?: {
-          email?: string | null;
-          firstName?: string | null;
-          username?: string | null;
-          lastLoginAt?: string | null;
-        };
-        userId?: string;
-      }>)
-    : [];
+  const members = Array.isArray(parsed.workspace?.members) ? parsed.workspace.members : [];
 
   console.log(chalk.bold(`\nMembers — ${targetWorkspace.name}\n`));
   if (members.length === 0) {

--- a/packages/cli/src/lib/pcp-mcp.test.ts
+++ b/packages/cli/src/lib/pcp-mcp.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../auth/tokens.js', () => ({
+  getValidAccessToken: vi.fn(),
+}));
+
+import * as tokensMod from '../auth/tokens.js';
+import { callPcpTool } from './pcp-mcp.js';
+
+const mockedGetValidAccessToken = vi.mocked(tokensMod.getValidAccessToken);
+
+function mockJsonResponse(payload: Record<string, unknown>): Partial<Response> {
+  return {
+    ok: true,
+    headers: new Headers({ 'content-type': 'application/json' }),
+    json: async () => payload,
+    text: async () => JSON.stringify(payload),
+  };
+}
+
+describe('pcp-mcp callPcpTool', () => {
+  const originalServerUrl = process.env.PCP_SERVER_URL;
+
+  beforeEach(() => {
+    process.env.PCP_SERVER_URL = 'http://localhost:3999';
+    mockedGetValidAccessToken.mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    process.env.PCP_SERVER_URL = originalServerUrl;
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('calls the MCP JSON-RPC endpoint (/mcp), not legacy /api/mcp/call', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(
+      mockJsonResponse({
+        jsonrpc: '2.0',
+        result: { content: [{ text: '{"success":true}' }] },
+        id: 1,
+      })
+    );
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const result = await callPcpTool<{ success: boolean }>('list_sessions', { limit: 1 });
+
+    expect(result).toEqual({ success: true });
+    expect(fetchSpy).toHaveBeenCalledOnce();
+
+    const [url, options] = fetchSpy.mock.calls[0];
+    expect(url).toBe('http://localhost:3999/mcp');
+    expect(String(url)).not.toContain('/api/mcp/call');
+
+    const body = JSON.parse(options.body as string) as {
+      method: string;
+      params: { name: string; arguments: Record<string, unknown> };
+    };
+    expect(body.method).toBe('tools/call');
+    expect(body.params.name).toBe('list_sessions');
+    expect(body.params.arguments).toEqual({ limit: 1 });
+  });
+
+  it('parses streamable SSE payloads using the final data line', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: new Headers({ 'content-type': 'text/event-stream' }),
+      text: async () =>
+        [
+          'event: message',
+          'data: {"jsonrpc":"2.0","result":{"content":[{"text":"{\\"partial\\":true}"}]},"id":1}',
+          '',
+          'event: message',
+          'data: {"jsonrpc":"2.0","result":{"content":[{"text":"{\\"final\\":true}"}]},"id":1}',
+          '',
+        ].join('\n'),
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const result = await callPcpTool<{ final: boolean }>('bootstrap', { agentId: 'lumen' });
+    expect(result).toEqual({ final: true });
+  });
+
+  it('attaches auth token when available', async () => {
+    mockedGetValidAccessToken.mockResolvedValue('jwt-token');
+    const fetchSpy = vi.fn().mockResolvedValue(
+      mockJsonResponse({
+        jsonrpc: '2.0',
+        result: { content: [{ text: '{"ok":true}' }] },
+        id: 1,
+      })
+    );
+    vi.stubGlobal('fetch', fetchSpy);
+
+    await callPcpTool('bootstrap', { agentId: 'lumen' });
+
+    const [, options] = fetchSpy.mock.calls[0];
+    expect(options.headers).toMatchObject({
+      Authorization: 'Bearer jwt-token',
+      Accept: 'application/json, text/event-stream',
+    });
+  });
+});

--- a/packages/cli/src/lib/pcp-mcp.ts
+++ b/packages/cli/src/lib/pcp-mcp.ts
@@ -1,0 +1,78 @@
+import { getValidAccessToken } from '../auth/tokens.js';
+
+let jsonRpcId = 1;
+
+export function getPcpServerUrl(): string {
+  return process.env.PCP_SERVER_URL || 'http://localhost:3001';
+}
+
+export async function callPcpTool<T = Record<string, unknown>>(
+  tool: string,
+  args: Record<string, unknown>,
+  options?: { timeoutMs?: number }
+): Promise<T> {
+  const serverUrl = getPcpServerUrl();
+  const url = `${serverUrl}/mcp`;
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    Accept: 'application/json, text/event-stream',
+  };
+
+  const token = await getValidAccessToken(serverUrl);
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      method: 'tools/call',
+      params: { name: tool, arguments: args },
+      id: jsonRpcId++,
+    }),
+    ...(options?.timeoutMs ? { signal: AbortSignal.timeout(options.timeoutMs) } : {}),
+  });
+
+  if (!response.ok) {
+    throw new Error(`PCP call failed (${response.status}): ${await response.text()}`);
+  }
+
+  const contentType = response.headers.get('content-type') || '';
+  let payload: Record<string, unknown>;
+
+  if (contentType.includes('text/event-stream')) {
+    const text = await response.text();
+    const dataLines = text
+      .split('\n')
+      .filter((line) => line.startsWith('data: '))
+      .map((line) => line.slice(6));
+    const lastData = dataLines[dataLines.length - 1];
+    if (!lastData) {
+      throw new Error('PCP SSE response contained no data lines');
+    }
+    payload = JSON.parse(lastData) as Record<string, unknown>;
+  } else {
+    payload = (await response.json()) as Record<string, unknown>;
+  }
+
+  if (payload.error) {
+    const err = payload.error as { message?: string; code?: number };
+    throw new Error(`PCP tool error (${err.code}): ${err.message}`);
+  }
+
+  const result = payload.result as { content?: Array<{ text?: string }> } | undefined;
+  const mcpText = result?.content?.[0]?.text;
+
+  if (typeof mcpText === 'string') {
+    try {
+      return JSON.parse(mcpText) as T;
+    } catch {
+      return { text: mcpText } as unknown as T;
+    }
+  }
+
+  return (result as unknown as T) ?? (payload as unknown as T);
+}


### PR DESCRIPTION
## Summary
- Treat backend CLI launches as first-class `tool_call` / `tool_result` activity events.
- Log execution start with backend/binary, sanitized args, cwd, studio/session linkage, and retry metadata.
- Log execution result with status, exit code, duration, backend session ID, and spawn errors.
- Keep logging best-effort (never block CLI execution if PCP is unavailable).
- Add tests for argument sanitization/redaction (`--append-system-prompt`, one-shot prompts, Codex trailing prompt parts).

## Why
We need queryable observability for backend runs so we can answer: what process ran, with which args, from which studio/path/session, and how it finished.

## Validation
- `yarn workspace @personal-context/cli test src/commands/claude.test.ts src/backends/adapters.test.ts`
- `yarn workspace @personal-context/cli type-check`
- `yarn workspace @personal-context/cli build`

## Notes
- Stacked on top of #119 to keep review scope tight.
- No schema changes needed (uses existing `activity_stream` and `log_activity`).

— Lumen