### PR TITLE
feat: auto-select migration target from env (by Lumen)

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ See [AGENTS.md](./AGENTS.md) for onboarding instructions.
 yarn dev                   # Start all services (pm2)
 yarn dev:direct            # Start API+web directly (no pm2, dev mode)
 yarn prod:refresh          # Install + build latest code after pull
-yarn prod:migrate          # Apply pending linked Supabase migrations
+yarn prod:migrate          # Apply pending migrations (auto local/linked via .env.local SUPABASE_URL)
 yarn prod:direct           # Run API+web directly in production mode (no pm2)
 yarn prod                  # Alias for prod:up (fast path)
 yarn prod:up               # One-shot: refresh build + migrate + start direct prod
@@ -208,7 +208,7 @@ If PM2/watcher overhead is undesirable on laptops, run PCP directly:
 # 1) After pulling latest changes
 yarn prod:refresh
 
-# 2) Apply pending linked migrations
+# 2) Apply pending migrations (auto local/linked)
 yarn prod:migrate
 
 # 3) Start in direct production mode (no PM2)
@@ -222,12 +222,16 @@ yarn prod
 Notes:
 
 - `yarn prod:direct` does **not rebuild** on start; it uses existing build artifacts.
-- `yarn prod:direct` now warns if linked migrations appear pending.
+- `yarn prod:migrate` / `migration-status` auto-select target:
+  - `local` when `SUPABASE_URL` (or `LOCAL_SUPABASE_URL`) points to localhost/127.0.0.1/::1
+  - otherwise `linked`
+  - source precedence: process env → `.env.local` → `.env`
+- `yarn prod:direct` now warns if migrations appear pending for the resolved target.
 - `yarn dev` / `yarn dev:direct` also run the same migration-status warning check before starting.
 - To run API only (no dashboard process): `PCP_RUN_WEB=false yarn prod:direct`
 - After `git pull`, run `yarn prod:refresh` and restart your direct/PM2 process.
 - The dashboard and `sb` CLI will warn when the running server is behind local HEAD and needs a restart.
-- `sb doctor` includes a linked migration status check and points to `yarn prod:migrate` / `yarn prod:up` when pending.
+- `sb doctor` includes a migration status check (local or linked) and points to `yarn prod:migrate` / `yarn prod:up` when pending.
 
 ## Contributing
 

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -48,6 +48,7 @@ type MigrationStatusResult = {
   pendingCount?: number;
   pending?: string[];
 };
