### PR TITLE
fix: allow hooks to use injected PCP_ACCESS_TOKEN for bootstrap (by lumen)

### DIFF
--- a/packages/api/src/mcp/server.ts
+++ b/packages/api/src/mcp/server.ts
@@ -278,10 +278,13 @@ export class MCPServer {
           }
         : {};
       const callerProfileHeader = req.header('x-pcp-caller-profile')?.trim().toLowerCase();
+<<<<<<< HEAD
       // Trust boundary note:
       // `x-pcp-caller-profile` is only consumed on the MCP transport entrypoint.
       // Supported MCP clients in our stack do not expose arbitrary header injection to model prompts,
       // so this remains a runtime/server-controlled signal rather than an LLM-controlled parameter.
+=======
+>>>>>>> c6e41c0 (feat: hide internal session lifecycle MCP tools from SB catalog)
       const callerProfile: 'agent' | 'runtime' =
         callerProfileHeader === 'runtime' ? 'runtime' : 'agent';
       Object.assign(ctx, { callerProfile });

--- a/packages/api/src/mcp/server.ts
+++ b/packages/api/src/mcp/server.ts
@@ -278,13 +278,10 @@ export class MCPServer {
           }
         : {};
       const callerProfileHeader = req.header('x-pcp-caller-profile')?.trim().toLowerCase();
-<<<<<<< HEAD
       // Trust boundary note:
       // `x-pcp-caller-profile` is only consumed on the MCP transport entrypoint.
       // Supported MCP clients in our stack do not expose arbitrary header injection to model prompts,
       // so this remains a runtime/server-controlled signal rather than an LLM-controlled parameter.
-=======
->>>>>>> c6e41c0 (feat: hide internal session lifecycle MCP tools from SB catalog)
       const callerProfile: 'agent' | 'runtime' =
         callerProfileHeader === 'runtime' ? 'runtime' : 'agent';
       Object.assign(ctx, { callerProfile });

--- a/packages/cli/src/auth/tokens.test.ts
+++ b/packages/cli/src/auth/tokens.test.ts
@@ -237,6 +237,12 @@ describe('getValidAccessToken', () => {
     const token = await getValidAccessToken('http://localhost:3001');
     expect(token).toBe('env-only-token');
   });
+
+  it('can skip env token lookup when allowEnvToken=false', async () => {
+    process.env.PCP_ACCESS_TOKEN = 'env-only-token';
+    const token = await getValidAccessToken('http://localhost:3001', { allowEnvToken: false });
+    expect(token).toBeNull();
+  });
 });
 
 // ============================================================================

