### PR TITLE
feat: one-command local Supabase setup with collision-safe env writes (by Lumen)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,10 @@ PORT=3000
 SUPABASE_URL=https://your-project.supabase.co
 SUPABASE_PUBLISHABLE_KEY=your-publishable-key
 SUPABASE_SECRET_KEY=your-secret-key
+# Optional local references written by `yarn supabase:local:setup` when canonical keys already exist:
+# LOCAL_SUPABASE_URL=http://127.0.0.1:54321
+# LOCAL_SUPABASE_PUBLISHABLE_KEY=your-local-publishable-key
+# LOCAL_SUPABASE_SECRET_KEY=your-local-secret-key
 
 # Legacy Supabase keys (fallback - use above instead)
 # SUPABASE_ANON_KEY=your-anon-key
@@ -45,6 +49,8 @@ ENABLE_HEARTBEATS=true
 
 # Authentication
 JWT_SECRET=your-jwt-secret-key-min-32-chars-long
+# Optional local reference written by `yarn supabase:local:setup` when JWT_SECRET already exists:
+# LOCAL_JWT_SECRET=your-local-jwt-secret
 JWT_EXPIRES_IN=7d
 
 # Logging & Monitoring

--- a/README.md
+++ b/README.md
@@ -86,30 +86,27 @@ yarn dev
 
 1. Install Supabase CLI and Docker:
    - Supabase CLI install docs: https://supabase.com/docs/guides/cli/getting-started
-2. Start local Supabase from this repo root:
+2. Run one command from repo root to start local Supabase, reset DB, and update `.env.local`:
 
 ```bash
-supabase start
+yarn supabase:local:setup
 ```
 
-3. Reset/apply migrations + seed data:
+This helper:
 
-```bash
-supabase db reset
-```
+- starts local Supabase (Docker required)
+- applies migrations + seed (`supabase db reset --local`)
+- reads local env values from `supabase status -o env`
+- writes them into `.env.local`
 
-4. Print local env values:
+If `.env.local` already has `SUPABASE_URL`, `SUPABASE_PUBLISHABLE_KEY`, `SUPABASE_SECRET_KEY`, or `JWT_SECRET`, the helper **won't overwrite** them. It logs a warning and writes local references instead:
 
-```bash
-supabase status -o env
-```
+- `LOCAL_SUPABASE_URL`
+- `LOCAL_SUPABASE_PUBLISHABLE_KEY`
+- `LOCAL_SUPABASE_SECRET_KEY`
+- `LOCAL_JWT_SECRET`
 