+const MIGRATION_CHECK_NAME = 'Migrations';
 
 function resolveCliRoot(fsOps: Pick<DoctorFs, 'existsSync' | 'readFileSync'>): string {
   let dir = process.cwd();
@@ -244,7 +245,7 @@ function formatPendingMigrationCheck(parsed: MigrationStatusResult): DoctorCheck
   const pendingList = (parsed.pending || []).slice(0, 5).join(', ');
   const scope = parsed.target === 'local' ? 'local' : 'linked';
   return {
-    name: 'Linked migrations',
+    name: MIGRATION_CHECK_NAME,
     status: 'warn',
     detail:
       `${pendingCount} pending ${scope} migration(s).` +
@@ -262,7 +263,7 @@ function buildMigrationHealthCheck(
   const scriptPath = join(repoRoot, 'scripts', 'migration-status.mjs');
   if (!fsOps.existsSync(scriptPath)) {
     return {
-      name: 'Linked migrations',
+      name: MIGRATION_CHECK_NAME,
       status: 'warn',
       detail: `Missing scripts/migration-status.mjs at ${scriptPath}`,
     };
@@ -286,7 +287,7 @@ function buildMigrationHealthCheck(
 
     const reason = parsed?.reason || String(error);
     return {
-      name: 'Linked migrations',
+      name: MIGRATION_CHECK_NAME,
       status: 'warn',
       detail: `Unable to determine linked migration status.\n      ${reason}`,
     };
@@ -295,7 +296,7 @@ function buildMigrationHealthCheck(
   const parsed = parseMigrationStatus(raw);
   if (!parsed) {
     return {
-      name: 'Linked migrations',
+      name: MIGRATION_CHECK_NAME,
       status: 'warn',
       detail: 'Unable to parse migration status output.',
     };
@@ -308,14 +309,14 @@ function buildMigrationHealthCheck(
   if (parsed.state === 'clean') {
     const scope = parsed.target === 'local' ? 'local' : 'linked';
     return {
-      name: 'Linked migrations',
+      name: MIGRATION_CHECK_NAME,
       status: 'ok',
       detail: `No pending ${scope} migrations.`,
     };
   }
 
   return {
-    name: 'Linked migrations',
+    name: MIGRATION_CHECK_NAME,
     status: 'warn',
     detail: parsed.reason || 'Unable to determine linked migration status.',
   };

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -42,6 +42,7 @@ const defaultFs: DoctorFs = {
 };
 
 type MigrationStatusResult = {
+  target?: 'linked' | 'local';
   state?: 'clean' | 'pending' | 'unknown';
   reason?: string | null;
   pendingCount?: number;
@@ -241,11 +242,12 @@ function parseMigrationStatus(raw: string): MigrationStatusResult | null {
 function formatPendingMigrationCheck(parsed: MigrationStatusResult): DoctorCheck {
   const pendingCount = parsed.pendingCount || parsed.pending?.length || 0;
   const pendingList = (parsed.pending || []).slice(0, 5).join(', ');
+  const scope = parsed.target === 'local' ? 'local' : 'linked';
   return {
     name: 'Linked migrations',
     status: 'warn',
     detail:
-      `${pendingCount} pending linked migration(s).` +
+      `${pendingCount} pending ${scope} migration(s).` +
       `${pendingList ? `\n      pending: ${pendingList}` : ''}\n` +
       `      run: yarn prod:migrate (or one-shot: yarn prod:up)`,
   };
@@ -304,10 +306,11 @@ function buildMigrationHealthCheck(
   }
 
   if (parsed.state === 'clean') {
+    const scope = parsed.target === 'local' ? 'local' : 'linked';
     return {
       name: 'Linked migrations',
       status: 'ok',
-      detail: 'No pending linked migrations.',
+      detail: `No pending ${scope} migrations.`,
     };
   }
 

--- a/scripts/migration-status.mjs
+++ b/scripts/migration-status.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { execFileSync } from 'child_process';
 import { resolve as resolvePath } from 'path';
+import { existsSync, readFileSync } from 'fs';
 
 function parseArgs(argv) {
   const args = {
@@ -8,6 +9,8 @@ function parseArgs(argv) {
     json: false,
     warnOnly: false,
     quiet: false,
+    target: 'auto',
+    printTarget: false,
   };
 
   for (let i = 0; i < argv.length; i += 1) {
@@ -29,9 +32,85 @@ function parseArgs(argv) {
       i += 1;
       continue;
     }
+    if (token === '--target') {
+      const next = String(argv[i + 1] || '').trim().toLowerCase();
+      if (next === 'linked' || next === 'local' || next === 'auto') {
+        args.target = next;
+        i += 1;
+      }
+      continue;
+    }
+    if (token === '--linked') {
+      args.target = 'linked';
+      continue;
+    }
+    if (token === '--local') {
+      args.target = 'local';
+      continue;
+    }
+    if (token === '--print-target') {
+      args.printTarget = true;
+      continue;
+    }
   }
 
   return args;
+}
+
+function parseEnvFile(filePath) {
+  if (!existsSync(filePath)) return {};
+  try {
+    const raw = readFileSync(filePath, 'utf-8');
+    const out = {};
+    for (const line of raw.split(/\r?\n/)) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith('#')) continue;
+
+      const candidate = trimmed.startsWith('export ') ? trimmed.slice(7).trim() : trimmed;
+      const eqIndex = candidate.indexOf('=');
+      if (eqIndex <= 0) continue;
+      const key = candidate.slice(0, eqIndex).trim();
+      if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue;
+      let value = candidate.slice(eqIndex + 1).trim();
+      if (
+        (value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'"))
+      ) {
+        value = value.slice(1, -1);
+      }
+      out[key] = value;
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+function isLocalSupabaseUrl(value) {
+  if (!value) return false;
+  try {
+    const { hostname } = new URL(value);
+    return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1';
+  } catch {
+    return false;
+  }
+}
+
+function resolveTarget(args) {
+  if (args.target === 'local' || args.target === 'linked') return args.target;
+
+  const envLocal = parseEnvFile(resolvePath(args.workdir, '.env.local'));
+  const envFallback = parseEnvFile(resolvePath(args.workdir, '.env'));
+
+  const supabaseUrl =
+    process.env.SUPABASE_URL ||
+    process.env.LOCAL_SUPABASE_URL ||
+    envLocal.SUPABASE_URL ||
+    envLocal.LOCAL_SUPABASE_URL ||
+    envFallback.SUPABASE_URL ||
+    envFallback.LOCAL_SUPABASE_URL;
+
+  return isLocalSupabaseUrl(supabaseUrl) ? 'local' : 'linked';
 }
 
 function boolLike(value) {
@@ -125,14 +204,18 @@ function classifyPending(rows) {
 }
 
 function printHuman(result) {
+  const scope = result.target === 'local' ? 'local' : 'linked';
+  if (result.target) {
+    console.log(`[migrations] Target: ${result.target}`);
+  }
   if (result.state === 'clean') {
-    console.log('[migrations] ✅ No pending linked migrations.');
+    console.log(`[migrations] ✅ No pending ${scope} migrations.`);
     return;
   }
 
   if (result.state === 'pending') {
     console.log(
-      `[migrations] ⚠ ${result.pendingCount} pending linked migration${
+      `[migrations] ⚠ ${result.pendingCount} pending ${scope} migration${
         result.pendingCount === 1 ? '' : 's'
       }.`
     );
@@ -148,7 +231,14 @@ function printHuman(result) {
 
 function main() {
   const args = parseArgs(process.argv.slice(2));
-  const commandArgs = ['migration', 'list', '--linked', '--workdir', args.workdir, '-o', 'json'];
+  const target = resolveTarget(args);
+  if (args.printTarget) {
+    console.log(target);
+    process.exit(0);
+    return;
+  }
+
+  const commandArgs = ['migration', 'list', `--${target}`, '--workdir', args.workdir, '-o', 'json'];
 
   let raw;
   try {
@@ -161,6 +251,7 @@ function main() {
     const stdout = error && typeof error === 'object' ? String(error.stdout || '').trim() : '';
     const detail = stderr || stdout || (error instanceof Error ? error.message : String(error));
     const result = {
+      target,
       state: 'unknown',
       reason: detail || 'supabase migration list failed',
       pendingCount: 0,
@@ -177,6 +268,7 @@ function main() {
     parsed = JSON.parse(raw);
   } catch (error) {
     const result = {
+      target,
       state: 'unknown',
       reason: `Could not parse Supabase migration JSON output: ${
         error instanceof Error ? error.message : String(error)
@@ -195,12 +287,14 @@ function main() {
   const result =
     pendingRows.length > 0
       ? {
+          target,
           state: 'pending',
           reason: null,
           pendingCount: pendingRows.length,
           pending: pendingRows.map(rowLabel),
         }
       : {
+          target,
           state: 'clean',
           reason: null,
           pendingCount: 0,

--- a/scripts/prod-migrate.sh
+++ b/scripts/prod-migrate.sh
@@ -36,4 +36,4 @@ supabase db push "--${target}" --workdir "${ROOT_DIR}"
 
 echo "[prod-migrate] Re-checking migration status..."
 node "${ROOT_DIR}/scripts/migration-status.mjs" --workdir "${ROOT_DIR}"
-echo "[prod-migrate] ✅ ${target^} migrations are up to date."
+echo "[prod-migrate] ✅ ${target} migrations are up to date."

--- a/scripts/prod-migrate.sh
+++ b/scripts/prod-migrate.sh
@@ -10,14 +10,20 @@ if ! command -v supabase >/dev/null 2>&1; then
   exit 1
 fi
 
-echo "[prod-migrate] Checking linked migration status..."
+echo "[prod-migrate] Checking migration status..."
 set +e
 node "${ROOT_DIR}/scripts/migration-status.mjs" --workdir "${ROOT_DIR}"
 status_code=$?
 set -e
 
+target="$(node "${ROOT_DIR}/scripts/migration-status.mjs" --workdir "${ROOT_DIR}" --print-target 2>/dev/null || echo linked)"
+target="${target//$'\n'/}"
+if [[ "${target}" != "local" && "${target}" != "linked" ]]; then
+  target="linked"
+fi
+
 if [[ "${status_code}" -eq 0 ]]; then
-  echo "[prod-migrate] No pending linked migrations."
+  echo "[prod-migrate] No pending ${target} migrations."
   exit 0
 fi
 
@@ -25,9 +31,9 @@ if [[ "${status_code}" -ne 10 ]]; then
   echo "[prod-migrate] Migration status check returned ${status_code}; proceeding with best-effort apply."
 fi
 
-echo "[prod-migrate] Applying linked migrations (supabase db push)..."
-supabase db push --linked --workdir "${ROOT_DIR}"
+echo "[prod-migrate] Applying ${target} migrations (supabase db push --${target})..."
+supabase db push "--${target}" --workdir "${ROOT_DIR}"
 
 echo "[prod-migrate] Re-checking migration status..."
 node "${ROOT_DIR}/scripts/migration-status.mjs" --workdir "${ROOT_DIR}"
-echo "[prod-migrate] ✅ Linked migrations are up to date."
+echo "[prod-migrate] ✅ ${target^} migrations are up to date."


### PR DESCRIPTION
## Summary
- auto-detect migration target (`local` vs `linked`) from runtime/env files when running migration status
- make `prod:migrate` apply using resolved target (`supabase db push --local|--linked`)
- update `sb doctor` migration messaging to reflect target scope
- document auto-target behavior in README

## Behavior
Target resolution order:
1. explicit flags (`--target`, `--local`, `--linked`)
2. process env (`SUPABASE_URL` / `LOCAL_SUPABASE_URL`)
3. `<workdir>/.env.local`
4. `<workdir>/.env`

If URL host is localhost/127.0.0.1/::1 -> `local`, otherwise `linked`.

## Validation
- `npx vitest run packages/cli/src/commands/doctor.test.ts`
- `SUPABASE_URL=http://localhost:54321 node scripts/migration-status.mjs --workdir . --print-target` => `local`
- `SUPABASE_URL=https://abc.supabase.co node scripts/migration-status.mjs --workdir . --print-target` => `linked`