### PR TITLE
feat: hide internal session lifecycle MCP tools from SB catalog (by lumen)

### DIFF
--- a/packages/api/src/config/constants.ts
+++ b/packages/api/src/config/constants.ts
@@ -19,7 +19,7 @@ Most tools require identifying a user. You can use ANY ONE of these methods:
 
 ## Core Capabilities
 - **Memory**: remember, recall, forget - Long-term memory with semantic search
-- **Sessions**: start_session, log_session, end_session - Track conversation sessions
+- **Sessions**: update_session_phase, get_session, list_sessions - Track and inspect session state
 - **Bootstrap**: bootstrap - Initialize agent with user context, identity, and recent memories
 - **Gmail**: list_emails, get_email, send_email, modify_emails - Full Gmail integration
 - **Calendar**: list_calendars, list_calendar_events - Google Calendar access

--- a/packages/api/src/mcp/server.test.ts
+++ b/packages/api/src/mcp/server.test.ts
@@ -76,6 +76,7 @@ vi.mock('@supabase/supabase-js', () => ({
 
 import { MCPServer } from './server';
 import { env } from '../config/env';
+import { registerAllTools } from './tools';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -99,11 +100,13 @@ function makeToolsListRequest(id: number) {
 /** POST to the MCP endpoint. */
 async function mcpPost(
   baseUrl: string,
-  body: unknown
+  body: unknown,
+  extraHeaders: Record<string, string> = {}
 ): Promise<{ status: number; headers: Headers; body: string }> {
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
     Accept: 'application/json, text/event-stream',
+    ...extraHeaders,
   };
   const res = await fetch(`${baseUrl}/mcp`, {
     method: 'POST',
@@ -239,6 +242,34 @@ describe('MCP StreamableHTTP Transport (stateless)', () => {
     // A separate tools/list request (new transport) should also work
     const listRes = await mcpPost(baseUrl, makeToolsListRequest(2));
     expect(listRes.status).toBe(200);
+  });
+
+  it('registers agent-facing MCP catalog without internal lifecycle tools by default', async () => {
+    if (serverUnavailableError) return;
+    const registerAllToolsMock = vi.mocked(registerAllTools);
+    const priorCalls = registerAllToolsMock.mock.calls.length;
+
+    const res = await mcpPost(baseUrl, makeToolsListRequest(21));
+    expect(res.status).toBe(200);
+
+    const newCalls = registerAllToolsMock.mock.calls.slice(priorCalls);
+    const lastCall = newCalls[newCalls.length - 1];
+    expect(lastCall?.[2]).toEqual({ includeInternalLifecycleTools: false });
+  });
+
+  it('registers runtime MCP catalog with internal lifecycle tools when caller profile is runtime', async () => {
+    if (serverUnavailableError) return;
+    const registerAllToolsMock = vi.mocked(registerAllTools);
+    const priorCalls = registerAllToolsMock.mock.calls.length;
+
+    const res = await mcpPost(baseUrl, makeToolsListRequest(22), {
+      'x-pcp-caller-profile': 'runtime',
+    });
+    expect(res.status).toBe(200);
+
+    const newCalls = registerAllToolsMock.mock.calls.slice(priorCalls);
+    const lastCall = newCalls[newCalls.length - 1];
+    expect(lastCall?.[2]).toEqual({ includeInternalLifecycleTools: true });
   });
 
   it('should handle multiple concurrent requests independently', async () => {

--- a/packages/api/src/mcp/server.ts
+++ b/packages/api/src/mcp/server.ts
@@ -158,7 +158,7 @@ export class MCPServer {
    * Create a new McpServer instance with all tools registered.
    * Each HTTP client session gets its own instance.
    */
-  private createMcpServerInstance(callerProfile: 'agent' | 'runtime' = 'runtime'): McpServer {
+  private createMcpServerInstance(callerProfile: 'agent' | 'runtime' = 'agent'): McpServer {
     const server = new McpServer({
       name: MCP_SERVER_NAME,
       version: MCP_SERVER_VERSION,
@@ -278,6 +278,10 @@ export class MCPServer {
           }
         : {};
       const callerProfileHeader = req.header('x-pcp-caller-profile')?.trim().toLowerCase();
+      // Trust boundary note:
+      // `x-pcp-caller-profile` is only consumed on the MCP transport entrypoint.
+      // Supported MCP clients in our stack do not expose arbitrary header injection to model prompts,
+      // so this remains a runtime/server-controlled signal rather than an LLM-controlled parameter.
       const callerProfile: 'agent' | 'runtime' =
         callerProfileHeader === 'runtime' ? 'runtime' : 'agent';
       Object.assign(ctx, { callerProfile });

--- a/packages/api/src/mcp/server.ts
+++ b/packages/api/src/mcp/server.ts
@@ -158,7 +158,7 @@ export class MCPServer {
    * Create a new McpServer instance with all tools registered.
    * Each HTTP client session gets its own instance.
    */
-  private createMcpServerInstance(): McpServer {
+  private createMcpServerInstance(callerProfile: 'agent' | 'runtime' = 'runtime'): McpServer {
     const server = new McpServer({
       name: MCP_SERVER_NAME,
       version: MCP_SERVER_VERSION,
@@ -166,7 +166,9 @@ export class MCPServer {
     });
 
     // Register all tools on this server instance
-    registerAllTools(server, this.dataComposer);
+    registerAllTools(server, this.dataComposer, {
+      includeInternalLifecycleTools: callerProfile === 'runtime',
+    });
     registerMiniAppTools(server, this.miniApps);
 
     // Error handling
@@ -275,6 +277,10 @@ export class MCPServer {
             identityId: userData.identityId,
           }
         : {};
+      const callerProfileHeader = req.header('x-pcp-caller-profile')?.trim().toLowerCase();
+      const callerProfile: 'agent' | 'runtime' =
+        callerProfileHeader === 'runtime' ? 'runtime' : 'agent';
+      Object.assign(ctx, { callerProfile });
 
       if (userData) {
         try {
@@ -302,7 +308,7 @@ export class MCPServer {
           transport = new StreamableHTTPServerTransport({
             sessionIdGenerator: undefined,
           });
-          mcpServer = this.createMcpServerInstance();
+          mcpServer = this.createMcpServerInstance(callerProfile);
 
           await mcpServer.connect(transport);
           await transport.handleRequest(req, res);

--- a/packages/api/src/mcp/tools/index.test.ts
+++ b/packages/api/src/mcp/tools/index.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { registerAllTools } from './index';
+
+class FakeMcpServer {
+  public registeredTools: string[] = [];
+
+  registerTool(name: string): void {
+    this.registeredTools.push(name);
+  }
+}
+
+describe('registerAllTools lifecycle visibility', () => {
+  it('omits internal lifecycle tools when includeInternalLifecycleTools=false', () => {
+    const server = new FakeMcpServer();
+    const dataComposer = { getClient: () => ({}) };
+    registerAllTools(server as unknown as any, dataComposer as any, {
+      includeInternalLifecycleTools: false,
+    });
+
+    expect(server.registeredTools).not.toContain('start_session');
+    expect(server.registeredTools).not.toContain('log_session');
+    expect(server.registeredTools).not.toContain('end_session');
+    expect(server.registeredTools).toContain('update_session_phase');
+  });
+
+  it('includes lifecycle tools when includeInternalLifecycleTools=true', () => {
+    const server = new FakeMcpServer();
+    const dataComposer = { getClient: () => ({}) };
+    registerAllTools(server as unknown as any, dataComposer as any, {
+      includeInternalLifecycleTools: true,
+    });
+
+    expect(server.registeredTools).toContain('start_session');
+    expect(server.registeredTools).toContain('log_session');
+    expect(server.registeredTools).toContain('end_session');
+    expect(server.registeredTools).toContain('update_session_phase');
+  });
+});

--- a/packages/api/src/mcp/tools/index.ts
+++ b/packages/api/src/mcp/tools/index.ts
@@ -272,7 +272,16 @@ const userIdentifierFields = {
     .describe('Platform-specific user ID — only needed for platform-based user lookup'),
 };
 
-export function registerAllTools(server: McpServer, dataComposer: DataComposer): void {
+export interface RegisterToolOptions {
+  includeInternalLifecycleTools?: boolean;
+}
+
+export function registerAllTools(
+  server: McpServer,
+  dataComposer: DataComposer,
+  options?: RegisterToolOptions
+): void {
+  const includeInternalLifecycleTools = options?.includeInternalLifecycleTools ?? true;
   // ---------------------------------------------------------------------------
   // Timing diagnostics — wraps every tool handler to log execution time.
   // Calls exceeding SLOW_TOOL_THRESHOLD_MS are logged at warn level.
@@ -1229,11 +1238,12 @@ User can be identified by ONE of: userId, email, phone, or platform + platformId
   // SESSION TOOLS (for tracking AI sessions)
   // =====================================================
 
-  // Register start_session tool
-  server.registerTool(
-    'start_session',
-    {
-      description: `Start a new AI session. Sessions track work done across a conversation and can be logged to.
+  if (includeInternalLifecycleTools) {
+    // Register start_session tool
+    server.registerTool(
+      'start_session',
+      {
+        description: `Start a new AI session. Sessions track work done across a conversation and can be logged to.
 
 Session matching priority:
 1. threadKey — if provided, returns an existing active session with the same agent+threadKey (enables cross-trigger session continuity, e.g., "pr:32").
@@ -1245,183 +1255,184 @@ workspaceId is accepted as a deprecated alias for studioId.
 When forceNew=true, start_session always creates a new session (skips active-session reuse). You can optionally provide sessionId to set a client-generated canonical UUID.
 
 User can be identified by ONE of: userId, email, phone, or platform + platformId`,
-      inputSchema: {
-        ...userIdentifierFields,
-        agentId: z
-          .string()
-          .optional()
-          .describe('Agent identifier (e.g., "claude-code", "telegram-myra")'),
-        sessionId: z
-          .string()
-          .uuid()
-          .optional()
-          .describe(
-            'Optional PCP session UUID to use when creating a new session (typically with forceNew=true).'
-          ),
-        studioId: z
-          .string()
-          .uuid()
-          .optional()
-          .describe(
-            'Studio ID to scope this session to. Allows multiple active sessions per agent (one per studio). Read from .pcp/identity.json.'
-          ),
-        workspaceId: z
-          .string()
-          .uuid()
-          .optional()
-          .describe('[Deprecated] Workspace ID alias for studioId.'),
-        threadKey: z
-          .string()
-          .optional()
-          .describe(
-            'Thread key for session routing (e.g., "pr:32"). If an active session with this threadKey exists for the same agent, it is returned instead of creating a new one.'
-          ),
-        backend: z
-          .string()
-          .optional()
-          .describe('Backend runtime (e.g., "claude-code", "codex", "gemini")'),
-        model: z
-          .string()
-          .optional()
-          .describe('Model identifier (e.g., "opus-4-6", "sonnet", "o3")'),
-        metadata: z.record(z.unknown()).optional().describe('Session metadata'),
-        forceNew: z
-          .boolean()
-          .optional()
-          .describe('If true, create a new session even if an active one exists for this scope.'),
+        inputSchema: {
+          ...userIdentifierFields,
+          agentId: z
+            .string()
+            .optional()
+            .describe('Agent identifier (e.g., "claude-code", "telegram-myra")'),
+          sessionId: z
+            .string()
+            .uuid()
+            .optional()
+            .describe(
+              'Optional PCP session UUID to use when creating a new session (typically with forceNew=true).'
+            ),
+          studioId: z
+            .string()
+            .uuid()
+            .optional()
+            .describe(
+              'Studio ID to scope this session to. Allows multiple active sessions per agent (one per studio). Read from .pcp/identity.json.'
+            ),
+          workspaceId: z
+            .string()
+            .uuid()
+            .optional()
+            .describe('[Deprecated] Workspace ID alias for studioId.'),
+          threadKey: z
+            .string()
+            .optional()
+            .describe(
+              'Thread key for session routing (e.g., "pr:32"). If an active session with this threadKey exists for the same agent, it is returned instead of creating a new one.'
+            ),
+          backend: z
+            .string()
+            .optional()
+            .describe('Backend runtime (e.g., "claude-code", "codex", "gemini")'),
+          model: z
+            .string()
+            .optional()
+            .describe('Model identifier (e.g., "opus-4-6", "sonnet", "o3")'),
+          metadata: z.record(z.unknown()).optional().describe('Session metadata'),
+          forceNew: z
+            .boolean()
+            .optional()
+            .describe('If true, create a new session even if an active one exists for this scope.'),
+        },
       },
-    },
-    async (args) => {
-      try {
-        return await handleStartSession(args, dataComposer);
-      } catch (error) {
-        logger.error('Error in start_session:', error);
-        return {
-          content: [
-            {
-              type: 'text' as const,
-              text: JSON.stringify({
-                success: false,
-                error: error instanceof Error ? error.message : 'Unknown error',
-              }),
-            },
-          ],
-          isError: true,
-        };
+      async (args) => {
+        try {
+          return await handleStartSession(args, dataComposer);
+        } catch (error) {
+          logger.error('Error in start_session:', error);
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: JSON.stringify({
+                  success: false,
+                  error: error instanceof Error ? error.message : 'Unknown error',
+                }),
+              },
+            ],
+            isError: true,
+          };
+        }
       }
-    }
-  );
+    );
 
-  // Register log_session tool
-  server.registerTool(
-    'log_session',
-    {
-      description: `[DEPRECATED] Add an entry to the current session log. Prefer update_session_phase for work status and remember for important decisions/events.
+    // Register log_session tool
+    server.registerTool(
+      'log_session',
+      {
+        description: `[DEPRECATED] Add an entry to the current session log. Prefer update_session_phase for work status and remember for important decisions/events.
 
 User can be identified by ONE of: userId, email, phone, or platform + platformId`,
-      inputSchema: {
-        ...userIdentifierFields,
-        sessionId: z
-          .string()
-          .uuid()
-          .optional()
-          .describe('Session ID (uses active session if not provided)'),
-        agentId: z
-          .string()
-          .optional()
-          .describe('Agent identifier for session resolution (e.g., "wren", "benson")'),
-        studioId: z
-          .string()
-          .uuid()
-          .optional()
-          .describe('Studio ID for session resolution when sessionId not provided'),
-        workspaceId: z
-          .string()
-          .uuid()
-          .optional()
-          .describe('[Deprecated] Workspace ID alias for studioId.'),
-        content: z.string().describe('Log entry content'),
-        salience: z
-          .enum(['low', 'medium', 'high', 'critical'])
-          .optional()
-          .describe('Importance (default: medium)'),
+        inputSchema: {
+          ...userIdentifierFields,
+          sessionId: z
+            .string()
+            .uuid()
+            .optional()
+            .describe('Session ID (uses active session if not provided)'),
+          agentId: z
+            .string()
+            .optional()
+            .describe('Agent identifier for session resolution (e.g., "wren", "benson")'),
+          studioId: z
+            .string()
+            .uuid()
+            .optional()
+            .describe('Studio ID for session resolution when sessionId not provided'),
+          workspaceId: z
+            .string()
+            .uuid()
+            .optional()
+            .describe('[Deprecated] Workspace ID alias for studioId.'),
+          content: z.string().describe('Log entry content'),
+          salience: z
+            .enum(['low', 'medium', 'high', 'critical'])
+            .optional()
+            .describe('Importance (default: medium)'),
+        },
       },
-    },
-    async (args) => {
-      try {
-        return await handleLogSession(args, dataComposer);
-      } catch (error) {
-        logger.error('Error in log_session:', error);
-        return {
-          content: [
-            {
-              type: 'text' as const,
-              text: JSON.stringify({
-                success: false,
-                error: error instanceof Error ? error.message : 'Unknown error',
-              }),
-            },
-          ],
-          isError: true,
-        };
+      async (args) => {
+        try {
+          return await handleLogSession(args, dataComposer);
+        } catch (error) {
+          logger.error('Error in log_session:', error);
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: JSON.stringify({
+                  success: false,
+                  error: error instanceof Error ? error.message : 'Unknown error',
+                }),
+              },
+            ],
+            isError: true,
+          };
+        }
       }
-    }
-  );
+    );
 
-  // Register end_session tool
-  server.registerTool(
-    'end_session',
-    {
-      description: `End a session with an optional summary. The summary is automatically saved as a high-salience memory.
+    // Register end_session tool
+    server.registerTool(
+      'end_session',
+      {
+        description: `End a session with an optional summary. The summary is automatically saved as a high-salience memory.
 
 Session resolution: sessionId (explicit) > agentId+studioId (scoped) > most recent active (fallback).
 workspaceId is accepted as a deprecated alias.
 
 User can be identified by ONE of: userId, email, phone, or platform + platformId`,
-      inputSchema: {
-        ...userIdentifierFields,
-        sessionId: z
-          .string()
-          .uuid()
-          .optional()
-          .describe('Session ID (uses active session if not provided)'),
-        agentId: z
-          .string()
-          .optional()
-          .describe('Agent identifier for session resolution (e.g., "wren", "benson")'),
-        studioId: z
-          .string()
-          .uuid()
-          .optional()
-          .describe('Studio ID for session resolution when sessionId not provided'),
-        workspaceId: z
-          .string()
-          .uuid()
-          .optional()
-          .describe('[Deprecated] Workspace ID alias for studioId.'),
-        summary: z.string().optional().describe('End-of-session summary (saved as memory)'),
+        inputSchema: {
+          ...userIdentifierFields,
+          sessionId: z
+            .string()
+            .uuid()
+            .optional()
+            .describe('Session ID (uses active session if not provided)'),
+          agentId: z
+            .string()
+            .optional()
+            .describe('Agent identifier for session resolution (e.g., "wren", "benson")'),
+          studioId: z
+            .string()
+            .uuid()
+            .optional()
+            .describe('Studio ID for session resolution when sessionId not provided'),
+          workspaceId: z
+            .string()
+            .uuid()
+            .optional()
+            .describe('[Deprecated] Workspace ID alias for studioId.'),
+          summary: z.string().optional().describe('End-of-session summary (saved as memory)'),
+        },
       },
-    },
-    async (args) => {
-      try {
-        return await handleEndSession(args, dataComposer);
-      } catch (error) {
-        logger.error('Error in end_session:', error);
-        return {
-          content: [
-            {
-              type: 'text' as const,
-              text: JSON.stringify({
-                success: false,
-                error: error instanceof Error ? error.message : 'Unknown error',
-              }),
-            },
-          ],
-          isError: true,
-        };
+      async (args) => {
+        try {
+          return await handleEndSession(args, dataComposer);
+        } catch (error) {
+          logger.error('Error in end_session:', error);
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: JSON.stringify({
+                  success: false,
+                  error: error instanceof Error ? error.message : 'Unknown error',
+                }),
+              },
+            ],
+            isError: true,
+          };
+        }
       }
-    }
-  );
+    );
+  }
 
   // Register get_session tool
   server.registerTool(

--- a/packages/api/src/utils/request-context.ts
+++ b/packages/api/src/utils/request-context.ts
@@ -43,6 +43,8 @@ export interface RequestContextData {
   conversationId?: string;
   /** Request timestamp */
   timestamp: Date;
+  /** Caller profile for MCP access control */
+  callerProfile?: 'agent' | 'runtime';
 }
 
 const asyncLocalStorage = new AsyncLocalStorage<RequestContextData>();

--- a/packages/cli/src/backends/identity.ts
+++ b/packages/cli/src/backends/identity.ts
@@ -169,7 +169,7 @@ export function buildIdentityPrompt(agentId: string): string {
 
 **You are ${agentId}. Your agent ID is \`${agentId}\`.**
 
-When calling PCP tools (bootstrap, remember, recall, start_session, etc.), use \`agentId: "${agentId}"\`.
+When calling PCP tools (bootstrap, remember, recall, update_session_phase, etc.), use \`agentId: "${agentId}"\`.
 Do NOT read \`.pcp/identity.json\` — your identity is set by this system prompt.
 Do NOT run \`echo $AGENT_ID\` — use the agentId provided above.
 
@@ -181,7 +181,7 @@ Always use **PCP cloud tools** (mcp__pcp__*) over file reads or Claude Code buil
 - Identity: use mcp__pcp__bootstrap, not file reads
 - Tasks: use mcp__pcp__create_task, not TaskCreate
 - Memory: use mcp__pcp__remember, not local notes
-- Sessions: use mcp__pcp__start_session/log_session/end_session
+- Sessions: use mcp__pcp__update_session_phase/get_session/list_sessions
 
 PCP tools persist across sessions and are shared with the user and other agents.`;
 }

--- a/packages/cli/src/commands/hooks.ts
+++ b/packages/cli/src/commands/hooks.ts
@@ -222,6 +222,7 @@ export async function callPcpTool(
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
     Accept: 'application/json, text/event-stream',
+    'x-pcp-caller-profile': 'runtime',
   };
 
   // Attach CLI auth token so hooks pass OAuth checks on the MCP server

--- a/packages/cli/src/commands/session.ts
+++ b/packages/cli/src/commands/session.ts
@@ -291,10 +291,14 @@ async function endCommand(sessionId?: string): Promise<void> {
   }
 
   try {
-    await callPcpTool('end_session', {
-      email: config.email,
-      sessionId,
-    });
+    await callPcpTool(
+      'end_session',
+      {
+        email: config.email,
+        sessionId,
+      },
+      { callerProfile: 'runtime' }
+    );
     console.log(chalk.green(`Session ${sessionId.substring(0, 8)} ended`));
   } catch (error) {
     console.error(chalk.red(`Failed to end session: ${error}`));

--- a/packages/cli/src/lib/pcp-mcp.ts
+++ b/packages/cli/src/lib/pcp-mcp.ts
@@ -9,7 +9,7 @@ export function getPcpServerUrl(): string {
 export async function callPcpTool<T = Record<string, unknown>>(
   tool: string,
   args: Record<string, unknown>,
-  options?: { timeoutMs?: number }
+  options?: { timeoutMs?: number; callerProfile?: 'agent' | 'runtime' }
 ): Promise<T> {
   const serverUrl = getPcpServerUrl();
   const url = `${serverUrl}/mcp`;
@@ -22,6 +22,9 @@ export async function callPcpTool<T = Record<string, unknown>>(
   const token = await getValidAccessToken(serverUrl);
   if (token) {
     headers.Authorization = `Bearer ${token}`;
+  }
+  if (options?.callerProfile) {
+    headers['x-pcp-caller-profile'] = options.callerProfile;
   }
 
   const response = await fetch(url, {


### PR DESCRIPTION
## Summary
- hide `start_session`, `log_session`, and `end_session` from the SB-facing MCP tool catalog
- keep lifecycle tools available for runtime/hook callers via MCP caller profile (`x-pcp-caller-profile: runtime`)
- keep `update_session_phase` public and SB-facing
- update hook and CLI session flows to send runtime caller profile where lifecycle tools are required
- refresh identity/server guidance text to prefer `update_session_phase`, `get_session`, and `list_sessions`

## Implementation details
- added `RegisterToolOptions` to `registerAllTools` with `includeInternalLifecycleTools`
- MCP server now builds per-request tool registration profile:
  - default agent profile: internal lifecycle tools excluded
  - runtime profile: internal lifecycle tools included
- hooks now set `x-pcp-caller-profile: runtime` on MCP calls
- `sb session end` now calls MCP with runtime caller profile

## Tests
- added `packages/api/src/mcp/tools/index.test.ts` to verify lifecycle tool registration toggling
- updated `packages/api/src/mcp/server.test.ts` to validate runtime vs agent profile registration behavior
- ran:
  - `npx vitest run packages/api/src/mcp/tools/index.test.ts packages/api/src/mcp/server.test.ts`
  - `npx vitest run packages/cli/src/commands/hooks.test.ts packages/cli/src/backends/identity.test.ts`

## Notes
- repo-wide `yarn type-check` still has pre-existing Ink typing/module issues unrelated to this PR.