### PR TITLE
feat: add prod up flow with migration checks and doctor warnings (by Lumen)

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ Notes:
 
 - `yarn prod:direct` does **not rebuild** on start; it uses existing build artifacts.
 - `yarn prod:direct` now warns if linked migrations appear pending.
+- `yarn dev` / `yarn dev:direct` also run the same migration-status warning check before starting.
 - To run API only (no dashboard process): `PCP_RUN_WEB=false yarn prod:direct`
 - After `git pull`, run `yarn prod:refresh` and restart your direct/PM2 process.
 - The dashboard and `sb` CLI will warn when the running server is behind local HEAD and needs a restart.

--- a/README.md
+++ b/README.md
@@ -183,7 +183,9 @@ See [AGENTS.md](./AGENTS.md) for onboarding instructions.
 yarn dev                   # Start all services (pm2)
 yarn dev:direct            # Start API+web directly (no pm2, dev mode)
 yarn prod:refresh          # Install + build latest code after pull
+yarn prod:migrate          # Apply pending linked Supabase migrations
 yarn prod:direct           # Run API+web directly in production mode (no pm2)
+yarn prod:up               # One-shot: refresh build + migrate + start direct prod
 yarn build                 # Build all packages
 yarn type-check            # Type check all packages
 yarn test                  # Unit tests (all workspaces)
@@ -205,16 +207,24 @@ If PM2/watcher overhead is undesirable on laptops, run PCP directly:
 # 1) After pulling latest changes
 yarn prod:refresh
 
-# 2) Start in direct production mode (no PM2)
+# 2) Apply pending linked migrations
+yarn prod:migrate
+
+# 3) Start in direct production mode (no PM2)
 yarn prod:direct
