### PR TITLE
feat: error classification + trigger failure notifications (by wren)

### DIFF
--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -39,6 +39,7 @@ import { getAgentGateway, type AgentTriggerPayload } from './channels/agent-gate
 import { resolveRouteAgentId } from './services/routing/resolve-route';
 import { resolveAgentFromMention } from './services/routing/resolve-mention';
 import { getHeartbeatProcessingConfig } from './config/heartbeat-flags';
+import { classifyError } from '@personal-context/shared';
 import { logger } from './utils/logger';
 import { env } from './config/env';
 
@@ -631,6 +632,110 @@ When you complete a task_request, mark it as completed using update_inbox_messag
     logger.info(`[Trigger] Successfully processed trigger for ${targetAgentId}`);
   });
   logger.info('Default agent trigger handler registered (stateless, database-driven)');
+
+  // 7b. Listen for trigger failures — restore inbox message + notify sender
+  agentGateway.on(
+    'trigger:error',
+    async ({
+      triggerId,
+      payload,
+      error,
+    }: {
+      triggerId: string;
+      payload: AgentTriggerPayload;
+      error: unknown;
+    }) => {
+      const errorText = error instanceof Error ? error.message : String(error);
+      const classification = classifyError({ errorText });
+
+      logger.warn('[TriggerFailure] Processing failure notification', {
+        triggerId,
+        from: payload.fromAgentId,
+        to: payload.toAgentId,
+        category: classification.category,
+        retryable: classification.retryable,
+        inboxMessageId: payload.inboxMessageId,
+      });
+
+      const client = dataComposer?.getClient();
+      if (!client) return;
+
+      // 1. Restore inbox message to unread (only if it was read — don't touch other states)
+      if (payload.inboxMessageId) {
+        const { error: restoreErr } = await client
+          .from('agent_inbox')
+          .update({ status: 'unread', read_at: null })
+          .eq('id', payload.inboxMessageId)
+          .eq('status', 'read');
+
+        if (restoreErr) {
+          logger.warn('[TriggerFailure] Failed to restore inbox message', {
+            inboxMessageId: payload.inboxMessageId,
+            error: restoreErr.message,
+          });
+        } else {
+          logger.info('[TriggerFailure] Restored inbox message to unread', {
+            inboxMessageId: payload.inboxMessageId,
+          });
+        }
+      }
+
+      // 2. Notify sender agent (if there is one) — skip if no sender to avoid loops
+      if (!payload.fromAgentId) return;
+
+      // Look up the userId from the original inbox message (needed for sender inbox insert)
+      let recipientUserId: string | undefined;
+      if (payload.inboxMessageId) {
+        const { data: origMsg } = await client
+          .from('agent_inbox')
+          .select('recipient_user_id')
+          .eq('id', payload.inboxMessageId)
+          .single();
+        recipientUserId = origMsg?.recipient_user_id;
+      }
+
+      if (!recipientUserId) {
+        logger.warn('[TriggerFailure] Cannot notify sender — no userId from inbox message');
+        return;
+      }
+
+      const categoryLabel =
+        classification.category !== 'unknown' ? ` (${classification.category})` : '';
+      const notificationContent = `Trigger to ${payload.toAgentId} failed${categoryLabel}: ${classification.summary}`;
+
+      const { error: insertErr } = await client.from('agent_inbox').insert({
+        recipient_user_id: recipientUserId,
+        recipient_agent_id: payload.fromAgentId,
+        sender_agent_id: payload.toAgentId,
+        subject: `Trigger failed: ${payload.toAgentId}`,
+        content: notificationContent,
+        message_type: 'notification',
+        priority: 'high',
+        thread_key: payload.threadKey || null,
+        metadata: {
+          triggerFailure: true,
+          triggerId,
+          errorCategory: classification.category,
+          errorSummary: classification.summary,
+          retryable: classification.retryable,
+          originalInboxMessageId: payload.inboxMessageId || null,
+        },
+        // No trigger — avoid infinite failure loops
+      });
+
+      if (insertErr) {
+        logger.error('[TriggerFailure] Failed to send failure notification to sender', {
+          sender: payload.fromAgentId,
+          error: insertErr.message,
+        });
+      } else {
+        logger.info('[TriggerFailure] Sent failure notification to sender', {
+          sender: payload.fromAgentId,
+          category: classification.category,
+        });
+      }
+    }
+  );
 
   // 8. Print status
   printStatus();