-5. Map local values into `.env.local`:
-   - `API_URL` → `SUPABASE_URL`
-   - `ANON_KEY` → `SUPABASE_PUBLISHABLE_KEY`
-   - `SERVICE_ROLE_KEY` → `SUPABASE_SECRET_KEY`
-
-6. Start PCP:
+3. Start PCP:
 
 ```bash
 yarn dev
@@ -183,6 +180,7 @@ yarn dev                   # Start all services (pm2)
 yarn build                 # Build all packages
 yarn type-check            # Type check all packages
 yarn test                  # Unit tests (all workspaces)
+yarn supabase:local:setup  # Start/reset local Supabase and sync env values into .env.local
 yarn test:integration:db:local  # DB integration suite against isolated local Supabase
 yarn test:integration:runtime    # Runtime/CLI integration suite
 yarn logs:pcp              # View PCP server logs

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "build": "yarn workspaces foreach -A -t run build",
     "build:web": "yarn workspace @personal-context/web build",
     "test": "yarn workspaces foreach -A -t run test",
+    "supabase:local:setup": "bash ./scripts/setup-local-supabase.sh",
     "test:integration:db:local": "bash ./scripts/test-integration-db-local.sh",
     "test:integration:runtime": "yarn workspace @personal-context/api test:integration:runtime",
     "lint": "yarn workspaces foreach -A run lint",

--- a/scripts/setup-local-supabase.sh
+++ b/scripts/setup-local-supabase.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_FILE="${PCP_ENV_FILE:-${ROOT_DIR}/.env.local}"
+
+require_cmd() {
+  local cmd="$1"
+  local install_hint="$2"
+  if ! command -v "${cmd}" >/dev/null 2>&1; then
+    echo "[supabase-setup] Missing required command: ${cmd}" >&2
+    echo "[supabase-setup] ${install_hint}" >&2
+    exit 1
+  fi
+}
+
+upsert_env_var() {
+  local key="$1"
+  local value="$2"
+  local file="$3"
+
+  if grep -qE "^${key}=" "${file}" 2>/dev/null; then
+    awk -v k="${key}" -v v="${value}" '
+      BEGIN { updated = 0 }
+      $0 ~ ("^" k "=") {
+        print k "=" v
+        updated = 1
+        next
+      }
+      { print }
+      END {
+        if (updated == 0) print k "=" v
+      }
+    ' "${file}" >"${file}.tmp"
+    mv "${file}.tmp" "${file}"
+  else
+    printf '\n%s=%s\n' "${key}" "${value}" >>"${file}"
+  fi
+}
+
+write_with_collision_guard() {
+  local canonical_key="$1"
+  local fallback_local_key="$2"
+  local value="$3"
+  local file="$4"
+
+  if grep -qE "^${canonical_key}=" "${file}" 2>/dev/null; then
+    echo "[supabase-setup] ⚠️  ${canonical_key} already exists in ${file}; preserving it."
+    echo "[supabase-setup]    Writing ${fallback_local_key} instead so local values are still available."
+    upsert_env_var "${fallback_local_key}" "${value}" "${file}"
+    return
+  fi
+
+  upsert_env_var "${canonical_key}" "${value}" "${file}"
+}
+
+require_cmd "supabase" "Install Supabase CLI: https://supabase.com/docs/guides/cli/getting-started"
+require_cmd "docker" "Docker is required to run local Supabase. Start Docker Desktop and retry."
+
+if ! docker info >/dev/null 2>&1; then
+  echo "[supabase-setup] Docker is installed but the daemon is not running." >&2
+  echo "[supabase-setup] Start Docker Desktop (or your docker daemon) and retry." >&2
+  exit 1
+fi
+
+if [[ ! -f "${ENV_FILE}" ]]; then
+  if [[ -f "${ROOT_DIR}/.env.example" ]]; then
+    cp "${ROOT_DIR}/.env.example" "${ENV_FILE}"
+    echo "[supabase-setup] Created ${ENV_FILE} from .env.example"
+  else
+    touch "${ENV_FILE}"
+    echo "[supabase-setup] Created empty ${ENV_FILE}"
+  fi
+fi
+
+echo "[supabase-setup] Starting local Supabase..."
+supabase start --workdir "${ROOT_DIR}" >/dev/null
+
+echo "[supabase-setup] Applying migrations + seed..."
+supabase db reset --workdir "${ROOT_DIR}" --local >/dev/null
+
+echo "[supabase-setup] Reading local Supabase env..."
+STATUS_ENV="$(supabase status --workdir "${ROOT_DIR}" -o env)"
+eval "${STATUS_ENV}"
+
+LOCAL_URL="${API_URL:-}"
+LOCAL_ANON="${ANON_KEY:-}"
+LOCAL_SERVICE="${SERVICE_ROLE_KEY:-}"
+LOCAL_JWT="${AUTH_JWT_SECRET:-}"
+
+if [[ -z "${LOCAL_URL}" || -z "${LOCAL_ANON}" || -z "${LOCAL_SERVICE}" || -z "${LOCAL_JWT}" ]]; then
+  echo "[supabase-setup] Failed to read required values from 'supabase status -o env'." >&2
+  echo "${STATUS_ENV}" >&2
+  exit 1
+fi
+
+write_with_collision_guard "SUPABASE_URL" "LOCAL_SUPABASE_URL" "${LOCAL_URL}" "${ENV_FILE}"
+write_with_collision_guard "SUPABASE_PUBLISHABLE_KEY" "LOCAL_SUPABASE_PUBLISHABLE_KEY" "${LOCAL_ANON}" "${ENV_FILE}"
+write_with_collision_guard "SUPABASE_SECRET_KEY" "LOCAL_SUPABASE_SECRET_KEY" "${LOCAL_SERVICE}" "${ENV_FILE}"
+write_with_collision_guard "JWT_SECRET" "LOCAL_JWT_SECRET" "${LOCAL_JWT}" "${ENV_FILE}"
+
+echo "[supabase-setup] ✅ Local Supabase is ready."
+echo "[supabase-setup] Environment file updated: ${ENV_FILE}"
+echo "[supabase-setup] Tip: run 'yarn dev' when ready."


### PR DESCRIPTION
## Summary
Adds a one-command local Supabase setup flow so contributors can bootstrap local DB + env quickly without manual copy/paste.

## What changed
- Added `scripts/setup-local-supabase.sh`
  - verifies `supabase` CLI + Docker daemon availability
  - runs `supabase start`
  - runs `supabase db reset --local`
  - reads values from `supabase status -o env`
  - writes env values into `.env.local`
- Added root script:
  - `yarn supabase:local:setup`
- Updated docs:
  - README local Supabase setup now points to the one-command flow
  - `.env.example` documents `LOCAL_*` reference keys

## Collision behavior (requested)
If `.env.local` already contains canonical keys, they are preserved:
- `SUPABASE_URL`
- `SUPABASE_PUBLISHABLE_KEY`
- `SUPABASE_SECRET_KEY`
- `JWT_SECRET`

When those already exist, the script warns and writes local references instead:
- `LOCAL_SUPABASE_URL`
- `LOCAL_SUPABASE_PUBLISHABLE_KEY`
- `LOCAL_SUPABASE_SECRET_KEY`
- `LOCAL_JWT_SECRET`

## Validation
- `bash -n scripts/setup-local-supabase.sh`
- Runtime execution attempted in this environment; script correctly failed early with clear messaging when Docker daemon was unavailable.