+
+# Or one-shot:
+yarn prod:up
 ```
 
 Notes:
 
 - `yarn prod:direct` does **not rebuild** on start; it uses existing build artifacts.
+- `yarn prod:direct` now warns if linked migrations appear pending.
 - To run API only (no dashboard process): `PCP_RUN_WEB=false yarn prod:direct`
 - After `git pull`, run `yarn prod:refresh` and restart your direct/PM2 process.
 - The dashboard and `sb` CLI will warn when the running server is behind local HEAD and needs a restart.
+- `sb doctor` includes a linked migration status check and points to `yarn prod:migrate` / `yarn prod:up` when pending.
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "packages/*"
   ],
   "scripts": {
-    "dev": "pm2 start ecosystem.config.cjs",
-    "dev:isolated": "PM2_HOME=.pm2 pm2 start ecosystem.config.cjs",
+    "dev": "./scripts/dev.sh",
+    "dev:isolated": "PM2_HOME=.pm2 ./scripts/dev.sh",
     "dev:direct": "./scripts/dev-direct.sh",
     "prod:direct": "./scripts/prod-direct.sh",
     "prod:refresh": "./scripts/prod-refresh.sh",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "dev:direct": "./scripts/dev-direct.sh",
     "prod:direct": "./scripts/prod-direct.sh",
     "prod:refresh": "./scripts/prod-refresh.sh",
+    "prod:migrate": "./scripts/prod-migrate.sh",
+    "prod:up": "./scripts/prod-up.sh",
     "dev:mcp": "yarn workspace @personal-context/api dev:mcp",
     "dev:myra:deprecated": "echo 'DEPRECATED: Myra is now triggered via heartbeat reminders through the PCP server. Use yarn dev instead.'",
     "dev:web": "yarn workspace @personal-context/web dev",

--- a/packages/cli/src/commands/doctor.test.ts
+++ b/packages/cli/src/commands/doctor.test.ts
@@ -38,6 +38,40 @@ function makeFs(overrides?: {
 }
 
 describe('analyzeCliLink', () => {
+  it('defaults to sb binary name when no identity hint is available', () => {
+    const originalAgentId = process.env.AGENT_ID;
+    delete process.env.AGENT_ID;
+    try {
+      const fsOps = makeFs();
+      const result = analyzeCliLink({ binDir: '/bin' }, fsOps as never);
+      expect(result.binaryName.startsWith('sb')).toBe(true);
+      const linkedBinaryCheck = result.checks.find((check) => check.name === 'Linked binary');
+      expect(linkedBinaryCheck?.detail).toContain('run: sb studio cli');
+    } finally {
+      if (originalAgentId === undefined) delete process.env.AGENT_ID;
+      else process.env.AGENT_ID = originalAgentId;
+    }
+  });
+
+  it('uses AGENT_ID as fallback binary hint when present', () => {
+    const originalAgentId = process.env.AGENT_ID;
+    process.env.AGENT_ID = 'lumen';
+    try {
+      const fsOps = makeFs();
+      const result = analyzeCliLink({ binDir: '/bin' }, fsOps as never);
+      expect(result.binaryName.startsWith('sb')).toBe(true);
+      const linkedBinaryCheck = result.checks.find((check) => check.name === 'Linked binary');
+      if (result.binaryName === 'sb-lumen') {
+        expect(linkedBinaryCheck?.detail).toContain('run: sb studio cli --name sb-lumen');
+      } else {
+        expect(linkedBinaryCheck?.detail).toContain('run: sb studio cli');
+      }
+    } finally {
+      if (originalAgentId === undefined) delete process.env.AGENT_ID;
+      else process.env.AGENT_ID = originalAgentId;
+    }
+  });
+
   it('reports failure when linked binary is missing', () => {
     const fsOps = makeFs();
     const result = analyzeCliLink({ name: 'sb-lumen', binDir: '/bin' }, fsOps as never);

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -70,6 +70,9 @@ function resolveCliRoot(fsOps: Pick<DoctorFs, 'existsSync' | 'readFileSync'>): s
 }
 
 function resolveDefaultCliName(fsOps: Pick<DoctorFs, 'existsSync' | 'readFileSync'>): string {
+  const fromEnv = process.env.AGENT_ID?.trim();
+  if (fromEnv) return `sb-${fromEnv}`;
+
   const cwd = process.cwd();
   const identityPath = join(cwd, '.pcp', 'identity.json');
   if (fsOps.existsSync(identityPath)) {
@@ -83,6 +86,23 @@ function resolveDefaultCliName(fsOps: Pick<DoctorFs, 'existsSync' | 'readFileSyn
   const dirName = basename(cwd);
   const match = dirName.match(/--(.+)$/);
   if (match) return `sb-${match[1]}`;
+
+  try {
+    const branch = execSync('git rev-parse --abbrev-ref HEAD', {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    const prefixMatch = branch.match(/^([a-z0-9_-]+)\//i);
+    if (prefixMatch?.[1]) {
+      const candidate = prefixMatch[1].toLowerCase();
+      if (!['main', 'master', 'develop', 'release'].includes(candidate)) {
+        return `sb-${candidate}`;
+      }
+    }
+  } catch {
+    // fall through
+  }
+
   return 'sb-dev';
 }
 

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -238,6 +238,19 @@ function parseMigrationStatus(raw: string): MigrationStatusResult | null {
   }
 }
 
+function formatPendingMigrationCheck(parsed: MigrationStatusResult): DoctorCheck {
+  const pendingCount = parsed.pendingCount || parsed.pending?.length || 0;
+  const pendingList = (parsed.pending || []).slice(0, 5).join(', ');
+  return {
+    name: 'Linked migrations',
+    status: 'warn',
+    detail:
+      `${pendingCount} pending linked migration(s).` +
+      `${pendingList ? `\n      pending: ${pendingList}` : ''}\n` +
+      `      run: yarn prod:migrate (or one-shot: yarn prod:up)`,
+  };
+}
+
 function buildMigrationHealthCheck(
   fsOps: Pick<DoctorFs, 'existsSync'> = defaultFs
 ): DoctorCheck | null {
@@ -266,15 +279,7 @@ function buildMigrationHealthCheck(
         : '';
     const parsed = parseMigrationStatus(stdout);
     if (parsed?.state === 'pending') {
-      const pendingList = (parsed.pending || []).slice(0, 5).join(', ');
-      return {
-        name: 'Linked migrations',
-        status: 'warn',
-        detail:
-          `${parsed.pendingCount || parsed.pending?.length || 0} pending linked migration(s).` +
-          `${pendingList ? `\n      pending: ${pendingList}` : ''}\n` +
-          `      run: yarn prod:migrate (or one-shot: yarn prod:up)`,
-      };
+      return formatPendingMigrationCheck(parsed);
     }
 
     const reason = parsed?.reason || String(error);
@@ -295,15 +300,7 @@ function buildMigrationHealthCheck(
   }
 
   if (parsed.state === 'pending') {
-    const pendingList = (parsed.pending || []).slice(0, 5).join(', ');
-    return {
-      name: 'Linked migrations',
-      status: 'warn',
-      detail:
-        `${parsed.pendingCount || parsed.pending?.length || 0} pending linked migration(s).` +
-        `${pendingList ? `\n      pending: ${pendingList}` : ''}\n` +
-        `      run: yarn prod:migrate (or one-shot: yarn prod:up)`,
-    };
+    return formatPendingMigrationCheck(parsed);
   }
 
   if (parsed.state === 'clean') {

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -1,16 +1,9 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
-import { execSync } from 'child_process';
+import { execFileSync, execSync } from 'child_process';
 import { createInterface } from 'readline/promises';
 import { stdin as input, stdout as output } from 'process';
-import {
-  existsSync,
-  lstatSync,
-  readFileSync,
-  readlinkSync,
-  realpathSync,
-  statSync,
-} from 'fs';
+import { existsSync, lstatSync, readFileSync, readlinkSync, realpathSync, statSync } from 'fs';
 import { basename, dirname, join, parse as parsePath, resolve } from 'path';
 import { homedir } from 'os';
 
@@ -46,6 +39,13 @@ const defaultFs: DoctorFs = {
   realpathSync,
   statSync,
   readFileSync,
+};
+
+type MigrationStatusResult = {
+  state?: 'clean' | 'pending' | 'unknown';
+  reason?: string | null;
+  pendingCount?: number;
+  pending?: string[];
 };
 
 function resolveCliRoot(fsOps: Pick<DoctorFs, 'existsSync' | 'readFileSync'>): string {
@@ -155,7 +155,9 @@ export function analyzeCliLink(
     checks.push({
       name: 'Executable bit',
       status: executable ? 'ok' : 'warn',
-      detail: executable ? 'Target is executable.' : 'Target is not executable (chmod +x may be needed).',
+      detail: executable
+        ? 'Target is executable.'
+        : 'Target is not executable (chmod +x may be needed).',
     });
   } catch {
     checks.push({
@@ -201,8 +203,120 @@ function buildFixCommand(binaryName: string): string {
   return `sb studio cli --name ${binaryName}`;
 }
 
-async function doctorCommand(options: { name?: string; json?: boolean; fix?: boolean }): Promise<void> {
+function resolveRepoRoot(fsOps: Pick<DoctorFs, 'existsSync'>): string | undefined {
+  let dir = process.cwd();
+  const { root } = parsePath(dir);
+  while (true) {
+    if (fsOps.existsSync(join(dir, 'supabase', 'config.toml'))) return dir;
+    if (dir === root) break;
+    dir = dirname(dir);
+  }
+  return undefined;
+}
+
+function parseMigrationStatus(raw: string): MigrationStatusResult | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  try {
+    return JSON.parse(trimmed) as MigrationStatusResult;
+  } catch {
+    return null;
+  }
+}
+
+function buildMigrationHealthCheck(
+  fsOps: Pick<DoctorFs, 'existsSync'> = defaultFs
+): DoctorCheck | null {
+  const repoRoot = resolveRepoRoot(fsOps);
+  if (!repoRoot) return null;
+
+  const scriptPath = join(repoRoot, 'scripts', 'migration-status.mjs');
+  if (!fsOps.existsSync(scriptPath)) {
+    return {
+      name: 'Linked migrations',
+      status: 'warn',
+      detail: `Missing scripts/migration-status.mjs at ${scriptPath}`,
+    };
+  }
+
+  let raw = '';
+  try {
+    raw = execFileSync('node', [scriptPath, '--json', '--workdir', repoRoot], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim();
+  } catch (error) {
+    const stdout =
+      error && typeof error === 'object' && 'stdout' in error
+        ? String((error as { stdout?: string }).stdout || '')
+        : '';
+    const parsed = parseMigrationStatus(stdout);
+    if (parsed?.state === 'pending') {
+      const pendingList = (parsed.pending || []).slice(0, 5).join(', ');
+      return {
+        name: 'Linked migrations',
+        status: 'warn',
+        detail:
+          `${parsed.pendingCount || parsed.pending?.length || 0} pending linked migration(s).` +
+          `${pendingList ? `\n      pending: ${pendingList}` : ''}\n` +
+          `      run: yarn prod:migrate (or one-shot: yarn prod:up)`,
+      };
+    }
+
+    const reason = parsed?.reason || String(error);
+    return {
+      name: 'Linked migrations',
+      status: 'warn',
+      detail: `Unable to determine linked migration status.\n      ${reason}`,
+    };
+  }
+
+  const parsed = parseMigrationStatus(raw);
+  if (!parsed) {
+    return {
+      name: 'Linked migrations',
+      status: 'warn',
+      detail: 'Unable to parse migration status output.',
+    };
+  }
+
+  if (parsed.state === 'pending') {
+    const pendingList = (parsed.pending || []).slice(0, 5).join(', ');
+    return {
+      name: 'Linked migrations',
+      status: 'warn',
+      detail:
+        `${parsed.pendingCount || parsed.pending?.length || 0} pending linked migration(s).` +
+        `${pendingList ? `\n      pending: ${pendingList}` : ''}\n` +
+        `      run: yarn prod:migrate (or one-shot: yarn prod:up)`,
+    };
+  }
+
+  if (parsed.state === 'clean') {
+    return {
+      name: 'Linked migrations',
+      status: 'ok',
+      detail: 'No pending linked migrations.',
+    };
+  }
+
+  return {
+    name: 'Linked migrations',
+    status: 'warn',
+    detail: parsed.reason || 'Unable to determine linked migration status.',
+  };
+}
+
+async function doctorCommand(options: {
+  name?: string;
+  json?: boolean;
+  fix?: boolean;
+}): Promise<void> {
   const result = analyzeCliLink({ name: options.name });
+  const migrationCheck = buildMigrationHealthCheck();
+  if (migrationCheck) {
+    result.checks.push(migrationCheck);
+  }
 
   if (options.json) {
     console.log(JSON.stringify(result, null, 2));
@@ -268,7 +382,9 @@ async function doctorCommand(options: { name?: string; json?: boolean; fix?: boo
         rl.close();
       }
     } else {
-      console.log(chalk.dim('\nTip: run sb doctor --fix to confirm and apply from this directory.'));
+      console.log(
+        chalk.dim('\nTip: run sb doctor --fix to confirm and apply from this directory.')
+      );
     }
     console.log('');
   }

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -70,7 +70,16 @@ function resolveCliRoot(fsOps: Pick<DoctorFs, 'existsSync' | 'readFileSync'>): s
 }
 
 function resolveDefaultCliName(fsOps: Pick<DoctorFs, 'existsSync' | 'readFileSync'>): string {
-  const fromEnv = process.env.AGENT_ID?.trim();
+  const invokedCandidates = [process.argv[1], process.env._]
+    .map((value) => basename(String(value || '')).trim())
+    .filter(Boolean);
+  for (const candidate of invokedCandidates) {
+    if (/^sb(?:-[a-z0-9][a-z0-9_-]*)?$/i.test(candidate)) {
+      return candidate.toLowerCase();
+    }
+  }
+
+  const fromEnv = process.env.AGENT_ID?.trim().toLowerCase();
   if (fromEnv) return `sb-${fromEnv}`;
 
   const cwd = process.cwd();
@@ -86,24 +95,7 @@ function resolveDefaultCliName(fsOps: Pick<DoctorFs, 'existsSync' | 'readFileSyn
   const dirName = basename(cwd);
   const match = dirName.match(/--(.+)$/);
   if (match) return `sb-${match[1]}`;
-
-  try {
-    const branch = execSync('git rev-parse --abbrev-ref HEAD', {
-      encoding: 'utf-8',
-      stdio: ['ignore', 'pipe', 'ignore'],
-    }).trim();
-    const prefixMatch = branch.match(/^([a-z0-9_-]+)\//i);
-    if (prefixMatch?.[1]) {
-      const candidate = prefixMatch[1].toLowerCase();
-      if (!['main', 'master', 'develop', 'release'].includes(candidate)) {
-        return `sb-${candidate}`;
-      }
-    }
-  } catch {
-    // fall through
-  }
-
-  return 'sb-dev';
+  return 'sb';
 }
 
 export function analyzeCliLink(
@@ -127,10 +119,11 @@ export function analyzeCliLink(
   }
 
   if (!fsOps.existsSync(linkPath)) {
+    const fixCmd = buildFixCommand(binaryName);
     checks.push({
       name: 'Linked binary',
       status: 'fail',
-      detail: `Missing ${linkPath} (run: sb studio cli${options.name ? ` --name ${binaryName}` : ''})`,
+      detail: `Missing ${linkPath} (run: ${fixCmd})`,
     });
     return { binaryName, linkPath, expectedTarget, checks };
   }
@@ -220,6 +213,7 @@ function iconForStatus(status: CheckStatus): string {
 }
 
 function buildFixCommand(binaryName: string): string {
+  if (binaryName === 'sb') return 'sb studio cli';
   return `sb studio cli --name ${binaryName}`;
 }
 

--- a/scripts/dev-direct.sh
+++ b/scripts/dev-direct.sh
@@ -37,6 +37,12 @@ load_env_file "${ROOT_DIR}/.env"
 # shellcheck disable=SC1090
 source "${PRESERVED_ENV_FILE}"
 
+if command -v supabase >/dev/null 2>&1; then
+  node "${ROOT_DIR}/scripts/migration-status.mjs" --workdir "${ROOT_DIR}" --warn-only || true
+else
+  echo "[migrations] ⚠ Supabase CLI not found; cannot check linked migration status."
+fi
+
 # Run API + web directly (no PM2), useful for parallel worktrees.
 BASE_PORT="${PCP_PORT_BASE:-3001}"
 WEB_PORT="${WEB_PORT:-$((BASE_PORT + 1))}"

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${ROOT_DIR}"
+
+if command -v supabase >/dev/null 2>&1; then
+  node "${ROOT_DIR}/scripts/migration-status.mjs" --workdir "${ROOT_DIR}" --warn-only || true
+else
+  echo "[migrations] ⚠ Supabase CLI not found; cannot check linked migration status."
+fi
+
+echo "[dev] Starting PM2 ecosystem..."
+exec pm2 start "${ROOT_DIR}/ecosystem.config.cjs"

--- a/scripts/migration-status.mjs
+++ b/scripts/migration-status.mjs
@@ -1,0 +1,223 @@
+#!/usr/bin/env node
+import { execFileSync } from 'child_process';
+import { resolve as resolvePath } from 'path';
+
+function parseArgs(argv) {
+  const args = {
+    workdir: process.cwd(),
+    json: false,
+    warnOnly: false,
+    quiet: false,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (token === '--json') {
+      args.json = true;
+      continue;
+    }
+    if (token === '--warn-only') {
+      args.warnOnly = true;
+      continue;
+    }
+    if (token === '--quiet') {
+      args.quiet = true;
+      continue;
+    }
+    if (token === '--workdir') {
+      args.workdir = resolvePath(argv[i + 1] || process.cwd());
+      i += 1;
+      continue;
+    }
+  }
+
+  return args;
+}
+
+function boolLike(value) {
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'number') return value > 0;
+  if (typeof value !== 'string') return undefined;
+
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) return undefined;
+
+  if (
+    normalized === 'true' ||
+    normalized === 'yes' ||
+    normalized === 'present' ||
+    normalized === 'applied'
+  ) {
+    return true;
+  }
+  if (
+    normalized === 'false' ||
+    normalized === 'no' ||
+    normalized === 'missing' ||
+    normalized === 'not applied'
+  ) {
+    return false;
+  }
+
+  if (normalized.includes('not applied') || normalized.includes('missing')) return false;
+  if (normalized.includes('applied') || normalized.includes('present')) return true;
+  return undefined;
+}
+
+function rowLabel(row) {
+  return (
+    row.version ||
+    row.name ||
+    row.id ||
+    row.filename ||
+    row.file ||
+    row.migration ||
+    '(unknown)'
+  );
+}
+
+function collectRows(node, out = []) {
+  if (Array.isArray(node)) {
+    for (const item of node) collectRows(item, out);
+    return out;
+  }
+
+  if (!node || typeof node !== 'object') return out;
+  const record = node;
+
+  const hasMigrationShape =
+    'version' in record ||
+    'name' in record ||
+    'migration' in record ||
+    'local' in record ||
+    'remote' in record ||
+    'applied' in record;
+
+  if (hasMigrationShape) out.push(record);
+
+  for (const value of Object.values(record)) collectRows(value, out);
+  return out;
+}
+
+function classifyPending(rows) {
+  const pending = [];
+
+  for (const row of rows) {
+    const local = boolLike(row.local ?? row.localExists ?? row.existsLocal);
+    const remote = boolLike(row.remote ?? row.remoteExists ?? row.existsRemote ?? row.applied);
+
+    if (local === true && remote === false) {
+      pending.push(row);
+      continue;
+    }
+
+    const statusText = String(row.status || row.state || '').toLowerCase();
+    if (
+      statusText.includes('pending') ||
+      statusText.includes('local only') ||
+      statusText.includes('not applied')
+    ) {
+      pending.push(row);
+    }
+  }
+
+  return pending;
+}
+
+function printHuman(result) {
+  if (result.state === 'clean') {
+    console.log('[migrations] ✅ No pending linked migrations.');
+    return;
+  }
+
+  if (result.state === 'pending') {
+    console.log(
+      `[migrations] ⚠ ${result.pendingCount} pending linked migration${
+        result.pendingCount === 1 ? '' : 's'
+      }.`
+    );
+    for (const item of result.pending.slice(0, 10)) {
+      console.log(`[migrations]   - ${item}`);
+    }
+    console.log('[migrations] Run: yarn prod:migrate');
+    return;
+  }
+
+  console.log(`[migrations] ⚠ Unable to determine linked migration status: ${result.reason}`);
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const commandArgs = ['migration', 'list', '--linked', '--workdir', args.workdir, '-o', 'json'];
+
+  let raw;
+  try {
+    raw = execFileSync('supabase', commandArgs, {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch (error) {
+    const stderr = error && typeof error === 'object' ? String(error.stderr || '').trim() : '';
+    const stdout = error && typeof error === 'object' ? String(error.stdout || '').trim() : '';
+    const detail = stderr || stdout || (error instanceof Error ? error.message : String(error));
+    const result = {
+      state: 'unknown',
+      reason: detail || 'supabase migration list failed',
+      pendingCount: 0,
+      pending: [],
+    };
+    if (args.json) console.log(JSON.stringify(result));
+    else if (!args.quiet) printHuman(result);
+    process.exit(args.warnOnly ? 0 : 2);
+    return;
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    const result = {
+      state: 'unknown',
+      reason: `Could not parse Supabase migration JSON output: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+      pendingCount: 0,
+      pending: [],
+    };
+    if (args.json) console.log(JSON.stringify(result));
+    else if (!args.quiet) printHuman(result);
+    process.exit(args.warnOnly ? 0 : 2);
+    return;
+  }
+
+  const rows = collectRows(parsed);
+  const pendingRows = classifyPending(rows);
+  const result =
+    pendingRows.length > 0
+      ? {
+          state: 'pending',
+          reason: null,
+          pendingCount: pendingRows.length,
+          pending: pendingRows.map(rowLabel),
+        }
+      : {
+          state: 'clean',
+          reason: null,
+          pendingCount: 0,
+          pending: [],
+        };
+
+  if (args.json) {
+    console.log(JSON.stringify(result));
+  } else if (!args.quiet) {
+    printHuman(result);
+  }
+
+  if (args.warnOnly) {
+    process.exit(0);
+    return;
+  }
+  process.exit(result.state === 'pending' ? 10 : 0);
+}
+
+main();