--- a/packages/api/src/services/sessions/gemini-runner.ts
+++ b/packages/api/src/services/sessions/gemini-runner.ts
@@ -155,6 +155,7 @@ export class GeminiRunner implements IClaudeRunner {
       const toolCalls: ToolCall[] = [];
       let usage: GeminiUsageStats | undefined;
       let finalTextResponse: string | undefined;
+      let capturedStreamError: string | undefined;
       let resolvedSessionId: string | undefined;
       let settled = false;
       let lastActivityAt = Date.now();
@@ -242,6 +243,13 @@ export class GeminiRunner implements IClaudeRunner {
                 typeof parsed.result === 'string' ? parsed.result : JSON.stringify(parsed.result);
             }
 
+            // Capture structured errors from Gemini stream-json
+            if (parsed.type === 'result' && parsed.status === 'error' && parsed.error) {
+              const errType = parsed.error.type || 'Error';
+              const errMsg = parsed.error.message || 'Unknown error';
+              capturedStreamError = `[${errType}] ${errMsg}`;
+            }
+
             // Gemini stream-json may emit text content differently
             if (parsed.type === 'assistant' && parsed.message?.content) {
               const content = parsed.message.content as Array<{ type: string; text?: string }>;
@@ -321,15 +329,24 @@ export class GeminiRunner implements IClaudeRunner {
               finalTextResponse =
                 typeof parsed.result === 'string' ? parsed.result : JSON.stringify(parsed.result);
             }
+            if (parsed.type === 'result' && parsed.status === 'error' && parsed.error) {
+              const errType = parsed.error.type || 'Error';
+              const errMsg = parsed.error.message || 'Unknown error';
+              capturedStreamError = `[${errType}] ${errMsg}`;
+            }
           } catch {
             // Non-JSON remainder — ignore
           }
         }
 
         if (code !== 0) {
-          logger.warn('Gemini CLI exited with non-zero code', { code, stderr });
+          logger.warn('Gemini CLI exited with non-zero code', {
+            code,
+            stderr,
+            capturedStreamError,
+          });
           if (responses.length === 0 && !finalTextResponse) {
-            reject(new Error(`Gemini exited with code ${code}: ${stderr}`));
+            reject(new Error(`Gemini exited with code ${code}: ${capturedStreamError || stderr}`));
             return;
           }
         }

--- a/packages/api/src/services/sessions/session-service.ts
+++ b/packages/api/src/services/sessions/session-service.ts
@@ -34,6 +34,7 @@ import { CodexRunner } from './codex-runner.js';
 import { GeminiRunner } from './gemini-runner.js';
 import { ActivityStreamRepository } from '../../data/repositories/activity-stream.repository.js';
 import { resolveIdentityId } from '../../auth/resolve-identity.js';
