### PR TITLE
fix: trigger all inbox message types by default (by Wren)

### DIFF
--- a/packages/api/src/mcp/tools/inbox-handlers.test.ts
+++ b/packages/api/src/mcp/tools/inbox-handlers.test.ts
@@ -371,7 +371,7 @@ describe('handleSendToInbox - threadKey', () => {
     );
   });
 
-  it('should not trigger by default for message type', async () => {
+  it('should trigger by default for message type (all types trigger by default)', async () => {
     const { getAgentGateway } = await import('../../channels/agent-gateway.js');
     const mockGateway = (getAgentGateway as ReturnType<typeof vi.fn>)();
 
@@ -390,8 +390,12 @@ describe('handleSendToInbox - threadKey', () => {
     );
 
     const parsed = JSON.parse(result.content[0].text);
-    expect(parsed.trigger.triggered).toBe(false);
-    expect(mockGateway.dispatchTrigger).not.toHaveBeenCalled();
+    expect(parsed.trigger.triggered).toBe(true);
+    expect(mockGateway.dispatchTrigger).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toAgentId: 'lumen',
+      })
+    );
   });
 
   it('should deliver actionable handoff without anchor and return routing hint', async () => {

--- a/packages/api/src/mcp/tools/inbox-handlers.ts
+++ b/packages/api/src/mcp/tools/inbox-handlers.ts
@@ -62,7 +62,7 @@ const sendToInboxSchema = userIdentifierBaseSchema.extend({
     .boolean()
     .optional()
     .describe(
-      'If true, automatically trigger the recipient agent after sending. Defaults to true for task_request, session_resume, notification, and permission_grant; false for message.'
+      'Whether to trigger (wake) the recipient agent after sending. Defaults to true for ALL message types. Only set to false if the message can genuinely wait 5+ hours for the next heartbeat cycle. Most agents do not have heartbeats — untriggered messages may never be seen.'
     ),
   triggerType: z
     .enum(['task_complete', 'approval_needed', 'message', 'error', 'custom'])
@@ -132,13 +132,10 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
   const effectiveRecipientSessionId = recipientSessionId;
 
   // Default trigger behavior:
-  // Wake recipient by default for actionable handoffs, but not for casual messages.
-  const shouldTriggerByDefault =
-    messageType === 'task_request' ||
-    messageType === 'session_resume' ||
-    messageType === 'notification' ||
-    messageType === 'permission_grant';
-  const trigger = parsed.trigger ?? shouldTriggerByDefault;
+  // All message types trigger by default. Most agents don't have heartbeats,
+  // so untriggered messages may sit unread for hours. Only set trigger=false
+  // for messages that can genuinely wait 5+ hours.
+  const trigger = parsed.trigger ?? true;
 
   const hasRoutingAnchor = Boolean(
     threadKey || effectiveRecipientSessionId || recipientStudioId || recipientStudioHint
@@ -558,7 +555,7 @@ export const inboxToolDefinitions = [
   {
     name: 'send_to_inbox',
     description:
-      "Send a message to another agent's inbox. Use for cross-agent communication, task handoff, or session resume requests.\n\nMessage types:\n- message: General communication\n- task_request: Request another agent to do work\n- session_resume: Request agent to resume a specific session\n- notification: FYI, no response needed\n- permission_grant: Grant or revoke tool permissions for recipient (include permissionGrant in metadata)\n\nReply conventions:\n- When replying to a task_request, send a task_request back on the SAME threadKey to signal completion\n- Use notification only for FYI messages that require no action from the recipient\n- Always include a threadKey (format: <type>:<id>, e.g. pr:127, spec:v0.1)\n\nTrigger defaults:\n- task_request / session_resume / notification / permission_grant: wake recipient by default\n- message: no automatic wake by default\n- override with `trigger` boolean\n\nUser can be identified by ONE of: userId, email, phone, or platform + platformId",
+      "Send a message to another agent's inbox. Use for cross-agent communication, task handoff, or session resume requests.\n\nMessage types:\n- message: General communication (triggers recipient by default)\n- task_request: Request another agent to do work (triggers recipient by default)\n- session_resume: Request agent to resume a specific session (triggers recipient by default)\n- notification: FYI, no response needed (triggers recipient by default)\n- permission_grant: Grant or revoke tool permissions for recipient (triggers recipient by default)\n\nIMPORTANT — Trigger behavior:\nAll message types trigger the recipient by default. This is intentional: most agents don't have heartbeats, so untriggered messages may sit unread for hours. Do NOT set `trigger: false` unless the message can genuinely wait 5+ hours for the next heartbeat cycle. Let the message type speak for itself — you almost never need to set `trigger` explicitly.\n\nReply conventions:\n- When replying to a task_request, send a task_request back on the SAME threadKey to signal completion\n- Use notification only for FYI messages that require no action from the recipient\n- Always include a threadKey (format: <type>:<id>, e.g. pr:127, spec:v0.1)\n\nUser can be identified by ONE of: userId, email, phone, or platform + platformId",
     schema: sendToInboxSchema,
     handler: handleSendToInbox,
   },

--- a/packages/api/src/mcp/tools/index.ts
+++ b/packages/api/src/mcp/tools/index.ts
@@ -3263,10 +3263,8 @@ Message types:
 - notification: FYI, no response needed
 - permission_grant: Grant or revoke tool permissions (include permissionGrant in metadata)
 
-Trigger defaults:
-- task_request / session_resume / notification / permission_grant: trigger recipient wake-up by default
-- message: does not trigger by default
-- Any default can be overridden with the \`trigger\` boolean flag
+Trigger behavior:
+All message types trigger the recipient by default. Most agents don't have heartbeats, so untriggered messages may sit unread for hours. Only set trigger=false if the message can genuinely wait 5+ hours.
 
 User can be identified by ONE of: userId, email, phone, or platform + platformId`,
       inputSchema: inboxToolDefinitions[0].schema,
@@ -3390,13 +3388,7 @@ User can be identified by ONE of: userId, email, phone, or platform + platformId
   server.registerTool(
     'trigger_agent',
     {
-      description: `Trigger another agent to wake up immediately. Use this after sending to an agent's inbox to avoid waiting for their polling interval.
-
-Pattern:
-1. send_to_inbox(toAgentId: "myra", content: "Task completed", ...)
-2. trigger_agent(toAgentId: "myra", fromAgentId: "wren", triggerType: "task_complete")
-
-This is the "doorbell" - the inbox is the "mailbox". Use both together for reliable async communication.`,
+      description: `Trigger another agent to wake up immediately. Note: send_to_inbox already triggers the recipient by default, so you rarely need this tool separately. Use this only for bare triggers without an inbox message (e.g., pinging an agent to check their inbox or resume work).`,
       inputSchema: triggerAgentSchema,
     },
     async (args) => {

--- a/packages/templates/starters/conventions.md
+++ b/packages/templates/starters/conventions.md
@@ -22,9 +22,10 @@ Messages with the same threadKey are routed to the same session on the recipient
 
 ### Trigger Etiquette
 
-- `task_request`, `session_resume`, and `notification` trigger the recipient by default
-- `message` does not trigger by default — use `trigger: true` if the message is time-sensitive
-- Avoid triggering agents for low-priority or non-urgent messages during quiet hours
+- **All message types trigger the recipient by default.** Most agents don't have heartbeats, so untriggered messages may sit unread for hours.
+- You almost never need to set `trigger` explicitly — let the message type speak for itself.
+- Only set `trigger: false` if the message can genuinely wait 5+ hours for the next heartbeat cycle.
+- Avoid triggering agents during quiet hours for non-urgent messages.
 
 ## Studio Branch Conventions
 


### PR DESCRIPTION
## Summary

- All inbox message types now trigger the recipient by default (previously `message` type did not trigger)
- Most agents don't have heartbeats — untriggered messages may sit unread for hours
- Only set `trigger: false` if the message can genuinely wait 5+ hours
- Updated tool descriptions, schema docs, conventions template, and PROCESS.md (server v8)

## Changes

- **`inbox-handlers.ts`** — Simplified trigger default from per-type logic to `parsed.trigger ?? true`
- **`index.ts`** — Updated `send_to_inbox` and `trigger_agent` tool descriptions
- **`inbox-handlers.test.ts`** — Updated test to expect `message` type triggers by default
- **`conventions.md`** — Updated Trigger Etiquette section
- **PROCESS.md** (PCP server) — Updated Handoff Protocol and Trigger Rules (v8)

## Test plan

- [x] All 910 API tests pass
- [x] API builds clean
- [ ] Review: does the "all types trigger by default" policy feel right?

🤖 Generated with [Claude Code](https://claude.com/claude-code)