--- a/scripts/prod-direct.sh
+++ b/scripts/prod-direct.sh
@@ -32,6 +32,12 @@ load_env_file "${ROOT_DIR}/.env.local"
 # shellcheck disable=SC1090
 source "${PRESERVED_ENV_FILE}"
 
+if command -v supabase >/dev/null 2>&1; then
+  node "${ROOT_DIR}/scripts/migration-status.mjs" --workdir "${ROOT_DIR}" --warn-only || true
+else
+  echo "[migrations] ⚠ Supabase CLI not found; cannot check linked migration status."
+fi
+
 if [[ ! -f "${ROOT_DIR}/packages/api/dist/server.js" ]]; then
   echo "Missing packages/api/dist/server.js."
   echo "Run: yarn prod:refresh"

--- a/scripts/prod-migrate.sh
+++ b/scripts/prod-migrate.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${ROOT_DIR}"
+
+if ! command -v supabase >/dev/null 2>&1; then
+  echo "[prod-migrate] Missing Supabase CLI."
+  echo "[prod-migrate] Install: https://supabase.com/docs/guides/cli/getting-started"
+  exit 1
+fi
+
+echo "[prod-migrate] Checking linked migration status..."
+if node "${ROOT_DIR}/scripts/migration-status.mjs" --workdir "${ROOT_DIR}" >/dev/null 2>&1; then
+  echo "[prod-migrate] No pending linked migrations."
+  exit 0
+fi
+
+echo "[prod-migrate] Applying linked migrations (supabase db push)..."
+supabase db push --linked --workdir "${ROOT_DIR}"
+
+echo "[prod-migrate] Re-checking migration status..."
+node "${ROOT_DIR}/scripts/migration-status.mjs" --workdir "${ROOT_DIR}"
+echo "[prod-migrate] ✅ Linked migrations are up to date."

