### PR TITLE
feat: improve session picker previews + runtime label fallback (by Lumen)

### DIFF
--- a/packages/cli/src/commands/claude.test.ts
+++ b/packages/cli/src/commands/claude.test.ts
@@ -746,6 +746,60 @@ describe('extractClaudeHistorySessionsForProject', () => {
   });
 });
 
+describe('getClaudeLocalSessionsForProject previews', () => {
+  it('extracts latest assistant preview from claude project jsonl', () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), 'sb-claude-preview-'));
+    const tempHome = join(tempRoot, 'home');
+    const projectPath = join(tempRoot, 'repo');
+    mkdirSync(tempHome, { recursive: true });
+    mkdirSync(projectPath, { recursive: true });
+
+    const projectDirName = projectPath.replace(/[\\/]/g, '-');
+    const projectDir = join(tempHome, '.claude', 'projects', projectDirName);
+    mkdirSync(projectDir, { recursive: true });
+
+    const sessionId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+    writeFileSync(
+      join(projectDir, `${sessionId}.jsonl`),
+      [
+        JSON.stringify({
+          type: 'user',
+          sessionId,
+          timestamp: '2026-03-04T08:00:00.000Z',
+          message: { role: 'user', content: 'Hello Wren' },
+        }),
+        JSON.stringify({
+          type: 'assistant',
+          sessionId,
+          timestamp: '2026-03-04T08:00:05.000Z',
+          message: {
+            role: 'assistant',
+            content: [{ type: 'text', text: 'Hi Conor — latest assistant reply' }],
+          },
+        }),
+      ].join('\n') + '\n'
+    );
+
+    const originalHome = process.env.HOME;
+    process.env.HOME = tempHome;
+
+    try {
+      const sessions = getClaudeLocalSessionsForProject(projectPath, 10);
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0]?.sessionId).toBe(sessionId);
+      expect(sessions[0]?.latestPrompt).toBe('assistant: Hi Conor — latest assistant reply');
+      expect(sessions[0]?.latestPromptAt).toBe('2026-03-04T08:00:05.000Z');
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+});
+
 describe('getCodexLocalSessionsForProject', () => {
   it('falls back to codex session jsonl files when sqlite db is unavailable', () => {
     const tempHome = mkdtempSync(join(tmpdir(), 'codex-jsonl-fallback-'));

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -49,6 +49,7 @@ interface PcpSessionSummary {
   studioId?: string | null;
   threadKey?: string | null;
   currentPhase?: string | null;
+  lifecycle?: string | null;
   status?: string | null;
   startedAt: string;
   endedAt?: string | null;
@@ -498,6 +499,19 @@ function withAgentPreviewSpeaker(preview: string | undefined, agentId: string): 
   return preview;
 }
 
+function getSessionPhaseLabel(session: PcpSessionSummary): string | undefined {
+  const currentPhase = (session.currentPhase || '').trim();
+  if (currentPhase) return currentPhase;
+
+  const lifecycle = (session.lifecycle || '').trim().toLowerCase();
+  if (lifecycle && lifecycle !== 'active') return `runtime:${lifecycle}`;
+
+  const status = (session.status || '').trim().toLowerCase();
+  if (status && status !== 'active') return `runtime:${status}`;
+
+  return undefined;
+}
+
 function extractLatestPreviewFromCodexRolloutJsonl(
   jsonl: string
 ): SessionPreviewSummary | undefined {
@@ -582,6 +596,28 @@ function extractLatestPreviewFromPcpTranscriptJsonl(
         ts: typeof event.ts === 'string' ? event.ts : undefined,
       };
     }
+  }
+  return latest;
+}
+
+function extractLatestPreviewFromClaudeSessionJsonl(
+  jsonl: string
+): SessionPreviewSummary | undefined {
+  const events = parseJsonl(jsonl);
+  let latest: SessionPreviewSummary | undefined;
+  for (const event of events) {
+    const ts = typeof event.timestamp === 'string' ? event.timestamp : undefined;
+    const message =
+      event.message && typeof event.message === 'object'
+        ? (event.message as Record<string, unknown>)
+        : undefined;
+
+    const role = roleFromUnknown(message?.role || event.role || event.type);
+    if (!role || role === 'inbox') continue;
+
+    const content = extractMessageText(message?.content || event.content || message);
+    if (!content) continue;
+    latest = { role, content, ts };
   }
   return latest;
 }
@@ -969,11 +1005,26 @@ export function getClaudeLocalSessionsForProject(
         }
 
         const stats = statSync(filePath);
+        let latestPrompt: string | undefined;
+        let latestPromptAt: string | undefined;
+        try {
+          const transcript = readFileSync(filePath, 'utf-8');
+          const preview = extractLatestPreviewFromClaudeSessionJsonl(transcript);
+          if (preview) {
+            latestPrompt = formatSessionPreviewText(preview);
+            latestPromptAt = preview.ts;
+          }
+        } catch {
+          // Best-effort preview extraction only.
+        }
+
         results.push({
           backend: 'claude',
           sessionId,
           projectPath: normalizedCwd,
           modified: stats.mtime.toISOString(),
+          latestPrompt,
+          latestPromptAt,
           transcriptPath: filePath,
         });
       } catch {
@@ -1915,7 +1966,7 @@ async function ensurePcpSessionContext(
           backend: session.backend || null,
           backendSessionId: session.backendSessionId || session.claudeSessionId || null,
           workingDir: session.workingDir || null,
-          phase: session.currentPhase || null,
+          phase: getSessionPhaseLabel(session) || null,
         })),
       });
     } catch (err) {
@@ -2131,16 +2182,19 @@ async function ensurePcpSessionContext(
       const linkedLocalSession = linkedBackendSessionId
         ? localBySessionId.get(linkedBackendSessionId)
         : undefined;
+      const linkedPreviewText = withAgentPreviewSpeaker(
+        linkedLocalSession?.latestPrompt || linkedLocalSession?.firstPrompt,
+        agentId
+      );
       return {
         type: 'pcp' as const,
         id: session.id,
         threadKey: session.threadKey || null,
-        phase: session.currentPhase || null,
+        phase: getSessionPhaseLabel(session) || null,
         backendSessionId: linkedBackendSessionId || null,
         linkedLocalModified:
           linkedLocalSession?.latestPromptAt || linkedLocalSession?.modified || null,
-        linkedLocalPreview:
-          linkedLocalSession?.latestPrompt || linkedLocalSession?.firstPrompt || null,
+        linkedLocalPreview: linkedPreviewText || null,
         pcpPreview: pcpPreviewBySessionId.get(session.id) || null,
       };
     });
