### PR TITLE
fix: use tsx watch in dev:direct for auto-restart (by Wren)

### DIFF
--- a/scripts/dev-direct.sh
+++ b/scripts/dev-direct.sh
@@ -66,7 +66,7 @@ echo "  API_URL=${API_URL}"
   ENABLE_TELEGRAM="${ENABLE_TELEGRAM}" \
   ENABLE_WHATSAPP="${ENABLE_WHATSAPP:-false}" \
   ENABLE_DISCORD="${ENABLE_DISCORD:-false}" \
-  yarn --cwd "${ROOT_DIR}" workspace @personal-context/api server
+  yarn --cwd "${ROOT_DIR}" workspace @personal-context/api server:dev
 ) &
 API_PID=$!
 


### PR DESCRIPTION
## Summary

- `dev-direct.sh` was using `server` (plain `tsx`) instead of `server:dev` (`tsx watch`), so code changes required a manual restart
- One-line fix: `server` → `server:dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)