### PR TITLE
fix(api): replace @shared path alias with local type definitions (by Wren)

### DIFF
--- a/packages/api/src/channels/adapter.ts
+++ b/packages/api/src/channels/adapter.ts
@@ -14,7 +14,7 @@ import type {
   ChannelPlatform,
   ExtractedContext,
 } from './types';
-import type { Platform } from '@shared/types/common';
+import type { Platform } from '../types/shared';
 
 export class ChannelAdapter {
   private dataComposer: DataComposer;

--- a/packages/api/src/channels/gateway.ts
+++ b/packages/api/src/channels/gateway.ts
@@ -25,7 +25,7 @@ import { env } from '../config/env';
 import { InboundMediaPipeline } from './media-pipeline';
 import { TextToSpeechService } from './text-to-speech';
 import telegramifyMarkdown from 'telegramify-markdown';
-import type { Platform } from '@shared/types/common';
+import type { Platform } from '../types/shared';
 
 // Supported messaging channels
 export type GatewayChannel = 'telegram' | 'whatsapp' | 'discord' | 'slack';

--- a/packages/api/src/data/models/conversation.model.ts
+++ b/packages/api/src/data/models/conversation.model.ts
@@ -1,5 +1,5 @@
 import type { Database } from '../supabase/types';
-import type { Platform, MessageType } from '@shared/types/common';
+import type { Platform, MessageType } from '../../types/shared';
 
 export type Conversation = Database['public']['Tables']['conversations']['Row'];
 export type ConversationInsert = Database['public']['Tables']['conversations']['Insert'];

--- a/packages/api/src/data/models/link.model.ts
+++ b/packages/api/src/data/models/link.model.ts
@@ -1,5 +1,5 @@
 import type { Database } from '../supabase/types';
-import type { Platform } from '@shared/types/common';
+import type { Platform } from '../../types/shared';
 
 export type Link = Database['public']['Tables']['links']['Row'];
 export type LinkInsert = Database['public']['Tables']['links']['Insert'];

--- a/packages/api/src/data/models/reminder.model.ts
+++ b/packages/api/src/data/models/reminder.model.ts
@@ -1,5 +1,5 @@
 import type { Database } from '../supabase/types';
-import type { ReminderStatus, RecurrenceConfig, Platform } from '@shared/types/common';
+import type { ReminderStatus, RecurrenceConfig, Platform } from '../../types/shared';
 
 export type Reminder = Database['public']['Tables']['reminders']['Row'];
 export type ReminderInsert = Database['public']['Tables']['reminders']['Insert'];

--- a/packages/api/src/data/models/task.model.ts
+++ b/packages/api/src/data/models/task.model.ts
@@ -1,5 +1,5 @@
 import type { Database } from '../supabase/types';
-import type { TaskStatus, TaskPriority } from '@shared/types/common';
+import type { TaskStatus, TaskPriority } from '../../types/shared';
 
 export type Task = Database['public']['Tables']['tasks']['Row'];
 export type TaskInsert = Database['public']['Tables']['tasks']['Insert'];

--- a/packages/api/src/types/shared.ts
+++ b/packages/api/src/types/shared.ts
@@ -1,0 +1,29 @@
+/**
+ * Types shared with @personal-context/shared.
+ *
+ * Duplicated here because the API (CJS) and shared (ESM) packages use
+ * different module systems. These are simple type aliases — if they diverge,
+ * update both locations.
+ */
+
+export type Platform =
+  | 'telegram'
+  | 'whatsapp'
+  | 'discord'
+  | 'slack'
+  | 'signal'
+  | 'imessage'
+  | 'api';
+
+export type TaskStatus = 'pending' | 'in_progress' | 'completed' | 'cancelled';
+
+export type TaskPriority = 'low' | 'medium' | 'high' | 'urgent';
+
+export type ReminderStatus = 'pending' | 'sent' | 'cancelled';
+
+export type MessageType = 'text' | 'link' | 'command' | 'system';
+
+export interface RecurrenceConfig {
+  frequency: 'once' | 'daily' | 'weekly' | 'monthly';
+  interval: number;
+}

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -6,11 +6,9 @@
     "composite": true,
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"],
-      "@shared/*": ["../shared/src/*"]
+      "@/*": ["./src/*"]
     }
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"],
-  "references": [{ "path": "../shared" }]
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
 }


### PR DESCRIPTION
## Summary\n\n- Fixes API build failure caused by PR #127 converting `@personal-context/shared` to ESM\n- API (CJS) can't import from shared (ESM) even for type-only imports under Node16 module resolution\n- Creates local `packages/api/src/types/shared.ts` with duplicated type definitions\n- Removes `@shared/*` path alias and project reference from API's tsconfig\n- Updates 6 import statements across model and channel files\n\n## Context\n\nAfter PR #127 added `\"type\": \"module\"` to shared's package.json, TypeScript's Node16 resolution blocks CJS→ESM imports even for `import type` statements. The API still uses CJS (`\"type\"` not set). Rather than converting the entire API to ESM (large blast radius), this creates a small local types file with the shared type definitions.\n\nThe duplicated types are simple aliases — a comment in the file notes they should stay in sync.\n\n## Test plan\n\n- [x] `yarn workspace @personal-context/api build` compiles successfully\n- [x] Existing API functionality unchanged (types are identical)\n- [x] No runtime impact (type-only imports are erased at compile time)\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)