### PR TITLE
fix(shared): ESM module format for CLI interop (by Wren)

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -2,6 +2,7 @@
   "name": "@personal-context/shared",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "description": "Shared types and utilities for personal context protocol",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,3 +1,3 @@
 // Shared types and utilities
-export * from './types';
-export * from './security';
+export * from './types/index.js';
+export * from './security/index.js';

--- a/packages/shared/src/security/index.ts
+++ b/packages/shared/src/security/index.ts
@@ -1,2 +1,2 @@
-export * from './tool-policy-core';
-export * from './delegation-token';
+export * from './tool-policy-core.js';
+export * from './delegation-token.js';

--- a/packages/shared/src/types/api.ts
+++ b/packages/shared/src/types/api.ts
@@ -1,4 +1,4 @@
-import { Pagination } from './common';
+import { Pagination } from './common.js';
 
 // API Response types
 

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -1,3 +1,3 @@
 // Common types used across packages
-export * from './common';
-export * from './api';
+export * from './common.js';
+export * from './api.js';


### PR DESCRIPTION
## Summary

- Convert `@personal-context/shared` from CJS to ESM by adding `"type": "module"` to its `package.json`
- Update all relative imports to use `.js` extensions per Node16 module resolution requirements
- Fixes `SyntaxError: Named export 'expandPolicySpecs' not found` when the CLI imports from shared

## Context

The CLI (`"type": "module"`) couldn't resolve named exports from `@personal-context/shared` (CJS default). Node.js ESM can't do named imports from CJS modules — this surfaced at runtime when the CLI's stop hook tried to import `expandPolicySpecs`, `matchesAnyPolicyPattern`, and `normalizePolicyToken`.

Only the CLI depends on shared (the API doesn't reference it), so the blast radius is minimal. If the API ever imports from shared, it would need `"type": "module"` too or shared would need dual CJS/ESM exports.

## Files changed

| File | Change |
|------|--------|
| `packages/shared/package.json` | Add `"type": "module"` |
| `packages/shared/src/index.ts` | `.js` extensions on re-exports |
| `packages/shared/src/types/index.ts` | `.js` extensions on re-exports |
| `packages/shared/src/types/api.ts` | `.js` extension on import |
| `packages/shared/src/security/index.ts` | `.js` extensions on re-exports |

## Test plan

- [x] `yarn workspace @personal-context/shared build` — compiles clean
- [x] `yarn workspace @personal-context/cli build` — compiles clean
- [x] `yarn workspace @personal-context/api build` — no regression
- [x] `node -e "import { expandPolicySpecs } from '@personal-context/shared'"` — named imports resolve
- [x] PM2 restart — server online

🤖 Generated with [Claude Code](https://claude.com/claude-code)