### PR TITLE
test: cover unresolved workspace scope on artifact update/comment writes (by Lumen)

### DIFF
--- a/packages/api/src/mcp/server.workspace-context.test.ts
+++ b/packages/api/src/mcp/server.workspace-context.test.ts
@@ -1,0 +1,173 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../config/env', () => ({
+  env: {
+    MCP_TRANSPORT: 'http',
+    MCP_HTTP_PORT: 0,
+    MCP_REQUIRE_OAUTH: false,
+    SUPABASE_URL: 'http://localhost:54321',
+    SUPABASE_SECRET_KEY: 'test-secret',
+    SUPABASE_ANON_KEY: 'test-anon',
+    JWT_SECRET: 'test-jwt-secret-that-is-at-least-32-characters-long',
+  },
+}));
+
+vi.mock('../utils/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock('./tools', () => ({
+  registerAllTools: vi.fn(),
+  registerChannelListener: vi.fn(),
+  setMiniAppsRegistry: vi.fn(),
+  setTelegramListener: vi.fn(),
+}));
+
+vi.mock('../mini-apps', () => ({
+  loadMiniApps: vi.fn(() => new Map()),
+  registerMiniAppTools: vi.fn(),
+  getMiniAppsInfo: vi.fn(() => []),
+}));
+
+vi.mock('../routes/admin', () => {
+  const { Router } = require('express');
+  return {
+    default: Router(),
+    setWhatsAppListener: vi.fn(),
+  };
+});
+
+vi.mock('../routes/agent-trigger', () => {
+  const { Router } = require('express');
+  return {
+    default: Router(),
+    getAgentGateway: vi.fn(),
+  };
+});
+
+vi.mock('../routes/chat', () => ({
+  createChatRouter: vi.fn(() => {
+    const { Router } = require('express');
+    return Router();
+  }),
+}));
+
+vi.mock('../channels/gateway', () => ({
+  ChannelGateway: vi.fn(),
+  createChannelGateway: vi.fn(() => null),
+}));
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(() => ({
+    auth: { getUser: vi.fn(async () => ({ data: { user: null }, error: null })) },
+    from: vi.fn(() => ({ select: vi.fn(() => ({ eq: vi.fn(() => ({ single: vi.fn() })) })) })),
+  })),
+}));
+
+import { MCPServer } from './server';
+
+const mockFindById = vi.fn();
+const mockFrom = vi.fn();
+
+function createDataComposerMock() {
+  return {
+    repositories: {
+      workspaces: {
+        findById: mockFindById,
+      },
+    },
+    getClient: () => ({
+      from: mockFrom,
+    }),
+  } as any;
+}
+
+function buildAgentIdentityChain(result: { data: unknown; error: unknown }) {
+  const secondEq = vi.fn().mockResolvedValue(result);
+  const firstEq = vi.fn().mockReturnValue({ eq: secondEq });
+  return {
+    select: vi.fn().mockReturnValue({ eq: firstEq }),
+  };
+}
+
+describe('MCPServer workspace context resolution', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('uses requested workspace header when accessible', async () => {
+    mockFindById.mockResolvedValue({ id: 'ws-header' });
+    mockFrom.mockImplementation(() => {
+      throw new Error('agent derivation should not be called for valid header scope');
+    });
+
+    const server = new MCPServer(createDataComposerMock());
+    const req = {
+      header: vi.fn((name: string) => (name === 'x-pcp-workspace-id' ? 'ws-header' : undefined)),
+    } as any;
+
+    const result = await (server as any).resolveWorkspaceContextForMcpRequest(req, {
+      userId: 'user-1',
+      email: 'user@example.com',
+      agentId: 'lumen',
+    });
+
+    expect(result).toEqual({ workspaceId: 'ws-header', workspaceSource: 'header' });
+    expect(mockFindById).toHaveBeenCalledWith('ws-header', 'user-1');
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+
+  it('throws when requested workspace header is not accessible', async () => {
+    mockFindById.mockResolvedValue(null);
+    const server = new MCPServer(createDataComposerMock());
+    const req = {
+      header: vi.fn((name: string) => (name === 'x-pcp-workspace-id' ? 'ws-missing' : undefined)),
+    } as any;
+
+    await expect(
+      (server as any).resolveWorkspaceContextForMcpRequest(req, {
+        userId: 'user-1',
+        email: 'user@example.com',
+        agentId: 'lumen',
+      })
+    ).rejects.toThrow('Workspace not found or not accessible');
+  });
+
+  it('derives workspace from agent identity when no header is provided', async () => {
+    mockFrom.mockReturnValue(
+      buildAgentIdentityChain({
+        data: [{ workspace_id: 'ws-derived' }],
+        error: null,
+      })
+    );
+
+    const server = new MCPServer(createDataComposerMock());
+    const req = { header: vi.fn(() => undefined) } as any;
+
+    const result = await (server as any).resolveWorkspaceContextForMcpRequest(req, {
+      userId: 'user-1',
+      email: 'user@example.com',
+      agentId: 'lumen',
+    });
+
+    expect(result).toEqual({ workspaceId: 'ws-derived', workspaceSource: 'derived' });
+    expect(mockFrom).toHaveBeenCalledWith('agent_identities');
+  });
+
+  it('returns empty context when no header and no derivable workspace', async () => {
+    const server = new MCPServer(createDataComposerMock());
+    const req = { header: vi.fn(() => undefined) } as any;
+
+    const result = await (server as any).resolveWorkspaceContextForMcpRequest(req, {
+      userId: 'user-1',
+      email: 'user@example.com',
+    });
+
+    expect(result).toEqual({});
+  });
+});

--- a/packages/api/src/mcp/tools/artifact-handlers.test.ts
+++ b/packages/api/src/mcp/tools/artifact-handlers.test.ts
@@ -428,6 +428,21 @@ describe('handleUpdateArtifact', () => {
       expect(parsed.success).toBe(true);
       expect(parsed.mergePerformed).toBeFalsy();
     });
+
+    it('should reject update writes when workspace scope cannot be resolved', async () => {
+      clearSessionContext();
+
+      await expect(
+        handleUpdateArtifact(
+          {
+            userId: '00000000-0000-0000-0000-000000000001',
+            uri: 'pcp://test/doc',
+            content: 'Updated content',
+          },
+          createMockDataComposer({ from: vi.fn() })
+        )
+      ).rejects.toThrow('Artifact write requires workspace scope');
+    });
   });
 });
 
