### PR TITLE
refactor: async resolveBinaryPath + execFile (by Wren)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -458,6 +458,7 @@ Defined in [CONTRIBUTING.md](./CONTRIBUTING.md). Key points repeated here for ag
 - Strict TypeScript, avoid `any`. Use Zod for runtime validation.
 - One class/module per file. Co-locate tests (`*.test.ts`).
 - **Upsert safety**: never set optional fields to `null` just because they weren't provided. Use `undefined` checks to distinguish "not provided" from "explicitly cleared". When adding new columns, also update archive/history triggers, history response mappings, and restore handlers.
+- **NEVER block the event loop.** The API server is a single-threaded Node.js process handling concurrent requests. Use async alternatives (`execFile` + `promisify`, `fs/promises`, etc.) instead of sync calls (`execSync`, `readFileSync`, `writeFileSync`). The only acceptable exception is during one-time server startup before the HTTP listener opens. Blocking calls in request handlers, tool handlers, or message processing will stall all other concurrent work.
 
 ## Environment Variables
 

--- a/packages/api/src/services/sessions/claude-runner.ts
+++ b/packages/api/src/services/sessions/claude-runner.ts
@@ -161,11 +161,12 @@ export class ClaudeRunner implements IClaudeRunner {
     finalTextResponse?: string;
     toolCalls: ToolCall[];
   }> {
+    const claudeBin = await resolveBinaryPath('claude');
     return new Promise((resolve, reject) => {
       // Strip CLAUDECODE to prevent "nested session" detection when PCP is
       // launched from inside a Claude Code session (e.g., via PM2).
       const { CLAUDECODE, ...cleanEnv } = process.env;
-      const proc = spawn(resolveBinaryPath('claude'), args, {
+      const proc = spawn(claudeBin, args, {
         cwd: config.workingDirectory,
         env: {
           ...cleanEnv,

--- a/packages/api/src/services/sessions/codex-runner.ts
+++ b/packages/api/src/services/sessions/codex-runner.ts
@@ -135,10 +135,11 @@ export class CodexRunner implements IClaudeRunner {
     toolCalls: ToolCall[];
     sessionId?: string;
   }> {
+    const codexBin = await resolveBinaryPath('codex');
     return new Promise((resolve, reject) => {
       // Strip CLAUDECODE to prevent env leaking into subprocess
       const { CLAUDECODE, ...cleanEnv } = process.env;
-      const proc = spawn(resolveBinaryPath('codex'), args, {
+      const proc = spawn(codexBin, args, {
         cwd: config.workingDirectory,
         env: {
           ...cleanEnv,

--- a/packages/api/src/services/sessions/gemini-runner.ts
+++ b/packages/api/src/services/sessions/gemini-runner.ts
@@ -136,10 +136,11 @@ export class GeminiRunner implements IClaudeRunner {
     toolCalls: ToolCall[];
     sessionId?: string;
   }> {
+    const geminiBin = await resolveBinaryPath('gemini');
     return new Promise((resolve, reject) => {
       // Strip CLAUDECODE to prevent env leaking into subprocess
       const { CLAUDECODE, ...cleanEnv } = process.env;
-      const proc = spawn(resolveBinaryPath('gemini'), args, {
+      const proc = spawn(geminiBin, args, {
         cwd: config.workingDirectory,
         env: {
           ...cleanEnv,

--- a/packages/api/src/services/sessions/resolve-binary.ts
+++ b/packages/api/src/services/sessions/resolve-binary.ts
@@ -11,8 +11,11 @@
  *   3. Cache resolved paths for the process lifetime
  */
 
-import { execSync } from 'child_process';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
 import { logger } from '../../utils/logger.js';
+
+const execFileAsync = promisify(execFile);
 
 const resolvedPaths = new Map<string, string | null>();
 
@@ -21,7 +24,7 @@ const resolvedPaths = new Map<string, string | null>();
  * Returns the binary name unchanged if resolution fails (spawn will produce
  * a clear ENOENT error).
  */
-export function resolveBinaryPath(binary: string): string {
+export async function resolveBinaryPath(binary: string): Promise<string> {
   const cached = resolvedPaths.get(binary);
   if (cached !== undefined) {
     return cached ?? binary;
@@ -29,11 +32,8 @@ export function resolveBinaryPath(binary: string): string {
 
   // 1. Try current process PATH
   try {
-    const path = execSync(`which ${binary}`, {
-      encoding: 'utf-8',
-      timeout: 3000,
-      stdio: ['ignore', 'pipe', 'ignore'],
-    }).trim();
+    const { stdout } = await execFileAsync('which', [binary], { timeout: 3000 });
+    const path = stdout.trim();
     if (path) {
       resolvedPaths.set(binary, path);
       logger.debug(`Resolved ${binary} from PATH: ${path}`);
@@ -45,13 +45,9 @@ export function resolveBinaryPath(binary: string): string {
 
   // 2. Fall back to zsh login shell (picks up nvm, homebrew, etc.)
   try {
-    const path = execSync(`zsh -ilc 'which ${binary}'`, {
-      encoding: 'utf-8',
-      timeout: 5000,
-      stdio: ['ignore', 'pipe', 'ignore'],
-    }).trim();
-    // zsh -il may print extra lines (nvm "Now using..." etc.) — take the last non-empty line
-    const lines = path.split('\n').filter((l) => l.trim() && l.startsWith('/'));
+    const { stdout } = await execFileAsync('zsh', ['-ilc', `which ${binary}`], { timeout: 5000 });
+    // zsh -il may print extra lines (nvm "Now using..." etc.) — take the last absolute path
+    const lines = stdout.split('\n').filter((l) => l.trim() && l.startsWith('/'));
     const resolved = lines[lines.length - 1];
     if (resolved) {
       resolvedPaths.set(binary, resolved);


### PR DESCRIPTION
## Summary

Follow-up to #171. Switches `resolveBinaryPath` from blocking `execSync` to async `execFile` (promisified) so binary resolution doesn't block the Node event loop. Also addresses Lumen's review nit from #171 — uses `execFile` with argv arrays instead of shell-interpolated strings.

Each runner's `spawnProcess` method now `await`s the resolution before entering the `new Promise()` constructor.

## Test plan

- [ ] Agent triggers still resolve binaries correctly
- [ ] No event loop blocking during first resolution