--- a/scripts/prod-migrate.sh
+++ b/scripts/prod-migrate.sh
@@ -11,9 +11,18 @@ if ! command -v supabase >/dev/null 2>&1; then
 fi
 
 echo "[prod-migrate] Checking linked migration status..."
-if node "${ROOT_DIR}/scripts/migration-status.mjs" --workdir "${ROOT_DIR}" >/dev/null 2>&1; then
+set +e
+node "${ROOT_DIR}/scripts/migration-status.mjs" --workdir "${ROOT_DIR}"
+status_code=$?
+set -e
+
+if [[ "${status_code}" -eq 0 ]]; then
   echo "[prod-migrate] No pending linked migrations."
   exit 0
+fi
+
+if [[ "${status_code}" -ne 10 ]]; then
+  echo "[prod-migrate] Migration status check returned ${status_code}; proceeding with best-effort apply."
 fi
 
 echo "[prod-migrate] Applying linked migrations (supabase db push)..."

--- a/scripts/prod-refresh.sh
+++ b/scripts/prod-refresh.sh
@@ -11,7 +11,8 @@ echo "[prod-refresh] Building all packages..."
 yarn build
 
 echo "[prod-refresh] ✅ Build complete."
-echo "[prod-refresh] Restart your running server process to pick up the latest code."
-echo "[prod-refresh] - PM2 mode: yarn restart"
-echo "[prod-refresh] - Direct mode: stop/re-run yarn prod:direct"
-
+echo "[prod-refresh] Next steps:"
+echo "[prod-refresh] - Apply linked DB migrations: yarn prod:migrate"
+echo "[prod-refresh] - Start direct mode: yarn prod:direct"
+echo "[prod-refresh] - One-shot all-in-one flow: yarn prod:up"
+echo "[prod-refresh] - PM2 mode restart: yarn restart"