+import { classifyError } from '@personal-context/shared';
 import { logger } from '../../utils/logger.js';
 
 /**
@@ -402,6 +403,11 @@ export class SessionService implements ISessionService {
     const turnDurationMs = Date.now() - turnStartMs;
 
     // 5b. Log backend CLI completion to activity stream (fire-and-forget)
+    const errorClassification =
+      !result.success && result.error
+        ? classifyError({ errorText: result.error, backend: resolvedBackend })
+        : null;
+
     this.activityStream
       .logActivity({
         userId,
@@ -410,7 +416,7 @@ export class SessionService implements ISessionService {
         subtype: `backend_cli:${resolvedBackend}`,
         content: result.success
           ? `Backend turn completed (${resolvedBackend}, ${Math.round(turnDurationMs / 1000)}s)`
-          : `Backend turn failed (${resolvedBackend}): ${result.error?.slice(0, 200) || 'unknown error'}`,
+          : `Backend turn failed (${resolvedBackend}): ${result.error?.slice(0, 500) || 'unknown error'}`,
         sessionId: session.id,
         payload: {
           backend: resolvedBackend,
@@ -419,7 +425,14 @@ export class SessionService implements ISessionService {
           ...(triggerSource ? { triggerSource } : {}),
           ...(request.sender?.id ? { triggeredBy: request.sender.id } : {}),
           ...(metadata?.threadKey ? { threadKey: metadata.threadKey } : {}),
-          ...(result.error ? { error: result.error.slice(0, 500) } : {}),
+          ...(result.error ? { error: result.error.slice(0, 2000) } : {}),
+          ...(errorClassification
+            ? {
+                errorCategory: errorClassification.category,
+                errorSummary: errorClassification.summary,
+                retryable: errorClassification.retryable,
+              }
+            : {}),
           ...(result.usage ? { usage: result.usage } : {}),
         } as unknown as Json,
       })

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -47,6 +47,7 @@ import {
 } from '../repl/tui-components.js';
 import { renderInkChat, InkExitSignal, type InkRepl } from '../repl/ink/index.js';
 import {
+  classifyError,
   decodeDelegationToken,
   mintDelegationToken,
   verifyDelegationToken,
@@ -2411,6 +2412,14 @@ export async function runChat(options: ChatOptions): Promise<void> {
       const turnContent = runResult.success
         ? `Backend turn completed (${runtime.backend}, ${turnDurationSeconds}s)`
         : `Backend turn failed (${runtime.backend}, exit ${runResult.exitCode})`;
+      const cliErrorClassification = !runResult.success
+        ? classifyError({
+            errorText: runResult.stderr,
+            backend: runtime.backend,
+            exitCode: runResult.exitCode,
+          })
+        : null;
+
       pcp
         .callTool('log_activity', {
           agentId,
@@ -2424,7 +2433,14 @@ export async function runChat(options: ChatOptions): Promise<void> {
             exitCode: runResult.exitCode,
             durationMs: turnDurationSeconds * 1000,
             studioId: runtime.studioId,
-            ...(runResult.success ? {} : { stderr: runResult.stderr.slice(0, 500) }),
+            ...(runResult.success ? {} : { stderr: runResult.stderr.slice(0, 2000) }),
+            ...(cliErrorClassification
+              ? {
+                  errorCategory: cliErrorClassification.category,
+                  errorSummary: cliErrorClassification.summary,
+                  retryable: cliErrorClassification.retryable,
+                }
+              : {}),
             ...(runResult.usage ? { usage: runResult.usage } : {}),
           },
         })

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -12,6 +12,7 @@ import { type Dirent, existsSync, readFileSync, readdirSync, realpathSync, statS
 import { join, resolve as resolvePath } from 'path';
 import { homedir } from 'os';
 import { getBackend, resolveAgentId } from '../backends/index.js';
+import { classifyError } from '@personal-context/shared';
 import { getValidAccessToken } from '../auth/tokens.js';
 import { callPcpTool, getPcpServerUrl } from '../lib/pcp-mcp.js';
 import { sbDebugLog } from '../lib/sb-debug.js';
@@ -1151,24 +1152,42 @@ async function logBackendExecutionResult(options: {
         status === 'completed'
           ? `Backend CLI finished (${options.context.binary})`
           : `Backend CLI failed (${options.context.binary})`,
-      payload: {
-        kind: 'backend_cli_execution',
-        phase: 'result',
-        backend: options.context.backend,
-        binary: options.context.binary,
-        cwd: options.context.cwd,
-        studioId: options.context.studioId || null,
-        pcpSessionId: options.context.pcpSessionId || null,
-        backendSessionId: options.backendSessionId || null,
-        retryAttempt: options.context.retryAttempt,
-        maxAttempts: options.context.maxAttempts,
-        retries: Math.max(options.context.retryAttempt - 1, 0),
-        exitCode: options.exitCode,
-        durationMs: options.durationMs,
-        error: options.error || null,
-        ...(options.context.threadKey ? { threadKey: options.context.threadKey } : {}),
-        ...(options.context.triggerSource ? { triggerSource: options.context.triggerSource } : {}),
-      },
+      payload: (() => {
+        const base = {
+          kind: 'backend_cli_execution' as const,
+          phase: 'result' as const,
+          backend: options.context.backend,
+          binary: options.context.binary,
+          cwd: options.context.cwd,
+          studioId: options.context.studioId || null,
+          pcpSessionId: options.context.pcpSessionId || null,
+          backendSessionId: options.backendSessionId || null,
+          retryAttempt: options.context.retryAttempt,
+          maxAttempts: options.context.maxAttempts,
+          retries: Math.max(options.context.retryAttempt - 1, 0),
+          exitCode: options.exitCode,
+          durationMs: options.durationMs,
+          error: options.error || null,
+          ...(options.context.threadKey ? { threadKey: options.context.threadKey } : {}),
+          ...(options.context.triggerSource
+            ? { triggerSource: options.context.triggerSource }
+            : {}),
+        };
+        if (options.error) {
+          const ec = classifyError({
+            errorText: options.error,
+            backend: options.context.backend,
+            exitCode: options.exitCode,
+          });
+          return {
+            ...base,
+            errorCategory: ec.category,
+            errorSummary: ec.summary,
+            retryable: ec.retryable,
+          };
+        }
+        return base;
+      })(),
     });
   } catch {
     // Best-effort telemetry only.

--- a/packages/cli/src/commands/mission.test.ts
+++ b/packages/cli/src/commands/mission.test.ts
@@ -357,6 +357,51 @@ describe('activityToFeedEvent', () => {
       const event = activityToFeedEvent(activity({ type: 'error', agentId: 'wren' }));
       expect(event.content).toBe('error: unknown error');
     });
+
+    it('shows errorCategory tag when present', () => {
+      const event = activityToFeedEvent(
+        activity({
+          type: 'error',
+          agentId: 'aster',
+          payload: {
+            backend: 'gemini',
+            error: 'We are currently experiencing high demand',
+            errorCategory: 'capacity',
+          },
+        })
+      );
+      expect(event.content).toBe(
+        'failed (gemini, capacity): We are currently experiencing high demand'
+      );
+    });
+
+    it('renders without errorCategory when absent', () => {
+      const event = activityToFeedEvent(
+        activity({
+          type: 'error',
+          agentId: 'wren',
+          payload: {
+            backend: 'claude',
+            error: 'something went wrong',
+          },
+        })
+      );
+      expect(event.content).toBe('failed (claude): something went wrong');
+    });
+
+    it('shows only errorCategory when no backend', () => {
+      const event = activityToFeedEvent(
+        activity({
+          type: 'error',
+          agentId: 'lumen',
+          payload: {
+            error: 'authentication_error: invalid API key',
+            errorCategory: 'auth',
+          },
+        })
+      );
+      expect(event.content).toBe('failed (auth): authentication_error: invalid API key');
+    });
   });
 
   describe('studio detail line', () => {

--- a/packages/cli/src/commands/mission.ts
+++ b/packages/cli/src/commands/mission.ts
@@ -802,9 +802,16 @@ export function activityToFeedEvent(
     const ap = activity.payload;
     const backend =
       (typeof ap?.backend === 'string' ? ap.backend : null) || backendFromSubtype(activity.subtype);
+    const errorCategory = typeof ap?.errorCategory === 'string' ? ap.errorCategory : null;
     const errorDetail =
       typeof ap?.error === 'string' ? ap.error : activity.content || 'unknown error';
-    const label = backend ? `failed (${backend})` : 'error';
+    const label = backend
+      ? errorCategory
+        ? `failed (${backend}, ${errorCategory})`
+        : `failed (${backend})`
+      : errorCategory
+        ? `failed (${errorCategory})`
+        : 'error';
     content = `${label}: ${errorDetail}`;
   } else {
     const subtype = activity.subtype ? `:${activity.subtype}` : '';

--- a/packages/shared/src/errors/classify-error.test.ts
+++ b/packages/shared/src/errors/classify-error.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from 'vitest';
+import { classifyError } from './classify-error.js';
+
+describe('classifyError', () => {
+  // ── capacity ──────────────────────────────────────────────────
+  it('Gemini "high demand" → capacity', () => {
+    const r = classifyError({
+      errorText: 'We are currently experiencing high demand. Please try again later.',
+    });
+    expect(r.category).toBe('capacity');
+    expect(r.retryable).toBe(true);
+  });
+
+  it('RESOURCE_EXHAUSTED → capacity', () => {
+    const r = classifyError({
+      errorText: '[RESOURCE_EXHAUSTED] quota exceeded',
+      backend: 'gemini',
+    });
+    expect(r.category).toBe('capacity');
+  });
+
+  it('Claude overloaded_error → capacity', () => {
+    const r = classifyError({ errorText: 'error: overloaded_error', backend: 'claude' });
+    expect(r.category).toBe('capacity');
+    expect(r.retryable).toBe(true);
+  });
+
+  it('503 status → capacity', () => {
+    const r = classifyError({ errorText: 'HTTP 503 Service Unavailable' });
+    expect(r.category).toBe('capacity');
+  });
+
+  it('529 → capacity', () => {
+    const r = classifyError({ errorText: 'Error 529: API overloaded' });
+    expect(r.category).toBe('capacity');
+  });
+
+  // ── quota ─────────────────────────────────────────────────────
+  it('TerminalQuotaError → quota', () => {
+    const r = classifyError({
+      errorText: 'TerminalQuotaError: You have exceeded your quota',
+      backend: 'gemini',
+    });
+    expect(r.category).toBe('quota');
+    expect(r.retryable).toBe(false);
+  });
+
+  it('rate_limit_error → quota', () => {
+    const r = classifyError({
+      errorText: 'rate_limit_error: too many requests',
+      backend: 'claude',
+    });
+    expect(r.category).toBe('quota');
+  });
+
+  it('429 → quota', () => {
+    const r = classifyError({ errorText: 'HTTP 429 Too Many Requests' });
+    expect(r.category).toBe('quota');
+  });
+
+  it('usage limit → quota', () => {
+    const r = classifyError({ errorText: 'You have exceeded your usage limit' });
+    expect(r.category).toBe('quota');
+  });
+
+  // ── timeout ───────────────────────────────────────────────────
+  it('"timed out" → timeout', () => {
+    const r = classifyError({ errorText: 'Process timed out after 300s idle' });
+    expect(r.category).toBe('timeout');
+    expect(r.retryable).toBe(true);
+  });
+
+  it('"timeout" → timeout', () => {
+    const r = classifyError({ errorText: 'Connection timeout' });
+    expect(r.category).toBe('timeout');
+  });
+
+  it('idle + kill → timeout', () => {
+    const r = classifyError({ errorText: 'Process idle too long, kill sent' });
+    expect(r.category).toBe('timeout');
+  });
+
+  it('exit code 124 → timeout', () => {
+    const r = classifyError({ errorText: 'command terminated', exitCode: 124 });
+    expect(r.category).toBe('timeout');
+  });
+
+  // ── auth ──────────────────────────────────────────────────────
+  it('authentication_error → auth', () => {
+    const r = classifyError({ errorText: 'authentication_error: invalid API key' });
+    expect(r.category).toBe('auth');
+    expect(r.retryable).toBe(false);
+  });
+
+  it('UNAUTHENTICATED → auth', () => {
+    const r = classifyError({ errorText: 'UNAUTHENTICATED: request had invalid credentials' });
+    expect(r.category).toBe('auth');
+  });
+
+  it('401 → auth', () => {
+    const r = classifyError({ errorText: 'HTTP 401 Unauthorized' });
+    expect(r.category).toBe('auth');
+  });
+
+  // ── config ────────────────────────────────────────────────────
+  it('ModelNotFoundError → config', () => {
+    const r = classifyError({ errorText: 'ModelNotFoundError: model xyz not available' });
+    expect(r.category).toBe('config');
+    expect(r.retryable).toBe(false);
+  });
+
+  it('ENOENT → config', () => {
+    const r = classifyError({ errorText: 'spawn gemini ENOENT' });
+    expect(r.category).toBe('config');
+  });
+
+  it('command not found → config', () => {
+    const r = classifyError({ errorText: 'gemini: command not found' });
+    expect(r.category).toBe('config');
+  });
+
+  it('model not found → config', () => {
+    const r = classifyError({ errorText: 'The model "gpt-5" was not found' });
+    expect(r.category).toBe('config');
+  });
+
+  // ── crash ─────────────────────────────────────────────────────
+  it('exit code 1 with no other pattern → crash', () => {
+    const r = classifyError({ errorText: 'something went wrong', exitCode: 1 });
+    expect(r.category).toBe('crash');
+    expect(r.retryable).toBe(false);
+  });
+
+  it('segfault → crash', () => {
+    const r = classifyError({ errorText: 'segfault at address 0x0' });
+    expect(r.category).toBe('crash');
+  });
+
+  it('OOM → crash', () => {
+    const r = classifyError({ errorText: 'OOM: JavaScript heap out of memory' });
+    expect(r.category).toBe('crash');
+  });
+
+  // ── unknown ───────────────────────────────────────────────────
+  it('empty string → unknown', () => {
+    const r = classifyError({ errorText: '' });
+    expect(r.category).toBe('unknown');
+    expect(r.retryable).toBe(false);
+  });
+
+  it('no matching pattern, exit code 0 → unknown', () => {
+    const r = classifyError({ errorText: 'some random log', exitCode: 0 });
+    expect(r.category).toBe('unknown');
+  });
+
+  // ── summary truncation ────────────────────────────────────────
+  it('truncates long summaries to 200 chars', () => {
+    const long = 'A'.repeat(300);
+    const r = classifyError({ errorText: long });
+    expect(r.summary.length).toBe(200);
+    expect(r.summary.endsWith('...')).toBe(true);
+  });
+
+  it('preserves short summaries as-is', () => {
+    const r = classifyError({ errorText: 'short error' });
+    expect(r.summary).toBe('short error');
+  });
+});

--- a/packages/shared/src/errors/classify-error.test.ts
+++ b/packages/shared/src/errors/classify-error.test.ts
@@ -35,6 +35,17 @@ describe('classifyError', () => {
     expect(r.category).toBe('capacity');
   });
 
+  it('Gemini 429 "No capacity available" → capacity (not quota)', () => {
+    const r = classifyError({
+      errorText:
+        'Attempt 1 failed with status 429. Retrying with backoff... GaxiosError: No capacity available for model gemini-3-pro-preview',
+      backend: 'gemini',
+      exitCode: 1,
+    });
+    expect(r.category).toBe('capacity');
+    expect(r.retryable).toBe(true);
+  });
+
   // ── quota ─────────────────────────────────────────────────────
   it('TerminalQuotaError → quota', () => {
     const r = classifyError({

--- a/packages/shared/src/errors/classify-error.ts
+++ b/packages/shared/src/errors/classify-error.ts
@@ -1,0 +1,128 @@
+/**
+ * Error Classification
+ *
+ * Classifies backend CLI errors (Gemini, Claude, Codex) into actionable categories.
+ * Used by session-service (server-side), chat.ts / claude.ts (CLI-side),
+ * and the trigger failure handler to produce consistent error metadata.
+ */
+
+export type ErrorCategory =
+  | 'capacity'
+  | 'quota'
+  | 'timeout'
+  | 'config'
+  | 'auth'
+  | 'crash'
+  | 'unknown';
+
+export interface ErrorClassification {
+  category: ErrorCategory;
+  summary: string;
+  retryable: boolean;
+}
+
+interface ClassifyInput {
+  errorText: string;
+  backend?: string;
+  exitCode?: number | null;
+}
+
+/** Pattern rules checked in priority order. First match wins. */
+const RULES: Array<{
+  category: ErrorCategory;
+  retryable: boolean;
+  test: (input: ClassifyInput) => boolean;
+}> = [
+  {
+    category: 'capacity',
+    retryable: true,
+    test: ({ errorText }) =>
+      /high demand/i.test(errorText) ||
+      /RESOURCE_EXHAUSTED/i.test(errorText) ||
+      /\b503\b/.test(errorText) ||
+      /overloaded_error/i.test(errorText) ||
+      /\b529\b/.test(errorText) ||
+      /\boverloaded\b/i.test(errorText),
+  },
+  {
+    category: 'quota',
+    retryable: false,
+    test: ({ errorText }) =>
+      /usage limit/i.test(errorText) ||
+      /\bquota\b/i.test(errorText) ||
+      /TerminalQuotaError/i.test(errorText) ||
+      /rate_limit_error/i.test(errorText) ||
+      /\b429\b/.test(errorText),
+  },
+  {
+    category: 'timeout',
+    retryable: true,
+    test: ({ errorText, exitCode }) =>
+      /timed? ?out/i.test(errorText) ||
+      /\btimeout\b/i.test(errorText) ||
+      (/\bidle\b/i.test(errorText) && /\bkill/i.test(errorText)) ||
+      exitCode === 124,
+  },
+  {
+    category: 'auth',
+    retryable: false,
+    test: ({ errorText }) =>
+      /authentication_error/i.test(errorText) ||
+      /UNAUTHENTICATED/i.test(errorText) ||
+      /\b401\b/.test(errorText) ||
+      /\b403\b/.test(errorText) ||
+      /\bunauthorized\b/i.test(errorText) ||
+      /invalid api key/i.test(errorText),
+  },
+  {
+    category: 'config',
+    retryable: false,
+    test: ({ errorText }) =>
+      /ModelNotFoundError/i.test(errorText) ||
+      /\bENOENT\b/.test(errorText) ||
+      /command not found/i.test(errorText) ||
+      (/\bmodel\b/i.test(errorText) && /not found/i.test(errorText)),
+  },
+  {
+    category: 'crash',
+    retryable: false,
+    test: ({ errorText, exitCode }) =>
+      /\bsegfault\b/i.test(errorText) ||
+      /\bOOM\b/.test(errorText) ||
+      /\bkilled\b/i.test(errorText) ||
+      (exitCode != null && exitCode !== 0),
+  },
+];
+
+/**
+ * Classify a backend error into an actionable category.
+ *
+ * @param input.errorText  The raw error text (stderr, exception message, etc.)
+ * @param input.backend    Optional backend name (gemini, claude, codex) — for future backend-specific rules
+ * @param input.exitCode   Optional process exit code
+ */
+export function classifyError(input: ClassifyInput): ErrorClassification {
+  const text = input.errorText || '';
+
+  for (const rule of RULES) {
+    if (rule.test({ ...input, errorText: text })) {
+      return {
+        category: rule.category,
+        summary: truncateSummary(text),
+        retryable: rule.retryable,
+      };
+    }
+  }
+
+  return {
+    category: 'unknown',
+    summary: truncateSummary(text),
+    retryable: false,
+  };
+}
+
+/** Keep the summary short but useful — first meaningful line, capped at 200 chars. */
+function truncateSummary(text: string): string {
+  const firstLine = text.split('\n').find((l) => l.trim()) || text;
+  return firstLine.length > 200 ? firstLine.slice(0, 197) + '...' : firstLine;
+}