--- a/packages/cli/src/auth/tokens.test.ts
+++ b/packages/cli/src/auth/tokens.test.ts
@@ -11,6 +11,7 @@ import {
   generatePkce,
   decodeJwtPayload,
   isTokenExpired,
+  getValidAccessToken,
   loadAuth,
   saveAuth,
   clearAuth,
@@ -202,6 +203,39 @@ describe('loadAuth / saveAuth / clearAuth', () => {
 
   it('clearAuth is safe when no file exists', () => {
     expect(() => clearAuth()).not.toThrow();
+  });
+});
+
+describe('getValidAccessToken', () => {
+  let origHome: string | undefined;
+  let tempHome: string;
+  let origEnvToken: string | undefined;
+
+  beforeEach(() => {
+    origHome = process.env.HOME;
+    origEnvToken = process.env.PCP_ACCESS_TOKEN;
+    tempHome = join(tmpdir(), `pcp-token-test-${Date.now()}`);
+    mkdirSync(tempHome, { recursive: true });
+    process.env.HOME = tempHome;
+  });
+
+  afterEach(() => {
+    process.env.HOME = origHome;
+    if (origEnvToken === undefined) delete process.env.PCP_ACCESS_TOKEN;
+    else process.env.PCP_ACCESS_TOKEN = origEnvToken;
+    rmSync(tempHome, { recursive: true, force: true });
+  });
+
+  it('prefers PCP_ACCESS_TOKEN from environment when present', async () => {
+    process.env.PCP_ACCESS_TOKEN = 'env-token';
+    const token = await getValidAccessToken('http://localhost:3001');
+    expect(token).toBe('env-token');
+  });
+
+  it('returns env token even when auth.json is absent', async () => {
+    process.env.PCP_ACCESS_TOKEN = 'env-only-token';
+    const token = await getValidAccessToken('http://localhost:3001');
+    expect(token).toBe('env-only-token');
   });
 });
 

--- a/packages/cli/src/auth/tokens.ts
+++ b/packages/cli/src/auth/tokens.ts
@@ -156,10 +156,16 @@ export async function refreshAccessToken(serverUrl: string, auth: StoredAuth): P
 // High-Level: Get Valid Access Token
 // ============================================================================
 
-export async function getValidAccessToken(serverUrl: string): Promise<string | null> {
-  const envToken = process.env.PCP_ACCESS_TOKEN?.trim();
-  if (envToken) {
-    return envToken;
+export async function getValidAccessToken(
+  serverUrl: string,
+  options?: { allowEnvToken?: boolean }
+): Promise<string | null> {
+  const allowEnvToken = options?.allowEnvToken !== false;
+  if (allowEnvToken) {
+    const envToken = process.env.PCP_ACCESS_TOKEN?.trim();
+    if (envToken) {
+      return envToken;
+    }
   }
 
   const auth = loadAuth();

--- a/packages/cli/src/auth/tokens.ts
+++ b/packages/cli/src/auth/tokens.ts
@@ -157,6 +157,11 @@ export async function refreshAccessToken(serverUrl: string, auth: StoredAuth): P
 // ============================================================================
 
 export async function getValidAccessToken(serverUrl: string): Promise<string | null> {
+  const envToken = process.env.PCP_ACCESS_TOKEN?.trim();
+  if (envToken) {
+    return envToken;
+  }
+
   const auth = loadAuth();
   if (!auth) return null;
 

--- a/packages/cli/src/commands/hooks.test.ts
+++ b/packages/cli/src/commands/hooks.test.ts
@@ -492,6 +492,7 @@ describe('callPcpTool: Streamable HTTP response formats', () => {
   afterEach(() => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
+    delete process.env.PCP_ACCESS_TOKEN;
   });
 
   it('should parse application/json response (enableJsonResponse mode)', async () => {
@@ -612,6 +613,57 @@ describe('callPcpTool: Streamable HTTP response formats', () => {
 
     const result = await callPcpTool('bootstrap', { agentId: 'wren' });
     expect(result).toEqual({ text: 'plain text result' });
+  });
+
+  it('retries with local auth fallback when injected env token is rejected (401)', async () => {
+    process.env.PCP_ACCESS_TOKEN = 'env-token';
+    mockedGetValidAccessToken
+      .mockResolvedValueOnce('env-token')
+      .mockResolvedValueOnce('fallback-token');
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    fetchSpy = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        text: async () => 'unauthorized',
+      })
+      .mockResolvedValueOnce(mockJsonResponse(TOOL_RESULT_PAYLOAD));
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const result = await callPcpTool('bootstrap', { agentId: 'wren' });
+    expect(result).toEqual({ success: true });
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+
+    const [, firstOptions] = fetchSpy.mock.calls[0];
+    const [, secondOptions] = fetchSpy.mock.calls[1];
+    expect(firstOptions.headers).toHaveProperty('Authorization', 'Bearer env-token');
+    expect(secondOptions.headers).toHaveProperty('Authorization', 'Bearer fallback-token');
+    expect(
+      mockedGetValidAccessToken.mock.calls.some(
+        ([, options]) =>
+          (options as { allowEnvToken?: boolean } | undefined)?.allowEnvToken === false
+      )
+    ).toBe(true);
+    expect(consoleSpy).toHaveBeenCalled();
+  });
+
+  it('does not retry on 401 when no env token is injected', async () => {
+    mockedGetValidAccessToken.mockResolvedValue('file-token');
+    fetchSpy = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      headers: new Headers({ 'content-type': 'application/json' }),
+      text: async () => 'unauthorized',
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+
+    await expect(callPcpTool('bootstrap', { agentId: 'wren' })).rejects.toThrow(
+      'PCP call failed (401)'
+    );
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/cli/src/commands/hooks.test.ts
+++ b/packages/cli/src/commands/hooks.test.ts
@@ -621,6 +621,7 @@ describe('callPcpTool: Streamable HTTP response formats', () => {
       .mockResolvedValueOnce('env-token')
       .mockResolvedValueOnce('fallback-token');
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const firstResponseTextSpy = vi.fn().mockResolvedValue('unauthorized');
 
     fetchSpy = vi
       .fn()
@@ -628,7 +629,7 @@ describe('callPcpTool: Streamable HTTP response formats', () => {
         ok: false,
         status: 401,
         headers: new Headers({ 'content-type': 'application/json' }),
-        text: async () => 'unauthorized',
+        text: firstResponseTextSpy,
       })
       .mockResolvedValueOnce(mockJsonResponse(TOOL_RESULT_PAYLOAD));
     vi.stubGlobal('fetch', fetchSpy);
@@ -647,6 +648,7 @@ describe('callPcpTool: Streamable HTTP response formats', () => {
           (options as { allowEnvToken?: boolean } | undefined)?.allowEnvToken === false
       )
     ).toBe(true);
+    expect(firstResponseTextSpy).toHaveBeenCalledTimes(1);
     expect(consoleSpy).toHaveBeenCalled();
   });
 

--- a/packages/cli/src/commands/hooks.ts
+++ b/packages/cli/src/commands/hooks.ts
@@ -218,29 +218,50 @@ export async function callPcpTool(
 ): Promise<Record<string, unknown>> {
   const serverUrl = getPcpServerUrl();
   const url = `${serverUrl}/mcp`;
+  const hasInjectedEnvToken = Boolean(process.env.PCP_ACCESS_TOKEN?.trim());
 
-  const headers: Record<string, string> = {
+  const baseHeaders: Record<string, string> = {
     'Content-Type': 'application/json',
     Accept: 'application/json, text/event-stream',
     'x-pcp-caller-profile': 'runtime',
   };
 
-  // Attach CLI auth token so hooks pass OAuth checks on the MCP server
-  const token = await getValidAccessToken(serverUrl);
-  if (token) {
-    headers.Authorization = `Bearer ${token}`;
-  }
+  const callOnce = async (token: string | null): Promise<Response> => {
+    const headers = { ...baseHeaders };
+    if (token) {
+      headers.Authorization = `Bearer ${token}`;
+    }
 
-  const response = await fetch(url, {
-    method: 'POST',
-    headers,
-    body: JSON.stringify({
-      jsonrpc: '2.0',
-      method: 'tools/call',
-      params: { name: tool, arguments: args },
-      id: jsonRpcId++,
-    }),
-  });
+    return fetch(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'tools/call',
+        params: { name: tool, arguments: args },
+        id: jsonRpcId++,
+      }),
+    });
+  };
+
+  // Attach CLI auth token so hooks pass OAuth checks on the MCP server.
+  // Prefer runtime-injected env token, then local auth file.
+  let response = await callOnce(await getValidAccessToken(serverUrl));
+
+  // If an injected env token is stale/invalid, retry once using local auth fallback.
+  if (response.status === 401 && hasInjectedEnvToken) {
+    sbDebugLog('hooks', 'mcp_auth_retry_without_env_token', {
+      tool,
+      status: 401,
+      reason: 'env_token_rejected',
+    });
+    console.error(
+      chalk.yellow(
+        '⚠ PCP hook auth token was rejected; retrying with local ~/.pcp/auth.json token fallback.'
+      )
+    );
+    response = await callOnce(await getValidAccessToken(serverUrl, { allowEnvToken: false }));
+  }
 
   if (!response.ok) {
     throw new Error(`PCP call failed (${response.status}): ${await response.text()}`);

--- a/packages/cli/src/commands/hooks.ts
+++ b/packages/cli/src/commands/hooks.ts
@@ -250,6 +250,14 @@ export async function callPcpTool(
 
   // If an injected env token is stale/invalid, retry once using local auth fallback.
   if (response.status === 401 && hasInjectedEnvToken) {
+    // Drain first response body before retrying so the underlying HTTP client
+    // can cleanly release the stream (avoids occasional undici body warnings).
+    try {
+      await response.text();
+    } catch {
+      // Best-effort: failure to read the body should not block retry.
+    }
+
     sbDebugLog('hooks', 'mcp_auth_retry_without_env_token', {
       tool,
       status: 401,


### PR DESCRIPTION
## Summary
- make `getValidAccessToken()` prefer `PCP_ACCESS_TOKEN` from environment before reading `~/.pcp/auth.json`
- this ensures hook subprocesses (Codex/Gemini/Claude hook paths) can authenticate to `/mcp` when token is injected by `sb`
- add regression tests for env-token precedence and env-only auth behavior

## Why
Codex hook bootstrapping could fail in subprocess contexts where local auth state is unavailable, even though `sb` injected a valid token.

## Validation
- `npx vitest run packages/cli/src/auth/tokens.test.ts`
- manual runtime check with empty HOME + only `PCP_ACCESS_TOKEN` confirming `callPcpTool('bootstrap')` succeeds
