### PR TITLE
feat: PCP conventions in bootstrap + send_to_inbox (by Wren)

### DIFF
--- a/packages/api/src/mcp/tools/inbox-handlers.ts
+++ b/packages/api/src/mcp/tools/inbox-handlers.ts
@@ -82,7 +82,9 @@ const getInboxSchema = userIdentifierBaseSchema.extend({
     .default('unread')
     .describe('Filter by status'),
   priority: z.enum(['low', 'normal', 'high', 'urgent']).optional().describe('Filter by priority'),
-  messageType: z.enum(['message', 'task_request', 'session_resume', 'notification', 'permission_grant']).optional(),
+  messageType: z
+    .enum(['message', 'task_request', 'session_resume', 'notification', 'permission_grant'])
+    .optional(),
   limit: z.number().min(1).max(100).optional().default(20).describe('Max messages'),
 });
 
@@ -543,7 +545,7 @@ export const inboxToolDefinitions = [
   {
     name: 'send_to_inbox',
     description:
-      "Send a message to another agent's inbox. Use for cross-agent communication, task handoff, or session resume requests.\n\nMessage types:\n- message: General communication\n- task_request: Request another agent to do work\n- session_resume: Request agent to resume a specific session\n- notification: FYI, no response needed\n- permission_grant: Grant or revoke tool permissions for recipient (include permissionGrant in metadata)\n\nTrigger defaults:\n- task_request / session_resume / notification / permission_grant: wake recipient by default\n- message: no automatic wake by default\n- override with `trigger` boolean\n\nUser can be identified by ONE of: userId, email, phone, or platform + platformId",
+      "Send a message to another agent's inbox. Use for cross-agent communication, task handoff, or session resume requests.\n\nMessage types:\n- message: General communication\n- task_request: Request another agent to do work\n- session_resume: Request agent to resume a specific session\n- notification: FYI, no response needed\n- permission_grant: Grant or revoke tool permissions for recipient (include permissionGrant in metadata)\n\nReply conventions:\n- When replying to a task_request, send a task_request back on the SAME threadKey to signal completion\n- Use notification only for FYI messages that require no action from the recipient\n- Always include a threadKey (format: <type>:<id>, e.g. pr:127, spec:v0.1)\n\nTrigger defaults:\n- task_request / session_resume / notification / permission_grant: wake recipient by default\n- message: no automatic wake by default\n- override with `trigger` boolean\n\nUser can be identified by ONE of: userId, email, phone, or platform + platformId",
     schema: sendToInboxSchema,
     handler: handleSendToInbox,
   },

--- a/packages/api/src/mcp/tools/memory-handlers.ts
+++ b/packages/api/src/mcp/tools/memory-handlers.ts
@@ -25,6 +25,18 @@ async function safeReadFile(filePath: string): Promise<string | null> {
   }
 }
 
+// Bundled conventions template (fallback when ~/.pcp/shared/CONVENTIONS.md doesn't exist)
+const BUNDLED_CONVENTIONS_PATH = path.resolve(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  '..',
+  'templates',
+  'starters',
+  'conventions.md'
+);
+
 // Enums for validation
 const memorySourceSchema = z.enum([
   'conversation',
@@ -1556,6 +1568,11 @@ export async function handleBootstrap(args: unknown, dataComposer: DataComposer)
     };
   }
 
+  // Conventions: shared across all agents, loaded from user override or bundled template
+  const conventionsContent = await safeReadFile(
+    path.join(basePath, 'shared', 'CONVENTIONS.md')
+  ).then((content) => content ?? safeReadFile(BUNDLED_CONVENTIONS_PATH));
+
   // Fetch all context in parallel (including timezone and skills)
   const cloudSkillsService = getCloudSkillsService(dataComposer.getClient());
 
@@ -1881,6 +1898,10 @@ export async function handleBootstrap(args: unknown, dataComposer: DataComposer)
 
             // Reflection status - prompt for periodic self-reflection
             reflectionStatus,
+
+            // PCP conventions — messaging best practices, loaded from
+            // ~/.pcp/shared/CONVENTIONS.md or bundled template fallback
+            conventions: conventionsContent || null,
 
             // User's installed skills (local + cloud merged)
             // Use these to understand what capabilities are available

--- a/packages/templates/starters/conventions.md
+++ b/packages/templates/starters/conventions.md
@@ -1,0 +1,27 @@
+# PCP Conventions
+
+Best practices for agents using the Personal Context Protocol. Loaded automatically during bootstrap.
+
+## Inbox Messaging
+
+### Reply Conventions
+
+When replying to a `task_request`, send a `task_request` back on the **same threadKey** to signal completion. This lets the original sender act on the result (e.g., merge a PR after a review).
+
+Use `notification` only for FYI messages that require no action from the recipient.
+
+### threadKey Format
+
+Always include a `threadKey` on inbox messages. Use the format `<type>:<id>`:
+
+- `pr:127` — pull request discussion
+- `spec:protocol-v0.1` — specification work
+- `task:deploy-staging` — task coordination
+
+Messages with the same threadKey are routed to the same session on the recipient side, preserving conversational continuity.
+
+### Trigger Etiquette
+
+- `task_request`, `session_resume`, and `notification` trigger the recipient by default
+- `message` does not trigger by default — use `trigger: true` if the message is time-sensitive
+- Avoid triggering agents for low-priority or non-urgent messages during quiet hours


### PR DESCRIPTION
## Summary

- Add `packages/templates/starters/conventions.md` — inbox messaging best practices (reply conventions, threadKey format, trigger etiquette)
- Bootstrap now loads and returns a `conventions` field from `~/.pcp/shared/CONVENTIONS.md` (user override) or the bundled template (fallback)
- Enriched `send_to_inbox` tool description with reply conventions inline — every MCP client sees these without needing skills or templates

## Why

Lumen replied to a PR review `task_request` with a `notification` instead of a `task_request` back on the same threadKey. The conventions weren't documented anywhere that all backends could see. This adds two layers:

1. **Tool description** — most universal, zero setup, every MCP client reads it
2. **Bootstrap conventions** — loaded from `packages/templates`, customizable via `~/.pcp/shared/CONVENTIONS.md`

## Files changed

| File | Change |
|------|--------|
| `packages/templates/starters/conventions.md` | New template with inbox best practices |
| `packages/api/src/mcp/tools/inbox-handlers.ts` | Reply conventions in `send_to_inbox` description |
| `packages/api/src/mcp/tools/memory-handlers.ts` | Bootstrap loads + returns conventions |

## Test plan

- [x] `yarn workspace @personal-context/api build` — compiles clean
- [x] `bootstrap(agentId: "wren")` — returns `conventions` field with template content
- [x] Bundled template fallback works (no `~/.pcp/shared/CONVENTIONS.md` exists)
- [x] PM2 restart — server online

🤖 Generated with [Claude Code](https://claude.com/claude-code)