--- a/packages/shared/src/errors/classify-error.ts
+++ b/packages/shared/src/errors/classify-error.ts
@@ -42,7 +42,9 @@ const RULES: Array<{
       /\b503\b/.test(errorText) ||
       /overloaded_error/i.test(errorText) ||
       /\b529\b/.test(errorText) ||
-      /\boverloaded\b/i.test(errorText),
+      /\boverloaded\b/i.test(errorText) ||
+      /\bno capacity\b/i.test(errorText) ||
+      /\bcapacity available\b/i.test(errorText),
   },
   {
     category: 'quota',

--- a/packages/shared/src/errors/index.ts
+++ b/packages/shared/src/errors/index.ts
@@ -1,0 +1,1 @@
+export * from './classify-error.js';

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,3 +1,4 @@
 // Shared types and utilities
 export * from './types/index.js';
 export * from './security/index.js';
+export * from './errors/index.js';

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,12 +6,8 @@ export default defineConfig({
     include: [
       'packages/api/src/**/*.test.ts',
       'packages/cli/src/**/*.test.ts',
+      'packages/shared/src/**/*.test.ts',
     ],
-    exclude: [
-      'node_modules',
-      'dist',
-      'packages/clawdbot/**',
-      '**/*.integration.test.ts',
-    ],
+    exclude: ['node_modules', 'dist', 'packages/clawdbot/**', '**/*.integration.test.ts'],
   },
 });


