### PR TITLE
fix: Telegram listener disabled under dev:direct (by Wren)

### DIFF
--- a/scripts/dev-direct.sh
+++ b/scripts/dev-direct.sh
@@ -47,14 +47,16 @@ fi
 BASE_PORT="${PCP_PORT_BASE:-3001}"
 WEB_PORT="${WEB_PORT:-$((BASE_PORT + 1))}"
 MYRA_PORT="${MYRA_HTTP_PORT:-$((BASE_PORT + 2))}"
-ENABLE_TELEGRAM="${ENABLE_TELEGRAM:-false}"
+# Default: unset → server.ts auto-enables if TELEGRAM_BOT_TOKEN is present.
+# Set ENABLE_TELEGRAM=false explicitly to force-disable.
+ENABLE_TELEGRAM="${ENABLE_TELEGRAM:-}"
 API_URL="${API_URL:-http://localhost:${BASE_PORT}}"
 
 echo "Starting direct dev mode"
 echo "  PCP_PORT_BASE=${BASE_PORT}"
 echo "  WEB_PORT=${WEB_PORT}"
 echo "  MYRA_HTTP_PORT=${MYRA_PORT}"
-echo "  ENABLE_TELEGRAM=${ENABLE_TELEGRAM}"
+echo "  ENABLE_TELEGRAM=${ENABLE_TELEGRAM:-<auto>}"
 echo "  ENABLE_HEARTBEATS=${ENABLE_HEARTBEATS:-<unset>}"
 echo "  ENABLE_REMINDERS=${ENABLE_REMINDERS:-<unset>}"
 echo "  API_URL=${API_URL}"


### PR DESCRIPTION
## Summary

`dev-direct.sh` defaults `ENABLE_TELEGRAM` to `'false'` (line 50), which overrides the server.ts auto-detection that enables Telegram when `TELEGRAM_BOT_TOKEN` is present. PM2's `ecosystem.config.cjs` doesn't set `ENABLE_TELEGRAM` at all, which is why Telegram works under PM2 but breaks under `yarn dev:direct`.

**Root cause**: The ternary in server.ts checks `ENABLE_TELEGRAM === 'false'` before falling through to `!!TELEGRAM_BOT_TOKEN`. The dev-direct default of `'false'` short-circuits the auto-detection.

**Fix**: Default to unset (empty string) so the auto-detection works. Users can still force-disable with `ENABLE_TELEGRAM=false yarn dev:direct`.

## Test plan

- [ ] `yarn dev:direct` with `TELEGRAM_BOT_TOKEN` in `.env.local` → Telegram connects
- [ ] `ENABLE_TELEGRAM=false yarn dev:direct` → Telegram stays disabled
- [ ] `ENABLE_TELEGRAM=true yarn dev:direct` → Telegram explicitly enabled