### PR TITLE
feat: display studio repo roots in dashboard and sessions (by Lumen)

### DIFF
--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -3678,6 +3678,7 @@ router.get('/sessions', async (req: Request, res: Response) => {
         id: string;
         branch: string | null;
         baseBranch: string | null;
+        repoRoot: string | null;
         purpose: string | null;
         workType: string | null;
         status: string;
@@ -3689,6 +3690,7 @@ router.get('/sessions', async (req: Request, res: Response) => {
         id: string;
         branch: string | null;
         baseBranch: string | null;
+        repoRoot: string | null;
         purpose: string | null;
         workType: string | null;
         status: string;
@@ -3698,7 +3700,7 @@ router.get('/sessions', async (req: Request, res: Response) => {
     if (studioIds.length > 0) {
       const { data: studios } = await supabase
         .from('studios')
-        .select('id, branch, base_branch, purpose, work_type, status')
+        .select('id, branch, base_branch, repo_root, purpose, work_type, status')
         .in('id', studioIds);
 
       for (const studio of studios || []) {
@@ -3706,6 +3708,7 @@ router.get('/sessions', async (req: Request, res: Response) => {
           id: studio.id,
           branch: studio.branch,
           baseBranch: studio.base_branch,
+          repoRoot: studio.repo_root,
           purpose: studio.purpose,
           workType: studio.work_type,
           status: studio.status,
@@ -3717,7 +3720,7 @@ router.get('/sessions', async (req: Request, res: Response) => {
     if (sessionIds.length > 0) {
       const { data: linkedWorkspaces } = await supabase
         .from('studios')
-        .select('id, session_id, branch, base_branch, purpose, work_type, status')
+        .select('id, session_id, branch, base_branch, repo_root, purpose, work_type, status')
         .in('session_id', sessionIds);
 
       for (const ws of linkedWorkspaces || []) {
@@ -3726,6 +3729,7 @@ router.get('/sessions', async (req: Request, res: Response) => {
             id: ws.id,
             branch: ws.branch,
             baseBranch: ws.base_branch,
+            repoRoot: ws.repo_root,
             purpose: ws.purpose,
             workType: ws.work_type,
             status: ws.status,
@@ -3816,6 +3820,9 @@ router.get('/sessions', async (req: Request, res: Response) => {
       stats,
       sessions: sessionRows.map((s) => {
         const identity = s.agent_id ? identitiesByAgentId.get(s.agent_id) : null;
+        const studio =
+          studiosById.get(s.studio_id || s.workspace_id || '') || workspacesBySessionId.get(s.id);
+
         return {
           id: s.id,
           backendSessionId: s.backend_session_id || s.claude_session_id || null,
@@ -3835,11 +3842,8 @@ router.get('/sessions', async (req: Request, res: Response) => {
           updatedAt: s.updated_at,
           endedAt: s.ended_at,
           preview: previewsBySessionId.get(s.id) || [],
-          workspace: workspacesBySessionId.get(s.id) || null,
-          studio:
-            studiosById.get(s.studio_id || s.workspace_id || '') ||
-            workspacesBySessionId.get(s.id) ||
-            null,
+          workspace: studio || null,
+          studio: studio || null,
         };
       }),
     });
@@ -3875,6 +3879,7 @@ router.get('/studios', async (req: Request, res: Response) => {
       agent_id: string | null;
       branch: string;
       base_branch: string | null;
+      repo_root: string | null;
       purpose: string | null;
       work_type: string | null;
       worktree_path: string;
@@ -3888,7 +3893,7 @@ router.get('/studios', async (req: Request, res: Response) => {
       const { data: scopedStudios } = await supabase
         .from('studios')
         .select(
-          'id, agent_id, branch, base_branch, purpose, work_type, worktree_path, slug, status, updated_at, created_at'
+          'id, agent_id, branch, base_branch, repo_root, purpose, work_type, worktree_path, slug, status, updated_at, created_at'
         )
         .eq('user_id', authReq.pcpUserId)
         .in('identity_id', identityIds)
@@ -3964,6 +3969,7 @@ router.get('/studios', async (req: Request, res: Response) => {
           id: s.id,
           branch: s.branch,
           baseBranch: s.base_branch,
+          repoRoot: s.repo_root,
           purpose: s.purpose,
           workType: s.work_type,
           worktreePath: s.worktree_path,

--- a/packages/web/src/app/(dashboard)/page.tsx
+++ b/packages/web/src/app/(dashboard)/page.tsx
@@ -23,6 +23,7 @@ interface StudioInfo {
   id: string;
   branch: string;
   baseBranch: string | null;
+  repoRoot: string | null;
   purpose: string | null;
   workType: string | null;
   worktreePath: string | null;
@@ -108,6 +109,20 @@ function getStudioSlug(worktreePath: string | null): string | null {
   const dashDashIdx = folder.indexOf('--');
   if (dashDashIdx === -1) return null;
   return folder.slice(dashDashIdx + 2);
+}
+
+function getRepoName(repoRoot: string | null, worktreePath: string | null): string | null {
+  if (repoRoot) {
+    const normalized = repoRoot.replace(/\/+$/, '');
+    const parts = normalized.split('/');
+    return parts[parts.length - 1] || normalized;
+  }
+
+  // Fallback: infer from worktree folder "<repo>--<slug>"
+  const folder = worktreePath?.split('/').pop() || '';
+  const dashDashIdx = folder.indexOf('--');
+  if (dashDashIdx === -1) return null;
+  return folder.slice(0, dashDashIdx) || null;
 }
 
 function getStudioStatusColor(status: string): string {
@@ -272,6 +287,7 @@ export default function DashboardPage() {
                     <div className="divide-y">
                       {agent.studios.map((studio) => {
                         const slug = studio.slug || getStudioSlug(studio.worktreePath);
+                        const repoName = getRepoName(studio.repoRoot, studio.worktreePath);
                         return (
                           <div key={studio.id} className="flex items-center gap-4 px-5 py-3">
                             <div className="flex items-center gap-3 flex-1 min-w-0">
@@ -283,6 +299,14 @@ export default function DashboardPage() {
                                   {slug || studio.branch}
                                 </span>
                               </div>
+                              {repoName && (
+                                <span
+                                  className="text-xs text-gray-400"
+                                  title={studio.repoRoot || undefined}
+                                >
+                                  {repoName}
+                                </span>
+                              )}
                               {studio.purpose && (
                                 <span className="text-xs text-gray-400 truncate">
                                   {studio.purpose}

--- a/packages/web/src/app/(dashboard)/sessions/page.tsx
+++ b/packages/web/src/app/(dashboard)/sessions/page.tsx
@@ -22,6 +22,7 @@ interface SessionWorkspace {
   id: string;
   branch: string | null;
   baseBranch: string | null;
+  repoRoot: string | null;
   purpose: string | null;
   workType: string | null;
   status: string;
@@ -148,10 +149,18 @@ function getSessionState(session: Session): {
   };
 }
 
+function getRepoName(repoRoot: string | null): string | null {
+  if (!repoRoot) return null;
+  const normalized = repoRoot.replace(/\/+$/, '');
+  const parts = normalized.split('/');
+  return parts[parts.length - 1] || normalized;
+}
+
 function SessionCard({ session }: { session: Session }) {
   const [expanded, setExpanded] = useState(false);
   const state = getSessionState(session);
   const phaseLabel = session.currentPhase;
+  const repoName = getRepoName(session.workspace?.repoRoot || null);
 
   return (
     <div className={clsx('rounded-lg border p-4', state.cardClass)}>
@@ -184,6 +193,15 @@ function SessionCard({ session }: { session: Session }) {
                 <GitBranch className="h-3 w-3" />
                 {session.workspace.branch || 'no branch'}
               </span>
+              {repoName && (
+                <span
+                  className="flex items-center gap-1"
+                  title={session.workspace?.repoRoot || undefined}
+                >
+                  <FolderGit2 className="h-3 w-3" />
+                  {repoName}
+                </span>
+              )}
               {session.workspace.purpose && (
                 <span className="truncate max-w-xs">{session.workspace.purpose}</span>
               )}
@@ -306,6 +324,12 @@ function SessionCard({ session }: { session: Session }) {
                     <div>
                       <span className="text-gray-400">Base: </span>
                       <code className="font-mono">{session.workspace.baseBranch}</code>
+                    </div>
+                  )}
+                  {session.workspace.repoRoot && (
+                    <div className="sm:col-span-2">
+                      <span className="text-gray-400">Repo root: </span>
+                      <code className="font-mono break-all">{session.workspace.repoRoot}</code>
                     </div>
                   )}
                   {session.workspace.purpose && (


### PR DESCRIPTION
## Summary
Surface repository root context for studios so same-agent studios across different repos are clearly distinguishable.

## Changes
- `GET /api/admin/studios`
  - include `repo_root` in studio payload as `repoRoot`
- `GET /api/admin/sessions`
  - include `repoRoot` on linked studio/workspace payload
  - prefer `studio_id` lookup for `workspace` response field, with session-id fallback
- Dashboard (`/(dashboard)/page`)
  - show repo name next to each studio slug/branch
  - tooltip shows full repo root path when present
- Sessions page (`/(dashboard)/sessions`)
  - show repo name in compact studio row
  - show full `Repo root` path in expanded Studio details

## Why
When an SB has multiple studios in parallel across repos, branch/slug alone can look ambiguous. Showing repo root makes cross-project parallel work visible and easier to reason about.

## Validation
- `npx vitest run packages/api/src/routes/admin-endpoints.test.ts`
- `yarn workspace @personal-context/web type-check`

(Repo-wide API type-check currently has unrelated pre-existing ESM/CJS errors in this branch baseline.)