### PR TITLE
feat: add PCP_MIGRATION_TARGET override for migration status (by Lumen)

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ Notes:
 
 - `yarn prod:direct` does **not rebuild** on start; it uses existing build artifacts.
 - `yarn prod:migrate` / `migration-status` auto-select target:
+  - explicit override: `PCP_MIGRATION_TARGET=local|linked`
   - `local` when `SUPABASE_URL` (or `LOCAL_SUPABASE_URL`) points to localhost/127.0.0.1/::1
   - otherwise `linked`
   - source precedence: process env → `.env.local` → `.env`

--- a/scripts/migration-status.mjs
+++ b/scripts/migration-status.mjs
@@ -99,6 +99,11 @@ function isLocalSupabaseUrl(value) {
 function resolveTarget(args) {
   if (args.target === 'local' || args.target === 'linked') return args.target;
 
+  const override = String(process.env.PCP_MIGRATION_TARGET || '')
+    .trim()
+    .toLowerCase();
+  if (override === 'local' || override === 'linked') return override;
+
   const envLocal = parseEnvFile(resolvePath(args.workdir, '.env.local'));
   const envFallback = parseEnvFile(resolvePath(args.workdir, '.env'));
 


### PR DESCRIPTION
## Summary
- add `PCP_MIGRATION_TARGET` override support to `scripts/migration-status.mjs`
- accepted values: `local` or `linked`
- update README migration-target docs to include this explicit hatch

## Why
This gives deterministic testing/behavior for `yarn dev` / `yarn dev:direct` migration warnings without editing `.env.local`.

## Validation
- `node scripts/migration-status.mjs --workdir . --print-target`
- `PCP_MIGRATION_TARGET=local SUPABASE_URL=https://abc.supabase.co node scripts/migration-status.mjs --workdir . --print-target` => `local`
- `PCP_MIGRATION_TARGET=linked SUPABASE_URL=http://localhost:54321 node scripts/migration-status.mjs --workdir . --print-target` => `linked`