### PR TITLE
feat: per-studio home branch defaults for worktrees (by Lumen)

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -246,7 +246,7 @@ Options for `create`:
 - `-a, --agent <agent>` — Agent ID for this studio (default: wren)
 - `-p, --purpose <desc>` — Description
 - `-b, --backend <name>` — Primary backend (claude-code, codex, gemini)
-- `-br, --branch <branch>` — Custom branch (default: `<agent>/studio/main`)
+- `-br, --branch <branch>` — Custom branch (default: `<agent>/studio/main-<studio-name>`)
 
 ### Agents (`sb agent`)
 

--- a/packages/cli/src/commands/studio.test.ts
+++ b/packages/cli/src/commands/studio.test.ts
@@ -19,6 +19,8 @@ import {
   listRoleTemplates,
   isValidTemplateName,
   BUILTIN_ROLE_TEMPLATES,
+  getDefaultStudioMainBranch,
+  slugifyStudioNameForBranch,
   type InitResult,
 } from './studio.js';
 
@@ -198,6 +200,19 @@ describe('Studio Commands', () => {
       const branches = git('branch', TEST_REPO);
       expect(branches).toContain(branchName);
     });
+  });
+});
+
+describe('Studio default branch naming', () => {
+  it('builds per-studio main branch names to avoid worktree branch collisions', () => {
+    expect(getDefaultStudioMainBranch('lumen', 'review')).toBe('lumen/studio/main-review');
+    expect(getDefaultStudioMainBranch('wren', 'my-feature')).toBe('wren/studio/main-my-feature');
+  });
+
+  it('slugifies studio names for safe branch suffixes', () => {
+    expect(slugifyStudioNameForBranch('  API Review  ')).toBe('api-review');
+    expect(slugifyStudioNameForBranch('ux/polish')).toBe('ux-polish');
+    expect(slugifyStudioNameForBranch('***')).toBe('studio');
   });
 });
 

--- a/packages/cli/src/commands/studio.ts
+++ b/packages/cli/src/commands/studio.ts
@@ -234,6 +234,19 @@ interface InteractiveResult {
   configDirs: string[];
 }
 
+function slugifyStudioNameForBranch(name: string): string {
+  const normalized = name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return normalized || 'studio';
+}
+
+function getDefaultStudioMainBranch(agentId: string, studioName: string): string {
+  return `${agentId}/studio/main-${slugifyStudioNameForBranch(studioName)}`;
+}
+
 function isPromptCancelError(err: unknown): boolean {
   if (!err || typeof err !== 'object') return false;
   const maybe = err as { name?: string; message?: string };
@@ -261,7 +274,7 @@ async function runInteractiveFlow(agentId: string, gitRoot: string): Promise<Int
   });
 
   // Step 2: Branch name (derived, editable)
-  const defaultBranch = `${agentId}/studio/main`;
+  const defaultBranch = getDefaultStudioMainBranch(agentId, name);
   const branch = await input({
     message: 'Branch name',
     default: defaultBranch,
@@ -609,7 +622,7 @@ async function createStudio(
   try {
     const gitRoot = findGitRoot();
     const wsPath = getStudioPath(gitRoot, name);
-    const branch = overrides?.branch || options.branch || `${agentId}/studio/main`;
+    const branch = overrides?.branch || options.branch || getDefaultStudioMainBranch(agentId, name);
 
     spinner.text = 'Creating studio...';
     await createStudioInner(name, options, overrides);
@@ -736,7 +749,7 @@ async function createStudioInner(
   const gitRoot = findGitRoot();
   const copySourceRoot = resolveCopySourceRoot(gitRoot, options.copyFrom);
   const wsPath = getStudioPath(gitRoot, name);
-  const branch = overrides?.branch || options.branch || `${agentId}/studio/main`;
+  const branch = overrides?.branch || options.branch || getDefaultStudioMainBranch(agentId, name);
 
   if (existsSync(wsPath)) {
     throw new Error(`Studio already exists at ${wsPath}`);
@@ -1237,6 +1250,8 @@ export {
   listRoleTemplates,
   isValidTemplateName,
   BUILTIN_ROLE_TEMPLATES,
+  getDefaultStudioMainBranch,
+  slugifyStudioNameForBranch,
   getCliLinkTargets,
   shouldWarnMissingCliBinPath,
   planInit,
@@ -1260,7 +1275,10 @@ export function registerStudioCommands(program: Command): void {
     .description('Create a new studio with git worktree')
     .option('-a, --agent <agent>', 'Agent ID for this studio')
     .option('-p, --purpose <desc>', 'Description/purpose of the studio')
-    .option('-br, --branch <branch>', 'Custom branch name (default: <agentId>/studio/main)')
+    .option(
+      '-br, --branch <branch>',
+      'Custom branch name (default: <agentId>/studio/main-<studio-name>)'
+    )
     .option('-b, --backend <name>', 'Primary backend (claude-code, codex, gemini)')
     .option('-t, --template <name>', 'Role template (reviewer, builder, product, or custom)')
     .option('--copy-config', 'Copy config directories into the new studio')

--- a/packages/templates/starters/conventions.md
+++ b/packages/templates/starters/conventions.md
@@ -25,3 +25,20 @@ Messages with the same threadKey are routed to the same session on the recipient
 - `task_request`, `session_resume`, and `notification` trigger the recipient by default
 - `message` does not trigger by default — use `trigger: true` if the message is time-sensitive
 - Avoid triggering agents for low-priority or non-urgent messages during quiet hours
+
+## Studio Branch Conventions
+
+Studios are git worktrees, and **a single branch can only be checked out in one worktree at a time**.
+
+- Each studio should use its own home branch: `<agentId>/studio/main-<studio-slug>`
+- Treat that branch as a **return point**, not a feature branch
+- Keep it fast-forwarded from `main` (`origin/main`)
+- Do **not** commit work directly on this branch
+
+Recommended flow:
+
+1. Enter studio on its home branch
+2. Fast-forward from `main`
+3. Create a feature branch for actual work
+4. Merge feature branch
+5. Return the studio home branch to a clean, fast-forward-only state


### PR DESCRIPTION
## Summary
- change default studio branch naming from `<agentId>/studio/main` to `<agentId>/studio/main-<studio-name>`
- use this default in both interactive and non-interactive `sb studio create`
- add branch-suffix slug sanitization for studio names
- update CLI help + README to reflect new default
- add starter conventions guidance explaining studio home-branch behavior under git worktrees

## Why
Git worktrees only allow one worktree checkout per branch. Reusing a single default branch (`<agentId>/studio/main`) across studios causes branch conflicts and flow breaks.

## Tests
- `yarn workspace @personal-context/cli test src/commands/studio.test.ts src/commands/studio-new.test.ts`
- `yarn workspace @personal-context/cli build`