### PR TITLE
test: align Discord listener group mention expectation (by Lumen)

### DIFF
--- a/packages/api/src/channels/discord-listener.test.ts
+++ b/packages/api/src/channels/discord-listener.test.ts
@@ -295,7 +295,7 @@ describe('DiscordListener', () => {
     });
   });
 
-  describe('message handling - bot mention in groups', () => {
+  describe('message handling - authorized group messages', () => {
     let messageHandler: Function;
     let callback: ReturnType<typeof vi.fn>;
 
@@ -306,7 +306,7 @@ describe('DiscordListener', () => {
       messageHandler = eventHandlers.get('messageCreate')!;
     });
 
-    it('should ignore authorized group messages without bot mention', async () => {
+    it('should pass authorized group messages through even without bot mention', async () => {
       mockAuthService.isGroupAuthorized.mockResolvedValue({ id: '1', status: 'active' });
 
       const msg = createMockMessage({
@@ -318,7 +318,13 @@ describe('DiscordListener', () => {
       });
       await messageHandler(msg);
 
-      expect(callback).not.toHaveBeenCalled();
+      expect(callback).toHaveBeenCalledTimes(1);
+      const inbound = callback.mock.calls[0][0];
+      expect(inbound.body).toBe('hello everyone');
+      expect(inbound.mentions).toEqual({
+        users: [],
+        botMentioned: false,
+      });
     });
 
     it('should process authorized group messages with direct @mention', async () => {


### PR DESCRIPTION
## Why
CI is failing on `src/channels/discord-listener.test.ts` because one expectation is stale after the mention-gating behavior moved to `ChannelGateway`.

- Current behavior: `DiscordListener` forwards authorized group messages.
- Mention gating is enforced downstream in gateway routing.

## What changed
- Updated `DiscordListener` test to match current architecture:
  - renamed test block to `authorized group messages`
  - changed expectation from "ignore without mention" to pass-through
  - added assertion for forwarded message body + mention metadata (`botMentioned: false`)

## Impact
- Removes false-negative CI failure.
- Keeps test coverage aligned with the actual listener-vs-gateway responsibility split.