--- a/scripts/prod-up.sh
+++ b/scripts/prod-up.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${ROOT_DIR}"
+
+echo "[prod-up] Refreshing build artifacts..."
+yarn prod:refresh
+
+echo "[prod-up] Applying linked database migrations..."
+yarn prod:migrate
+
+echo "[prod-up] Starting direct production runtime..."
+exec yarn prod:direct


### PR DESCRIPTION
## Summary
- add one-shot `yarn prod:up` flow to run build refresh + linked migration apply + direct prod start
- add `yarn prod:migrate` helper for linked `supabase db push`
- warn on pending/unknown linked migration status when launching **prod and dev** startup flows
- surface linked migration status in `sb doctor`
- make `sb doctor` default binary inference stable (`sb` first, no misleading `sb-dev` fallback)

## Changes
- new scripts:
  - `scripts/migration-status.mjs`
  - `scripts/prod-migrate.sh`
  - `scripts/prod-up.sh`
  - `scripts/dev.sh`
- updated scripts:
  - `scripts/prod-direct.sh` (warn-only migration check before launch)
  - `scripts/dev-direct.sh` (warn-only migration check before launch)
  - `scripts/prod-refresh.sh` (next-step guidance includes migrate/up)
  - `package.json` `dev` now runs through `scripts/dev.sh`
- CLI doctor:
  - `packages/cli/src/commands/doctor.ts` now includes linked migration health check
  - improved default binary inference (invoked sb name → AGENT_ID/identity hints → `sb`)
- docs + scripts:
  - `package.json` scripts updated (`prod:migrate`, `prod:up`)
  - `README.md` updated with new production/dev flow notes

## Validation
- `npx vitest run packages/cli/src/commands/doctor.test.ts packages/cli/src/commands/claude.test.ts`
- `bash -n scripts/dev.sh scripts/dev-direct.sh scripts/prod-direct.sh scripts/prod-refresh.sh scripts/prod-migrate.sh scripts/prod-up.sh`
- `node scripts/migration-status.mjs --workdir . --warn-only`