### PR TITLE
fix: remove 'recent session' studio heuristic to prevent routing loops (by Wren)

### DIFF
--- a/packages/api/src/services/sessions/session-service.ts
+++ b/packages/api/src/services/sessions/session-service.ts
@@ -784,23 +784,7 @@ export class SessionService implements ISessionService {
       }
     }
 
-    // 3) Agent default studio (derived from recent sessions, then studio records)
-    const { data: recentAgentStudioSession } = await this.supabase
-      .from('sessions')
-      .select('studio_id, workspace_id, updated_at')
-      .eq('user_id', userId)
-      .eq('agent_id', agentId)
-      .or('studio_id.not.is.null,workspace_id.not.is.null')
-      .order('updated_at', { ascending: false })
-      .limit(1)
-      .maybeSingle();
-
-    const recentAgentStudio =
-      recentAgentStudioSession?.studio_id || recentAgentStudioSession?.workspace_id || undefined;
-    if (recentAgentStudio) {
-      return recentAgentStudio;
-    }
-
+    // 3) Agent's own studio (authoritative — from studios table, not session history)
     const { data: agentStudio } = await this.supabase
       .from('studios')
       .select('id, updated_at')
@@ -814,6 +798,10 @@ export class SessionService implements ISessionService {
     if (agentStudio?.id) {
       return agentStudio.id;
     }
+
+    // NOTE: We intentionally skip "most recent session's studio" as a fallback.
+    // It creates feedback loops: if an agent is misrouted once, all future sessions
+    // inherit the bad studio. The studios table is the authoritative source.
 
     // 4) Shared per-user main studio fallback
     const mainStudioId = await this.resolveMainStudioId(userId);


### PR DESCRIPTION
## Summary

- Remove the "most recent session's studio" fallback from `resolveStudioId()`. It creates feedback loops: if an agent is misrouted once (e.g., Myra landing in Lumen's studio), all future sessions inherit the bad studio because the heuristic just copies the last session's studio_id.
- Agents now resolve studios from the authoritative `studios` table only. Agents without their own studio (like Myra) fall through to `defaultWorkingDirectory` (the repo root) — which is the correct behavior.
- The "recent session" heuristic was fundamentally broken for multi-agent parallelization: any agent could inherit another agent's studio just by having a recent misrouted session.

## Test plan

- [x] 908 tests pass
- [ ] Trigger Myra via inbox — verify she lands in root repo (no studio_id), not Lumen's studio
- [ ] Verify agents with studios (wren, lumen) still resolve to their own studios via the studios table lookup

Generated with [Claude Code](https://claude.com/claude-code)

— Wren