@@ -1176,6 +1191,21 @@ describe('artifact comment + identity UUID flows', () => {
         createMockDataComposer(supabase)
       )
     ).rejects.toThrow('Parent comment not found');
+  });
+
+  it('handleAddArtifactComment rejects writes when workspace scope cannot be resolved', async () => {
+    clearSessionContext();
+
+    await expect(
+      handleAddArtifactComment(
+        {
+          userId: '00000000-0000-0000-0000-000000000001',
+          artifactId: '11111111-1111-1111-1111-111111111111',
+          content: 'Missing scope',
+        },
+        createMockDataComposer({ from: vi.fn() })
+      )
+    ).rejects.toThrow('Artifact write requires workspace scope');
   });
 
   it('handleListArtifactComments enriches comments with identity details', async () => {

--- a/packages/api/src/routes/admin-auth.test.ts
+++ b/packages/api/src/routes/admin-auth.test.ts
@@ -644,6 +644,28 @@ describe('adminAuthMiddleware', () => {
       expect((req as any).pcpWorkspaceRole).toBe('member');
     });
 
+    it('should set request context workspaceSource=header when x-pcp-workspace-id is used', async () => {
+      mockFindById.mockResolvedValue({ id: 'requested-ws' });
+
+      const req = createMockReq({
+        header: vi.fn((name: string) => {
+          if (name === 'x-pcp-workspace-id') return 'requested-ws';
+          return undefined;
+        }),
+      });
+      const res = createMockRes();
+      const next = vi.fn();
+
+      await middleware(req, res, next);
+
+      expect(next).toHaveBeenCalled();
+      expect(capturedRunContext).toMatchObject({
+        userId: 'user-ws',
+        workspaceId: 'requested-ws',
+        workspaceSource: 'header',
+      });
+    });
+
     it('should return 404 when requested workspace does not exist', async () => {
       mockFindById.mockResolvedValue(null);
       mockFindRawById.mockResolvedValue(null);


### PR DESCRIPTION
## What this adds
Adds explicit regression coverage so artifact write paths cannot silently regress into NULL/unscoped workspace writes:

- `handleUpdateArtifact` now has a test that verifies it **throws** when workspace scope cannot be resolved.
- `handleAddArtifactComment` now has a test that verifies it **throws** when workspace scope cannot be resolved.

These complement existing create-path tests and keep all artifact write operations guarded (`create`, `update`, `add_comment`).

## Validation
- `npx vitest run packages/api/src/mcp/tools/artifact-handlers.test.ts`
- Also previously verified with related suites:
  - `packages/api/src/utils/workspace-scope.test.ts`
  - `packages/api/src/utils/request-context.test.ts`
  - `packages/api/src/routes/admin-auth.test.ts`