### PR TITLE
fix: pass through codex resume without opening PCP resume picker (by Lumen)

### DIFF
--- a/packages/cli/src/commands/claude.test.ts
+++ b/packages/cli/src/commands/claude.test.ts
@@ -34,8 +34,8 @@ describe('hasBackendSessionOverride', () => {
   it('does not treat plain prompt text as resume override', () => {
     expect(hasBackendSessionOverride('codex', [], ['resume this bug'])).toBe(false);
     expect(hasBackendSessionOverride('codex', [], ['resume'])).toBe(false);
-    expect(hasBackendSessionOverride('codex', ['resume'])).toBe(false);
-    expect(hasBackendSessionOverride('codex', ['resume', '--latest'])).toBe(false);
+    expect(hasBackendSessionOverride('codex', ['resume'])).toBe(true);
+    expect(hasBackendSessionOverride('codex', ['resume', '--latest'])).toBe(true);
   });
 
   it('still respects flag-based resume overrides', () => {

--- a/packages/cli/src/commands/claude.test.ts
+++ b/packages/cli/src/commands/claude.test.ts
@@ -34,6 +34,9 @@ describe('hasBackendSessionOverride', () => {
   it('does not treat plain prompt text as resume override', () => {
     expect(hasBackendSessionOverride('codex', [], ['resume this bug'])).toBe(false);
     expect(hasBackendSessionOverride('codex', [], ['resume'])).toBe(false);
+  });
+
+  it('treats codex resume passthrough args as override', () => {
     expect(hasBackendSessionOverride('codex', ['resume'])).toBe(true);
     expect(hasBackendSessionOverride('codex', ['resume', '--latest'])).toBe(true);
   });

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -1425,10 +1425,7 @@ export function hasBackendSessionOverride(
     Boolean(promptParts[1]) &&
     !promptParts[1]?.startsWith('-');
   const isCodexResumePassthrough =
-    backend === 'codex' &&
-    passthroughArgs[0]?.toLowerCase() === 'resume' &&
-    Boolean(passthroughArgs[1]) &&
-    !passthroughArgs[1]?.startsWith('-');
+    backend === 'codex' && passthroughArgs[0]?.toLowerCase() === 'resume';
 
   if (isCodexResumePrompt || isCodexResumePassthrough) return true;
 


### PR DESCRIPTION
## Summary
- fix Codex resume override detection so `sb -a <agent> -b codex resume` is treated as backend resume passthrough
- prevent SB from launching its own PCP session resume picker in this Codex flow
- keep prompt-text behavior unchanged (`resume` in normal prompt text is **not** treated as override)

## Root cause
`hasBackendSessionOverride()` only considered Codex passthrough resume as an override when `resume` had a non-flag second arg. Bare `resume` (list mode) was incorrectly ignored.

## Changes
- `packages/cli/src/commands/claude.ts`
  - treat `passthroughArgs[0] === 'resume'` as sufficient override for Codex
- `packages/cli/src/commands/claude.test.ts`
  - update expectations to assert Codex passthrough `resume` and `resume --latest` are override cases

## Validation
- `npx vitest run packages/cli/src/commands/claude.test.ts packages/cli/src/cli.test.ts`
