### PR TITLE
fix: ignore stale tracked backend session IDs when resuming PCP sessions (by Lumen)

### DIFF
--- a/packages/cli/src/backends/adapters.test.ts
+++ b/packages/cli/src/backends/adapters.test.ts
@@ -32,6 +32,22 @@ describe('backend adapters session resume wiring', () => {
     expect(prepared.args).not.toContain('pcp-session-123');
   });
 
+  it('passes claude backendSessionSeedId through --session-id', () => {
+    const adapter = new ClaudeAdapter();
+    const prepared = adapter.prepare({
+      agentId: 'wren',
+      model: undefined,
+      promptParts: [],
+      passthroughArgs: [],
+      pcpSessionId: 'pcp-session-123',
+      backendSessionSeedId: 'pcp-session-123',
+    });
+
+    const sessionIdFlagIndex = prepared.args.indexOf('--session-id');
+    expect(sessionIdFlagIndex).toBeGreaterThanOrEqual(0);
+    expect(prepared.args[sessionIdFlagIndex + 1]).toBe('pcp-session-123');
+  });
+
   it('passes backendSessionId through codex resume subcommand', () => {
     const adapter = new CodexAdapter();
     const prepared = adapter.prepare({

--- a/packages/cli/src/backends/adapters.test.ts
+++ b/packages/cli/src/backends/adapters.test.ts
@@ -1,8 +1,37 @@
 import { describe, expect, it } from 'vitest';
+import { ClaudeAdapter } from './claude.js';
 import { CodexAdapter } from './codex.js';
 import { GeminiAdapter } from './gemini.js';
 
 describe('backend adapters session resume wiring', () => {
+  it('passes claude backendSessionId through --resume', () => {
+    const adapter = new ClaudeAdapter();
+    const prepared = adapter.prepare({
+      agentId: 'wren',
+      model: undefined,
+      promptParts: [],
+      passthroughArgs: [],
+      backendSessionId: 'claude-session-789',
+    });
+
+    expect(prepared.args).toContain('--resume');
+    expect(prepared.args).toContain('claude-session-789');
+  });
+
+  it('does not force claude --session-id from pcp session id', () => {
+    const adapter = new ClaudeAdapter();
+    const prepared = adapter.prepare({
+      agentId: 'wren',
+      model: undefined,
+      promptParts: [],
+      passthroughArgs: [],
+      pcpSessionId: 'pcp-session-123',
+    });
+
+    expect(prepared.args).not.toContain('--session-id');
+    expect(prepared.args).not.toContain('pcp-session-123');
+  });
+
   it('passes backendSessionId through codex resume subcommand', () => {
     const adapter = new CodexAdapter();
     const prepared = adapter.prepare({

--- a/packages/cli/src/backends/claude.ts
+++ b/packages/cli/src/backends/claude.ts
@@ -35,6 +35,8 @@ export class ClaudeAdapter implements BackendAdapter {
     // Session routing
     if (config.backendSessionId) {
       args.push('--resume', config.backendSessionId);
+    } else if (config.backendSessionSeedId) {
+      args.push('--session-id', config.backendSessionSeedId);
     }
 
     // MCP config (if present in CWD)

--- a/packages/cli/src/backends/claude.ts
+++ b/packages/cli/src/backends/claude.ts
@@ -35,9 +35,6 @@ export class ClaudeAdapter implements BackendAdapter {
     // Session routing
     if (config.backendSessionId) {
       args.push('--resume', config.backendSessionId);
-    } else if (config.pcpSessionId) {
-      // Keep Claude session ID aligned with PCP session ID when possible
-      args.push('--session-id', config.pcpSessionId);
     }
 
     // MCP config (if present in CWD)

--- a/packages/cli/src/backends/types.ts
+++ b/packages/cli/src/backends/types.ts
@@ -13,6 +13,7 @@ export interface BackendConfig {
   passthroughArgs: string[];
   pcpSessionId?: string;
   backendSessionId?: string;
+  backendSessionSeedId?: string;
 }
 
 export interface PreparedBackend {

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -51,4 +51,10 @@ describe('extractArgs', () => {
     expect(result.passthroughArgs).toEqual(['--resume', 'abc123']);
     expect(result.promptParts).toEqual(['do', 'stuff']);
   });
+
+  it('parses session candidate debug flags', () => {
+    const result = extractArgs(['--session-candidates', '--session-choice', 'pcp:e03f522a']);
+    expect(result.sbOptions.sessionCandidates).toBe(true);
+    expect(result.sbOptions.sessionChoice).toBe('pcp:e03f522a');
+  });
 });

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -51,6 +51,8 @@ const SB_FLAGS: Record<string, { hasValue: boolean; key: string }> = {
   '-v': { hasValue: false, key: 'verbose' },
   '--verbose': { hasValue: false, key: 'verbose' },
   '--no-session': { hasValue: false, key: 'noSession' },
+  '--session-candidates': { hasValue: false, key: 'sessionCandidates' },
+  '--session-choice': { hasValue: true, key: 'sessionChoice' },
 };
 
 interface ParsedArgs {
@@ -60,6 +62,8 @@ interface ParsedArgs {
     model: string | undefined; // undefined = use backend's default
     session: boolean;
     verbose: boolean;
+    sessionCandidates: boolean;
+    sessionChoice: string | undefined;
   };
   passthroughArgs: string[];
   promptParts: string[];
@@ -92,6 +96,8 @@ export function extractArgs(argv: string[]): ParsedArgs {
     model: undefined, // undefined = use backend's default
     session: true,
     verbose: false,
+    sessionCandidates: false,
+    sessionChoice: undefined,
   };
   const passthroughArgs: string[] = [];
   const promptParts: string[] = [];
@@ -108,9 +114,11 @@ export function extractArgs(argv: string[]): ParsedArgs {
         if (flag.key === 'agent') sbOptions.agent = val;
         if (flag.key === 'backend') sbOptions.backend = val;
         if (flag.key === 'model') sbOptions.model = val;
+        if (flag.key === 'sessionChoice') sbOptions.sessionChoice = val;
       } else if (!flag.hasValue) {
         if (flag.key === 'noSession') sbOptions.session = false;
         else if (flag.key === 'verbose') sbOptions.verbose = true;
+        else if (flag.key === 'sessionCandidates') sbOptions.sessionCandidates = true;
       }
     } else if (arg === '--') {
       // Explicit passthrough boundary — everything after goes to claude
@@ -154,6 +162,11 @@ program
   .option('-b, --backend <name>', 'AI backend (claude, codex, gemini)', 'claude')
   .option('-m, --model <model>', 'Model to use (defaults to backend-specific)')
   .option('--no-session', 'Disable session tracking')
+  .option(
+    '--session-candidates',
+    'List session candidates and exit (or combine with --session-choice)'
+  )
+  .option('--session-choice <choice>', 'Force session selection (new | pcp:<id> | local:<id>)')
   .option('-v, --verbose', 'Verbose output')
   .argument('[prompt...]', 'Prompt to send (omit for interactive)')
   .action(async () => {

--- a/packages/cli/src/commands/claude.integration.test.ts
+++ b/packages/cli/src/commands/claude.integration.test.ts
@@ -27,6 +27,28 @@ async function waitForFile(path: string, timeoutMs = 5_000): Promise<void> {
   throw new Error(`Timed out waiting for file: ${path}`);
 }
 
+async function waitForRuntimeBackendSessionId(
+  runtimePath: string,
+  timeoutMs = 5_000
+): Promise<string | undefined> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (existsSync(runtimePath)) {
+      try {
+        const parsed = JSON.parse(readFileSync(runtimePath, 'utf-8')) as {
+          sessions?: Array<{ backendSessionId?: string }>;
+        };
+        const id = parsed.sessions?.[0]?.backendSessionId;
+        if (id) return id;
+      } catch {
+        // keep polling
+      }
+    }
+    await delay(50);
+  }
+  return undefined;
+}
+
 afterEach(() => {
   vi.unstubAllGlobals();
 
@@ -38,7 +60,7 @@ afterEach(() => {
 });
 
 describe('claude command integration', () => {
-  it('links a captured backend session id and does not inject --session-id from PCP id', async () => {
+  it('seeds --session-id for first run and persists captured backend session id', async () => {
     const root = mkdtempSync(join(tmpdir(), 'sb-claude-int-'));
     cleanupPaths.push(root);
 
@@ -143,13 +165,21 @@ console.log(JSON.stringify({ session_id: process.env.FAKE_CLAUDE_SESSION_ID || '
       await waitForFile(runtimePath);
 
       const backendArgs = JSON.parse(readFileSync(fakeClaudeArgsPath, 'utf-8')) as string[];
+      const startSessionCall = pcpToolCalls.find((call) => call.name === 'start_session');
+      const seededPcpSessionId = String(startSessionCall?.args.sessionId || '');
+      expect(seededPcpSessionId).not.toBe('');
       expect(backendArgs).toContain('-p');
-      expect(backendArgs).not.toContain('--session-id');
+      const sessionIdFlagIndex = backendArgs.indexOf('--session-id');
+      expect(sessionIdFlagIndex).toBeGreaterThanOrEqual(0);
+      expect(backendArgs[sessionIdFlagIndex + 1]).toBe(seededPcpSessionId);
 
       const runtimeState = JSON.parse(readFileSync(runtimePath, 'utf-8')) as {
         sessions: Array<{ backendSessionId?: string }>;
       };
-      expect(runtimeState.sessions[0]?.backendSessionId).toBe('claude-session-int-1');
+      const persistedBackendSessionId =
+        runtimeState.sessions[0]?.backendSessionId ||
+        (await waitForRuntimeBackendSessionId(runtimePath, 5_000));
+      expect(persistedBackendSessionId).toBe('claude-session-int-1');
 
       const phaseUpdatesWithBackendId = pcpToolCalls
         .filter((call) => call.name === 'update_session_phase')

--- a/packages/cli/src/commands/claude.integration.test.ts
+++ b/packages/cli/src/commands/claude.integration.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { runClaude, type SbOptions } from './claude.js';
+
+const cleanupPaths: string[] = [];
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForFile(path: string, timeoutMs = 5_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (existsSync(path)) return;
+    await delay(50);
+  }
+  throw new Error(`Timed out waiting for file: ${path}`);
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+
+  while (cleanupPaths.length > 0) {
+    const path = cleanupPaths.pop();
+    if (!path) continue;
+    rmSync(path, { recursive: true, force: true });
+  }
+});
+
+describe('claude command integration', () => {
+  it('links a captured backend session id and does not inject --session-id from PCP id', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'sb-claude-int-'));
+    cleanupPaths.push(root);
+
+    const homeDir = join(root, 'home');
+    const repoDir = join(root, 'repo');
+    const binDir = join(root, 'bin');
+    mkdirSync(homeDir, { recursive: true });
+    mkdirSync(repoDir, { recursive: true });
+    mkdirSync(binDir, { recursive: true });
+    mkdirSync(join(homeDir, '.pcp'), { recursive: true });
+    mkdirSync(join(repoDir, '.pcp'), { recursive: true });
+
+    writeFileSync(
+      join(homeDir, '.pcp', 'config.json'),
+      JSON.stringify({ email: 'integration@example.com' }, null, 2)
+    );
+    writeFileSync(
+      join(repoDir, '.pcp', 'identity.json'),
+      JSON.stringify({ studioId: 'studio-test' }, null, 2)
+    );
+
+    const fakeClaudeArgsPath = join(root, 'fake-claude-args.json');
+    const fakeClaudePath = join(binDir, 'claude');
+    writeFileSync(
+      fakeClaudePath,
+      `#!/usr/bin/env node
+const { writeFileSync } = require('fs');
+writeFileSync(process.env.FAKE_CLAUDE_ARGS_PATH, JSON.stringify(process.argv.slice(2)));
+console.log(JSON.stringify({ session_id: process.env.FAKE_CLAUDE_SESSION_ID || 'claude-int-default' }));
+`
+    );
+    chmodSync(fakeClaudePath, 0o755);
+
+    const pcpToolCalls: Array<{ name: string; args: Record<string, unknown> }> = [];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (_input: unknown, init?: { body?: unknown }) => {
+        const body = JSON.parse(String(init?.body || '{}')) as {
+          id?: number;
+          params?: { name?: string; arguments?: Record<string, unknown> };
+        };
+        const toolName = body.params?.name || '';
+        const toolArgs = body.params?.arguments || {};
+        pcpToolCalls.push({ name: toolName, args: toolArgs });
+
+        let payload: Record<string, unknown> = { success: true };
+        if (toolName === 'list_sessions') {
+          payload = { sessions: [] };
+        } else if (toolName === 'start_session') {
+          payload = {
+            session: {
+              id: String(toolArgs.sessionId || 'generated-session-id'),
+              startedAt: new Date().toISOString(),
+              backend: 'claude',
+            },
+          };
+        }
+
+        return new Response(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            id: body.id ?? 1,
+            result: {
+              content: [{ type: 'text', text: JSON.stringify(payload) }],
+            },
+          }),
+          {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }
+        );
+      })
+    );
+
+    const oldHome = process.env.HOME;
+    const oldPath = process.env.PATH;
+    const oldPcpUrl = process.env.PCP_SERVER_URL;
+    const oldArgsPath = process.env.FAKE_CLAUDE_ARGS_PATH;
+    const oldFakeSessionId = process.env.FAKE_CLAUDE_SESSION_ID;
+    const oldCwd = process.cwd();
+
+    process.env.HOME = homeDir;
+    process.env.PATH = `${binDir}:${oldPath || ''}`;
+    process.env.PCP_SERVER_URL = 'http://pcp.test.local';
+    process.env.FAKE_CLAUDE_ARGS_PATH = fakeClaudeArgsPath;
+    process.env.FAKE_CLAUDE_SESSION_ID = 'claude-session-int-1';
+    process.chdir(repoDir);
+
+    try {
+      const options: SbOptions = {
+        agent: 'wren',
+        model: undefined,
+        session: true,
+        verbose: false,
+        backend: 'claude',
+      };
+
+      await runClaude('hello integration', ['hello', 'integration'], options, []);
+      await waitForFile(fakeClaudeArgsPath);
+
+      const runtimePath = join(repoDir, '.pcp', 'runtime', 'sessions.json');
+      await waitForFile(runtimePath);
+
+      const backendArgs = JSON.parse(readFileSync(fakeClaudeArgsPath, 'utf-8')) as string[];
+      expect(backendArgs).toContain('-p');
+      expect(backendArgs).not.toContain('--session-id');
+
+      const runtimeState = JSON.parse(readFileSync(runtimePath, 'utf-8')) as {
+        sessions: Array<{ backendSessionId?: string }>;
+      };
+      expect(runtimeState.sessions[0]?.backendSessionId).toBe('claude-session-int-1');
+
+      const phaseUpdatesWithBackendId = pcpToolCalls
+        .filter((call) => call.name === 'update_session_phase')
+        .some((call) => call.args.backendSessionId === 'claude-session-int-1');
+      expect(phaseUpdatesWithBackendId).toBe(true);
+    } finally {
+      process.chdir(oldCwd);
+
+      if (oldHome === undefined) delete process.env.HOME;
+      else process.env.HOME = oldHome;
+
+      if (oldPath === undefined) delete process.env.PATH;
+      else process.env.PATH = oldPath;
+
+      if (oldPcpUrl === undefined) delete process.env.PCP_SERVER_URL;
+      else process.env.PCP_SERVER_URL = oldPcpUrl;
+
+      if (oldArgsPath === undefined) delete process.env.FAKE_CLAUDE_ARGS_PATH;
+      else process.env.FAKE_CLAUDE_ARGS_PATH = oldArgsPath;
+
+      if (oldFakeSessionId === undefined) delete process.env.FAKE_CLAUDE_SESSION_ID;
+      else process.env.FAKE_CLAUDE_SESSION_ID = oldFakeSessionId;
+    }
+  });
+});

--- a/packages/cli/src/commands/claude.test.ts
+++ b/packages/cli/src/commands/claude.test.ts
@@ -4,6 +4,7 @@ import {
   filterPcpSessionsForContext,
   filterUntrackedLocalClaudeSessions,
   hasBackendSessionOverride,
+  resolveCapturedBackendSessionIdFromRuntime,
   resolveBackendSessionIdForResume,
   sanitizeBackendExecutionArgs,
   shouldAutoResumeRuntimeSession,
@@ -257,6 +258,18 @@ describe('resolveBackendSessionIdForResume', () => {
     ).toEqual({ backendSessionId: 'local-a' });
   });
 });
+
+describe('resolveCapturedBackendSessionIdFromRuntime', () => {
+  it('returns fallback when no pcp session id is present', () => {
+    expect(
+      resolveCapturedBackendSessionIdFromRuntime({
+        backend: 'claude',
+        fallbackBackendSessionId: 'fallback-id',
+      })
+    ).toBe('fallback-id');
+  });
+});
+
 describe('extractClaudeHistorySessionsForProject', () => {
   it('parses local claude sessions from history.jsonl for the current project path', () => {
     const jsonl = [

--- a/packages/cli/src/commands/claude.test.ts
+++ b/packages/cli/src/commands/claude.test.ts
@@ -251,6 +251,22 @@ describe('resolveBackendSessionIdForResume', () => {
     });
   });
 
+  it('does not classify session as stale when it exists in global backend index', () => {
+    expect(
+      resolveBackendSessionIdForResume({
+        backend: 'claude',
+        chosen: {
+          id: 'pcp-1',
+          startedAt: '2026-02-28T00:00:00.000Z',
+          backend: 'claude',
+          backendSessionId: 'known-global-id',
+        },
+        localBackendSessionIds: new Set(['local-a', 'local-b']),
+        knownBackendSessionIds: new Set(['known-global-id', 'local-a']),
+      })
+    ).toEqual({ backendSessionId: 'known-global-id' });
+  });
+
   it('keeps tracked backend id when it matches local project sessions', () => {
     expect(
       resolveBackendSessionIdForResume({

--- a/packages/cli/src/commands/claude.test.ts
+++ b/packages/cli/src/commands/claude.test.ts
@@ -11,6 +11,7 @@ import {
   resolveBackendSessionIdForResume,
   resolveBackendSessionSeedId,
   sanitizeBackendExecutionArgs,
+  shouldRetryWithFreshBackendSession,
   shouldAutoResumeRuntimeSession,
 } from './claude.js';
 
@@ -212,6 +213,37 @@ describe('shouldAutoResumeRuntimeSession', () => {
     expect(shouldAutoResumeRuntimeSession({ pcpSessionId: 'pcp-1' }, true)).toBe(false);
     expect(shouldAutoResumeRuntimeSession(undefined, false)).toBe(false);
     expect(shouldAutoResumeRuntimeSession({ backendSessionId: 'b-1' }, false)).toBe(false);
+  });
+});
+
+describe('shouldRetryWithFreshBackendSession', () => {
+  it('retries claude when resume fails with no conversation found', () => {
+    expect(
+      shouldRetryWithFreshBackendSession({
+        backend: 'claude',
+        attemptedBackendSessionId: 'abc123',
+        stderrText: 'No conversation found with session ID: abc123',
+      })
+    ).toBe(true);
+  });
+
+  it('retries claude when session id is already in use', () => {
+    expect(
+      shouldRetryWithFreshBackendSession({
+        backend: 'claude',
+        attemptedBackendSessionId: 'abc123',
+        stderrText: 'Error: Session ID abc123 is already in use.',
+      })
+    ).toBe(true);
+  });
+
+  it('does not retry when no backend session id was attempted', () => {
+    expect(
+      shouldRetryWithFreshBackendSession({
+        backend: 'claude',
+        stderrText: 'No conversation found with session ID: abc123',
+      })
+    ).toBe(false);
   });
 });
 

--- a/packages/cli/src/commands/claude.test.ts
+++ b/packages/cli/src/commands/claude.test.ts
@@ -9,6 +9,7 @@ import {
   hasBackendSessionOverride,
   resolveCapturedBackendSessionIdFromRuntime,
   resolveBackendSessionIdForResume,
+  resolveBackendSessionSeedId,
   sanitizeBackendExecutionArgs,
   shouldAutoResumeRuntimeSession,
 } from './claude.js';
@@ -259,6 +260,41 @@ describe('resolveBackendSessionIdForResume', () => {
         localBackendSessionIds: new Set(['local-a', 'local-b']),
       })
     ).toEqual({ backendSessionId: 'local-a' });
+  });
+});
+
+describe('resolveBackendSessionSeedId', () => {
+  it('seeds claude on first run when pcp session is newly created', () => {
+    expect(
+      resolveBackendSessionSeedId({
+        backend: 'claude',
+        chosenSessionId: 'pcp-new-1',
+        createdNewPcpSession: true,
+      })
+    ).toBe('pcp-new-1');
+  });
+
+  it('seeds claude when tracked backend id is stale on existing pcp session', () => {
+    expect(
+      resolveBackendSessionSeedId({
+        backend: 'claude',
+        chosenSessionId: 'pcp-existing-1',
+        createdNewPcpSession: false,
+        staleTrackedBackendSessionId: 'stale-backend-id',
+      })
+    ).toBe('pcp-existing-1');
+  });
+
+  it('does not seed when backend-native session id is already known', () => {
+    expect(
+      resolveBackendSessionSeedId({
+        backend: 'claude',
+        chosenSessionId: 'pcp-existing-1',
+        backendSessionId: 'claude-123',
+        createdNewPcpSession: false,
+        staleTrackedBackendSessionId: 'stale-backend-id',
+      })
+    ).toBeUndefined();
   });
 });
 

--- a/packages/cli/src/commands/claude.test.ts
+++ b/packages/cli/src/commands/claude.test.ts
@@ -4,6 +4,7 @@ import {
   filterPcpSessionsForContext,
   filterUntrackedLocalClaudeSessions,
   hasBackendSessionOverride,
+  resolveBackendSessionIdForResume,
   sanitizeBackendExecutionArgs,
   shouldAutoResumeRuntimeSession,
 } from './claude.js';
@@ -209,6 +210,53 @@ describe('shouldAutoResumeRuntimeSession', () => {
   });
 });
 
+describe('resolveBackendSessionIdForResume', () => {
+  it('keeps selected local backend session id when provided', () => {
+    expect(
+      resolveBackendSessionIdForResume({
+        backend: 'claude',
+        chosen: {
+          id: 'pcp-1',
+          startedAt: '2026-02-28T00:00:00.000Z',
+          backend: 'claude',
+          backendSessionId: 'stale-id',
+        },
+        selectedLocalBackendSessionId: 'local-id',
+        localBackendSessionIds: new Set(['local-id']),
+      })
+    ).toEqual({ backendSessionId: 'local-id' });
+  });
+
+  it('drops stale tracked backend id when local project sessions are known and do not match', () => {
+    expect(
+      resolveBackendSessionIdForResume({
+        backend: 'claude',
+        chosen: {
+          id: 'pcp-1',
+          startedAt: '2026-02-28T00:00:00.000Z',
+          backend: 'claude',
+          backendSessionId: 'stale-id',
+        },
+        localBackendSessionIds: new Set(['local-a', 'local-b']),
+      })
+    ).toEqual({ staleTrackedBackendSessionId: 'stale-id' });
+  });
+
+  it('keeps tracked backend id when it matches local project sessions', () => {
+    expect(
+      resolveBackendSessionIdForResume({
+        backend: 'claude',
+        chosen: {
+          id: 'pcp-1',
+          startedAt: '2026-02-28T00:00:00.000Z',
+          backend: 'claude',
+          backendSessionId: 'local-a',
+        },
+        localBackendSessionIds: new Set(['local-a', 'local-b']),
+      })
+    ).toEqual({ backendSessionId: 'local-a' });
+  });
+});
 describe('extractClaudeHistorySessionsForProject', () => {
   it('parses local claude sessions from history.jsonl for the current project path', () => {
     const jsonl = [

--- a/packages/cli/src/commands/claude.test.ts
+++ b/packages/cli/src/commands/claude.test.ts
@@ -333,43 +333,27 @@ describe('resolveCapturedBackendSessionIdFromRuntime', () => {
     mkdirSync(tempHome, { recursive: true });
     mkdirSync(tempRepo, { recursive: true });
 
-    const projectKeyDir = join(tempHome, '.claude', 'projects', 'clearpol-ai');
+    const projectDirName = tempRepo.replace(/[\\/]/g, '-');
+    const projectKeyDir = join(tempHome, '.claude', 'projects', projectDirName);
     mkdirSync(projectKeyDir, { recursive: true });
 
     const oldHome = process.env.HOME;
     process.env.HOME = tempHome;
 
     try {
-      writeFileSync(
-        join(projectKeyDir, 'sessions-index.json'),
-        JSON.stringify(
-          {
-            entries: [
-              {
-                sessionId: 'old-local-session',
-                projectPath: tempRepo,
-                modified: '2026-02-28T09:00:00.000Z',
-              },
-              {
-                sessionId: 'new-local-session',
-                projectPath: tempRepo,
-                modified: '2026-02-28T10:00:00.000Z',
-              },
-            ],
-          },
-          null,
-          2
-        )
-      );
+      const oldSessionId = '11111111-1111-4111-8111-111111111111';
+      const newSessionId = '22222222-2222-4222-8222-222222222222';
+      writeFileSync(join(projectKeyDir, `${oldSessionId}.jsonl`), '');
+      writeFileSync(join(projectKeyDir, `${newSessionId}.jsonl`), '');
 
       const resolved = resolveCapturedBackendSessionIdFromRuntime({
         cwd: tempRepo,
         backend: 'claude',
         pcpSessionId: 'pcp-session-1',
-        knownLocalSessionIds: new Set(['old-local-session']),
+        knownLocalSessionIds: new Set([oldSessionId]),
       });
 
-      expect(resolved).toBe('new-local-session');
+      expect(resolved).toBe(newSessionId);
     } finally {
       if (oldHome === undefined) {
         delete process.env.HOME;

--- a/packages/cli/src/commands/claude.test.ts
+++ b/packages/cli/src/commands/claude.test.ts
@@ -244,7 +244,11 @@ describe('resolveBackendSessionIdForResume', () => {
         },
         localBackendSessionIds: new Set(['local-a', 'local-b']),
       })
-    ).toEqual({ staleTrackedBackendSessionId: 'stale-id' });
+    ).toEqual({
+      backendSessionId: 'pcp-1',
+      staleTrackedBackendSessionId: 'stale-id',
+      fallbackMode: 'resume_pcp_session_id',
+    });
   });
 
   it('keeps tracked backend id when it matches local project sessions', () => {
@@ -274,15 +278,14 @@ describe('resolveBackendSessionSeedId', () => {
     ).toBe('pcp-new-1');
   });
 
-  it('seeds claude when tracked backend id is stale on existing pcp session', () => {
+  it('does not seed claude for stale existing sessions (uses resume fallback instead)', () => {
     expect(
       resolveBackendSessionSeedId({
         backend: 'claude',
         chosenSessionId: 'pcp-existing-1',
         createdNewPcpSession: false,
-        staleTrackedBackendSessionId: 'stale-backend-id',
       })
-    ).toBe('pcp-existing-1');
+    ).toBeUndefined();
   });
 
   it('does not seed when backend-native session id is already known', () => {
@@ -292,7 +295,6 @@ describe('resolveBackendSessionSeedId', () => {
         chosenSessionId: 'pcp-existing-1',
         backendSessionId: 'claude-123',
         createdNewPcpSession: false,
-        staleTrackedBackendSessionId: 'stale-backend-id',
       })
     ).toBeUndefined();
   });

--- a/packages/cli/src/commands/claude.test.ts
+++ b/packages/cli/src/commands/claude.test.ts
@@ -84,6 +84,25 @@ describe('filterPcpSessionsForContext', () => {
     expect(filtered.map((session) => session.id)).toEqual(['pcp-1']);
   });
 
+  it('strictly excludes claude sessions outside current project when no local match exists', () => {
+    const filtered = filterPcpSessionsForContext(
+      [
+        {
+          id: 'pcp-1',
+          startedAt: '2026-02-28T00:00:00.000Z',
+          backend: 'claude',
+          backendSessionId: 'remote-session-id',
+          workingDir: '/tmp/another-project',
+        },
+      ],
+      'claude',
+      '/tmp/current-project',
+      new Set()
+    );
+
+    expect(filtered).toEqual([]);
+  });
+
   it('filters non-claude sessions only by backend', () => {
     const filtered = filterPcpSessionsForContext(
       [

--- a/packages/cli/src/commands/claude.test.ts
+++ b/packages/cli/src/commands/claude.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
 import {
   extractClaudeHistorySessionsForProject,
   filterPcpSessionsForContext,
@@ -267,6 +270,60 @@ describe('resolveCapturedBackendSessionIdFromRuntime', () => {
         fallbackBackendSessionId: 'fallback-id',
       })
     ).toBe('fallback-id');
+  });
+
+  it('falls back to new local backend session for the project when runtime linkage is missing', () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), 'sb-claude-runtime-'));
+    const tempHome = join(tempRoot, 'home');
+    const tempRepo = join(tempRoot, 'repo');
+    mkdirSync(tempHome, { recursive: true });
+    mkdirSync(tempRepo, { recursive: true });
+
+    const projectKeyDir = join(tempHome, '.claude', 'projects', 'clearpol-ai');
+    mkdirSync(projectKeyDir, { recursive: true });
+
+    const oldHome = process.env.HOME;
+    process.env.HOME = tempHome;
+
+    try {
+      writeFileSync(
+        join(projectKeyDir, 'sessions-index.json'),
+        JSON.stringify(
+          {
+            entries: [
+              {
+                sessionId: 'old-local-session',
+                projectPath: tempRepo,
+                modified: '2026-02-28T09:00:00.000Z',
+              },
+              {
+                sessionId: 'new-local-session',
+                projectPath: tempRepo,
+                modified: '2026-02-28T10:00:00.000Z',
+              },
+            ],
+          },
+          null,
+          2
+        )
+      );
+
+      const resolved = resolveCapturedBackendSessionIdFromRuntime({
+        cwd: tempRepo,
+        backend: 'claude',
+        pcpSessionId: 'pcp-session-1',
+        knownLocalSessionIds: new Set(['old-local-session']),
+      });
+
+      expect(resolved).toBe('new-local-session');
+    } finally {
+      if (oldHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = oldHome;
+      }
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
   });
 });
 

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -930,6 +930,22 @@ function parseSessionIdFromJsonLine(line: string): string | undefined {
   }
 }
 
+export function shouldRetryWithFreshBackendSession(options: {
+  backend: string;
+  attemptedBackendSessionId?: string;
+  stderrText?: string;
+}): boolean {
+  const { backend, attemptedBackendSessionId, stderrText = '' } = options;
+  if (backend !== 'claude') return false;
+  if (!attemptedBackendSessionId) return false;
+
+  const lowered = stderrText.toLowerCase();
+  return (
+    lowered.includes('no conversation found with session id') ||
+    (lowered.includes('session id') && lowered.includes('already in use'))
+  );
+}
+
 async function persistBackendSessionLink(options: {
   pcpSessionId?: string;
   backendSessionId?: string;
@@ -1445,38 +1461,8 @@ export async function runClaudeInteractive(
     }
   }
 
-  const prepared = adapter.prepare({
-    agentId,
-    model: options.model,
-    promptParts: [],
-    passthroughArgs,
-    ...sessionContext,
-  });
-
   const authEnv = await resolvePcpAuthEnv(options.verbose);
-
-  if (options.verbose) {
-    console.log(chalk.dim(`Running: ${prepared.binary} ${prepared.args.join(' ')}`));
-  }
-
   const pcpConfig = getPcpConfig();
-  const executionContext: BackendExecutionLogContext = {
-    pcpConfig,
-    agentId,
-    backend: options.backend,
-    binary: prepared.binary,
-    args: prepared.args,
-    pcpSessionId: sessionContext.pcpSessionId,
-    backendSessionId: sessionContext.backendSessionId,
-    studioId,
-    runtimeLinkId,
-    cwd: process.cwd(),
-    mode: 'interactive',
-    retryAttempt: 1,
-    maxAttempts: 1,
-  };
-  const executionStartedAt = Date.now();
-  const backendStartActivityId = await logBackendExecutionStart(executionContext);
   const knownLocalSessionIds = options.session
     ? new Set(
         getBackendLocalSessionsForProject(options.backend, process.cwd(), 50).map(
@@ -1484,51 +1470,129 @@ export async function runClaudeInteractive(
         )
       )
     : undefined;
-  let capturedBackendSessionId = sessionContext.backendSessionId;
-  let cleanedUp = false;
-  let finalizedExecution = false;
-  const ensureCleanup = (): void => {
-    if (cleanedUp) return;
-    cleanedUp = true;
-    prepared.cleanup();
-  };
-  const finalizeExecution = async (exitCode: number | null, error?: string): Promise<void> => {
-    if (finalizedExecution) return;
-    finalizedExecution = true;
-    await logBackendExecutionResult({
-      context: executionContext,
-      parentActivityId: backendStartActivityId,
-      exitCode,
-      durationMs: Date.now() - executionStartedAt,
-      error,
-      backendSessionId: capturedBackendSessionId,
-    });
-  };
+  const maxAttempts = sessionContext.backendSessionId ? 2 : 1;
+  let attempt = 1;
+  let attemptBackendSessionId = sessionContext.backendSessionId;
+  let attemptBackendSessionSeedId = sessionContext.backendSessionSeedId;
+  let finalCapturedBackendSessionId = sessionContext.backendSessionId;
 
-  const child = spawn(prepared.binary, prepared.args, {
-    stdio: 'inherit',
-    env: {
-      ...process.env,
-      ...authEnv,
-      ...prepared.env,
-      ...(runtimeLinkId ? { PCP_RUNTIME_LINK_ID: runtimeLinkId } : {}),
-    },
-  });
-
-  child.on('close', async (code) => {
-    ensureCleanup();
-    capturedBackendSessionId = resolveCapturedBackendSessionIdFromRuntime({
-      backend: options.backend,
-      pcpSessionId: sessionContext.pcpSessionId,
-      runtimeLinkId,
+  const runAttempt = async (): Promise<{ code: number | null; stderrText: string }> => {
+    const prepared = adapter.prepare({
       agentId,
-      studioId,
-      knownLocalSessionIds,
-      fallbackBackendSessionId: capturedBackendSessionId,
+      model: options.model,
+      promptParts: [],
+      passthroughArgs,
+      ...sessionContext,
+      ...(attemptBackendSessionId ? { backendSessionId: attemptBackendSessionId } : {}),
+      ...(attemptBackendSessionSeedId ? { backendSessionSeedId: attemptBackendSessionSeedId } : {}),
     });
+
+    if (options.verbose) {
+      console.log(chalk.dim(`Running: ${prepared.binary} ${prepared.args.join(' ')}`));
+    }
+
+    const executionContext: BackendExecutionLogContext = {
+      pcpConfig,
+      agentId,
+      backend: options.backend,
+      binary: prepared.binary,
+      args: prepared.args,
+      pcpSessionId: sessionContext.pcpSessionId,
+      backendSessionId: attemptBackendSessionId,
+      studioId,
+      runtimeLinkId,
+      cwd: process.cwd(),
+      mode: 'interactive',
+      retryAttempt: attempt,
+      maxAttempts,
+    };
+    const executionStartedAt = Date.now();
+    const backendStartActivityId = await logBackendExecutionStart(executionContext);
+
+    return await new Promise<{ code: number | null; stderrText: string }>((resolve) => {
+      let stderrText = '';
+
+      const child = spawn(prepared.binary, prepared.args, {
+        stdio: ['inherit', 'inherit', 'pipe'],
+        env: {
+          ...process.env,
+          ...authEnv,
+          ...prepared.env,
+          ...(runtimeLinkId ? { PCP_RUNTIME_LINK_ID: runtimeLinkId } : {}),
+        },
+      });
+
+      child.stderr?.on('data', (chunk) => {
+        const text = chunk.toString();
+        stderrText += text;
+        process.stderr.write(chunk);
+      });
+
+      child.on('close', async (code) => {
+        prepared.cleanup();
+        finalCapturedBackendSessionId = resolveCapturedBackendSessionIdFromRuntime({
+          backend: options.backend,
+          pcpSessionId: sessionContext.pcpSessionId,
+          runtimeLinkId,
+          agentId,
+          studioId,
+          knownLocalSessionIds,
+          fallbackBackendSessionId: finalCapturedBackendSessionId,
+        });
+
+        await logBackendExecutionResult({
+          context: executionContext,
+          parentActivityId: backendStartActivityId,
+          exitCode: code ?? null,
+          durationMs: Date.now() - executionStartedAt,
+          backendSessionId: finalCapturedBackendSessionId,
+        });
+        resolve({ code: code ?? null, stderrText });
+      });
+
+      child.on('error', async (err) => {
+        prepared.cleanup();
+        const errorText = err.message || 'spawn failed';
+        await logBackendExecutionResult({
+          context: executionContext,
+          parentActivityId: backendStartActivityId,
+          exitCode: null,
+          durationMs: Date.now() - executionStartedAt,
+          error: errorText,
+          backendSessionId: finalCapturedBackendSessionId,
+        });
+        resolve({ code: 1, stderrText: `${stderrText}\n${errorText}`.trim() });
+      });
+    });
+  };
+
+  while (true) {
+    const { code, stderrText } = await runAttempt();
+    const shouldRetry =
+      attempt < maxAttempts &&
+      shouldRetryWithFreshBackendSession({
+        backend: options.backend,
+        attemptedBackendSessionId: attemptBackendSessionId,
+        stderrText,
+      });
+
+    if (shouldRetry) {
+      if (attemptBackendSessionId) {
+        console.log(
+          chalk.yellow(
+            `\nLinked Claude session ${attemptBackendSessionId.slice(0, 8)} failed to resume; retrying once with a fresh backend session.`
+          )
+        );
+      }
+      attempt += 1;
+      attemptBackendSessionId = undefined;
+      attemptBackendSessionSeedId = undefined;
+      continue;
+    }
+
     await persistBackendSessionLink({
       pcpSessionId: sessionContext.pcpSessionId,
-      backendSessionId: capturedBackendSessionId,
+      backendSessionId: finalCapturedBackendSessionId,
       backend: options.backend,
       agentId,
       runtimeLinkId,
@@ -1536,13 +1600,7 @@ export async function runClaudeInteractive(
       identityId,
       email: pcpConfig?.email,
     });
-    await finalizeExecution(code ?? null);
-    process.exit(code || 0);
-  });
 
-  child.on('error', async (err) => {
-    ensureCleanup();
-    await finalizeExecution(null, err.message || 'spawn failed');
-    process.exit(1);
-  });
+    process.exit(code || 0);
+  }
 }

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -891,7 +891,7 @@ async function ensurePcpSessionContext(
   passthroughArgs: string[],
   verbose: boolean,
   promptParts: string[] = []
-): Promise<{ pcpSessionId?: string; backendSessionId?: string }> {
+): Promise<{ pcpSessionId?: string; backendSessionId?: string; backendSessionSeedId?: string }> {
   if (hasBackendSessionOverride(backend, passthroughArgs, promptParts)) return {};
 
   const config = getPcpConfig();
@@ -950,6 +950,7 @@ async function ensurePcpSessionContext(
 
   let chosen: PcpSessionSummary | undefined;
   let selectedLocalBackendSessionId: string | undefined;
+  let createdNewPcpSession = false;
 
   const startNewPcpSession = async (): Promise<PcpSessionSummary | undefined> => {
     if (!pcpAvailable || !email) return undefined;
@@ -1013,6 +1014,7 @@ async function ensurePcpSessionContext(
       });
       if (selection === '__new__') {
         chosen = await startNewPcpSession();
+        createdNewPcpSession = Boolean(chosen?.id);
       } else if (selection.startsWith('__pcp__:')) {
         const sessionId = sessionChoiceByValue.get(selection);
         chosen = activeSessions.find((session) => session.id === sessionId);
@@ -1020,6 +1022,7 @@ async function ensurePcpSessionContext(
         selectedLocalBackendSessionId = sessionChoiceByValue.get(selection);
         if (selectedLocalBackendSessionId && pcpAvailable) {
           chosen = await startNewPcpSession();
+          createdNewPcpSession = Boolean(chosen?.id);
         }
       }
     } catch (err) {
@@ -1033,6 +1036,7 @@ async function ensurePcpSessionContext(
 
   if (!chosen && !selectedLocalBackendSessionId && pcpAvailable) {
     chosen = await startNewPcpSession();
+    createdNewPcpSession = Boolean(chosen?.id);
   }
 
   if (!chosen?.id && !selectedLocalBackendSessionId) return {};
@@ -1049,6 +1053,8 @@ async function ensurePcpSessionContext(
     selectedLocalBackendSessionId,
     localBackendSessionIds,
   });
+  const backendSessionSeedId =
+    backend === 'claude' && !backendSessionId && createdNewPcpSession ? chosen.id : undefined;
 
   if (staleTrackedBackendSessionId && process.stdin.isTTY) {
     const backendLabel = backend[0].toUpperCase() + backend.slice(1);
@@ -1099,6 +1105,7 @@ async function ensurePcpSessionContext(
   return {
     pcpSessionId: chosen.id,
     backendSessionId,
+    ...(backendSessionSeedId ? { backendSessionSeedId } : {}),
   };
 }
 

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -16,6 +16,7 @@ import { getValidAccessToken } from '../auth/tokens.js';
 import { callPcpTool, getPcpServerUrl } from '../lib/pcp-mcp.js';
 import {
   getCurrentRuntimeSession,
+  listRuntimeSessions,
   setCurrentRuntimeSession,
   upsertRuntimeSession,
 } from '../session/runtime.js';
@@ -300,6 +301,62 @@ export function resolveBackendSessionIdForResume(options: {
   }
 
   return { backendSessionId: candidate };
+}
+
+export function resolveCapturedBackendSessionIdFromRuntime(options: {
+  cwd?: string;
+  backend: string;
+  pcpSessionId?: string;
+  runtimeLinkId?: string;
+  agentId?: string;
+  studioId?: string;
+  fallbackBackendSessionId?: string;
+}): string | undefined {
+  const {
+    cwd = process.cwd(),
+    backend,
+    pcpSessionId,
+    runtimeLinkId,
+    agentId,
+    studioId,
+    fallbackBackendSessionId,
+  } = options;
+
+  const resolveFromRecord = (
+    record?: { backendSessionId?: string; backendSessionIds?: string[] } | null
+  ): string | undefined => {
+    if (!record) return undefined;
+    if (record.backendSessionId) return record.backendSessionId;
+    const last = record.backendSessionIds?.at(-1);
+    return typeof last === 'string' && last.trim() ? last : undefined;
+  };
+
+  if (!pcpSessionId) return fallbackBackendSessionId;
+
+  const scopedRecords = listRuntimeSessions(cwd, backend).filter(
+    (record) =>
+      record.pcpSessionId === pcpSessionId &&
+      (!agentId || record.agentId === agentId) &&
+      (!studioId || record.studioId === studioId)
+  );
+
+  if (runtimeLinkId) {
+    const byRuntimeLink = scopedRecords.find((record) => record.runtimeLinkId === runtimeLinkId);
+    const linked = resolveFromRecord(byRuntimeLink);
+    if (linked) return linked;
+  }
+
+  const current = getCurrentRuntimeSession(cwd, backend);
+  if (
+    current?.pcpSessionId === pcpSessionId &&
+    (!agentId || current.agentId === agentId) &&
+    (!studioId || current.studioId === studioId)
+  ) {
+    const currentSessionId = resolveFromRecord(current);
+    if (currentSessionId) return currentSessionId;
+  }
+
+  return resolveFromRecord(scopedRecords[0]) || fallbackBackendSessionId;
 }
 
 export function getClaudeLocalSessionsForProject(
@@ -1287,6 +1344,7 @@ export async function runClaudeInteractive(
   };
   const executionStartedAt = Date.now();
   const backendStartActivityId = await logBackendExecutionStart(executionContext);
+  let capturedBackendSessionId = sessionContext.backendSessionId;
   let cleanedUp = false;
   let finalizedExecution = false;
   const ensureCleanup = (): void => {
@@ -1303,7 +1361,7 @@ export async function runClaudeInteractive(
       exitCode,
       durationMs: Date.now() - executionStartedAt,
       error,
-      backendSessionId: sessionContext.backendSessionId,
+      backendSessionId: capturedBackendSessionId,
     });
   };
 
@@ -1319,6 +1377,24 @@ export async function runClaudeInteractive(
 
   child.on('close', async (code) => {
     ensureCleanup();
+    capturedBackendSessionId = resolveCapturedBackendSessionIdFromRuntime({
+      backend: options.backend,
+      pcpSessionId: sessionContext.pcpSessionId,
+      runtimeLinkId,
+      agentId,
+      studioId,
+      fallbackBackendSessionId: capturedBackendSessionId,
+    });
+    await persistBackendSessionLink({
+      pcpSessionId: sessionContext.pcpSessionId,
+      backendSessionId: capturedBackendSessionId,
+      backend: options.backend,
+      agentId,
+      runtimeLinkId,
+      studioId,
+      identityId,
+      email: pcpConfig?.email,
+    });
     await finalizeExecution(code ?? null);
     process.exit(code || 0);
   });

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -282,12 +282,19 @@ export function resolveBackendSessionIdForResume(options: {
   chosen?: PcpSessionSummary;
   selectedLocalBackendSessionId?: string;
   localBackendSessionIds: Set<string>;
+  knownBackendSessionIds?: Set<string>;
 }): {
   backendSessionId?: string;
   staleTrackedBackendSessionId?: string;
   fallbackMode?: 'resume_pcp_session_id';
 } {
-  const { backend, chosen, selectedLocalBackendSessionId, localBackendSessionIds } = options;
+  const {
+    backend,
+    chosen,
+    selectedLocalBackendSessionId,
+    localBackendSessionIds,
+    knownBackendSessionIds,
+  } = options;
 
   if (selectedLocalBackendSessionId) {
     return { backendSessionId: selectedLocalBackendSessionId };
@@ -301,6 +308,13 @@ export function resolveBackendSessionIdForResume(options: {
   if (!candidate) return {};
 
   if (localBackendSessionIds.size > 0 && !localBackendSessionIds.has(candidate)) {
+    // Local project indexes can be incomplete (history truncation, worktree sharing,
+    // path drift). If we can still find the session in the broader backend-local index,
+    // prefer resume and avoid false stale classification.
+    if (knownBackendSessionIds?.has(candidate)) {
+      return { backendSessionId: candidate };
+    }
+
     if (backend === 'claude' && chosen.id) {
       return {
         backendSessionId: chosen.id,
@@ -475,6 +489,50 @@ export function getClaudeLocalSessionsForProject(
   return Array.from(dedupedBySessionId.values())
     .sort((a, b) => new Date(b.modified).getTime() - new Date(a.modified).getTime())
     .slice(0, limit);
+}
+
+export function getKnownClaudeSessionIds(limitPerProject = 500): Set<string> {
+  const sessionIds = new Set<string>();
+  const claudeProjectsDir = join(homedir(), '.claude', 'projects');
+
+  if (existsSync(claudeProjectsDir)) {
+    for (const entry of readdirSync(claudeProjectsDir, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      const indexPath = join(claudeProjectsDir, entry.name, 'sessions-index.json');
+      if (!existsSync(indexPath)) continue;
+
+      try {
+        const parsed = JSON.parse(readFileSync(indexPath, 'utf-8')) as {
+          entries?: Array<{ sessionId?: string }>;
+        };
+        for (const item of (parsed.entries || []).slice(0, limitPerProject)) {
+          if (item.sessionId?.trim()) sessionIds.add(item.sessionId.trim());
+        }
+      } catch {
+        // Ignore malformed local index files and continue.
+      }
+    }
+  }
+
+  const historyPath = join(homedir(), '.claude', 'history.jsonl');
+  if (existsSync(historyPath)) {
+    try {
+      for (const line of readFileSync(historyPath, 'utf-8').split('\n')) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        try {
+          const parsed = JSON.parse(trimmed) as { sessionId?: string };
+          if (parsed.sessionId?.trim()) sessionIds.add(parsed.sessionId.trim());
+        } catch {
+          // Ignore malformed history lines.
+        }
+      }
+    } catch {
+      // Ignore unreadable history file.
+    }
+  }
+
+  return sessionIds;
 }
 
 export function extractClaudeHistorySessionsForProject(
@@ -931,6 +989,8 @@ async function ensurePcpSessionContext(
   const { studioId, identityId } = getIdentityContextFromIdentityJson(cwd);
   const localBackendSessions = getBackendLocalSessionsForProject(backend, cwd, 20);
   const localBackendSessionIds = new Set(localBackendSessions.map((session) => session.sessionId));
+  const knownBackendSessionIds =
+    backend === 'claude' ? getKnownClaudeSessionIds() : localBackendSessionIds;
   const sessionChoiceByValue = new Map<string, string>();
 
   // Fast path: runtime already knows current session for this backend.
@@ -1084,6 +1144,7 @@ async function ensurePcpSessionContext(
       chosen,
       selectedLocalBackendSessionId,
       localBackendSessionIds,
+      knownBackendSessionIds,
     });
   const backendSessionSeedId = resolveBackendSessionSeedId({
     backend,

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -282,7 +282,11 @@ export function resolveBackendSessionIdForResume(options: {
   chosen?: PcpSessionSummary;
   selectedLocalBackendSessionId?: string;
   localBackendSessionIds: Set<string>;
-}): { backendSessionId?: string; staleTrackedBackendSessionId?: string } {
+}): {
+  backendSessionId?: string;
+  staleTrackedBackendSessionId?: string;
+  fallbackMode?: 'resume_pcp_session_id';
+} {
   const { backend, chosen, selectedLocalBackendSessionId, localBackendSessionIds } = options;
 
   if (selectedLocalBackendSessionId) {
@@ -297,6 +301,13 @@ export function resolveBackendSessionIdForResume(options: {
   if (!candidate) return {};
 
   if (localBackendSessionIds.size > 0 && !localBackendSessionIds.has(candidate)) {
+    if (backend === 'claude' && chosen.id) {
+      return {
+        backendSessionId: chosen.id,
+        staleTrackedBackendSessionId: candidate,
+        fallbackMode: 'resume_pcp_session_id',
+      };
+    }
     return { staleTrackedBackendSessionId: candidate };
   }
 
@@ -308,25 +319,15 @@ export function resolveBackendSessionSeedId(options: {
   chosenSessionId?: string;
   backendSessionId?: string;
   createdNewPcpSession: boolean;
-  staleTrackedBackendSessionId?: string;
 }): string | undefined {
-  const {
-    backend,
-    chosenSessionId,
-    backendSessionId,
-    createdNewPcpSession,
-    staleTrackedBackendSessionId,
-  } = options;
+  const { backend, chosenSessionId, backendSessionId, createdNewPcpSession } = options;
 
   if (backend !== 'claude') return undefined;
   if (!chosenSessionId) return undefined;
   if (backendSessionId) return undefined;
 
-  // Seed Claude session ID when:
-  // 1) this invocation created the PCP session (first run), or
-  // 2) the previously tracked backend-native ID is stale and we are effectively
-  //    re-seeding from a fresh backend launch.
-  if (createdNewPcpSession || staleTrackedBackendSessionId) {
+  // Seed Claude session ID only on first run when PCP session is created now.
+  if (createdNewPcpSession) {
     return chosenSessionId;
   }
 
@@ -1077,27 +1078,35 @@ async function ensurePcpSessionContext(
 
   if (!chosen?.id) return {};
 
-  const { backendSessionId, staleTrackedBackendSessionId } = resolveBackendSessionIdForResume({
-    backend,
-    chosen,
-    selectedLocalBackendSessionId,
-    localBackendSessionIds,
-  });
+  const { backendSessionId, staleTrackedBackendSessionId, fallbackMode } =
+    resolveBackendSessionIdForResume({
+      backend,
+      chosen,
+      selectedLocalBackendSessionId,
+      localBackendSessionIds,
+    });
   const backendSessionSeedId = resolveBackendSessionSeedId({
     backend,
     chosenSessionId: chosen.id,
     backendSessionId,
     createdNewPcpSession,
-    staleTrackedBackendSessionId,
   });
 
   if (staleTrackedBackendSessionId && process.stdin.isTTY) {
-    const backendLabel = backend[0].toUpperCase() + backend.slice(1);
-    console.log(
-      chalk.yellow(
-        `\nLinked ${backendLabel} session ${staleTrackedBackendSessionId.slice(0, 8)} is unavailable for this project; starting backend fresh.`
-      )
-    );
+    if (fallbackMode === 'resume_pcp_session_id' && chosen.id) {
+      console.log(
+        chalk.yellow(
+          `\nLinked Claude session ${staleTrackedBackendSessionId.slice(0, 8)} is unavailable for this project; retrying with PCP-linked Claude session ${chosen.id.slice(0, 8)}.`
+        )
+      );
+    } else {
+      const backendLabel = backend[0].toUpperCase() + backend.slice(1);
+      console.log(
+        chalk.yellow(
+          `\nLinked ${backendLabel} session ${staleTrackedBackendSessionId.slice(0, 8)} is unavailable for this project; starting backend fresh.`
+        )
+      );
+    }
   }
 
   upsertRuntimeSession(cwd, {

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -303,6 +303,36 @@ export function resolveBackendSessionIdForResume(options: {
   return { backendSessionId: candidate };
 }
 
+export function resolveBackendSessionSeedId(options: {
+  backend: string;
+  chosenSessionId?: string;
+  backendSessionId?: string;
+  createdNewPcpSession: boolean;
+  staleTrackedBackendSessionId?: string;
+}): string | undefined {
+  const {
+    backend,
+    chosenSessionId,
+    backendSessionId,
+    createdNewPcpSession,
+    staleTrackedBackendSessionId,
+  } = options;
+
+  if (backend !== 'claude') return undefined;
+  if (!chosenSessionId) return undefined;
+  if (backendSessionId) return undefined;
+
+  // Seed Claude session ID when:
+  // 1) this invocation created the PCP session (first run), or
+  // 2) the previously tracked backend-native ID is stale and we are effectively
+  //    re-seeding from a fresh backend launch.
+  if (createdNewPcpSession || staleTrackedBackendSessionId) {
+    return chosenSessionId;
+  }
+
+  return undefined;
+}
+
 export function resolveCapturedBackendSessionIdFromRuntime(options: {
   cwd?: string;
   backend: string;
@@ -1053,8 +1083,13 @@ async function ensurePcpSessionContext(
     selectedLocalBackendSessionId,
     localBackendSessionIds,
   });
-  const backendSessionSeedId =
-    backend === 'claude' && !backendSessionId && createdNewPcpSession ? chosen.id : undefined;
+  const backendSessionSeedId = resolveBackendSessionSeedId({
+    backend,
+    chosenSessionId: chosen.id,
+    backendSessionId,
+    createdNewPcpSession,
+    staleTrackedBackendSessionId,
+  });
 
   if (staleTrackedBackendSessionId && process.stdin.isTTY) {
     const backendLabel = backend[0].toUpperCase() + backend.slice(1);

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -27,6 +27,8 @@ export interface SbOptions {
   session: boolean;
   verbose: boolean;
   backend: string;
+  sessionCandidates?: boolean;
+  sessionChoice?: string;
 }
 
 interface PcpConfig {
@@ -273,6 +275,10 @@ export function filterPcpSessionsForContext(
     const normalizedWorkingDir = normalizePath(session.workingDir);
     return !!normalizedWorkingDir && normalizedWorkingDir === normalizedCwd;
   });
+
+  if (backend === 'claude') {
+    return pathScoped;
+  }
 
   return pathScoped.length > 0 ? pathScoped : backendMatched;
 }
@@ -988,7 +994,8 @@ async function ensurePcpSessionContext(
   backend: string,
   passthroughArgs: string[],
   verbose: boolean,
-  promptParts: string[] = []
+  promptParts: string[] = [],
+  options: { listCandidates?: boolean; selectionOverride?: string } = {}
 ): Promise<{ pcpSessionId?: string; backendSessionId?: string; backendSessionSeedId?: string }> {
   if (hasBackendSessionOverride(backend, passthroughArgs, promptParts)) return {};
 
@@ -1052,6 +1059,22 @@ async function ensurePcpSessionContext(
   let selectedLocalBackendSessionId: string | undefined;
   let createdNewPcpSession = false;
 
+  const normalizedSelectionOverride = options.selectionOverride?.trim();
+  const pcpSelection = (selection: string): string | undefined => {
+    const value = selection.replace(/^__pcp__:/, '').replace(/^pcp:/, '');
+    const found = activeSessions.find(
+      (session) => session.id === value || session.id.startsWith(value)
+    );
+    return found?.id;
+  };
+  const localSelection = (selection: string): string | undefined => {
+    const value = selection.replace(/^__local__:/, '').replace(/^local:/, '');
+    const found = untrackedLocalBackendSessions.find(
+      (session) => session.sessionId === value || session.sessionId.startsWith(value)
+    );
+    return found?.sessionId;
+  };
+
   const startNewPcpSession = async (): Promise<PcpSessionSummary | undefined> => {
     if (!pcpAvailable || !email) return undefined;
 
@@ -1071,7 +1094,54 @@ async function ensurePcpSessionContext(
     }
   };
 
-  if (process.stdin.isTTY) {
+  if (options.listCandidates) {
+    console.log(chalk.bold(`\nSession candidates for ${agentId}/${backend}:`));
+    console.log(chalk.dim('  new'));
+    for (const session of activeSessions) {
+      const linkedBackendSessionId =
+        backend === 'claude' ? getSessionBackendId(session) : undefined;
+      console.log(
+        chalk.dim(
+          `  pcp:${session.id}${session.threadKey ? ` (${session.threadKey})` : ''}${session.currentPhase ? ` — ${session.currentPhase}` : ''}${linkedBackendSessionId ? ` · tracks ${linkedBackendSessionId}` : ''}`
+        )
+      );
+    }
+    for (const localSession of untrackedLocalBackendSessions) {
+      console.log(
+        chalk.dim(
+          `  local:${localSession.sessionId}${localSession.firstPrompt ? ` — ${truncateText(localSession.firstPrompt)}` : ''}`
+        )
+      );
+    }
+    console.log('');
+    if (!normalizedSelectionOverride) {
+      process.exit(0);
+    }
+  }
+
+  if (normalizedSelectionOverride) {
+    const selection = normalizedSelectionOverride.toLowerCase();
+    if (selection === 'new' || selection === '__new__') {
+      chosen = await startNewPcpSession();
+      createdNewPcpSession = Boolean(chosen?.id);
+    } else if (selection.startsWith('pcp:') || selection.startsWith('__pcp__:')) {
+      const matchedSessionId = pcpSelection(selection);
+      chosen = activeSessions.find((session) => session.id === matchedSessionId);
+    } else if (selection.startsWith('local:') || selection.startsWith('__local__:')) {
+      selectedLocalBackendSessionId = localSelection(selection);
+      if (selectedLocalBackendSessionId && pcpAvailable) {
+        chosen = await startNewPcpSession();
+        createdNewPcpSession = Boolean(chosen?.id);
+      }
+    } else {
+      console.error(
+        chalk.red(
+          `Unknown session choice "${options.selectionOverride}". Use "new", "pcp:<id>", or "local:<id>".`
+        )
+      );
+      process.exit(1);
+    }
+  } else if (process.stdin.isTTY) {
     const choices: Array<{ name: string; value: string }> = [
       {
         name: pcpAvailable ? 'Start new session' : 'Start new backend session',
@@ -1248,7 +1318,11 @@ export async function runClaude(
         options.backend,
         passthroughArgs,
         options.verbose,
-        promptParts
+        promptParts,
+        {
+          listCandidates: options.sessionCandidates,
+          selectionOverride: options.sessionChoice,
+        }
       )
     : {};
   const runtimeLinkId = options.session ? randomUUID() : undefined;
@@ -1432,7 +1506,17 @@ export async function runClaudeInteractive(
   }
   const adapter = getBackend(options.backend);
   const sessionContext = options.session
-    ? await ensurePcpSessionContext(agentId, options.backend, passthroughArgs, options.verbose, [])
+    ? await ensurePcpSessionContext(
+        agentId,
+        options.backend,
+        passthroughArgs,
+        options.verbose,
+        [],
+        {
+          listCandidates: options.sessionCandidates,
+          selectionOverride: options.sessionChoice,
+        }
+      )
     : {};
   const runtimeLinkId = options.session ? randomUUID() : undefined;
   const { studioId, identityId } = getIdentityContextFromIdentityJson(process.cwd());

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -276,6 +276,32 @@ export function filterPcpSessionsForContext(
   return pathScoped.length > 0 ? pathScoped : backendMatched;
 }
 
+export function resolveBackendSessionIdForResume(options: {
+  backend: string;
+  chosen?: PcpSessionSummary;
+  selectedLocalBackendSessionId?: string;
+  localBackendSessionIds: Set<string>;
+}): { backendSessionId?: string; staleTrackedBackendSessionId?: string } {
+  const { backend, chosen, selectedLocalBackendSessionId, localBackendSessionIds } = options;
+
+  if (selectedLocalBackendSessionId) {
+    return { backendSessionId: selectedLocalBackendSessionId };
+  }
+
+  if (!chosen || (chosen.backend && chosen.backend !== backend)) {
+    return {};
+  }
+
+  const candidate = chosen.backendSessionId || chosen.claudeSessionId || undefined;
+  if (!candidate) return {};
+
+  if (localBackendSessionIds.size > 0 && !localBackendSessionIds.has(candidate)) {
+    return { staleTrackedBackendSessionId: candidate };
+  }
+
+  return { backendSessionId: candidate };
+}
+
 export function getClaudeLocalSessionsForProject(
   cwd = process.cwd(),
   limit = 20
@@ -950,11 +976,21 @@ async function ensurePcpSessionContext(
 
   if (!chosen?.id) return {};
 
-  const backendSessionId =
-    selectedLocalBackendSessionId ||
-    (!chosen.backend || chosen.backend === backend
-      ? chosen.backendSessionId || chosen.claudeSessionId || undefined
-      : undefined);
+  const { backendSessionId, staleTrackedBackendSessionId } = resolveBackendSessionIdForResume({
+    backend,
+    chosen,
+    selectedLocalBackendSessionId,
+    localBackendSessionIds,
+  });
+
+  if (staleTrackedBackendSessionId && process.stdin.isTTY) {
+    const backendLabel = backend[0].toUpperCase() + backend.slice(1);
+    console.log(
+      chalk.yellow(
+        `\nLinked ${backendLabel} session ${staleTrackedBackendSessionId.slice(0, 8)} is unavailable for this project; starting backend fresh.`
+      )
+    );
+  }
 
   upsertRuntimeSession(cwd, {
     pcpSessionId: chosen.id,

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -8,7 +8,7 @@
 import { spawn, spawnSync } from 'child_process';
 import chalk from 'chalk';
 import { randomUUID } from 'crypto';
-import { existsSync, readFileSync, readdirSync, realpathSync } from 'fs';
+import { existsSync, readFileSync, readdirSync, realpathSync, statSync } from 'fs';
 import { join, resolve as resolvePath } from 'path';
 import { homedir } from 'os';
 import { getBackend, resolveAgentId } from '../backends/index.js';
@@ -425,41 +425,34 @@ export function getClaudeLocalSessionsForProject(
   if (!normalizedCwd) return [];
 
   const results: BackendLocalSessionSummary[] = [];
+  const normalizedDirName = normalizedCwd.replace(/[\\/]/g, '-');
+  const projectDirCandidates = new Set<string>([
+    join(claudeProjectsDir, normalizedDirName),
+    join(claudeProjectsDir, cwd.replace(/[\\/]/g, '-')),
+  ]);
 
-  for (const entry of readdirSync(claudeProjectsDir, { withFileTypes: true })) {
-    if (!entry.isDirectory()) continue;
-    const indexPath = join(claudeProjectsDir, entry.name, 'sessions-index.json');
-    if (!existsSync(indexPath)) continue;
+  const sessionFileIdRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
-    try {
-      const parsed = JSON.parse(readFileSync(indexPath, 'utf-8')) as {
-        entries?: Array<{
-          sessionId?: string;
-          projectPath?: string;
-          modified?: string;
-          firstPrompt?: string;
-          messageCount?: number;
-          gitBranch?: string;
-        }>;
-      };
+  for (const projectDir of projectDirCandidates) {
+    if (!existsSync(projectDir)) continue;
 
-      for (const item of parsed.entries || []) {
-        if (!item.sessionId || !item.projectPath || !item.modified) continue;
-        const normalizedProjectPath = normalizePath(item.projectPath);
-        if (!normalizedProjectPath || normalizedProjectPath !== normalizedCwd) continue;
+    for (const entry of readdirSync(projectDir, { withFileTypes: true })) {
+      if (!entry.isFile() || !entry.name.endsWith('.jsonl')) continue;
+      const sessionId = entry.name.slice(0, -'.jsonl'.length);
+      if (!sessionFileIdRegex.test(sessionId)) continue;
 
+      const filePath = join(projectDir, entry.name);
+      try {
+        const stats = statSync(filePath);
         results.push({
           backend: 'claude',
-          sessionId: item.sessionId,
-          projectPath: item.projectPath,
-          modified: item.modified,
-          firstPrompt: item.firstPrompt,
-          messageCount: item.messageCount,
-          gitBranch: item.gitBranch,
+          sessionId,
+          projectPath: normalizedCwd,
+          modified: stats.mtime.toISOString(),
         });
+      } catch {
+        // Ignore unreadable file stats.
       }
-    } catch {
-      // Ignore malformed local index files and continue.
     }
   }
 
@@ -495,21 +488,21 @@ export function getKnownClaudeSessionIds(limitPerProject = 500): Set<string> {
   const sessionIds = new Set<string>();
   const claudeProjectsDir = join(homedir(), '.claude', 'projects');
 
+  const sessionFileIdRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
   if (existsSync(claudeProjectsDir)) {
     for (const entry of readdirSync(claudeProjectsDir, { withFileTypes: true })) {
       if (!entry.isDirectory()) continue;
-      const indexPath = join(claudeProjectsDir, entry.name, 'sessions-index.json');
-      if (!existsSync(indexPath)) continue;
-
-      try {
-        const parsed = JSON.parse(readFileSync(indexPath, 'utf-8')) as {
-          entries?: Array<{ sessionId?: string }>;
-        };
-        for (const item of (parsed.entries || []).slice(0, limitPerProject)) {
-          if (item.sessionId?.trim()) sessionIds.add(item.sessionId.trim());
-        }
-      } catch {
-        // Ignore malformed local index files and continue.
+      let seenForProject = 0;
+      for (const file of readdirSync(join(claudeProjectsDir, entry.name), {
+        withFileTypes: true,
+      })) {
+        if (!file.isFile() || !file.name.endsWith('.jsonl')) continue;
+        const sessionId = file.name.slice(0, -'.jsonl'.length);
+        if (!sessionFileIdRegex.test(sessionId)) continue;
+        sessionIds.add(sessionId);
+        seenForProject += 1;
+        if (seenForProject >= limitPerProject) break;
       }
     }
   }

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -310,6 +310,7 @@ export function resolveCapturedBackendSessionIdFromRuntime(options: {
   runtimeLinkId?: string;
   agentId?: string;
   studioId?: string;
+  knownLocalSessionIds?: Set<string>;
   fallbackBackendSessionId?: string;
 }): string | undefined {
   const {
@@ -319,6 +320,7 @@ export function resolveCapturedBackendSessionIdFromRuntime(options: {
     runtimeLinkId,
     agentId,
     studioId,
+    knownLocalSessionIds,
     fallbackBackendSessionId,
   } = options;
 
@@ -354,6 +356,14 @@ export function resolveCapturedBackendSessionIdFromRuntime(options: {
   ) {
     const currentSessionId = resolveFromRecord(current);
     if (currentSessionId) return currentSessionId;
+  }
+
+  if (knownLocalSessionIds && knownLocalSessionIds.size > 0) {
+    const postRunLocalSessions = getBackendLocalSessionsForProject(backend, cwd, 50);
+    const newLocalSession = postRunLocalSessions.find(
+      (session) => !knownLocalSessionIds.has(session.sessionId)
+    );
+    if (newLocalSession?.sessionId) return newLocalSession.sessionId;
   }
 
   return resolveFromRecord(scopedRecords[0]) || fallbackBackendSessionId;
@@ -1182,6 +1192,13 @@ export async function runClaude(
   };
   const executionStartedAt = Date.now();
   const backendStartActivityId = await logBackendExecutionStart(executionContext);
+  const knownLocalSessionIds = options.session
+    ? new Set(
+        getBackendLocalSessionsForProject(options.backend, process.cwd(), 50).map(
+          (session) => session.sessionId
+        )
+      )
+    : undefined;
   let capturedBackendSessionId = sessionContext.backendSessionId;
   let stdoutLineBuffer = '';
   let cleanedUp = false;
@@ -1238,6 +1255,17 @@ export async function runClaude(
     if (stdoutLineBuffer.trim()) {
       const parsedSessionId = parseSessionIdFromJsonLine(stdoutLineBuffer.trim());
       if (parsedSessionId) capturedBackendSessionId = parsedSessionId;
+    }
+    if (!capturedBackendSessionId) {
+      capturedBackendSessionId = resolveCapturedBackendSessionIdFromRuntime({
+        backend: options.backend,
+        pcpSessionId: sessionContext.pcpSessionId,
+        runtimeLinkId,
+        agentId,
+        studioId,
+        knownLocalSessionIds,
+        fallbackBackendSessionId: capturedBackendSessionId,
+      });
     }
 
     await persistBackendSessionLink({
@@ -1344,6 +1372,13 @@ export async function runClaudeInteractive(
   };
   const executionStartedAt = Date.now();
   const backendStartActivityId = await logBackendExecutionStart(executionContext);
+  const knownLocalSessionIds = options.session
+    ? new Set(
+        getBackendLocalSessionsForProject(options.backend, process.cwd(), 50).map(
+          (session) => session.sessionId
+        )
+      )
+    : undefined;
   let capturedBackendSessionId = sessionContext.backendSessionId;
   let cleanedUp = false;
   let finalizedExecution = false;
@@ -1383,6 +1418,7 @@ export async function runClaudeInteractive(
       runtimeLinkId,
       agentId,
       studioId,
+      knownLocalSessionIds,
       fallbackBackendSessionId: capturedBackendSessionId,
     });
     await persistBackendSessionLink({


### PR DESCRIPTION
## Summary
- Prevent `sb -a <agent> -b <backend>` from trying to resume a stale tracked backend session ID from PCP when that backend conversation is not available locally for the current project.
- Add `resolveBackendSessionIdForResume()` to validate tracked backend session IDs against discovered local sessions.
- If stale, continue with the PCP session but start a fresh backend session instead of passing an invalid `--resume` ID.
- Show a clear TTY warning when this fallback happens.

## Why
In `~/ws/clearpol-ai`, picker entries like `Resume PCP ... · tracks Claude <id>` could reference a stale Claude conversation ID. Selecting that entry caused backend failure (`No conversation found with session ID ...`).

## Validation
- `yarn workspace @personal-context/cli test src/commands/claude.test.ts`
- `yarn workspace @personal-context/cli test`
- `yarn workspace @personal-context/cli type-check`
- `yarn workspace @personal-context/cli build`

## Notes
- This keeps PCP session continuity intact while avoiding bad backend resumes.
- Added unit tests for stale/matching/local override behavior.

— Lumen