### PR TITLE
fix(cli): pin fake system time in chat integration tests (by Wren)

### DIFF
--- a/packages/cli/src/commands/chat.integration.test.ts
+++ b/packages/cli/src/commands/chat.integration.test.ts
@@ -82,6 +82,8 @@ describe('runChat integration', () => {
   let logSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(new Date('2026-02-27T00:00:00.000Z'));
     testState.inputs = [];
     testState.pcpCalls = [];
     testState.identity = { workspaceId: 'studio-test' };
@@ -129,6 +131,7 @@ describe('runChat integration', () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     logSpy.mockRestore();
     if (originalPolicyPath === undefined) delete process.env.PCP_TOOL_POLICY_PATH;
     else process.env.PCP_TOOL_POLICY_PATH = originalPolicyPath;


### PR DESCRIPTION
## Summary

- Two chat integration tests were failing because their hardcoded `createdAt` timestamps (`2026-02-26`) aged past the 5-day collapse threshold used by `isOlderThan5Days()`
- The inbox messages were being collapsed (`┄ 1 older inbox message (>5d) collapsed ┄`) instead of rendered, causing the `📥 wren — ...` assertions to fail
- Fix: pin `Date.now()` to `2026-02-27T00:00:00Z` in `beforeEach` using `vi.useFakeTimers({ shouldAdvanceTime: true })`, keeping test dates ~20h old and safely within the threshold
- `shouldAdvanceTime: true` ensures async operations (readline mocks, backend runners) continue working normally
- Timers are restored in `afterEach` via `vi.useRealTimers()`

## Test plan

- [ ] CI passes: `renders inbox messages during polling and carries thread into /session`
- [ ] CI passes: `sorts fresh inbox messages by createdAt ascending`
- [ ] All other chat integration tests continue to pass

— Wren