@@ -2236,16 +2290,18 @@ async function ensurePcpSessionContext(
       const linkedLocalSession = linkedBackendSessionId
         ? localBySessionId.get(linkedBackendSessionId)
         : undefined;
-      const linkedPreview = linkedLocalSession?.firstPrompt
-        ? ` — ${truncateText(linkedLocalSession.firstPrompt)}`
-        : '';
-      const linkedWhen = linkedLocalSession?.modified
-        ? ` (${new Date(linkedLocalSession.modified).toLocaleString()})`
-        : '';
+      const linkedPreviewText = withAgentPreviewSpeaker(
+        linkedLocalSession?.latestPrompt || linkedLocalSession?.firstPrompt,
+        agentId
+      );
+      const linkedPreview = linkedPreviewText ? ` — ${truncateText(linkedPreviewText)}` : '';
+      const linkedAt = linkedLocalSession?.latestPromptAt || linkedLocalSession?.modified;
+      const linkedWhen = linkedAt ? ` (${new Date(linkedAt).toLocaleString()})` : '';
       const backendLabel = backend[0].toUpperCase() + backend.slice(1);
       const preview = pcpPreviewBySessionId.get(session.id);
+      const phaseLabel = getSessionPhaseLabel(session);
       choices.push({
-        name: `Resume PCP ${session.id.slice(0, 8)}${session.threadKey ? ` (${session.threadKey})` : ''}${session.currentPhase ? ` — ${session.currentPhase}` : ''}${linkedBackendSessionId ? ` · tracks ${backendLabel} ${linkedBackendSessionId.slice(0, 8)}` : ''}${linkedWhen}${linkedPreview}${preview ? ` — ${truncateText(preview, 120)}` : ''}`,
+        name: `Resume PCP ${session.id.slice(0, 8)}${session.threadKey ? ` (${session.threadKey})` : ''}${phaseLabel ? ` — ${phaseLabel}` : ''}${linkedBackendSessionId ? ` · tracks ${backendLabel} ${linkedBackendSessionId.slice(0, 8)}` : ''}${linkedWhen}${linkedPreview}${preview ? ` — ${truncateText(preview, 120)}` : ''}`,
         value,
       });
       sessionChoiceByValue.set(value, session.id);


### PR DESCRIPTION
## Summary
- add Claude local transcript preview extraction from project JSONL session files (latest user/assistant line)
- use latest available linked-local preview (not only first prompt) when rendering PCP rows in picker
- keep speaker labels consistent (`assistant:` => `<agentId>:`) for linked/local previews
- add fallback runtime label rendering from `lifecycle`/`status` when `currentPhase` is absent

## Why
Two UX gaps:
1. Claude picker rows often lacked message preview while Codex/Gemini showed rich latest-message snippets.
2. Some PCP rows showed phase info inconsistently after lifecycle changes when `currentPhase` was null.

## Validation
- `yarn workspace @personal-context/cli type-check`
- `yarn workspace @personal-context/cli exec vitest run src/commands/claude.test.ts src/commands/claude.integration.test.ts src/cli.test.ts`
- manual loops:
  - `sb-alpha -a wren -b claude --session-candidates --sb-debug` in multiple repos/worktrees
  - `sb-alpha -a lumen -b codex --session-candidates --sb-debug`

## Notes
- branch was cut fresh from latest `origin/main` after merging PR #156
- includes a new unit test that validates Claude local preview extraction from `.claude/projects/*.jsonl`