### PR DESCRIPTION
## Summary

- **Shared error classifier** (`packages/shared/src/errors/classify-error.ts`) — 7 categories (capacity, quota, timeout, auth, config, crash, unknown) with pattern-based priority matching and retryable flags
- **Gemini error capture** — structured `{type: "result", status: "error"}` events from stream-json now captured instead of lost
- **Error classification integrated** into session-service (server), chat.ts and claude.ts (CLI) — adds `errorCategory`/`errorSummary`/`retryable` to activity payloads
- **Trigger failure handler** replaced naive regex (`"capacity/rate-limit"` vs `"execution error"`) with shared classifier — tested against real Gemini IDE connection failures (correctly classifies as `crash` instead of misclassifying as capacity)
- **Mission control** shows classification tag: `failed (gemini, crash)` instead of `failed (gemini)`
- **Truncation limits raised**: content 200→500, error 500→2000 chars

## Context

Backend CLI errors were unclassified (raw text), truncated too aggressively, and the existing trigger failure handler used a naive regex that misclassified IDE connection failures as "capacity/rate-limit". Tested against real Gemini failures — exit code 42 with IDE MCP fetch error now correctly classified as `crash, retryable: false`.

## Test plan

- [x] 27 classifier tests covering all 7 categories + edge cases
- [x] 3 new mission.test.ts tests for error tag rendering
- [x] Full suite: 1371 tests passing (84 files)
- [x] Clean `yarn build`
- [ ] Deploy server, trigger Aster, verify `errorCategory` in activity payload
- [ ] Verify mission control shows `failed (gemini, crash)` for real errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)