### PR TITLE
chore: add yarn prod alias and update docs (by Lumen)

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ yarn dev:direct            # Start API+web directly (no pm2, dev mode)
 yarn prod:refresh          # Install + build latest code after pull
 yarn prod:migrate          # Apply pending linked Supabase migrations
 yarn prod:direct           # Run API+web directly in production mode (no pm2)
+yarn prod                  # Alias for prod:up (fast path)
 yarn prod:up               # One-shot: refresh build + migrate + start direct prod
 yarn build                 # Build all packages
 yarn type-check            # Type check all packages
@@ -214,7 +215,8 @@ yarn prod:migrate
 yarn prod:direct
 
 # Or one-shot:
-yarn prod:up
+yarn prod
+# (same as: yarn prod:up)
 ```
 
 Notes:

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "prod:refresh": "./scripts/prod-refresh.sh",
     "prod:migrate": "./scripts/prod-migrate.sh",
     "prod:up": "./scripts/prod-up.sh",
+    "prod": "yarn prod:up",
     "dev:mcp": "yarn workspace @personal-context/api dev:mcp",
     "dev:myra:deprecated": "echo 'DEPRECATED: Myra is now triggered via heartbeat reminders through the PCP server. Use yarn dev instead.'",
     "dev:web": "yarn workspace @personal-context/web dev",


### PR DESCRIPTION
## Summary
- add `yarn prod` as a convenience alias to `yarn prod:up`
- update README command list and low-power runtime section to highlight the fast-path command

## Why
Running PCP in prod mode now has a clear one-liner for build + migrate + run.

## Validation
- `node -e "const p=require('./package.json');console.log(p.scripts.prod)"` -> `yarn prod:up`