### PR TITLE
fix: resolve CLI binary paths with zsh login shell fallback (by Wren)

### DIFF
--- a/packages/api/src/services/sessions/claude-runner.ts
+++ b/packages/api/src/services/sessions/claude-runner.ts
@@ -18,6 +18,7 @@ import type {
 } from './types.js';
 import { formatInjectedContext } from './context-builder.js';
 import { logger } from '../../utils/logger.js';
+import { resolveBinaryPath } from './resolve-binary.js';
 
 /** Maximum time (ms) to wait for a Claude Code subprocess before killing it */
 const PROCESS_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
@@ -164,7 +165,7 @@ export class ClaudeRunner implements IClaudeRunner {
       // Strip CLAUDECODE to prevent "nested session" detection when PCP is
       // launched from inside a Claude Code session (e.g., via PM2).
       const { CLAUDECODE, ...cleanEnv } = process.env;
-      const proc = spawn('claude', args, {
+      const proc = spawn(resolveBinaryPath('claude'), args, {
         cwd: config.workingDirectory,
         env: {
           ...cleanEnv,

--- a/packages/api/src/services/sessions/codex-runner.ts
+++ b/packages/api/src/services/sessions/codex-runner.ts
@@ -21,6 +21,7 @@ import type {
 } from './types.js';
 import { formatInjectedContext } from './context-builder.js';
 import { logger } from '../../utils/logger.js';
+import { resolveBinaryPath } from './resolve-binary.js';
 
 const PROCESS_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
 const DIAGNOSTIC_MAX_CHARS = 4000;
@@ -137,7 +138,7 @@ export class CodexRunner implements IClaudeRunner {
     return new Promise((resolve, reject) => {
       // Strip CLAUDECODE to prevent env leaking into subprocess
       const { CLAUDECODE, ...cleanEnv } = process.env;
-      const proc = spawn('codex', args, {
+      const proc = spawn(resolveBinaryPath('codex'), args, {
         cwd: config.workingDirectory,
         env: {
           ...cleanEnv,

--- a/packages/api/src/services/sessions/gemini-runner.ts
+++ b/packages/api/src/services/sessions/gemini-runner.ts
@@ -26,6 +26,7 @@ import type {
 } from './types.js';
 import { formatInjectedContext } from './context-builder.js';
 import { logger } from '../../utils/logger.js';
+import { resolveBinaryPath } from './resolve-binary.js';
 
 /** Maximum time (ms) to wait for a Gemini CLI subprocess before killing it */
 const PROCESS_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
@@ -138,7 +139,7 @@ export class GeminiRunner implements IClaudeRunner {
     return new Promise((resolve, reject) => {
       // Strip CLAUDECODE to prevent env leaking into subprocess
       const { CLAUDECODE, ...cleanEnv } = process.env;
-      const proc = spawn('gemini', args, {
+      const proc = spawn(resolveBinaryPath('gemini'), args, {
         cwd: config.workingDirectory,
         env: {
           ...cleanEnv,

--- a/packages/api/src/services/sessions/resolve-binary.ts
+++ b/packages/api/src/services/sessions/resolve-binary.ts
@@ -1,0 +1,71 @@
+/**
+ * Binary Path Resolution
+ *
+ * Resolves CLI binary paths (claude, codex) with fallback to zsh login shell.
+ * Node's spawn() only searches the current process PATH, which may be a
+ * stripped-down bash PATH missing user-installed tools (nvm, homebrew, etc.).
+ *
+ * Resolution order:
+ *   1. Check current process PATH via `which`
+ *   2. Fall back to `zsh -ilc 'which <binary>'` to pick up login shell paths
+ *   3. Cache resolved paths for the process lifetime
+ */
+
+import { execSync } from 'child_process';
+import { logger } from '../../utils/logger.js';
+
+const resolvedPaths = new Map<string, string | null>();
+
+/**
+ * Resolve a binary name to its full path, with zsh login shell fallback.
+ * Returns the binary name unchanged if resolution fails (spawn will produce
+ * a clear ENOENT error).
+ */
+export function resolveBinaryPath(binary: string): string {
+  const cached = resolvedPaths.get(binary);
+  if (cached !== undefined) {
+    return cached ?? binary;
+  }
+
+  // 1. Try current process PATH
+  try {
+    const path = execSync(`which ${binary}`, {
+      encoding: 'utf-8',
+      timeout: 3000,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    if (path) {
+      resolvedPaths.set(binary, path);
+      logger.debug(`Resolved ${binary} from PATH: ${path}`);
+      return path;
+    }
+  } catch {
+    // Not found in current PATH
+  }
+
+  // 2. Fall back to zsh login shell (picks up nvm, homebrew, etc.)
+  try {
+    const path = execSync(`zsh -ilc 'which ${binary}'`, {
+      encoding: 'utf-8',
+      timeout: 5000,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    // zsh -il may print extra lines (nvm "Now using..." etc.) — take the last non-empty line
+    const lines = path.split('\n').filter((l) => l.trim() && l.startsWith('/'));
+    const resolved = lines[lines.length - 1];
+    if (resolved) {
+      resolvedPaths.set(binary, resolved);
+      logger.info(`Resolved ${binary} via zsh login shell: ${resolved}`);
+      return resolved;
+    }
+  } catch {
+    // zsh fallback also failed
+  }
+
+  // 3. Not found anywhere — cache the miss and warn
+  resolvedPaths.set(binary, null);
+  logger.warn(
+    `Could not resolve ${binary} in PATH or zsh login shell. Spawn will likely fail with ENOENT.`
+  );
+  return binary;
+}


### PR DESCRIPTION
## Summary

Agent triggers fail with `spawn codex ENOENT` because the PCP server runs under bash (via `dev-direct.sh`), which doesn't inherit zsh login shell paths where nvm/homebrew install CLI tools.

All three runners (`claude-runner.ts`, `codex-runner.ts`, `gemini-runner.ts`) used bare `spawn('binary', ...)`. New `resolve-binary.ts` utility:

1. Tries `which` against current process PATH
2. Falls back to `zsh -ilc 'which <binary>'` to pick up nvm, homebrew, etc.
3. Caches resolved paths for the process lifetime
4. Warns if binary not found anywhere (clear diagnostic before ENOENT)

This explains why PM2 worked but dev:direct didn't — PM2 inherits the parent shell's full environment, while `dev-direct.sh` (`#!/usr/bin/env bash`) gets a stripped PATH.

## Test plan

- [ ] Start server with `yarn dev:direct`, trigger Lumen via inbox → Codex spawns successfully
- [ ] `claude` and `gemini` triggers still work
- [ ] If binary genuinely missing, warning logged before spawn failure