### PR TITLE
feat: codex/gemini debug visibility + codex JSONL fallback (by Lumen)

### DIFF
--- a/packages/cli/src/backends/codex.ts
+++ b/packages/cli/src/backends/codex.ts
@@ -31,6 +31,10 @@ export class CodexAdapter implements BackendAdapter {
     if (config.backendSessionId) {
       args.push('resume', config.backendSessionId);
     }
+    // NOTE:
+    // Codex does not currently expose a reliable "set session id on first run"
+    // equivalent to Claude's --session-id seeding flow, so we only pass resume
+    // when a backend-native id is already known.
 
     // Passthrough flags
     args.push(...config.passthroughArgs);

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -33,6 +33,7 @@ import { registerMissionCommand } from './commands/mission.js';
 import { registerStatusCommand } from './commands/status.js';
 import { runClaude, runClaudeInteractive } from './commands/claude.js';
 import { resolveBackend } from './backends/index.js';
+import { initSbDebug, sbDebugLog } from './lib/sb-debug.js';
 
 const VERSION = '0.3.0';
 
@@ -56,6 +57,7 @@ const SB_FLAGS: Record<string, { hasValue: boolean; key: string }> = {
   '--no-session': { hasValue: false, key: 'noSession' },
   '--session-candidates': { hasValue: false, key: 'sessionCandidates' },
   '--session-choice': { hasValue: true, key: 'sessionChoice' },
+  '--sb-debug': { hasValue: false, key: 'sbDebug' },
 };
 
 interface ParsedArgs {
@@ -67,6 +69,7 @@ interface ParsedArgs {
     verbose: boolean;
     sessionCandidates: boolean;
     sessionChoice: string | undefined;
+    sbDebug: boolean;
   };
   passthroughArgs: string[];
   promptParts: string[];
@@ -101,6 +104,7 @@ export function extractArgs(argv: string[]): ParsedArgs {
     verbose: false,
     sessionCandidates: false,
     sessionChoice: undefined,
+    sbDebug: false,
   };
   const passthroughArgs: string[] = [];
   const promptParts: string[] = [];
@@ -122,6 +126,7 @@ export function extractArgs(argv: string[]): ParsedArgs {
         if (flag.key === 'noSession') sbOptions.session = false;
         else if (flag.key === 'verbose') sbOptions.verbose = true;
         else if (flag.key === 'sessionCandidates') sbOptions.sessionCandidates = true;
+        else if (flag.key === 'sbDebug') sbOptions.sbDebug = true;
       }
     } else if (arg === '--') {
       // Explicit passthrough boundary — everything after goes to claude
@@ -170,6 +175,7 @@ program
     'List session candidates and exit (or combine with --session-choice)'
   )
   .option('--session-choice <choice>', 'Force session selection (new | pcp:<id> | local:<id>)')
+  .option('--sb-debug', 'Enable SB debug logging to ~/.pcp/sb-debug.log')
   .option('-v, --verbose', 'Verbose output')
   .argument('[prompt...]', 'Prompt to send (omit for interactive)')
   .action(async () => {
@@ -179,6 +185,23 @@ program
 
     // Resolve backend from identity.json if not explicitly set
     const resolvedOptions = { ...sbOptions, backend: resolveBackend(sbOptions.backend) };
+    const debugFile = initSbDebug({
+      enabled: resolvedOptions.sbDebug,
+      context: {
+        argv: process.argv.slice(2),
+        backend: resolvedOptions.backend,
+        agent: resolvedOptions.agent || null,
+      },
+    });
+    if (resolvedOptions.sbDebug) {
+      console.log(chalk.dim(`SB debug log: ${debugFile}`));
+    }
+    sbDebugLog('sb', 'parsed_args', {
+      sbOptions: resolvedOptions,
+      passthroughArgs,
+      promptParts,
+      hasPrompt: Boolean(prompt),
+    });
 
     const isInteractiveSubcommand = isBackendInteractiveSubcommand(
       resolvedOptions.backend,
@@ -186,6 +209,10 @@ program
     );
 
     if (isInteractiveSubcommand) {
+      sbDebugLog('sb', 'run_interactive_subcommand', {
+        backend: resolvedOptions.backend,
+        passthroughArgs: [...passthroughArgs, ...promptParts],
+      });
       // Move positional args to passthrough so the backend receives them as subcommand args
       await runClaudeInteractive(resolvedOptions, [...passthroughArgs, ...promptParts]);
     } else if (!prompt && !passthroughArgs.length && !process.stdin.isTTY) {
@@ -195,13 +222,25 @@ program
       for await (const chunk of process.stdin) {
         stdinData += chunk;
       }
+      sbDebugLog('sb', 'run_prompt_from_stdin', {
+        backend: resolvedOptions.backend,
+        stdinChars: stdinData.length,
+      });
       await runClaude(stdinData.trim(), [stdinData.trim()], resolvedOptions, passthroughArgs);
     } else if (prompt) {
       // Prompt mode (one-shot)
+      sbDebugLog('sb', 'run_prompt_mode', {
+        backend: resolvedOptions.backend,
+        promptPartsCount: promptParts.length,
+      });
       await runClaude(prompt, promptParts, resolvedOptions, passthroughArgs);
     } else {
       // No prompt — launch interactive session
       // Passthrough args (like --resume) still forwarded
+      sbDebugLog('sb', 'run_interactive_mode', {
+        backend: resolvedOptions.backend,
+        passthroughArgs,
+      });
       await runClaudeInteractive(resolvedOptions, passthroughArgs);
     }
   });

--- a/packages/cli/src/commands/claude.test.ts
+++ b/packages/cli/src/commands/claude.test.ts
@@ -6,6 +6,7 @@ import {
   extractClaudeHistorySessionsForProject,
   filterPcpSessionsForContext,
   filterUntrackedLocalClaudeSessions,
+  getCodexLocalSessionsForProject,
   hasBackendSessionOverride,
   resolveCapturedBackendSessionIdFromRuntime,
   resolveBackendSessionIdForResume,
@@ -441,5 +442,54 @@ describe('extractClaudeHistorySessionsForProject', () => {
     expect(parsed[0].sessionId).toBe('sess-clearpol-1');
     expect(parsed[0].backend).toBe('claude');
     expect(parsed[0].firstPrompt).toBe('Hi Wren');
+  });
+});
+
+describe('getCodexLocalSessionsForProject', () => {
+  it('falls back to codex session jsonl files when sqlite db is unavailable', () => {
+    const tempHome = mkdtempSync(join(tmpdir(), 'codex-jsonl-fallback-'));
+    const projectPath = join(tempHome, 'repo');
+    mkdirSync(projectPath, { recursive: true });
+
+    const codexSessionsDir = join(tempHome, '.codex', 'sessions', '2026', '03', '02');
+    mkdirSync(codexSessionsDir, { recursive: true });
+
+    const matchingSessionId = '019a23ac-e563-7d53-8bf0-5a948546bf29';
+    const nonMatchingSessionId = '019a23b9-b211-7972-b007-012a8bc1d6f2';
+    writeFileSync(
+      join(codexSessionsDir, `rollout-2026-03-02T11-44-41-${matchingSessionId}.jsonl`),
+      `${JSON.stringify({
+        timestamp: '2026-03-02T11:44:41.000Z',
+        type: 'session_meta',
+        payload: {
+          id: matchingSessionId,
+          cwd: projectPath,
+          timestamp: '2026-03-02T11:44:41.000Z',
+        },
+      })}\n`
+    );
+    writeFileSync(
+      join(codexSessionsDir, `rollout-2026-03-02T11-44-41-${nonMatchingSessionId}.jsonl`),
+      `${JSON.stringify({
+        timestamp: '2026-03-02T11:44:41.000Z',
+        type: 'session_meta',
+        payload: {
+          id: nonMatchingSessionId,
+          cwd: join(tempHome, 'other-repo'),
+          timestamp: '2026-03-02T11:44:41.000Z',
+        },
+      })}\n`
+    );
+
+    const originalHome = process.env.HOME;
+    process.env.HOME = tempHome;
+
+    try {
+      const sessions = getCodexLocalSessionsForProject(projectPath, 10);
+      expect(sessions.map((session) => session.sessionId)).toEqual([matchingSessionId]);
+    } finally {
+      process.env.HOME = originalHome;
+      rmSync(tempHome, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -8,7 +8,7 @@
 import { spawn, spawnSync } from 'child_process';
 import chalk from 'chalk';
 import { randomUUID } from 'crypto';
-import { existsSync, readFileSync, readdirSync, realpathSync, statSync } from 'fs';
+import { type Dirent, existsSync, readFileSync, readdirSync, realpathSync, statSync } from 'fs';
 import { join, resolve as resolvePath } from 'path';
 import { homedir } from 'os';
 import { getBackend, resolveAgentId } from '../backends/index.js';
@@ -67,6 +67,16 @@ interface ClaudeHistoryLine {
   timestamp?: number;
   project?: string;
   sessionId?: string;
+}
+
+interface CodexSessionMetaLine {
+  timestamp?: string;
+  type?: string;
+  payload?: {
+    id?: string;
+    cwd?: string;
+    timestamp?: string;
+  };
 }
 
 interface BackendExecutionLogContext {
@@ -574,11 +584,28 @@ export function getCodexLocalSessionsForProject(
   cwd = process.cwd(),
   limit = 20
 ): BackendLocalSessionSummary[] {
+  const fallbackToJsonl = (reason: string): BackendLocalSessionSummary[] => {
+    const fallback = getCodexLocalSessionsFromJsonl(cwd, limit);
+    sbDebugLog('backend', 'codex_local_sessions_fallback_jsonl', {
+      cwd,
+      reason,
+      returnedSessions: fallback.length,
+      sessionIds: fallback.map((session) => session.sessionId),
+    });
+    return fallback;
+  };
+
   const codexStateDbPath = join(homedir(), '.codex', 'state_5.sqlite');
-  if (!existsSync(codexStateDbPath)) return [];
+  if (!existsSync(codexStateDbPath)) {
+    sbDebugLog('backend', 'codex_local_sessions_missing_db', { cwd, codexStateDbPath });
+    return fallbackToJsonl('missing_state_db');
+  }
 
   const normalizedCwd = normalizePath(cwd);
-  if (!normalizedCwd) return [];
+  if (!normalizedCwd) {
+    sbDebugLog('backend', 'codex_local_sessions_unresolved_cwd', { cwd });
+    return [];
+  }
 
   const query = `
 SELECT id, cwd, updated_at,
@@ -591,7 +618,16 @@ LIMIT 200;
 `;
 
   const result = spawnSync('sqlite3', ['-tabs', codexStateDbPath, query], { encoding: 'utf-8' });
-  if (result.error || result.status !== 0 || !result.stdout) return [];
+  if (result.error || result.status !== 0 || !result.stdout) {
+    sbDebugLog('backend', 'codex_local_sessions_query_failed', {
+      cwd: normalizedCwd,
+      codexStateDbPath,
+      status: result.status ?? null,
+      error: result.error?.message || null,
+      stderr: result.stderr?.toString()?.slice(-1000) || null,
+    });
+    return fallbackToJsonl('sqlite_query_failed');
+  }
 
   const sessions: BackendLocalSessionSummary[] = [];
   const lines = result.stdout.split('\n').map((line) => line.trim());
@@ -618,12 +654,121 @@ LIMIT 200;
     });
   }
 
-  return sessions.slice(0, limit);
+  const scoped = sessions.slice(0, limit);
+  sbDebugLog('backend', 'codex_local_sessions_loaded', {
+    cwd: normalizedCwd,
+    totalScopedSessions: sessions.length,
+    returnedSessions: scoped.length,
+    sessionIds: scoped.map((session) => session.sessionId),
+  });
+  return scoped.length > 0 ? scoped : fallbackToJsonl('sqlite_query_empty');
+}
+
+function getCodexLocalSessionsFromJsonl(
+  cwd = process.cwd(),
+  limit = 20
+): BackendLocalSessionSummary[] {
+  const codexSessionsDir = join(homedir(), '.codex', 'sessions');
+  if (!existsSync(codexSessionsDir)) return [];
+
+  const normalizedCwd = normalizePath(cwd);
+  if (!normalizedCwd) return [];
+
+  const sessionFiles: Array<{ path: string; modified: string }> = [];
+  const stack: string[] = [codexSessionsDir];
+  while (stack.length > 0) {
+    const dir = stack.pop();
+    if (!dir) continue;
+
+    let entries: Dirent[];
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      const fullPath = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(fullPath);
+        continue;
+      }
+      if (!entry.isFile() || !entry.name.endsWith('.jsonl')) continue;
+      try {
+        const stats = statSync(fullPath);
+        sessionFiles.push({ path: fullPath, modified: stats.mtime.toISOString() });
+      } catch {
+        // Ignore unreadable files.
+      }
+    }
+  }
+
+  const maxFilesToInspect = Math.max(limit * 25, 250);
+  const sortedFiles = sessionFiles
+    .sort((a, b) => new Date(b.modified).getTime() - new Date(a.modified).getTime())
+    .slice(0, maxFilesToInspect);
+
+  const sessions: BackendLocalSessionSummary[] = [];
+  for (const sessionFile of sortedFiles) {
+    let content: string;
+    try {
+      content = readFileSync(sessionFile.path, 'utf-8');
+    } catch {
+      continue;
+    }
+
+    let matched: BackendLocalSessionSummary | undefined;
+    const lines = content.split('\n');
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+
+      let parsed: CodexSessionMetaLine;
+      try {
+        parsed = JSON.parse(trimmed) as CodexSessionMetaLine;
+      } catch {
+        continue;
+      }
+
+      if (parsed.type !== 'session_meta') continue;
+      const sessionId = parsed.payload?.id?.trim();
+      const sessionCwd = parsed.payload?.cwd?.trim();
+      if (!sessionId || !sessionCwd) break;
+
+      const normalizedSessionCwd = normalizePath(sessionCwd);
+      if (!normalizedSessionCwd || normalizedSessionCwd !== normalizedCwd) break;
+
+      matched = {
+        backend: 'codex',
+        sessionId,
+        projectPath: sessionCwd,
+        modified: parsed.payload?.timestamp || parsed.timestamp || sessionFile.modified,
+      };
+      break;
+    }
+
+    if (matched) sessions.push(matched);
+  }
+
+  const deduped = new Map<string, BackendLocalSessionSummary>();
+  for (const session of sessions) {
+    const existing = deduped.get(session.sessionId);
+    if (!existing || new Date(session.modified).getTime() > new Date(existing.modified).getTime()) {
+      deduped.set(session.sessionId, session);
+    }
+  }
+
+  return Array.from(deduped.values())
+    .sort((a, b) => new Date(b.modified).getTime() - new Date(a.modified).getTime())
+    .slice(0, limit);
 }
 
 function getGeminiProjectKeysForCwd(cwd = process.cwd()): string[] {
   const normalizedCwd = normalizePath(cwd);
-  if (!normalizedCwd) return [];
+  if (!normalizedCwd) {
+    sbDebugLog('backend', 'gemini_project_keys_unresolved_cwd', { cwd });
+    return [];
+  }
 
   const keys = new Set<string>();
 
@@ -661,7 +806,13 @@ function getGeminiProjectKeysForCwd(cwd = process.cwd()): string[] {
     }
   }
 
-  return Array.from(keys);
+  const resolved = Array.from(keys);
+  sbDebugLog('backend', 'gemini_project_keys_loaded', {
+    cwd: normalizedCwd,
+    keyCount: resolved.length,
+    keys: resolved,
+  });
+  return resolved;
 }
 
 function getGeminiSessionsForProjectKey(projectKey: string): BackendLocalSessionSummary[] {
@@ -719,7 +870,10 @@ export function getGeminiLocalSessionsForProject(
   limit = 20
 ): BackendLocalSessionSummary[] {
   const projectKeys = getGeminiProjectKeysForCwd(cwd);
-  if (projectKeys.length === 0) return [];
+  if (projectKeys.length === 0) {
+    sbDebugLog('backend', 'gemini_local_sessions_no_project_keys', { cwd });
+    return [];
+  }
 
   const sessions = projectKeys.flatMap((projectKey) => getGeminiSessionsForProjectKey(projectKey));
   const deduped = new Map<string, BackendLocalSessionSummary>();
@@ -730,9 +884,17 @@ export function getGeminiLocalSessionsForProject(
     }
   }
 
-  return Array.from(deduped.values())
+  const sorted = Array.from(deduped.values())
     .sort((a, b) => new Date(b.modified).getTime() - new Date(a.modified).getTime())
     .slice(0, limit);
+  sbDebugLog('backend', 'gemini_local_sessions_loaded', {
+    cwd,
+    projectKeyCount: projectKeys.length,
+    dedupedCount: deduped.size,
+    returnedSessions: sorted.length,
+    sessionIds: sorted.map((session) => session.sessionId),
+  });
+  return sorted;
 }
 
 export function getBackendLocalSessionsForProject(

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -14,6 +14,7 @@ import { homedir } from 'os';
 import { getBackend, resolveAgentId } from '../backends/index.js';
 import { getValidAccessToken } from '../auth/tokens.js';
 import { callPcpTool, getPcpServerUrl } from '../lib/pcp-mcp.js';
+import { sbDebugLog } from '../lib/sb-debug.js';
 import {
   getCurrentRuntimeSession,
   listRuntimeSessions,

--- a/packages/cli/src/commands/hooks.ts
+++ b/packages/cli/src/commands/hooks.ts
@@ -439,7 +439,7 @@ async function reconcileBackendSignal(
 ): Promise<{ pcpSessionId?: string; threadKey?: string; backendSessionId?: string }> {
   const detectedBackend = detectBackend(cwd);
   const sessionBackend = normalizeSessionBackend(detectedBackend.name);
-  const backendSessionId = extractBackendSessionId(stdin);
+  const backendSessionId = extractBackendSessionId(stdin, sessionBackend);
   const runtimeLinkId = getRuntimeLinkId();
   if (runtimeLinkId) {
     writeRuntimeFile(cwd, 'runtime-link-id', runtimeLinkId);
@@ -566,22 +566,67 @@ async function updateRuntimeGenerationState(
   }
 }
 
-function extractBackendSessionId(stdin: Record<string, unknown>): string | undefined {
-  const candidates: unknown[] = [
-    stdin.session_id,
-    stdin.sessionId,
-    (stdin.session as Record<string, unknown> | undefined)?.id,
-    (stdin.session as Record<string, unknown> | undefined)?.session_id,
-    (stdin.data as Record<string, unknown> | undefined)?.session_id,
-    (stdin.data as Record<string, unknown> | undefined)?.sessionId,
+export function extractBackendSessionId(
+  stdin: Record<string, unknown>,
+  sessionBackend?: string
+): string | undefined {
+  // Claude hook payload session_id values are not stable conversation IDs.
+  // They can rotate on each run and poison backendSessionId mapping.
+  //
+  // Real-world failure we observed:
+  // 1) fallback repair correctly set backendSessionId to a resumable id
+  // 2) later hook events emitted a new transient UUID
+  // 3) hook reconciliation overwrote backendSessionId with that transient id
+  // 4) next launch failed on --resume <transient-id>
+  //
+  // Therefore hooks MUST NOT source Claude backendSessionId from stdin payloads.
+  // For Claude, backendSessionId should be captured by sb launch path from
+  // explicit "claude --resume <id>" output, not hook stdin fields.
+  if (sessionBackend === 'claude') {
+    sbDebugLog('hooks', 'backend_session_extract_skip', {
+      sessionBackend,
+      reason: 'claude_transient_ids_blocked',
+    });
+    return undefined;
+  }
+
+  const candidates: Array<{ source: string; value: unknown }> = [
+    { source: 'stdin.session_id', value: stdin.session_id },
+    { source: 'stdin.sessionId', value: stdin.sessionId },
+    {
+      source: 'stdin.session.id',
+      value: (stdin.session as Record<string, unknown> | undefined)?.id,
+    },
+    {
+      source: 'stdin.session.session_id',
+      value: (stdin.session as Record<string, unknown> | undefined)?.session_id,
+    },
+    {
+      source: 'stdin.data.session_id',
+      value: (stdin.data as Record<string, unknown> | undefined)?.session_id,
+    },
+    {
+      source: 'stdin.data.sessionId',
+      value: (stdin.data as Record<string, unknown> | undefined)?.sessionId,
+    },
   ];
 
   for (const candidate of candidates) {
-    if (typeof candidate === 'string' && candidate.trim()) {
-      return candidate.trim();
+    if (typeof candidate.value === 'string' && candidate.value.trim()) {
+      const normalized = candidate.value.trim();
+      sbDebugLog('hooks', 'backend_session_extract_success', {
+        sessionBackend: sessionBackend || 'unknown',
+        source: candidate.source,
+        backendSessionId: normalized,
+      });
+      return normalized;
     }
   }
 
+  sbDebugLog('hooks', 'backend_session_extract_none', {
+    sessionBackend: sessionBackend || 'unknown',
+    stdinKeys: Object.keys(stdin),
+  });
   return undefined;
 }
 

--- a/packages/cli/src/commands/hooks.ts
+++ b/packages/cli/src/commands/hooks.ts
@@ -31,6 +31,7 @@ import {
   setCurrentRuntimeSession,
   upsertRuntimeSession,
 } from '../session/runtime.js';
+import { sbDebugLog } from '../lib/sb-debug.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);

--- a/packages/cli/src/lib/sb-debug.test.ts
+++ b/packages/cli/src/lib/sb-debug.test.ts
@@ -1,0 +1,54 @@
+import { mkdtempSync, readFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { initSbDebug, isSbDebugEnabled, resolveSbDebugFile, sbDebugLog } from './sb-debug.js';
+
+const originalSbDebug = process.env.SB_DEBUG;
+const originalSbDebugFile = process.env.SB_DEBUG_FILE;
+
+afterEach(() => {
+  if (originalSbDebug === undefined) delete process.env.SB_DEBUG;
+  else process.env.SB_DEBUG = originalSbDebug;
+
+  if (originalSbDebugFile === undefined) delete process.env.SB_DEBUG_FILE;
+  else process.env.SB_DEBUG_FILE = originalSbDebugFile;
+});
+
+describe('sb-debug helpers', () => {
+  it('enables debug when explicit flag is true', () => {
+    delete process.env.SB_DEBUG;
+    delete process.env.SB_DEBUG_FILE;
+    expect(isSbDebugEnabled(true)).toBe(true);
+  });
+
+  it('enables debug from env toggles', () => {
+    process.env.SB_DEBUG = 'true';
+    delete process.env.SB_DEBUG_FILE;
+    expect(isSbDebugEnabled()).toBe(true);
+
+    process.env.SB_DEBUG = '0';
+    process.env.SB_DEBUG_FILE = '/tmp/from-env.log';
+    expect(isSbDebugEnabled()).toBe(true);
+  });
+
+  it('resolves file path from explicit arg, then env', () => {
+    process.env.SB_DEBUG_FILE = '/tmp/from-env.log';
+    expect(resolveSbDebugFile('/tmp/from-arg.log')).toBe('/tmp/from-arg.log');
+    expect(resolveSbDebugFile()).toBe('/tmp/from-env.log');
+  });
+
+  it('writes debug records only when enabled', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'sb-debug-test-'));
+    const logFile = join(dir, 'sb-debug.log');
+
+    sbDebugLog('test', 'before_enabled', { a: 1 }, { file: logFile });
+    expect(() => readFileSync(logFile, 'utf-8')).toThrow();
+
+    initSbDebug({ enabled: true, file: logFile });
+    sbDebugLog('test', 'after_enabled', { a: 2 });
+    const written = readFileSync(logFile, 'utf-8');
+    expect(written).toContain('"event":"debug_enabled"');
+    expect(written).toContain('"event":"after_enabled"');
+  });
+});

--- a/packages/cli/src/lib/sb-debug.ts
+++ b/packages/cli/src/lib/sb-debug.ts
@@ -1,0 +1,78 @@
+import { appendFileSync, mkdirSync } from 'fs';
+import { dirname, join } from 'path';
+import { homedir } from 'os';
+
+const initializedDirs = new Set<string>();
+
+function envEnabled(value: string | undefined): boolean {
+  if (!value) return false;
+  const normalized = value.trim().toLowerCase();
+  return normalized === '1' || normalized === 'true' || normalized === 'yes' || normalized === 'on';
+}
+
+export function isSbDebugEnabled(explicit?: boolean): boolean {
+  if (explicit) return true;
+  return envEnabled(process.env.SB_DEBUG) || Boolean(process.env.SB_DEBUG_FILE?.trim());
+}
+
+export function resolveSbDebugFile(explicitPath?: string): string {
+  const fromArg = explicitPath?.trim();
+  if (fromArg) return fromArg;
+  const fromEnv = process.env.SB_DEBUG_FILE?.trim();
+  if (fromEnv) return fromEnv;
+  return join(homedir(), '.pcp', 'sb-debug.log');
+}
+
+export function sbDebugLog(
+  scope: string,
+  event: string,
+  payload?: Record<string, unknown>,
+  options?: { force?: boolean; file?: string }
+): void {
+  if (!isSbDebugEnabled(options?.force)) return;
+
+  const targetFile = resolveSbDebugFile(options?.file);
+  const record = {
+    ts: new Date().toISOString(),
+    pid: process.pid,
+    scope,
+    event,
+    cwd: process.cwd(),
+    ...(payload || {}),
+  };
+
+  try {
+    const dir = dirname(targetFile);
+    if (!initializedDirs.has(dir)) {
+      mkdirSync(dir, { recursive: true });
+      initializedDirs.add(dir);
+    }
+    appendFileSync(targetFile, `${JSON.stringify(record)}\n`, 'utf-8');
+  } catch {
+    // Never fail main flow because debug logging failed.
+  }
+}
+
+export function initSbDebug(options?: {
+  enabled?: boolean;
+  file?: string;
+  context?: Record<string, unknown>;
+}): string | undefined {
+  if (!isSbDebugEnabled(options?.enabled)) return undefined;
+
+  const file = resolveSbDebugFile(options?.file);
+  process.env.SB_DEBUG = '1';
+  process.env.SB_DEBUG_FILE = file;
+
+  sbDebugLog(
+    'sb',
+    'debug_enabled',
+    {
+      file,
+      ...(options?.context || {}),
+    },
+    { force: true, file }
+  );
+
+  return file;
+}


### PR DESCRIPTION
## Summary
- add Codex/Gemini-focused `--sb-debug` traces so backend session discovery/extraction paths are visible in debug logs
- add Codex session discovery fallback to `~/.codex/sessions/**/*.jsonl` when SQLite discovery is unavailable or empty
- keep Codex adapter behavior explicit: resume only when a backend-native ID is known (no deterministic first-run seed path)
- add regression coverage for Codex JSONL fallback path

## Why
We stabilized Claude session mapping with deep debug traces; we need equivalent observability for Codex/Gemini and a more portable Codex local-session source.

Codex-specific constraints from upstream issues:
- no deterministic first-run session-id seeding API today
- startup/session-id visibility can be limited depending on mode

This change improves our practical recovery/debug story without overfitting to SQLite-only local state.

## Validation
- `yarn workspace @personal-context/cli test src/commands/claude.test.ts src/commands/hooks.test.ts`
- `yarn workspace @personal-context/cli test src/commands/claude.test.ts`
- `yarn workspace @personal-context/cli type-check`

## Notes
- Claude-specific protections from prior work remain intact (transient ID blocking, stale recovery).
- This PR layers Codex/Gemini observability and Codex JSONL fallback on top.

— Lumen