### PR TITLE
feat: enrich session resumption pickers with latest message previews (by Lumen)

### DIFF
--- a/packages/cli/src/commands/chat.integration.test.ts
+++ b/packages/cli/src/commands/chat.integration.test.ts
@@ -38,6 +38,11 @@ vi.mock('../repl/skills.js', () => ({
     testState.loadSkillInstructionImpl(skill, maxChars),
 }));
 
+vi.mock('../repl/ink/index.js', () => ({
+  renderInkChat: async () => null,
+  InkExitSignal: class InkExitSignal extends Error {},
+}));
+
 vi.mock('readline/promises', () => ({
   createInterface: () => ({
     question: async () => {
@@ -174,7 +179,10 @@ describe('runChat integration', () => {
     });
 
     expect(testState.runBackendImpl).toHaveBeenCalledTimes(1);
-    const backendRequest = testState.runBackendImpl.mock.calls[0][0] as { prompt: string; backend: string };
+    const backendRequest = testState.runBackendImpl.mock.calls[0][0] as {
+      prompt: string;
+      backend: string;
+    };
     expect(backendRequest.backend).toBe('gemini');
     expect(backendRequest.prompt).toContain('Latest user message:\nheartbeat pulse');
     // Newly created session in non-interactive mode should be ended.
@@ -196,7 +204,9 @@ describe('runChat integration', () => {
     expect(testState.pcpCalls.some((call) => call.tool === 'end_session')).toBe(false);
 
     const transcriptDir = join(testCwd, '.pcp', 'runtime', 'repl');
-    const transcriptFiles = readdirSync(transcriptDir).filter((entry) => entry.includes('sess-attach-1'));
+    const transcriptFiles = readdirSync(transcriptDir).filter((entry) =>
+      entry.includes('sess-attach-1')
+    );
     expect(transcriptFiles.length).toBeGreaterThan(0);
     const transcript = readFileSync(join(transcriptDir, transcriptFiles[0]!), 'utf-8');
     expect(transcript).toContain('"type":"session_attach"');
@@ -210,8 +220,16 @@ describe('runChat integration', () => {
     writeFileSync(
       transcriptPath,
       [
-        JSON.stringify({ ts: '2026-02-25T07:00:00.000Z', type: 'user', content: 'old user message' }),
-        JSON.stringify({ ts: '2026-02-25T07:00:01.000Z', type: 'assistant', content: 'old assistant reply' }),
+        JSON.stringify({
+          ts: '2026-02-25T07:00:00.000Z',
+          type: 'user',
+          content: 'old user message',
+        }),
+        JSON.stringify({
+          ts: '2026-02-25T07:00:01.000Z',
+          type: 'assistant',
+          content: 'old assistant reply',
+        }),
       ].join('\n') + '\n'
     );
 
@@ -326,6 +344,83 @@ describe('runChat integration', () => {
     const sessionStatusLine = stripAnsi(logSpy.mock.calls.flat().join('\n'));
     expect(sessionStatusLine).toContain('sess-b222');
     expect(sessionStatusLine).toContain('Thread: spec:cli-session-hooks');
+  });
+
+  it('renders latest transcript message previews in attach picker', async () => {
+    testState.callToolImpl.mockImplementation(async (tool: string) => {
+      switch (tool) {
+        case 'bootstrap':
+          return { user: { timezone: 'America/Los_Angeles' } };
+        case 'list_sessions':
+          return {
+            sessions: [
+              {
+                id: 'sess-a111',
+                agentId: 'lumen',
+                status: 'active',
+                currentPhase: 'implementing',
+                threadKey: 'pr:61',
+                studioId: 'aaaaaaaa-bbbb-cccc-dddd-111111111111',
+                studioName: 'main',
+                startedAt: '2026-03-03T18:00:00.000Z',
+              },
+              {
+                id: 'sess-b222',
+                agentId: 'lumen',
+                status: 'active',
+                currentPhase: 'reviewing',
+                threadKey: 'spec:cli-session-hooks',
+                studioId: 'bbbbbbbb-cccc-dddd-eeee-222222222222',
+                studioName: 'review',
+                startedAt: '2026-03-03T19:00:00.000Z',
+              },
+            ],
+          };
+        case 'get_inbox':
+          return { messages: [] };
+        default:
+          return { success: true };
+      }
+    });
+
+    const replDir = join(testCwd, '.pcp', 'runtime', 'repl');
+    mkdirSync(replDir, { recursive: true });
+    writeFileSync(
+      join(replDir, 'sess-a111-1111111111111.jsonl'),
+      [
+        JSON.stringify({
+          ts: '2026-03-03T18:01:00.000Z',
+          type: 'user',
+          content: 'Testing attach previews with the latest message from me',
+        }),
+      ].join('\n') + '\n'
+    );
+    writeFileSync(
+      join(replDir, 'sess-b222-2222222222222.jsonl'),
+      [
+        JSON.stringify({
+          ts: '2026-03-03T19:02:00.000Z',
+          type: 'assistant',
+          content: 'Latest assistant response appears as a preview in the picker',
+        }),
+      ].join('\n') + '\n'
+    );
+
+    testState.inputs = ['1', '/quit'];
+    await runChat({
+      agent: 'lumen',
+      backend: 'claude',
+      attach: true,
+      pollSeconds: '999',
+    });
+
+    const sessionStatusLine = stripAnsi(logSpy.mock.calls.flat().join('\n'));
+    expect(sessionStatusLine).toContain(
+      '↳ you: Testing attach previews with the latest message from me'
+    );
+    expect(sessionStatusLine).toContain(
+      '↳ lumen: Latest assistant response appears as a preview in the picker'
+    );
   });
 
   it('supports attach-latest without prompting', async () => {
@@ -576,7 +671,9 @@ describe('runChat integration', () => {
       const logText = stripAnsi(logSpy.mock.calls.slice(before).flat().join('\n'));
       expect(logText, `visibility=${row.visibility}`).toContain(row.expectedSession);
       if (row.expectsAutoAttach) {
-        expect(logText, `visibility=${row.visibility}`).toContain('Auto-attached to latest session');
+        expect(logText, `visibility=${row.visibility}`).toContain(
+          'Auto-attached to latest session'
+        );
       } else {
         expect(logText, `visibility=${row.visibility}`).not.toContain(
           'Auto-attached to latest session'
@@ -919,7 +1016,9 @@ describe('runChat integration', () => {
     const logText = stripAnsi(logSpy.mock.calls.flat().join('\n'));
     expect(logText).toContain('Skill trust mode set to trusted-only');
     expect(logText).toContain('1 skills hidden by trust policy mode');
-    expect(logText).toContain('Skill blocked by trust policy (local); set /skill-trust all to allow.');
+    expect(logText).toContain(
+      'Skill blocked by trust policy (local); set /skill-trust all to allow.'
+    );
   });
 
   it('renders backend token usage when available', async () => {
@@ -948,7 +1047,9 @@ describe('runChat integration', () => {
 
     const logText = stripAnsi(logSpy.mock.calls.flat().join('\n'));
     expect(logText).toContain('claude usage (json): in 1,200 · out 400 · total 1,600');
-    expect(logText).toContain('Last backend usage: claude usage (json): in 1,200 · out 400 · total 1,600');
+    expect(logText).toContain(
+      'Last backend usage: claude usage (json): in 1,200 · out 400 · total 1,600'
+    );
   });
 
   it('shows capabilities snapshot including MCP servers and policy', async () => {
@@ -1073,7 +1174,9 @@ describe('runChat integration', () => {
     expect(logText).toContain('Mutation scope set to global.');
     expect(logText).toContain('Persistently allowed send_to_inbox');
     expect(logText).toContain('Mutation scope: global');
-    expect(logText).toContain('Active scopes: global -> workspace:studio-test -> agent:lumen -> studio:studio-test');
+    expect(logText).toContain(
+      'Active scopes: global -> workspace:studio-test -> agent:lumen -> studio:studio-test'
+    );
   });
 
   it('supports /session-visibility and /policy-reset controls', async () => {
@@ -1099,7 +1202,12 @@ describe('runChat integration', () => {
   });
 
   it('passes effective backend allowlist to backend runner in backend routing mode', async () => {
-    testState.inputs = ['/policy-scope global', '/allow send_to_inbox', 'run backend allowlist', '/quit'];
+    testState.inputs = [
+      '/policy-scope global',
+      '/allow send_to_inbox',
+      'run backend allowlist',
+      '/quit',
+    ];
 
     await runChat({
       agent: 'lumen',
@@ -1141,21 +1249,23 @@ describe('runChat integration', () => {
       durationMs: 5,
       command: 'mock',
     });
-    testState.callToolImpl.mockImplementation(async (tool: string, args?: Record<string, unknown>) => {
-      switch (tool) {
-        case 'bootstrap':
-          return { user: { timezone: 'America/Los_Angeles' } };
-        case 'start_session':
-          return { session: { id: 'sess-1' } };
-        case 'get_inbox':
-          return { messages: [], echo: args || {} };
-        case 'update_session_phase':
-        case 'end_session':
-          return { success: true };
-        default:
-          return { success: true };
+    testState.callToolImpl.mockImplementation(
+      async (tool: string, args?: Record<string, unknown>) => {
+        switch (tool) {
+          case 'bootstrap':
+            return { user: { timezone: 'America/Los_Angeles' } };
+          case 'start_session':
+            return { session: { id: 'sess-1' } };
+          case 'get_inbox':
+            return { messages: [], echo: args || {} };
+          case 'update_session_phase':
+          case 'end_session':
+            return { success: true };
+          default:
+            return { success: true };
+        }
       }
-    });
+    );
 
     testState.inputs = ['run local tool routing', '/quit'];
     await runChat({

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -167,6 +167,8 @@ interface SessionTranscriptMetadata {
   assistantCount: number;
   inboxCount: number;
   lastMessageAt?: string;
+  lastMessageRole?: 'user' | 'assistant' | 'inbox';
+  lastMessagePreview?: string;
 }
 
 interface HistoryHydrationResult {
@@ -297,22 +299,59 @@ function getSessionTranscriptMetadata(sessionId: string): SessionTranscriptMetad
   let assistantCount = 0;
   let inboxCount = 0;
   let lastMessageAt: string | undefined;
+  let lastMessageRole: SessionTranscriptMetadata['lastMessageRole'];
+  let lastMessagePreview: string | undefined;
+
+  const compactSessionMessagePreview = (raw: string): string => {
+    const singleLine = raw.replace(/\s+/g, ' ').trim();
+    if (!singleLine) return '';
+    const maxChars = 120;
+    if (singleLine.length <= maxChars) return singleLine;
+    return `${singleLine.slice(0, Math.max(1, maxChars - 1))}…`;
+  };
+
+  const recordLastMessage = (
+    role: 'user' | 'assistant' | 'inbox',
+    content: string | undefined,
+    ts?: string
+  ) => {
+    if (ts) lastMessageAt = ts;
+    lastMessageRole = role;
+    const compacted = content ? compactSessionMessagePreview(content) : '';
+    lastMessagePreview = compacted || undefined;
+  };
 
   for (const event of events) {
     const type = typeof event.type === 'string' ? event.type : '';
     if (type === 'user') {
       userCount += 1;
-      if (typeof event.ts === 'string') lastMessageAt = event.ts;
+      recordLastMessage(
+        'user',
+        typeof event.content === 'string' ? event.content : undefined,
+        typeof event.ts === 'string' ? event.ts : undefined
+      );
       continue;
     }
     if (type === 'assistant') {
       assistantCount += 1;
-      if (typeof event.ts === 'string') lastMessageAt = event.ts;
+      recordLastMessage(
+        'assistant',
+        typeof event.content === 'string' ? event.content : undefined,
+        typeof event.ts === 'string' ? event.ts : undefined
+      );
       continue;
     }
     if (type === 'inbox') {
       inboxCount += 1;
-      if (typeof event.ts === 'string') lastMessageAt = event.ts;
+      recordLastMessage(
+        'inbox',
+        typeof event.rendered === 'string'
+          ? event.rendered
+          : typeof event.content === 'string'
+            ? event.content
+            : undefined,
+        typeof event.ts === 'string' ? event.ts : undefined
+      );
     }
   }
 
@@ -324,6 +363,8 @@ function getSessionTranscriptMetadata(sessionId: string): SessionTranscriptMetad
     assistantCount,
     inboxCount,
     lastMessageAt,
+    lastMessageRole,
+    lastMessagePreview,
   };
 }
 
@@ -1058,6 +1099,20 @@ function sessionHistoryLabel(meta: SessionTranscriptMetadata | null): string {
   return `${meta.messageCount} msgs`;
 }
 
+function sessionLatestMessagePreview(
+  session: Pick<SessionSummary, 'agentId'>,
+  meta: SessionTranscriptMetadata | null
+): string | null {
+  if (!meta?.lastMessagePreview) return null;
+  const speaker =
+    meta.lastMessageRole === 'assistant'
+      ? session.agentId || 'assistant'
+      : meta.lastMessageRole === 'inbox'
+        ? 'inbox'
+        : 'you';
+  return `${speaker}: ${meta.lastMessagePreview}`;
+}
+
 function chip(label: string, value: string, color: (text: string) => string): string {
   return `${chalk.dim(`${label}:`)} ${color(value)}`;
 }
@@ -1310,6 +1365,7 @@ async function pickSessionToAttach(
     const transcriptMeta = getSessionTranscriptMetadata(session.id);
     const historyMeta = sessionHistoryLabel(transcriptMeta);
     const lastMsg = formatTimestampForSessionList(transcriptMeta?.lastMessageAt, options?.timezone);
+    const preview = sessionLatestMessagePreview(session, transcriptMeta);
     const studioName = session.studioName || session.workspaceName;
     const thread = session.threadKey || '';
 
@@ -1325,6 +1381,9 @@ async function pickSessionToAttach(
     console.log(
       `  ${chalk.white(`${num}.`)} ${chalk.cyan(session.id.slice(0, 8))}  ${chalk.dim(parts.join('  ·  '))}`
     );
+    if (preview) {
+      console.log(chalk.dim(`      ↳ ${preview}`));
+    }
   }
   console.log('');
 

--- a/packages/cli/src/commands/claude.test.ts
+++ b/packages/cli/src/commands/claude.test.ts
@@ -570,15 +570,26 @@ describe('getCodexLocalSessionsForProject', () => {
     const nonMatchingSessionId = '019a23b9-b211-7972-b007-012a8bc1d6f2';
     writeFileSync(
       join(codexSessionsDir, `rollout-2026-03-02T11-44-41-${matchingSessionId}.jsonl`),
-      `${JSON.stringify({
-        timestamp: '2026-03-02T11:44:41.000Z',
-        type: 'session_meta',
-        payload: {
-          id: matchingSessionId,
-          cwd: projectPath,
+      [
+        JSON.stringify({
           timestamp: '2026-03-02T11:44:41.000Z',
-        },
-      })}\n`
+          type: 'session_meta',
+          payload: {
+            id: matchingSessionId,
+            cwd: projectPath,
+            timestamp: '2026-03-02T11:44:41.000Z',
+          },
+        }),
+        JSON.stringify({
+          timestamp: '2026-03-02T11:44:51.000Z',
+          type: 'response_item',
+          payload: {
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: 'Most recent assistant reply' }],
+          },
+        }),
+      ].join('\n') + '\n'
     );
     writeFileSync(
       join(codexSessionsDir, `rollout-2026-03-02T11-44-41-${nonMatchingSessionId}.jsonl`),
@@ -599,6 +610,8 @@ describe('getCodexLocalSessionsForProject', () => {
     try {
       const sessions = getCodexLocalSessionsForProject(projectPath, 10);
       expect(sessions.map((session) => session.sessionId)).toEqual([matchingSessionId]);
+      expect(sessions[0]?.latestPrompt).toBe('assistant: Most recent assistant reply');
+      expect(sessions[0]?.transcriptPath).toContain(matchingSessionId);
     } finally {
       process.env.HOME = originalHome;
       rmSync(tempHome, { recursive: true, force: true });

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -67,6 +67,7 @@ interface BackendLocalSessionSummary {
   modified: string;
   firstPrompt?: string;
   latestPrompt?: string;
+  latestPromptAt?: string;
   messageCount?: number;
   gitBranch?: string;
   transcriptPath?: string;
@@ -453,6 +454,14 @@ function formatSessionPreviewText(
         ? 'inbox'
         : 'you';
   return `${speaker}: ${truncateText(summary.content, 110)}`;
+}
+
+function withAgentPreviewSpeaker(preview: string | undefined, agentId: string): string | undefined {
+  if (!preview) return undefined;
+  if (/^assistant:\s*/i.test(preview)) {
+    return `${agentId}: ${preview.replace(/^assistant:\s*/i, '')}`;
+  }
+  return preview;
 }
 
 function extractLatestPreviewFromCodexRolloutJsonl(
@@ -1018,6 +1027,7 @@ LIMIT 200;
       : new Date().toISOString();
 
     let latestPrompt: string | undefined;
+    let latestPromptAt: string | undefined;
     const transcriptPath = rolloutPath?.trim() || undefined;
     if (transcriptPath && existsSync(transcriptPath)) {
       try {
@@ -1025,6 +1035,7 @@ LIMIT 200;
         const preview = extractLatestPreviewFromCodexRolloutJsonl(transcript);
         if (preview) {
           latestPrompt = formatSessionPreviewText(preview);
+          latestPromptAt = preview.ts;
         }
       } catch {
         // Best-effort preview extraction only.
@@ -1038,6 +1049,7 @@ LIMIT 200;
       modified,
       firstPrompt: firstPrompt?.trim(),
       latestPrompt,
+      latestPromptAt,
       gitBranch: gitBranch?.trim(),
       transcriptPath,
     });
@@ -1134,6 +1146,7 @@ function getCodexLocalSessionsFromJsonl(
         projectPath: sessionCwd,
         modified: parsed.payload?.timestamp || parsed.timestamp || sessionFile.modified,
         latestPrompt: latestPreview ? formatSessionPreviewText(latestPreview) : undefined,
+        latestPromptAt: latestPreview?.ts,
         transcriptPath: sessionFile.path,
       };
       break;
@@ -1782,7 +1795,10 @@ async function ensurePcpSessionContext(
       );
     }
     for (const localSession of untrackedLocalBackendSessions) {
-      const previewText = localSession.latestPrompt || localSession.firstPrompt;
+      const previewText = withAgentPreviewSpeaker(
+        localSession.latestPrompt || localSession.firstPrompt,
+        agentId
+      );
       console.log(
         chalk.dim(
           `  local:${localSession.sessionId}${previewText ? ` — ${truncateText(previewText)}` : ''}`
@@ -1839,14 +1855,18 @@ async function ensurePcpSessionContext(
 
     for (const localSession of untrackedLocalBackendSessions) {
       const value = `__local__:${localSession.sessionId}`;
-      const previewText = localSession.latestPrompt || localSession.firstPrompt;
+      const previewText = withAgentPreviewSpeaker(
+        localSession.latestPrompt || localSession.firstPrompt,
+        agentId
+      );
       const preview = previewText ? ` — ${truncateText(previewText)}` : '';
+      const previewAt = localSession.latestPromptAt || localSession.modified;
       const backendLabel = localSession.backend[0].toUpperCase() + localSession.backend.slice(1);
       choices.push({
         name:
           localSession.backend === 'claude'
-            ? `Resume Claude local ${localSession.sessionId.slice(0, 8)} (${new Date(localSession.modified).toLocaleString()})${preview}`
-            : `Resume ${backendLabel} local ${localSession.sessionId.slice(0, 8)} (${new Date(localSession.modified).toLocaleString()})${preview}`,
+            ? `Resume Claude local ${localSession.sessionId.slice(0, 8)} (${new Date(previewAt).toLocaleString()})${preview}`
+            : `Resume ${backendLabel} local ${localSession.sessionId.slice(0, 8)} (${new Date(previewAt).toLocaleString()})${preview}`,
         value,
       });
       sessionChoiceByValue.set(value, localSession.sessionId);

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -66,8 +66,16 @@ interface BackendLocalSessionSummary {
   projectPath: string;
   modified: string;
   firstPrompt?: string;
+  latestPrompt?: string;
   messageCount?: number;
   gitBranch?: string;
+  transcriptPath?: string;
+}
+
+interface SessionPreviewSummary {
+  role: 'user' | 'assistant' | 'inbox';
+  content: string;
+  ts?: string;
 }
 
 function toEpochMs(value: string | undefined): number | undefined {
@@ -384,6 +392,201 @@ function truncateText(text: string | null | undefined, max = 90): string {
   return `${compact.slice(0, max - 1)}…`;
 }
 
+function parseJsonl(content: string): Array<Record<string, unknown>> {
+  const parsed: Array<Record<string, unknown>> = [];
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const obj = JSON.parse(trimmed) as Record<string, unknown>;
+      parsed.push(obj);
+    } catch {
+      // ignore malformed lines
+    }
+  }
+  return parsed;
+}
+
+function extractMessageText(value: unknown): string | undefined {
+  if (typeof value === 'string') {
+    const compact = value.replace(/\s+/g, ' ').trim();
+    return compact || undefined;
+  }
+  if (Array.isArray(value)) {
+    const chunks: string[] = [];
+    for (const item of value) {
+      const chunk = extractMessageText(item);
+      if (chunk) chunks.push(chunk);
+    }
+    if (chunks.length === 0) return undefined;
+    return chunks.join(' ');
+  }
+  if (value && typeof value === 'object') {
+    const record = value as Record<string, unknown>;
+    const textLikeKeys = ['text', 'message', 'content', 'output', 'input'];
+    const chunks: string[] = [];
+    for (const key of textLikeKeys) {
+      const chunk = extractMessageText(record[key]);
+      if (chunk) chunks.push(chunk);
+    }
+    if (chunks.length === 0) return undefined;
+    return chunks.join(' ');
+  }
+  return undefined;
+}
+
+function roleFromUnknown(value: unknown): SessionPreviewSummary['role'] | undefined {
+  if (value === 'user') return 'user';
+  if (value === 'assistant' || value === 'model') return 'assistant';
+  if (value === 'inbox') return 'inbox';
+  return undefined;
+}
+
+function formatSessionPreviewText(
+  summary: SessionPreviewSummary,
+  options?: { assistantLabel?: string }
+): string {
+  const speaker =
+    summary.role === 'assistant'
+      ? options?.assistantLabel || 'assistant'
+      : summary.role === 'inbox'
+        ? 'inbox'
+        : 'you';
+  return `${speaker}: ${truncateText(summary.content, 110)}`;
+}
+
+function extractLatestPreviewFromCodexRolloutJsonl(
+  jsonl: string
+): SessionPreviewSummary | undefined {
+  const events = parseJsonl(jsonl);
+  let latest: SessionPreviewSummary | undefined;
+  for (const event of events) {
+    const eventType = typeof event.type === 'string' ? event.type : '';
+    const ts =
+      typeof event.timestamp === 'string'
+        ? event.timestamp
+        : typeof event.ts === 'string'
+          ? event.ts
+          : undefined;
+
+    if (eventType === 'response_item') {
+      const payload =
+        event.payload && typeof event.payload === 'object'
+          ? (event.payload as Record<string, unknown>)
+          : undefined;
+      if (!payload) continue;
+      if (payload.type !== 'message') continue;
+
+      const role = roleFromUnknown(payload.role);
+      if (!role || role === 'inbox') continue;
+      const content = extractMessageText(payload.content);
+      if (!content) continue;
+      latest = { role, content, ts };
+      continue;
+    }
+
+    if (eventType === 'event_msg') {
+      const payload =
+        event.payload && typeof event.payload === 'object'
+          ? (event.payload as Record<string, unknown>)
+          : undefined;
+      if (!payload) continue;
+      if (payload.type === 'user_message') {
+        const content = extractMessageText(payload.message);
+        if (content) latest = { role: 'user', content, ts };
+      } else if (payload.type === 'agent_message') {
+        const content = extractMessageText(payload.message);
+        if (content) latest = { role: 'assistant', content, ts };
+      }
+    }
+  }
+  return latest;
+}
+
+function extractLatestPreviewFromPcpTranscriptJsonl(
+  jsonl: string
+): SessionPreviewSummary | undefined {
+  const events = parseJsonl(jsonl);
+  let latest: SessionPreviewSummary | undefined;
+  for (const event of events) {
+    const type = typeof event.type === 'string' ? event.type : '';
+    if (type === 'user') {
+      const content = extractMessageText(event.content);
+      if (!content) continue;
+      latest = {
+        role: 'user',
+        content,
+        ts: typeof event.ts === 'string' ? event.ts : undefined,
+      };
+      continue;
+    }
+    if (type === 'assistant') {
+      const content = extractMessageText(event.content);
+      if (!content) continue;
+      latest = {
+        role: 'assistant',
+        content,
+        ts: typeof event.ts === 'string' ? event.ts : undefined,
+      };
+      continue;
+    }
+    if (type === 'inbox') {
+      const content = extractMessageText(event.rendered) || extractMessageText(event.content);
+      if (!content) continue;
+      latest = {
+        role: 'inbox',
+        content,
+        ts: typeof event.ts === 'string' ? event.ts : undefined,
+      };
+    }
+  }
+  return latest;
+}
+
+function findLatestPcpReplTranscriptForSession(
+  sessionId: string,
+  cwd = process.cwd()
+): string | undefined {
+  const dir = join(cwd, '.pcp', 'runtime', 'repl');
+  if (!existsSync(dir)) return undefined;
+  const prefix = `${sessionId}-`;
+  const candidates = readdirSync(dir)
+    .filter((entry) => entry.startsWith(prefix) && entry.endsWith('.jsonl'))
+    .map((entry) => join(dir, entry))
+    .filter((fullPath) => {
+      try {
+        return statSync(fullPath).isFile();
+      } catch {
+        return false;
+      }
+    })
+    .sort((a, b) => {
+      try {
+        return statSync(b).mtimeMs - statSync(a).mtimeMs;
+      } catch {
+        return 0;
+      }
+    });
+  return candidates[0];
+}
+
+function getPcpSessionPreviewLabel(
+  session: PcpSessionSummary,
+  agentId: string,
+  cwd = process.cwd()
+): string | undefined {
+  const transcriptPath = findLatestPcpReplTranscriptForSession(session.id, cwd);
+  if (!transcriptPath) return undefined;
+  try {
+    const content = readFileSync(transcriptPath, 'utf-8');
+    const summary = extractLatestPreviewFromPcpTranscriptJsonl(content);
+    if (!summary) return undefined;
+    return formatSessionPreviewText(summary, { assistantLabel: agentId });
+  } catch {
+    return undefined;
+  }
+}
+
 export function sanitizeBackendExecutionArgs(
   args: string[],
   backend: string,
@@ -632,6 +835,7 @@ export function getClaudeLocalSessionsForProject(
           sessionId,
           projectPath: normalizedCwd,
           modified: stats.mtime.toISOString(),
+          transcriptPath: filePath,
         });
       } catch {
         // Ignore unreadable file stats.
@@ -777,6 +981,7 @@ export function getCodexLocalSessionsForProject(
   const query = `
 SELECT id, cwd, updated_at,
        replace(replace(first_user_message, char(10), ' '), char(9), ' ') AS first_user_message,
+       rollout_path,
        git_branch
 FROM threads
 WHERE archived = 0
@@ -800,7 +1005,8 @@ LIMIT 200;
   const lines = result.stdout.split('\n').map((line) => line.trim());
   for (const line of lines) {
     if (!line) continue;
-    const [sessionId, sessionCwd, updatedAtRaw, firstPrompt, gitBranch] = line.split('\t');
+    const [sessionId, sessionCwd, updatedAtRaw, firstPrompt, rolloutPath, gitBranch] =
+      line.split('\t');
     if (!sessionId || !sessionCwd || !updatedAtRaw) continue;
 
     const normalizedSessionPath = normalizePath(sessionCwd);
@@ -811,13 +1017,29 @@ LIMIT 200;
       ? new Date(updatedAtSeconds * 1000).toISOString()
       : new Date().toISOString();
 
+    let latestPrompt: string | undefined;
+    const transcriptPath = rolloutPath?.trim() || undefined;
+    if (transcriptPath && existsSync(transcriptPath)) {
+      try {
+        const transcript = readFileSync(transcriptPath, 'utf-8');
+        const preview = extractLatestPreviewFromCodexRolloutJsonl(transcript);
+        if (preview) {
+          latestPrompt = formatSessionPreviewText(preview);
+        }
+      } catch {
+        // Best-effort preview extraction only.
+      }
+    }
+
     sessions.push({
       backend: 'codex',
       sessionId,
       projectPath: sessionCwd,
       modified,
       firstPrompt: firstPrompt?.trim(),
+      latestPrompt,
       gitBranch: gitBranch?.trim(),
+      transcriptPath,
     });
   }
 
@@ -885,6 +1107,7 @@ function getCodexLocalSessionsFromJsonl(
     }
 
     let matched: BackendLocalSessionSummary | undefined;
+    const latestPreview = extractLatestPreviewFromCodexRolloutJsonl(content);
     const lines = content.split('\n');
     for (const line of lines) {
       const trimmed = line.trim();
@@ -910,6 +1133,8 @@ function getCodexLocalSessionsFromJsonl(
         sessionId,
         projectPath: sessionCwd,
         modified: parsed.payload?.timestamp || parsed.timestamp || sessionFile.modified,
+        latestPrompt: latestPreview ? formatSessionPreviewText(latestPreview) : undefined,
+        transcriptPath: sessionFile.path,
       };
       break;
     }
@@ -1011,11 +1236,21 @@ function getGeminiSessionsForProjectKey(projectKey: string): BackendLocalSession
       if (!modified) continue;
 
       const firstUserMessage = (parsed.messages || []).find((message) => message.type === 'user');
+      const latestMessage = [...(parsed.messages || [])]
+        .reverse()
+        .find((message) => Boolean(message?.content?.trim()));
       const firstPrompt =
         parsed.summary ||
         (typeof firstUserMessage?.content === 'string'
           ? firstUserMessage.content.trim()
           : undefined);
+      const latestPrompt =
+        latestMessage && typeof latestMessage.content === 'string'
+          ? formatSessionPreviewText({
+              role: latestMessage.type === 'user' ? 'user' : 'assistant',
+              content: latestMessage.content,
+            })
+          : undefined;
 
       sessions.push({
         backend: 'gemini',
@@ -1023,6 +1258,8 @@ function getGeminiSessionsForProjectKey(projectKey: string): BackendLocalSession
         projectPath,
         modified,
         firstPrompt,
+        latestPrompt,
+        transcriptPath: sessionPath,
       });
     } catch {
       // Ignore malformed session files.
@@ -1486,6 +1723,11 @@ async function ensurePcpSessionContext(
     localBackendSessions,
     activeSessions
   );
+  const pcpPreviewBySessionId = new Map<string, string>();
+  for (const session of activeSessions) {
+    const preview = getPcpSessionPreviewLabel(session, agentId, cwd);
+    if (preview) pcpPreviewBySessionId.set(session.id, preview);
+  }
 
   let chosen: PcpSessionSummary | undefined;
   let selectedLocalBackendSessionId: string | undefined;
@@ -1532,16 +1774,18 @@ async function ensurePcpSessionContext(
     for (const session of activeSessions) {
       const linkedBackendSessionId =
         backend === 'claude' ? getSessionBackendId(session) : undefined;
+      const preview = pcpPreviewBySessionId.get(session.id);
       console.log(
         chalk.dim(
-          `  pcp:${session.id}${session.threadKey ? ` (${session.threadKey})` : ''}${session.currentPhase ? ` — ${session.currentPhase}` : ''}${linkedBackendSessionId ? ` · tracks ${linkedBackendSessionId}` : ''}`
+          `  pcp:${session.id}${session.threadKey ? ` (${session.threadKey})` : ''}${session.currentPhase ? ` — ${session.currentPhase}` : ''}${linkedBackendSessionId ? ` · tracks ${linkedBackendSessionId}` : ''}${preview ? ` — ${preview}` : ''}`
         )
       );
     }
     for (const localSession of untrackedLocalBackendSessions) {
+      const previewText = localSession.latestPrompt || localSession.firstPrompt;
       console.log(
         chalk.dim(
-          `  local:${localSession.sessionId}${localSession.firstPrompt ? ` — ${truncateText(localSession.firstPrompt)}` : ''}`
+          `  local:${localSession.sessionId}${previewText ? ` — ${truncateText(previewText)}` : ''}`
         )
       );
     }
@@ -1585,8 +1829,9 @@ async function ensurePcpSessionContext(
       const value = `__pcp__:${session.id}`;
       const linkedBackendSessionId = getSessionBackendId(session);
       const backendLabel = backend[0].toUpperCase() + backend.slice(1);
+      const preview = pcpPreviewBySessionId.get(session.id);
       choices.push({
-        name: `Resume PCP ${session.id.slice(0, 8)}${session.threadKey ? ` (${session.threadKey})` : ''}${session.currentPhase ? ` — ${session.currentPhase}` : ''}${linkedBackendSessionId ? ` · tracks ${backendLabel} ${linkedBackendSessionId.slice(0, 8)}` : ''}`,
+        name: `Resume PCP ${session.id.slice(0, 8)}${session.threadKey ? ` (${session.threadKey})` : ''}${session.currentPhase ? ` — ${session.currentPhase}` : ''}${linkedBackendSessionId ? ` · tracks ${backendLabel} ${linkedBackendSessionId.slice(0, 8)}` : ''}${preview ? ` — ${truncateText(preview, 120)}` : ''}`,
         value,
       });
       sessionChoiceByValue.set(value, session.id);
@@ -1594,9 +1839,8 @@ async function ensurePcpSessionContext(
 
     for (const localSession of untrackedLocalBackendSessions) {
       const value = `__local__:${localSession.sessionId}`;
-      const preview = localSession.firstPrompt
-        ? ` — ${truncateText(localSession.firstPrompt)}`
-        : '';
+      const previewText = localSession.latestPrompt || localSession.firstPrompt;
+      const preview = previewText ? ` — ${truncateText(previewText)}` : '';
       const backendLabel = localSession.backend[0].toUpperCase() + localSession.backend.slice(1);
       choices.push({
         name:


### PR DESCRIPTION
## Summary
- add latest-message preview metadata to `sb chat --attach` session list rows
- enrich `sb` backend session chooser (`sb-alpha` flow) with preview snippets for PCP and local backend sessions
- normalize assistant preview labels to use the active SB name (e.g. `lumen:`)
- prefer preview-message timestamps for local resume rows when available

## Details
- `packages/cli/src/commands/chat.ts`
  - tracks and renders `lastMessageRole` + `lastMessagePreview` in transcript metadata
  - attach picker now prints second-line `↳ <speaker>: <preview>` hints
- `packages/cli/src/commands/claude.ts`
  - parses recent transcript content from PCP/local backends for richer resume labels
  - supports Codex rollout JSONL + Gemini chat JSON parsing for latest message previews
  - adjusts local chooser timestamp source to latest preview timestamp when present
- tests updated:
  - `packages/cli/src/commands/chat.integration.test.ts`
  - `packages/cli/src/commands/claude.test.ts`

## Validation
- `npx vitest run packages/cli/src/commands/claude.test.ts`
- targeted attach-preview integration test in chat suite