### PR TITLE
perf: tail-read Claude local session previews (by Lumen)

### DIFF
--- a/packages/cli/src/commands/claude.test.ts
+++ b/packages/cli/src/commands/claude.test.ts
@@ -759,9 +759,11 @@ describe('getClaudeLocalSessionsForProject previews', () => {
     mkdirSync(projectDir, { recursive: true });
 
     const sessionId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+    const hugePrefix = 'x'.repeat(400_000);
     writeFileSync(
       join(projectDir, `${sessionId}.jsonl`),
       [
+        hugePrefix,
         JSON.stringify({
           type: 'user',
           sessionId,

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -8,7 +8,17 @@
 import { spawn, spawnSync } from 'child_process';
 import chalk from 'chalk';
 import { randomUUID } from 'crypto';
-import { type Dirent, existsSync, readFileSync, readdirSync, realpathSync, statSync } from 'fs';
+import {
+  closeSync,
+  openSync,
+  readSync,
+  type Dirent,
+  existsSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  statSync,
+} from 'fs';
 import { join, resolve as resolvePath } from 'path';
 import { homedir } from 'os';
 import { getBackend, resolveAgentId } from '../backends/index.js';
@@ -441,6 +451,20 @@ function parseJsonl(content: string): Array<Record<string, unknown>> {
     }
   }
   return parsed;
+}
+
+function readFileTailUtf8(filePath: string, maxBytes = 256 * 1024): string {
+  const fd = openSync(filePath, 'r');
+  try {
+    const size = statSync(filePath).size;
+    const bytesToRead = Math.min(size, Math.max(1, maxBytes));
+    const offset = Math.max(0, size - bytesToRead);
+    const buffer = Buffer.allocUnsafe(bytesToRead);
+    const readBytes = readSync(fd, buffer, 0, bytesToRead, offset);
+    return buffer.subarray(0, readBytes).toString('utf-8');
+  } finally {
+    closeSync(fd);
+  }
 }
 
 function extractMessageText(value: unknown): string | undefined {
@@ -1008,7 +1032,7 @@ export function getClaudeLocalSessionsForProject(
         let latestPrompt: string | undefined;
         let latestPromptAt: string | undefined;
         try {
-          const transcript = readFileSync(filePath, 'utf-8');
+          const transcript = readFileTailUtf8(filePath);
           const preview = extractLatestPreviewFromClaudeSessionJsonl(transcript);
           if (preview) {
             latestPrompt = formatSessionPreviewText(preview);

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -467,6 +467,42 @@ function readFileTailUtf8(filePath: string, maxBytes = 256 * 1024): string {
   }
 }
 
+function readFilePrefixByLineCountUtf8(
+  filePath: string,
+  lineLimit: number,
+  maxBytes = 2 * 1024 * 1024
+): string {
+  const fd = openSync(filePath, 'r');
+  try {
+    const chunkSize = 64 * 1024;
+    const chunks: Buffer[] = [];
+    const buffer = Buffer.allocUnsafe(chunkSize);
+    let totalRead = 0;
+    let position = 0;
+    let newlineCount = 0;
+
+    while (totalRead < maxBytes && newlineCount < lineLimit) {
+      const remaining = maxBytes - totalRead;
+      const bytesToRead = Math.min(chunkSize, remaining);
+      const bytesRead = readSync(fd, buffer, 0, bytesToRead, position);
+      if (bytesRead <= 0) break;
+
+      const slice = Buffer.from(buffer.subarray(0, bytesRead));
+      chunks.push(slice);
+      totalRead += bytesRead;
+      position += bytesRead;
+
+      for (let i = 0; i < bytesRead; i += 1) {
+        if (slice[i] === 10) newlineCount += 1; // '\n'
+      }
+    }
+
+    return Buffer.concat(chunks).toString('utf-8');
+  } finally {
+    closeSync(fd);
+  }
+}
+
 function extractMessageText(value: unknown): string | undefined {
   if (typeof value === 'string') {
     const compact = value.replace(/\s+/g, ' ').trim();
@@ -1088,7 +1124,9 @@ export function getClaudeLocalSessionsForProject(
 function isLikelyClaudeResumableSessionFile(filePath: string, sessionId: string): boolean {
   let content: string;
   try {
-    content = readFileSync(filePath, 'utf-8');
+    // Read just enough prefix to scan the first logical JSONL entries, without
+    // loading entire large transcripts into memory.
+    content = readFilePrefixByLineCountUtf8(filePath, 30);
   } catch {
     return false;
   }


### PR DESCRIPTION
## Summary
Lightweight follow-up to picker preview UX:

- switch Claude local preview extraction from full-file read to tail-read (`readFileTailUtf8`, 256KB default)
- continue parsing JSONL best-effort from tail chunk, so we still capture the latest message preview while avoiding loading large session files into memory
- keep poison-session filtering logic unchanged (still checks early lines for explicit session id)

## Why
Wren flagged a non-blocking perf concern on PR #157: some Claude JSONL files can become very large. This change minimizes I/O and memory pressure in picker rendering while preserving behavior.

## Validation
- `yarn workspace @personal-context/cli type-check`
- `yarn workspace @personal-context/cli exec vitest run src/commands/claude.test.ts src/commands/claude.integration.test.ts src/cli.test.ts`
- manual check:
  - `sb-alpha -a wren -b claude --session-candidates --sb-debug`

## Test update
- extended Claude preview test to include a large prefix payload and verify latest preview still resolves correctly via tail-read path.
