### PR TITLE
chore: downgrade per-request tool registration logs to debug (by Wren)

### DIFF
--- a/packages/api/src/mcp/tools/index.ts
+++ b/packages/api/src/mcp/tools/index.ts
@@ -4598,5 +4598,5 @@ User can be identified by ONE of: userId, email, phone, or platform + platformId
     }
   );
 
-  logger.info('All MCP tools registered (timing diagnostics enabled)');
+  logger.debug('All MCP tools registered (timing diagnostics enabled)');
 }

--- a/packages/api/src/mcp/tools/mini-app-records.ts
+++ b/packages/api/src/mcp/tools/mini-app-records.ts
@@ -1117,5 +1117,5 @@ export function registerMiniAppRecordTools(server: McpServer, dataComposer: Data
     }
   );
 
-  logger.info('Mini-app record tools registered');
+  logger.debug('Mini-app record tools registered');
 }

--- a/packages/api/src/mini-apps/loader.ts
+++ b/packages/api/src/mini-apps/loader.ts
@@ -176,7 +176,7 @@ export function registerMiniAppTools(
         }
       );
 
-      logger.info(`Registered tool: ${toolName}`);
+      logger.debug(`Registered tool: ${toolName}`);
     }
   }
 }


### PR DESCRIPTION
## Summary

- Downgrade `logger.info` → `logger.debug` for tool registration messages in `index.ts`, `mini-app-records.ts`, and `loader.ts`
- Each HTTP request creates a fresh MCP server instance and re-registers all tools. At INFO level, this spams logs with "Registered tool: bill_split_*" and "All MCP tools registered" every few seconds.

## Test plan

- [x] Build passes
- [ ] Verify logs no longer show tool registration at default log level

Generated with [Claude Code](https://claude.com/claude-code)

— Wren