### PR TITLE
feat: SB-scoped delegated token path for hooks (by lumen)

### DIFF
--- a/packages/api/src/mcp/server.test.ts
+++ b/packages/api/src/mcp/server.test.ts
@@ -5,7 +5,10 @@
  * tools) and validates stateless request handling via fetch.
  */
 
-import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { describe, it, expect, beforeAll, beforeEach, afterAll, vi } from 'vitest';
+import { verifyPcpAccessToken } from '../auth/pcp-tokens';
+
+const mockVerifyAccessToken = vi.fn();
 
 // ---------------------------------------------------------------------------
 // Mocks — must be declared before importing the module under test
@@ -19,6 +22,7 @@ vi.mock('../config/env', () => ({
     SUPABASE_URL: 'http://localhost:54321',
     SUPABASE_SECRET_KEY: 'test-key',
     SUPABASE_ANON_KEY: 'test-anon-key',
+    JWT_SECRET: 'test-jwt-secret',
   },
 }));
 
@@ -42,6 +46,18 @@ vi.mock('../mini-apps', () => ({
   registerMiniAppTools: vi.fn(),
   getMiniAppsInfo: vi.fn(() => []),
 }));
+
+vi.mock('./auth/pcp-auth-provider', () => {
+  class MockPcpAuthProvider {
+    verifyAccessToken = mockVerifyAccessToken;
+    createPendingAuth = vi.fn(() => 'pending-id');
+    handleAuthCallback = vi.fn(async () => ({ error: 'invalid_request' }));
+    exchangeAuthorizationCode = vi.fn(async () => ({ error: 'invalid_grant' }));
+    exchangeRefreshToken = vi.fn(async () => ({ error: 'invalid_grant' }));
+    cleanupExpiredDatabaseTokens = vi.fn();
+  }
+  return { PcpAuthProvider: MockPcpAuthProvider };
+});
 
 vi.mock('../routes/admin', () => {
   const { Router } = require('express');
@@ -142,16 +158,39 @@ describe('MCP StreamableHTTP Transport (stateless)', () => {
   let server: MCPServer;
   let baseUrl: string;
   let serverUnavailableError: Error | null = null;
+  let delegatedIdentity: { id: string; agent_id: string } | null = null;
 
   // Minimal DataComposer stub
   const mockDataComposer = {
     getClient: () => ({
-      from: () => ({
-        select: () => ({
-          limit: () => ({ error: null }),
-          eq: () => ({ single: () => ({ data: null, error: null }) }),
-        }),
-      }),
+      from: (table: string) => {
+        if (table === 'agent_identities') {
+          const filters: Record<string, string> = {};
+          const query = {
+            select: () => query,
+            eq: (field: string, value: string) => {
+              filters[field] = value;
+              return query;
+            },
+            maybeSingle: async () => {
+              const matches =
+                delegatedIdentity &&
+                filters.user_id === 'user-123' &&
+                filters.agent_id === delegatedIdentity.agent_id;
+              return { data: matches ? delegatedIdentity : null, error: null };
+            },
+            single: async () => ({ data: null, error: null }),
+            limit: () => ({ error: null }),
+          };
+          return query;
+        }
+        return {
+          select: () => ({
+            limit: () => ({ error: null }),
+            eq: () => ({ single: async () => ({ data: null, error: null }) }),
+          }),
+        };
+      },
     }),
   } as any;
 
@@ -182,8 +221,13 @@ describe('MCP StreamableHTTP Transport (stateless)', () => {
   });
 
   afterAll(async () => {
-    if (serverUnavailableError) return;
+    if (serverUnavailableError || !server) return;
     await server.shutdown();
+  });
+
+  beforeEach(() => {
+    mockVerifyAccessToken.mockReset();
+    delegatedIdentity = null;
   });
 
   // =========================================================================
@@ -313,5 +357,60 @@ describe('MCP StreamableHTTP Transport (stateless)', () => {
     expect(typeof body.build.updateAvailable).toBe('boolean');
     expect(body.checks.mcp.details.mode).toBe('stateless');
     expect(body.checks.mcp.details.toolsVersion).toBeDefined();
+  });
+
+  // =========================================================================
+  // Delegated token endpoint
+  // =========================================================================
+
+  it('issues a delegated agent-bound token', async () => {
+    if (serverUnavailableError) return;
+    mockVerifyAccessToken.mockResolvedValue({ userId: 'user-123', email: 'user@example.com' });
+    delegatedIdentity = { id: 'identity-abc', agent_id: 'wren' };
+
+    const res = await fetch(`${baseUrl}/token/delegate`, {
+      method: 'POST',
+      headers: { Authorization: 'Bearer valid', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ agentId: 'wren' }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.delegated_agent_id).toBe('wren');
+    expect(body.identity_id).toBe('identity-abc');
+    expect(body.expires_in).toBe(3600);
+
+    const token = body.access_token as string;
+    const payload = verifyPcpAccessToken(token, 'mcp_access');
+    expect(payload?.sub).toBe('user-123');
+    expect(payload?.agentId).toBe('wren');
+    expect(payload?.identityId).toBe('identity-abc');
+  });
+
+  it('rejects delegated token requests without valid auth', async () => {
+    if (serverUnavailableError) return;
+    mockVerifyAccessToken.mockResolvedValue(null);
+
+    const res = await fetch(`${baseUrl}/token/delegate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ agentId: 'wren' }),
+    });
+
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects delegated token requests for unknown agent identity', async () => {
+    if (serverUnavailableError) return;
+    mockVerifyAccessToken.mockResolvedValue({ userId: 'user-123', email: 'user@example.com' });
+    delegatedIdentity = null;
+
+    const res = await fetch(`${baseUrl}/token/delegate`, {
+      method: 'POST',
+      headers: { Authorization: 'Bearer valid', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ agentId: 'aster' }),
+    });
+
+    expect(res.status).toBe(403);
   });
 });

--- a/packages/api/src/mcp/server.ts
+++ b/packages/api/src/mcp/server.ts
@@ -34,6 +34,7 @@ import { runWithRequestContext } from '../utils/request-context';
 import { resolveWorkspaceContextForRequest } from '../utils/workspace-scope';
 import { getRuntimeBuildInfo } from '../utils/runtime-build-info';
 import { PcpAuthProvider } from './auth/pcp-auth-provider';
+import { signPcpAccessToken } from '../auth/pcp-tokens';
 
 export { setWhatsAppListener, getAgentGateway };
 
@@ -45,6 +46,8 @@ export interface MCPServerConfig {
   /** Getter for the session service (for chat routes) */
   getSessionService?: () => import('../services/sessions/session-service').SessionService | null;
 }
+
+const DELEGATED_ACCESS_TOKEN_LIFETIME_SECONDS = 60 * 60; // 1 hour
 
 export class MCPServer {
   /** Primary server instance (used for stdio transport only) */
@@ -574,6 +577,79 @@ export class MCPServer {
           error_description: `Grant type '${grant_type}' is not supported`,
         });
       }
+    });
+
+    // Delegated token endpoint — mint short-lived agent-bound MCP access tokens.
+    app.post('/token/delegate', express.json(), async (req, res) => {
+      const authHeader = req.header('authorization');
+      const userData = await this.authProvider.verifyAccessToken(authHeader);
+      if (!userData) {
+        res.status(401).json({
+          error: 'invalid_token',
+          error_description: 'Missing or invalid bearer token',
+        });
+        return;
+      }
+
+      const requestedAgentId =
+        typeof req.body?.agentId === 'string' ? req.body.agentId.trim().toLowerCase() : '';
+      if (!requestedAgentId) {
+        res.status(400).json({
+          error: 'invalid_request',
+          error_description: 'Missing required field: agentId',
+        });
+        return;
+      }
+
+      const { data: identity, error: identityError } = await this.dataComposer
+        .getClient()
+        .from('agent_identities')
+        .select('id, agent_id')
+        .eq('user_id', userData.userId)
+        .eq('agent_id', requestedAgentId)
+        .maybeSingle();
+
+      if (identityError) {
+        logger.error('Failed to resolve agent identity for delegated token', {
+          userId: userData.userId,
+          requestedAgentId,
+          error: identityError.message,
+        });
+        res.status(500).json({
+          error: 'server_error',
+          error_description: 'Failed to resolve requested agent identity',
+        });
+        return;
+      }
+
+      if (!identity) {
+        res.status(403).json({
+          error: 'forbidden',
+          error_description: 'Agent identity not found for this user',
+        });
+        return;
+      }
+
+      const accessToken = signPcpAccessToken(
+        {
+          type: 'mcp_access',
+          sub: userData.userId,
+          email: userData.email,
+          scope: 'mcp:tools',
+          agentId: identity.agent_id,
+          identityId: identity.id,
+        },
+        DELEGATED_ACCESS_TOKEN_LIFETIME_SECONDS
+      );
+
+      res.json({
+        access_token: accessToken,
+        token_type: 'Bearer',
+        expires_in: DELEGATED_ACCESS_TOKEN_LIFETIME_SECONDS,
+        scope: 'mcp:tools',
+        delegated_agent_id: identity.agent_id,
+        identity_id: identity.id,
+      });
     });
 
     // OAuth Authorization Server Metadata (RFC 8414)

--- a/packages/cli/src/auth/tokens.test.ts
+++ b/packages/cli/src/auth/tokens.test.ts
@@ -12,8 +12,12 @@ import {
   decodeJwtPayload,
   isTokenExpired,
   getValidAccessToken,
+  getValidDelegatedAccessToken,
   loadAuth,
   saveAuth,
+  loadDelegatedAuth,
+  saveDelegatedAuth,
+  clearDelegatedAuth,
   clearAuth,
   updateConfigEmail,
   type StoredAuth,
@@ -203,6 +207,71 @@ describe('loadAuth / saveAuth / clearAuth', () => {
 
   it('clearAuth is safe when no file exists', () => {
     expect(() => clearAuth()).not.toThrow();
+  });
+});
+
+describe('delegated auth storage', () => {
+  let origHome: string | undefined;
+  let tempHome: string;
+
+  beforeEach(() => {
+    origHome = process.env.HOME;
+    tempHome = join(tmpdir(), `pcp-delegated-auth-test-${Date.now()}`);
+    mkdirSync(tempHome, { recursive: true });
+    process.env.HOME = tempHome;
+  });
+
+  afterEach(() => {
+    process.env.HOME = origHome;
+    rmSync(tempHome, { recursive: true, force: true });
+  });
+
+  it('round-trips delegated token data', () => {
+    saveDelegatedAuth('wren', {
+      access_token: 'delegated-token',
+      expires_in: 3600,
+      issued_at: Date.now(),
+      agent_id: 'wren',
+      identity_id: 'identity-123',
+      scope: 'mcp:tools',
+    });
+
+    const loaded = loadDelegatedAuth('wren');
+    expect(loaded).not.toBeNull();
+    expect(loaded!.access_token).toBe('delegated-token');
+    expect(loaded!.agent_id).toBe('wren');
+    expect(loaded!.identity_id).toBe('identity-123');
+  });
+
+  it('returns delegated token only when not expired', () => {
+    saveDelegatedAuth('lumen', {
+      access_token: 'fresh-delegated-token',
+      expires_in: 3600,
+      issued_at: Date.now(),
+      agent_id: 'lumen',
+    });
+    expect(getValidDelegatedAccessToken('lumen')).toBe('fresh-delegated-token');
+
+    saveDelegatedAuth('lumen', {
+      access_token: 'stale-delegated-token',
+      expires_in: 60,
+      issued_at: Date.now() - 2 * 60 * 1000,
+      agent_id: 'lumen',
+    });
+    expect(getValidDelegatedAccessToken('lumen')).toBeNull();
+  });
+
+  it('clears delegated auth safely', () => {
+    saveDelegatedAuth('aster', {
+      access_token: 'token',
+      expires_in: 3600,
+      issued_at: Date.now(),
+      agent_id: 'aster',
+    });
+    expect(loadDelegatedAuth('aster')).not.toBeNull();
+    clearDelegatedAuth('aster');
+    expect(loadDelegatedAuth('aster')).toBeNull();
+    expect(() => clearDelegatedAuth('aster')).not.toThrow();
   });
 });
 

--- a/packages/cli/src/auth/tokens.ts
+++ b/packages/cli/src/auth/tokens.ts
@@ -22,6 +22,20 @@ export interface StoredAuth {
   issued_at: number; // Date.now() at storage time
 }
 
+export interface StoredDelegatedAuth {
+  access_token: string;
+  expires_in: number; // seconds from issuance
+  issued_at: number; // Date.now() at storage time
+  scope?: string;
+  agent_id: string;
+  identity_id?: string;
+}
+
+type ExpiringToken = {
+  expires_in: number;
+  issued_at: number;
+};
+
 export interface JwtPayload {
   type: string;
   sub: string; // userId
@@ -45,6 +59,21 @@ function authFilePath(): string {
 
 function configFilePath(): string {
   return join(homedir(), '.pcp', 'config.json');
+}
+
+function delegatedAuthDirPath(): string {
+  return join(homedir(), '.pcp', 'auth', 'agents');
+}
+
+function sanitizeAgentId(agentId: string): string {
+  return agentId
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]/g, '_');
+}
+
+function delegatedAuthFilePath(agentId: string): string {
+  return join(delegatedAuthDirPath(), `${sanitizeAgentId(agentId)}.json`);
 }
 
 // ============================================================================
@@ -86,6 +115,37 @@ export function clearAuth(): void {
   }
 }
 
+export function loadDelegatedAuth(agentId: string): StoredDelegatedAuth | null {
+  const path = delegatedAuthFilePath(agentId);
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, 'utf-8'));
+  } catch {
+    return null;
+  }
+}
+
+export function saveDelegatedAuth(agentId: string, auth: StoredDelegatedAuth): void {
+  const dir = delegatedAuthDirPath();
+  mkdirSync(dir, { recursive: true });
+  try {
+    chmodSync(dir, 0o700);
+  } catch {
+    // Best-effort only; some environments may not support chmod.
+  }
+
+  const path = delegatedAuthFilePath(agentId);
+  writeFileSync(path, JSON.stringify(auth, null, 2) + '\n');
+  chmodSync(path, 0o600);
+}
+
+export function clearDelegatedAuth(agentId: string): void {
+  const path = delegatedAuthFilePath(agentId);
+  if (existsSync(path)) {
+    unlinkSync(path);
+  }
+}
+
 // ============================================================================
 // JWT Decode (no verification — server-issued, trusted locally)
 // ============================================================================
@@ -105,7 +165,7 @@ export function decodeJwtPayload(token: string): JwtPayload | null {
 // Token Expiry
 // ============================================================================
 
-export function isTokenExpired(auth: StoredAuth, bufferSeconds = 300): boolean {
+export function isTokenExpired(auth: ExpiringToken, bufferSeconds = 300): boolean {
   const expiresAtMs = auth.issued_at + auth.expires_in * 1000;
   return Date.now() + bufferSeconds * 1000 >= expiresAtMs;
 }
@@ -185,6 +245,16 @@ export async function getValidAccessToken(
     clearAuth();
     return null;
   }
+}
+
+export function getValidDelegatedAccessToken(
+  agentId: string,
+  options?: { bufferSeconds?: number }
+): string | null {
+  const auth = loadDelegatedAuth(agentId);
+  if (!auth) return null;
+  if (isTokenExpired(auth, options?.bufferSeconds ?? 300)) return null;
+  return auth.access_token;
 }
 
 // ============================================================================

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -22,6 +22,8 @@ import {
   clearAuth,
   decodeJwtPayload,
   isTokenExpired,
+  getValidAccessToken,
+  saveDelegatedAuth,
   updateConfigEmail,
   CLIENT_ID,
 } from '../auth/tokens.js';
@@ -268,11 +270,15 @@ async function statusCommand(): Promise<void> {
 
   if (expired) {
     console.log(`  ${chalk.bold('Token:')}   ${chalk.yellow('expired')}`);
-    console.log(chalk.dim('\n  Token will refresh automatically on next sb launch, or run: sb auth login'));
+    console.log(
+      chalk.dim('\n  Token will refresh automatically on next sb launch, or run: sb auth login')
+    );
   } else {
     const expiresAtMs = auth.issued_at + auth.expires_in * 1000;
     const daysLeft = Math.floor((expiresAtMs - Date.now()) / (1000 * 60 * 60 * 24));
-    console.log(`  ${chalk.bold('Token:')}   ${chalk.green('valid')} ${chalk.dim(`(expires in ${daysLeft}d)`)}`);
+    console.log(
+      `  ${chalk.bold('Token:')}   ${chalk.green('valid')} ${chalk.dim(`(expires in ${daysLeft}d)`)}`
+    );
   }
   console.log('');
 }
@@ -292,6 +298,69 @@ async function logoutCommand(): Promise<void> {
   console.log(chalk.green('Logged out. Tokens cleared.'));
 }
 
+async function delegateCommand(options: { agent: string }): Promise<void> {
+  const serverUrl = getPcpServerUrl();
+  const agentId = options.agent?.trim().toLowerCase();
+  if (!agentId) {
+    console.log(chalk.red('Missing --agent <agentId>'));
+    process.exitCode = 1;
+    return;
+  }
+
+  const baseToken = await getValidAccessToken(serverUrl);
+  if (!baseToken) {
+    console.log(chalk.yellow('Not authenticated. Run: sb auth login'));
+    process.exitCode = 1;
+    return;
+  }
+
+  const response = await fetch(`${serverUrl}/token/delegate`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${baseToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ agentId }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    console.log(chalk.red(`Delegation failed (${response.status}): ${text}`));
+    process.exitCode = 1;
+    return;
+  }
+
+  const payload = (await response.json()) as {
+    access_token?: string;
+    expires_in?: number;
+    scope?: string;
+    delegated_agent_id?: string;
+    identity_id?: string;
+  };
+
+  if (!payload.access_token || typeof payload.expires_in !== 'number') {
+    console.log(chalk.red('Delegation response missing access token payload.'));
+    process.exitCode = 1;
+    return;
+  }
+
+  saveDelegatedAuth(agentId, {
+    access_token: payload.access_token,
+    expires_in: payload.expires_in,
+    issued_at: Date.now(),
+    scope: payload.scope,
+    agent_id: payload.delegated_agent_id || agentId,
+    identity_id: payload.identity_id,
+  });
+
+  const expiresAt = new Date(Date.now() + payload.expires_in * 1000);
+  console.log(
+    chalk.green(
+      `Delegated token saved for ${agentId} (expires ${expiresAt.toLocaleString('en-US')}).`
+    )
+  );
+}
+
 // ============================================================================
 // Register
 // ============================================================================
@@ -307,8 +376,11 @@ export function registerAuthCommands(program: Command): void {
 
   auth.command('status').description('Show current authentication status').action(statusCommand);
 
+  auth.command('logout').description('Clear stored authentication tokens').action(logoutCommand);
+
   auth
-    .command('logout')
-    .description('Clear stored authentication tokens')
-    .action(logoutCommand);
+    .command('delegate')
+    .description('Mint and store an SB-scoped delegated MCP token')
+    .requiredOption('-a, --agent <agentId>', 'SB agentId (e.g. wren, lumen, aster)')
+    .action(delegateCommand);
 }

--- a/packages/cli/src/commands/hooks.test.ts
+++ b/packages/cli/src/commands/hooks.test.ts
@@ -379,6 +379,7 @@ describe('installHooks: detection priority', () => {
 
 vi.mock('../auth/tokens.js', () => ({
   getValidAccessToken: vi.fn(),
+  getValidDelegatedAccessToken: vi.fn(),
   loadAuth: vi.fn(),
   isTokenExpired: vi.fn(),
   decodeJwtPayload: vi.fn(),
@@ -387,6 +388,7 @@ vi.mock('../auth/tokens.js', () => ({
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import * as tokensMod from '../auth/tokens.js';
 const mockedGetValidAccessToken = vi.mocked(tokensMod.getValidAccessToken);
+const mockedGetValidDelegatedAccessToken = vi.mocked(tokensMod.getValidDelegatedAccessToken);
 
 // ============================================================================
 // Helpers for mock fetch responses
@@ -428,6 +430,10 @@ describe('callPcpTool: auth header', () => {
   beforeEach(() => {
     fetchSpy = vi.fn().mockResolvedValue(mockJsonResponse(TOOL_RESULT_PAYLOAD));
     vi.stubGlobal('fetch', fetchSpy);
+    mockedGetValidAccessToken.mockReset();
+    mockedGetValidAccessToken.mockResolvedValue('token');
+    mockedGetValidDelegatedAccessToken.mockReset();
+    mockedGetValidDelegatedAccessToken.mockReturnValue(null);
   });
 
   afterEach(() => {
@@ -443,6 +449,19 @@ describe('callPcpTool: auth header', () => {
     expect(fetchSpy).toHaveBeenCalledOnce();
     const [, options] = fetchSpy.mock.calls[0];
     expect(options.headers).toHaveProperty('Authorization', 'Bearer test-jwt-token');
+  });
+
+  it('should prefer delegated token and include x-pcp-agent-id header when available', async () => {
+    mockedGetValidDelegatedAccessToken.mockReturnValue('delegated-jwt-token');
+    mockedGetValidAccessToken.mockResolvedValue('fallback-token');
+
+    await callPcpTool('bootstrap', { agentId: 'wren' });
+
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    const [, options] = fetchSpy.mock.calls[0];
+    expect(options.headers).toHaveProperty('Authorization', 'Bearer delegated-jwt-token');
+    expect(options.headers).toHaveProperty('x-pcp-agent-id', 'wren');
+    expect(mockedGetValidAccessToken).not.toHaveBeenCalled();
   });
 
   it('should omit Authorization header when no token is available', async () => {

--- a/packages/cli/src/commands/hooks.test.ts
+++ b/packages/cli/src/commands/hooks.test.ts
@@ -505,6 +505,9 @@ describe('callPcpTool: Streamable HTTP response formats', () => {
   let fetchSpy: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
+    mockedGetValidDelegatedAccessToken.mockReset();
+    mockedGetValidDelegatedAccessToken.mockReturnValue(null);
+    mockedGetValidAccessToken.mockReset();
     mockedGetValidAccessToken.mockResolvedValue('token');
   });
 
@@ -687,6 +690,60 @@ describe('callPcpTool: Streamable HTTP response formats', () => {
     ).toBe(true);
     expect(firstResponseTextSpy).toHaveBeenCalledTimes(1);
     expect(consoleSpy).toHaveBeenCalled();
+  });
+
+  it('retries with base token and skips delegated token after delegated 401', async () => {
+    process.env.PCP_ACCESS_TOKEN = 'env-token';
+    mockedGetValidDelegatedAccessToken.mockReturnValue('delegated-token');
+    mockedGetValidAccessToken.mockResolvedValueOnce('fallback-token');
+
+    fetchSpy = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        text: async () => 'delegated unauthorized',
+      })
+      .mockResolvedValueOnce(mockJsonResponse(TOOL_RESULT_PAYLOAD));
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const result = await callPcpTool('bootstrap', { agentId: 'wren' });
+    expect(result).toEqual({ success: true });
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+
+    const [, firstOptions] = fetchSpy.mock.calls[0];
+    const [, secondOptions] = fetchSpy.mock.calls[1];
+    expect(firstOptions.headers).toHaveProperty('Authorization', 'Bearer delegated-token');
+    expect(secondOptions.headers).toHaveProperty('Authorization', 'Bearer fallback-token');
+
+    expect(mockedGetValidDelegatedAccessToken).toHaveBeenCalledTimes(1);
+    expect(
+      mockedGetValidAccessToken.mock.calls.some(
+        ([, options]) =>
+          (options as { allowEnvToken?: boolean } | undefined)?.allowEnvToken === false
+      )
+    ).toBe(true);
+  });
+
+  it('retries delegated 401 even without injected env token', async () => {
+    mockedGetValidDelegatedAccessToken.mockReturnValue('delegated-token');
+    mockedGetValidAccessToken.mockResolvedValueOnce('file-token');
+
+    fetchSpy = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        text: async () => 'delegated unauthorized',
+      })
+      .mockResolvedValueOnce(mockJsonResponse(TOOL_RESULT_PAYLOAD));
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const result = await callPcpTool('bootstrap', { agentId: 'wren' });
+    expect(result).toEqual({ success: true });
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
   });
 
   it('does not retry on 401 when no env token is injected', async () => {

--- a/packages/cli/src/commands/hooks.ts
+++ b/packages/cli/src/commands/hooks.ts
@@ -236,6 +236,8 @@ export async function callPcpTool(
     'Content-Type': 'application/json',
     Accept: 'application/json, text/event-stream',
     'x-pcp-caller-profile': 'runtime',
+    // Forward-looking runtime identity signal for stricter server-side enforcement.
+    // Today, effective agent identity is still sourced from JWT claims.
     ...(delegatedAgentId ? { 'x-pcp-agent-id': delegatedAgentId } : {}),
   };
 
@@ -259,20 +261,27 @@ export async function callPcpTool(
 
   // Attach CLI auth token so hooks pass OAuth checks on the MCP server.
   // Prefer runtime-injected env token, then local auth file.
+  let usedDelegatedTokenOnFirstAttempt = false;
   const resolveHookToken = async (options?: {
     allowEnvToken?: boolean;
-  }): Promise<string | null> => {
-    if (delegatedAgentId) {
+    skipDelegated?: boolean;
+  }): Promise<{ token: string | null; source: 'delegated' | 'base' }> => {
+    if (delegatedAgentId && !options?.skipDelegated) {
       const delegatedToken = getValidDelegatedAccessToken(delegatedAgentId);
-      if (delegatedToken) return delegatedToken;
+      if (delegatedToken) {
+        return { token: delegatedToken, source: 'delegated' };
+      }
     }
-    return getValidAccessToken(serverUrl, options);
+    return { token: await getValidAccessToken(serverUrl, options), source: 'base' };
   };
 
-  let response = await callOnce(await resolveHookToken());
+  const firstToken = await resolveHookToken();
+  usedDelegatedTokenOnFirstAttempt = firstToken.source === 'delegated';
+  let response = await callOnce(firstToken.token);
 
-  // If an injected env token is stale/invalid, retry once using local auth fallback.
-  if (response.status === 401 && hasInjectedEnvToken) {
+  // Retry once if a runtime token was injected OR if we attempted a delegated token.
+  // This allows fallback to local auth token when the first credential is rejected.
+  if (response.status === 401 && (hasInjectedEnvToken || usedDelegatedTokenOnFirstAttempt)) {
     // Drain first response body before retrying so the underlying HTTP client
     // can cleanly release the stream (avoids occasional undici body warnings).
     try {
@@ -284,14 +293,21 @@ export async function callPcpTool(
     sbDebugLog('hooks', 'mcp_auth_retry_without_env_token', {
       tool,
       status: 401,
-      reason: 'env_token_rejected',
+      reason: usedDelegatedTokenOnFirstAttempt ? 'delegated_token_rejected' : 'env_token_rejected',
+      skipDelegatedOnRetry: usedDelegatedTokenOnFirstAttempt,
     });
-    console.error(
-      chalk.yellow(
-        '⚠ PCP hook auth token was rejected; retrying with local ~/.pcp/auth.json token fallback.'
-      )
-    );
-    response = await callOnce(await resolveHookToken({ allowEnvToken: false }));
+    if (hasInjectedEnvToken) {
+      console.error(
+        chalk.yellow(
+          '⚠ PCP hook auth token was rejected; retrying with local ~/.pcp/auth.json token fallback.'
+        )
+      );
+    }
+    const retryToken = await resolveHookToken({
+      allowEnvToken: false,
+      skipDelegated: usedDelegatedTokenOnFirstAttempt,
+    });
+    response = await callOnce(retryToken.token);
   }
 
   if (!response.ok) {

--- a/packages/cli/src/commands/hooks.ts
+++ b/packages/cli/src/commands/hooks.ts
@@ -24,7 +24,7 @@ import { execSync } from 'child_process';
 import { homedir } from 'os';
 import { createHash } from 'crypto';
 import { resolveAgentId, readIdentityJson, readRoleMd } from '../backends/identity.js';
-import { getValidAccessToken } from '../auth/tokens.js';
+import { getValidAccessToken, getValidDelegatedAccessToken } from '../auth/tokens.js';
 import {
   findRuntimeSessionByLinkId,
   getCurrentRuntimeSession,
@@ -227,11 +227,16 @@ export async function callPcpTool(
   const serverUrl = getPcpServerUrl();
   const url = `${serverUrl}/mcp`;
   const hasInjectedEnvToken = Boolean(process.env.PCP_ACCESS_TOKEN?.trim());
+  const delegatedAgentId =
+    typeof args.agentId === 'string' && args.agentId.trim().length > 0
+      ? args.agentId.trim().toLowerCase()
+      : null;
 
   const baseHeaders: Record<string, string> = {
     'Content-Type': 'application/json',
     Accept: 'application/json, text/event-stream',
     'x-pcp-caller-profile': 'runtime',
+    ...(delegatedAgentId ? { 'x-pcp-agent-id': delegatedAgentId } : {}),
   };
 
   const callOnce = async (token: string | null): Promise<Response> => {
@@ -254,7 +259,17 @@ export async function callPcpTool(
 
   // Attach CLI auth token so hooks pass OAuth checks on the MCP server.
   // Prefer runtime-injected env token, then local auth file.
-  let response = await callOnce(await getValidAccessToken(serverUrl));
+  const resolveHookToken = async (options?: {
+    allowEnvToken?: boolean;
+  }): Promise<string | null> => {
+    if (delegatedAgentId) {
+      const delegatedToken = getValidDelegatedAccessToken(delegatedAgentId);
+      if (delegatedToken) return delegatedToken;
+    }
+    return getValidAccessToken(serverUrl, options);
+  };
+
+  let response = await callOnce(await resolveHookToken());
 
   // If an injected env token is stale/invalid, retry once using local auth fallback.
   if (response.status === 401 && hasInjectedEnvToken) {
@@ -276,7 +291,7 @@ export async function callPcpTool(
         '⚠ PCP hook auth token was rejected; retrying with local ~/.pcp/auth.json token fallback.'
       )
     );
-    response = await callOnce(await getValidAccessToken(serverUrl, { allowEnvToken: false }));
+    response = await callOnce(await resolveHookToken({ allowEnvToken: false }));
   }
 
   if (!response.ok) {

--- a/packages/spec/protocol-v0.1.md
+++ b/packages/spec/protocol-v0.1.md
@@ -574,6 +574,25 @@ Implementations SHOULD support user-defined delivery windows (quiet hours) that 
 
 The quiet hours mechanism is implementation-defined. Implementations SHOULD store user timezone and delivery preferences as part of the user profile.
 
+### 8.10 Delegated SB Access Tokens
+
+When a human principal authenticates via OAuth, implementations MAY issue **delegated short-lived SB tokens** derived from the parent user token.
+
+If delegated tokens are used, implementations MUST:
+
+- Bind each delegated token to exactly one SB identity (`agentId`, and ideally canonical `identityId`)
+- Keep delegated tokens short-lived (recommended: 15-60 minutes)
+- Validate that the requested SB belongs to the authenticated user before minting
+- Preserve user-level ownership (`sub` remains the user principal) while enforcing SB-level scope
+
+Implementations SHOULD:
+
+- Store delegated tokens in a secure local location with strict file permissions (e.g., `0600`)
+- Prefer delegated SB tokens for runtime hook flows, with parent token fallback only when needed
+- Include explicit runtime identity signaling (for example, agent-bound headers) so servers can audit effective actor identity
+
+This model supports least-privilege SB execution in multi-agent environments while preserving a single user trust root.
+
 ---
 
 ## 9. Relationship to MCP


### PR DESCRIPTION
## Summary
Start implementing SB token delegation for runtime hooks so calls can be scoped per agent even when multiple SBs share a studio.

## What’s included
- Added delegated token storage under secure folder paths in CLI auth utilities (`~/.pcp/auth/agents/<agent>.json`, 0600 perms).
- Added CLI support to mint delegated tokens:
  - `sb auth delegate -a <agentId>`
  - Calls new server endpoint and persists short-lived delegated token locally.
- Added MCP server endpoint:
  - `POST /token/delegate`
  - Requires valid bearer token
  - Verifies requested `agentId` belongs to the authenticated user
  - Returns short-lived `mcp_access` JWT bound to `{ agentId, identityId }`.
- Hook runtime transport update:
  - `callPcpTool` now prefers delegated token for `args.agentId` when available.
  - Sends `x-pcp-agent-id` header from hooks for explicit runtime identity signaling.

## Tests
- `npx vitest run packages/cli/src/auth/tokens.test.ts packages/cli/src/commands/hooks.test.ts`
- `npx vitest run packages/api/src/mcp/server.test.ts`
- `yarn workspace @personal-context/cli type-check`

## Notes
- This is the first step: hooks now *consume* delegated tokens when present.
- Next step can enforce delegated-token-only mode for hooks (or auto-mint/refresh strategy) once we align on rollout policy.