### PR TITLE
feat: add --dangerous flag to sb CLI (by Wren)

### DIFF
--- a/packages/api/src/services/sessions/resolve-binary.ts
+++ b/packages/api/src/services/sessions/resolve-binary.ts
@@ -12,7 +12,7 @@
  */
 
 import { execFile } from 'child_process';
-import { dirname } from 'path';
+import { delimiter, dirname, isAbsolute } from 'path';
 import { promisify } from 'util';
 import { logger } from '../../utils/logger.js';
 
@@ -73,12 +73,20 @@ export async function resolveBinaryPath(binary: string): Promise<string> {
  * can find the interpreter even when the server's own PATH doesn't include it.
  */
 export function buildSpawnPath(resolvedBinaryPath: string): string {
-  const binDir = dirname(resolvedBinaryPath);
   const currentPath = process.env.PATH || '';
 
-  if (currentPath.split(':').includes(binDir)) {
+  // If resolution failed and we got a bare name (e.g. "codex"), dirname
+  // returns "." which would inject CWD into the child PATH — skip it.
+  if (!isAbsolute(resolvedBinaryPath)) {
     return currentPath;
   }
 
-  return `${binDir}:${currentPath}`;
+  const binDir = dirname(resolvedBinaryPath);
+  const parts = currentPath.split(delimiter).filter(Boolean);
+
+  if (parts.includes(binDir)) {
+    return currentPath;
+  }
+
+  return parts.length ? `${binDir}${delimiter}${currentPath}` : binDir;
 }

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -179,14 +179,15 @@ echo "explain this" | sb        # Pipe input as prompt
 
 ### SB Options
 
-| Flag                        | Description                                              | Default                                |
-| --------------------------- | -------------------------------------------------------- | -------------------------------------- |
-| `-a, --agent <id>`          | Agent identity                                           | from `.pcp/identity.json`              |
-| `-b, --backend <name>`      | AI backend                                               | from `.pcp/identity.json`, or `claude` |
-| `--no-session`              | Disable session tracking                                 | enabled                                |
-| `--sb-verbose`              | Show SB verbose output                                   | off                                    |
-| `--session-candidates`      | Print picker candidates and exit                         | off                                    |
-| `--session-candidates-json` | Print picker candidates as JSON and exit (testing/debug) | off                                    |
+| Flag                        | Description                                                | Default                                |
+| --------------------------- | ---------------------------------------------------------- | -------------------------------------- |
+| `-a, --agent <id>`          | Agent identity                                             | from `.pcp/identity.json`              |
+| `-b, --backend <name>`      | AI backend                                                 | from `.pcp/identity.json`, or `claude` |
+| `--no-session`              | Disable session tracking                                   | enabled                                |
+| `--sb-verbose`              | Show SB verbose output                                     | off                                    |
+| `--session-candidates`      | Print picker candidates and exit                           | off                                    |
+| `--session-candidates-json` | Print picker candidates as JSON and exit (testing/debug)   | off                                    |
+| `--dangerous`               | Skip all permission prompts (maps to backend auto-approve) | off                                    |
 
 Any flag not listed above is forwarded to the backend.
 
@@ -326,6 +327,24 @@ Options for `create`:
 Options for `invite`:
 
 - `--role <role>` — Role: `owner`, `admin`, `member`, or `viewer` (default: member)
+
+### Permissions (`sb permissions`)
+
+Manages Claude Code permission rules — allow-all with a deny list for destructive commands. Claude-only; Codex and Gemini lack per-command deny support.
+
+```bash
+sb permissions auto          # Write allow-all + deny-dangerous rules to .claude/settings.local.json
+sb permissions auto --dry-run  # Preview what would be written
+sb permissions show          # Show current allow/deny rules
+sb permissions reset         # Remove all rules (Claude will prompt for everything)
+```
+
+**`sb permissions auto`** sets:
+
+- **Allow**: `Bash(*)`, `Edit(*)`, `Write(*)`, `Read(*)`, `WebFetch(*)`, MCP tools — no prompts for normal dev work
+- **Deny**: `rm -rf`, `git push --force`, `git reset --hard`, `git clean -f` — always blocked
+
+> ⚠️ **`--dangerous` bypasses deny rules entirely.** It maps to each backend's native full-autonomy flag and ignores any configured allow/deny rules. Use it when you explicitly want zero guardrails for a session.
 
 ### Mission Control (`sb mission`)
 

--- a/packages/cli/src/backends/adapters.test.ts
+++ b/packages/cli/src/backends/adapters.test.ts
@@ -105,7 +105,7 @@ describe('backend adapters session resume wiring', () => {
     expect(prepared.args).toContain('--dangerously-skip-permissions');
   });
 
-  it('maps --dangerous to codex --full-auto', () => {
+  it('maps --dangerous to codex --dangerously-bypass-approvals-and-sandbox', () => {
     const adapter = new CodexAdapter();
     const prepared = adapter.prepare({
       agentId: 'lumen',
@@ -116,7 +116,7 @@ describe('backend adapters session resume wiring', () => {
     });
 
     try {
-      expect(prepared.args).toContain('--full-auto');
+      expect(prepared.args).toContain('--dangerously-bypass-approvals-and-sandbox');
     } finally {
       prepared.cleanup();
     }
@@ -157,7 +157,7 @@ describe('backend adapters session resume wiring', () => {
       passthroughArgs: [],
     });
     try {
-      expect(codexPrep.args).not.toContain('--full-auto');
+      expect(codexPrep.args).not.toContain('--dangerously-bypass-approvals-and-sandbox');
     } finally {
       codexPrep.cleanup();
     }

--- a/packages/cli/src/backends/adapters.test.ts
+++ b/packages/cli/src/backends/adapters.test.ts
@@ -92,6 +92,90 @@ describe('backend adapters session resume wiring', () => {
     }
   });
 
+  it('maps --dangerous to claude --dangerously-skip-permissions', () => {
+    const adapter = new ClaudeAdapter();
+    const prepared = adapter.prepare({
+      agentId: 'wren',
+      model: undefined,
+      promptParts: [],
+      passthroughArgs: [],
+      dangerous: true,
+    });
+
+    expect(prepared.args).toContain('--dangerously-skip-permissions');
+  });
+
+  it('maps --dangerous to codex --full-auto', () => {
+    const adapter = new CodexAdapter();
+    const prepared = adapter.prepare({
+      agentId: 'lumen',
+      model: undefined,
+      promptParts: [],
+      passthroughArgs: [],
+      dangerous: true,
+    });
+
+    try {
+      expect(prepared.args).toContain('--full-auto');
+    } finally {
+      prepared.cleanup();
+    }
+  });
+
+  it('maps --dangerous to gemini --yolo', () => {
+    const adapter = new GeminiAdapter();
+    const prepared = adapter.prepare({
+      agentId: 'aster',
+      model: undefined,
+      promptParts: [],
+      passthroughArgs: [],
+      dangerous: true,
+    });
+
+    try {
+      expect(prepared.args).toContain('--yolo');
+    } finally {
+      prepared.cleanup();
+    }
+  });
+
+  it('does not add auto-approve flags when dangerous is false', () => {
+    const claude = new ClaudeAdapter();
+    const claudePrep = claude.prepare({
+      agentId: 'wren',
+      model: undefined,
+      promptParts: [],
+      passthroughArgs: [],
+    });
+    expect(claudePrep.args).not.toContain('--dangerously-skip-permissions');
+
+    const codex = new CodexAdapter();
+    const codexPrep = codex.prepare({
+      agentId: 'lumen',
+      model: undefined,
+      promptParts: [],
+      passthroughArgs: [],
+    });
+    try {
+      expect(codexPrep.args).not.toContain('--full-auto');
+    } finally {
+      codexPrep.cleanup();
+    }
+
+    const gemini = new GeminiAdapter();
+    const geminiPrep = gemini.prepare({
+      agentId: 'aster',
+      model: undefined,
+      promptParts: [],
+      passthroughArgs: [],
+    });
+    try {
+      expect(geminiPrep.args).not.toContain('--yolo');
+    } finally {
+      geminiPrep.cleanup();
+    }
+  });
+
   it('passes backendSessionId through gemini --resume flag', () => {
     const adapter = new GeminiAdapter();
     const prepared = adapter.prepare({

--- a/packages/cli/src/backends/claude.ts
+++ b/packages/cli/src/backends/claude.ts
@@ -47,6 +47,11 @@ export class ClaudeAdapter implements BackendAdapter {
       args.push('--mcp-config', mcpConfig);
     }
 
+    // Auto-approve: skip all permission prompts
+    if (config.dangerous) {
+      args.push('--dangerously-skip-permissions');
+    }
+
     // Passthrough flags
     args.push(...config.passthroughArgs);
 

--- a/packages/cli/src/backends/codex.ts
+++ b/packages/cli/src/backends/codex.ts
@@ -39,9 +39,9 @@ export class CodexAdapter implements BackendAdapter {
     // equivalent to Claude's --session-id seeding flow, so we only pass resume
     // when a backend-native id is already known.
 
-    // Auto-approve: skip all permission prompts
+    // Auto-approve: skip all permission prompts and sandbox restrictions
     if (config.dangerous) {
-      args.push('--full-auto');
+      args.push('--dangerously-bypass-approvals-and-sandbox');
     }
 
     // Passthrough flags

--- a/packages/cli/src/backends/codex.ts
+++ b/packages/cli/src/backends/codex.ts
@@ -39,6 +39,11 @@ export class CodexAdapter implements BackendAdapter {
     // equivalent to Claude's --session-id seeding flow, so we only pass resume
     // when a backend-native id is already known.
 
+    // Auto-approve: skip all permission prompts
+    if (config.dangerous) {
+      args.push('--full-auto');
+    }
+
     // Passthrough flags
     args.push(...config.passthroughArgs);
 

--- a/packages/cli/src/backends/gemini.ts
+++ b/packages/cli/src/backends/gemini.ts
@@ -37,6 +37,11 @@ export class GeminiAdapter implements BackendAdapter {
       args.push('--resume', config.backendSessionId);
     }
 
+    // Auto-approve: skip all permission prompts
+    if (config.dangerous) {
+      args.push('--yolo');
+    }
+
     // Passthrough flags
     args.push(...config.passthroughArgs);
 

--- a/packages/cli/src/backends/types.ts
+++ b/packages/cli/src/backends/types.ts
@@ -15,6 +15,7 @@ export interface BackendConfig {
   pcpSessionId?: string;
   backendSessionId?: string;
   backendSessionSeedId?: string;
+  dangerous?: boolean;
 }
 
 export interface PreparedBackend {

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -69,6 +69,17 @@ describe('extractArgs', () => {
     expect(result.promptParts).toEqual(['hello']);
   });
 
+  it('parses --dangerous flag', () => {
+    const result = extractArgs(['--dangerous', 'hello']);
+    expect(result.sbOptions.dangerous).toBe(true);
+    expect(result.promptParts).toEqual(['hello']);
+  });
+
+  it('defaults dangerous to false', () => {
+    const result = extractArgs(['hello']);
+    expect(result.sbOptions.dangerous).toBe(false);
+  });
+
   it('forwards -v to backend passthrough', () => {
     const result = extractArgs(['-v', '--resume', 'abc123']);
     expect(result.sbOptions.verbose).toBe(false);

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -59,6 +59,7 @@ const SB_FLAGS: Record<string, { hasValue: boolean; key: string }> = {
   '--session-candidates-json': { hasValue: false, key: 'sessionCandidatesJson' },
   '--session-choice': { hasValue: true, key: 'sessionChoice' },
   '--sb-debug': { hasValue: false, key: 'sbDebug' },
+  '--dangerous': { hasValue: false, key: 'dangerous' },
 };
 
 interface ParsedArgs {
@@ -72,6 +73,7 @@ interface ParsedArgs {
     sessionCandidatesJson: boolean;
     sessionChoice: string | undefined;
     sbDebug: boolean;
+    dangerous: boolean;
   };
   passthroughArgs: string[];
   promptParts: string[];
@@ -108,6 +110,7 @@ export function extractArgs(argv: string[]): ParsedArgs {
     sessionCandidatesJson: false,
     sessionChoice: undefined,
     sbDebug: false,
+    dangerous: false,
   };
   const passthroughArgs: string[] = [];
   const promptParts: string[] = [];
@@ -131,6 +134,7 @@ export function extractArgs(argv: string[]): ParsedArgs {
         else if (flag.key === 'sessionCandidates') sbOptions.sessionCandidates = true;
         else if (flag.key === 'sessionCandidatesJson') sbOptions.sessionCandidatesJson = true;
         else if (flag.key === 'sbDebug') sbOptions.sbDebug = true;
+        else if (flag.key === 'dangerous') sbOptions.dangerous = true;
       }
     } else if (arg === '--') {
       // Explicit passthrough boundary — everything after goes to claude
@@ -182,6 +186,7 @@ program
   .option('--session-choice <choice>', 'Force session selection (new | pcp:<id> | local:<id>)')
   .option('--sb-debug', 'Enable SB debug logging to ~/.pcp/sb-debug.log')
   .option('--sb-verbose', 'Verbose SB output')
+  .option('--dangerous', 'Skip all permission prompts (maps to backend-native auto-approve)')
   .argument('[prompt...]', 'Prompt to send (omit for interactive)')
   .action(async () => {
     // We parse argv ourselves for clean passthrough — Commander's parsed
@@ -200,6 +205,14 @@ program
     });
     if (resolvedOptions.sbDebug) {
       console.log(chalk.dim(`SB debug log: ${debugFile}`));
+    }
+    if (resolvedOptions.dangerous) {
+      console.log(
+        chalk.bgYellow.black(' DANGEROUS ') +
+          chalk.yellow(
+            ' All permission prompts will be skipped. The backend can execute any tool without confirmation.'
+          )
+      );
     }
     await maybeWarnServerUpdate();
     sbDebugLog('sb', 'parsed_args', {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -31,6 +31,7 @@ import { registerChatCommand } from './commands/chat.js';
 import { registerDoctorCommand } from './commands/doctor.js';
 import { registerMissionCommand } from './commands/mission.js';
 import { registerStatusCommand } from './commands/status.js';
+import { registerPermissionsCommands } from './commands/permissions.js';
 import { runClaude, runClaudeInteractive } from './commands/claude.js';
 import { resolveBackend } from './backends/index.js';
 import { initSbDebug, sbDebugLog } from './lib/sb-debug.js';
@@ -278,6 +279,7 @@ registerChatCommand(program);
 registerDoctorCommand(program);
 registerMissionCommand(program);
 registerStatusCommand(program);
+registerPermissionsCommands(program);
 
 // ============================================================================
 // Subcommand detection

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -42,6 +42,7 @@ export interface SbOptions {
   sessionCandidates?: boolean;
   sessionCandidatesJson?: boolean;
   sessionChoice?: string;
+  dangerous?: boolean;
 }
 
 interface PcpConfig {
@@ -2619,6 +2620,7 @@ export async function runClaude(
     passthroughArgs,
     ...(startupContextBlock ? { startupContextBlock } : {}),
     ...sessionContext,
+    ...(options.dangerous ? { dangerous: true } : {}),
   });
 
   if (options.verbose) {
@@ -2836,6 +2838,7 @@ export async function runClaudeInteractive(
       ...sessionContext,
       ...(attemptBackendSessionId ? { backendSessionId: attemptBackendSessionId } : {}),
       ...(attemptBackendSessionSeedId ? { backendSessionSeedId: attemptBackendSessionSeedId } : {}),
+      ...(options.dangerous ? { dangerous: true } : {}),
     });
 
     if (options.verbose) {

--- a/packages/cli/src/commands/permissions.test.ts
+++ b/packages/cli/src/commands/permissions.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, rmSync, existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { execFileSync } from 'child_process';
+
+const CLI_PATH = join(__dirname, '..', '..', 'dist', 'cli.js');
+
+function runSb(args: string[], cwd: string): string {
+  return execFileSync('node', [CLI_PATH, ...args], {
+    cwd,
+    encoding: 'utf-8',
+    env: { ...process.env, NO_COLOR: '1' },
+  });
+}
+
+function readSettings(cwd: string): Record<string, unknown> {
+  const p = join(cwd, '.claude', 'settings.local.json');
+  if (!existsSync(p)) return {};
+  return JSON.parse(readFileSync(p, 'utf-8'));
+}
+
+describe('sb permissions', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'sb-perms-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('auto creates allow and deny rules', () => {
+    runSb(['permissions', 'auto'], tmpDir);
+    const settings = readSettings(tmpDir);
+    const perms = settings.permissions as { allow: string[]; deny: string[] };
+
+    expect(perms.allow).toContain('Bash(*)');
+    expect(perms.allow).toContain('Edit(*)');
+    expect(perms.deny).toContain('Bash(rm -rf *)');
+    expect(perms.deny).toContain('Bash(git push --force *)');
+    expect(perms.deny).toContain('Bash(git reset --hard *)');
+  });
+
+  it('preserves existing non-permission settings', () => {
+    mkdirSync(join(tmpDir, '.claude'), { recursive: true });
+    writeFileSync(
+      join(tmpDir, '.claude', 'settings.local.json'),
+      JSON.stringify({
+        hooks: { Stop: [{ hooks: [{ type: 'command', command: 'echo bye' }] }] },
+        enableAllProjectMcpServers: true,
+      })
+    );
+
+    runSb(['permissions', 'auto'], tmpDir);
+    const settings = readSettings(tmpDir);
+
+    expect(settings.hooks).toBeDefined();
+    expect(settings.enableAllProjectMcpServers).toBe(true);
+    expect((settings.permissions as { allow: string[] }).allow).toContain('Bash(*)');
+  });
+
+  it('show reports no rules when none configured', () => {
+    const output = runSb(['permissions', 'show'], tmpDir);
+    expect(output).toContain('No permission rules configured');
+  });
+
+  it('show displays configured rules', () => {
+    runSb(['permissions', 'auto'], tmpDir);
+    const output = runSb(['permissions', 'show'], tmpDir);
+    expect(output).toContain('Bash(*)');
+    expect(output).toContain('rm -rf');
+  });
+
+  it('reset removes permission rules', () => {
+    mkdirSync(join(tmpDir, '.claude'), { recursive: true });
+    writeFileSync(
+      join(tmpDir, '.claude', 'settings.local.json'),
+      JSON.stringify({
+        permissions: { allow: ['Bash(*)'], deny: ['Bash(rm -rf *)'] },
+        hooks: { Stop: [] },
+      })
+    );
+
+    runSb(['permissions', 'reset'], tmpDir);
+    const settings = readSettings(tmpDir);
+
+    expect(settings.permissions).toBeUndefined();
+    expect(settings.hooks).toBeDefined();
+  });
+
+  it('dry-run does not write file', () => {
+    const output = runSb(['permissions', 'auto', '--dry-run'], tmpDir);
+    expect(output).toContain('Would write');
+    expect(existsSync(join(tmpDir, '.claude', 'settings.local.json'))).toBe(false);
+  });
+});

--- a/packages/cli/src/commands/permissions.ts
+++ b/packages/cli/src/commands/permissions.ts
@@ -1,0 +1,172 @@
+/**
+ * sb permissions — manage backend permission configs
+ *
+ * Currently supports Claude Code only (the only backend with granular
+ * allow/deny rules). Codex and Gemini lack per-command deny support.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import chalk from 'chalk';
+import type { Command } from 'commander';
+
+const CLAUDE_SETTINGS_PATH = '.claude/settings.local.json';
+
+/**
+ * Default deny rules — destructive commands that should require confirmation
+ * even when everything else is auto-approved.
+ */
+const DEFAULT_DENY_RULES: string[] = [
+  'Bash(rm -rf *)',
+  'Bash(git push --force *)',
+  'Bash(git push -f *)',
+  'Bash(git reset --hard *)',
+  'Bash(git clean -fd *)',
+  'Bash(git clean -f *)',
+  'Bash(git checkout -- .)',
+];
+
+/**
+ * Default allow rules — broad permissions for normal development work.
+ */
+const DEFAULT_ALLOW_RULES: string[] = [
+  'Bash(*)',
+  'Edit(*)',
+  'Write(*)',
+  'Read(*)',
+  'WebFetch(*)',
+  'WebSearch',
+  'mcp__pcp__*',
+  'mcp__github__*',
+  'mcp__supabase__*',
+];
+
+interface ClaudeSettings {
+  permissions?: {
+    allow?: string[];
+    deny?: string[];
+  };
+  [key: string]: unknown;
+}
+
+function readClaudeSettings(cwd: string): ClaudeSettings {
+  const configPath = join(cwd, CLAUDE_SETTINGS_PATH);
+  if (!existsSync(configPath)) return {};
+  try {
+    return JSON.parse(readFileSync(configPath, 'utf-8'));
+  } catch {
+    return {};
+  }
+}
+
+function writeClaudeSettings(cwd: string, settings: ClaudeSettings): void {
+  const configPath = join(cwd, CLAUDE_SETTINGS_PATH);
+  mkdirSync(join(cwd, '.claude'), { recursive: true });
+  writeFileSync(configPath, JSON.stringify(settings, null, 2) + '\n');
+}
+
+export function registerPermissionsCommands(parent: Command): void {
+  const perms = parent.command('permissions').description('Manage backend permission configs');
+
+  perms
+    .command('auto')
+    .description('Set up auto-approve with deny rules for dangerous commands (Claude only)')
+    .option('--dry-run', 'Show what would be written without making changes')
+    .action((options: { dryRun?: boolean }) => {
+      const cwd = process.cwd();
+      const existing = readClaudeSettings(cwd);
+
+      const updated: ClaudeSettings = {
+        ...existing,
+        permissions: {
+          ...existing.permissions,
+          allow: DEFAULT_ALLOW_RULES,
+          deny: DEFAULT_DENY_RULES,
+        },
+      };
+
+      if (options.dryRun) {
+        console.log(chalk.dim('Would write to ' + CLAUDE_SETTINGS_PATH + ':'));
+        console.log();
+        console.log(chalk.green('Allow (auto-approve):'));
+        for (const rule of DEFAULT_ALLOW_RULES) {
+          console.log(chalk.green(`  + ${rule}`));
+        }
+        console.log();
+        console.log(chalk.red('Deny (always block):'));
+        for (const rule of DEFAULT_DENY_RULES) {
+          console.log(chalk.red(`  - ${rule}`));
+        }
+        return;
+      }
+
+      writeClaudeSettings(cwd, updated);
+
+      console.log(chalk.green('Permissions configured in ' + CLAUDE_SETTINGS_PATH));
+      console.log();
+      console.log(chalk.dim('Allow (auto-approve):'));
+      for (const rule of DEFAULT_ALLOW_RULES) {
+        console.log(chalk.dim(`  + ${rule}`));
+      }
+      console.log();
+      console.log(chalk.dim('Deny (always block):'));
+      for (const rule of DEFAULT_DENY_RULES) {
+        console.log(chalk.dim(`  - ${rule}`));
+      }
+      console.log();
+      console.log(
+        chalk.yellow('Note: deny rules are Claude Code only. Use --dangerous for Codex/Gemini.')
+      );
+    });
+
+  perms
+    .command('show')
+    .description('Show current permission rules')
+    .action(() => {
+      const cwd = process.cwd();
+      const settings = readClaudeSettings(cwd);
+      const perms = settings.permissions;
+
+      if (!perms?.allow?.length && !perms?.deny?.length) {
+        console.log(chalk.dim('No permission rules configured.'));
+        console.log(
+          chalk.dim('Run `sb permissions auto` to set up auto-approve with safety deny rules.')
+        );
+        return;
+      }
+
+      if (perms.allow?.length) {
+        console.log(chalk.green('Allow:'));
+        for (const rule of perms.allow) {
+          console.log(chalk.green(`  + ${rule}`));
+        }
+      }
+
+      if (perms.deny?.length) {
+        console.log();
+        console.log(chalk.red('Deny:'));
+        for (const rule of perms.deny) {
+          console.log(chalk.red(`  - ${rule}`));
+        }
+      }
+    });
+
+  perms
+    .command('reset')
+    .description('Remove all auto-approve and deny rules')
+    .action(() => {
+      const cwd = process.cwd();
+      const existing = readClaudeSettings(cwd);
+
+      if (!existing.permissions?.allow?.length && !existing.permissions?.deny?.length) {
+        console.log(chalk.dim('No permission rules to reset.'));
+        return;
+      }
+
+      const updated: ClaudeSettings = { ...existing };
+      delete updated.permissions;
+      writeClaudeSettings(cwd, updated);
+
+      console.log(chalk.green('Permission rules removed. Claude will prompt for all actions.'));
+    });
+}


### PR DESCRIPTION
## Summary

- **`sb --dangerous`** — unified flag that maps to each backend's native full-autonomy mode:
  - Claude → `--dangerously-skip-permissions`
  - Codex → `--dangerously-bypass-approvals-and-sandbox`
  - Gemini → `--yolo`
  - Shows yellow warning banner when active
- **`sb permissions auto`** — writes allow-all + deny-dangerous rules to `.claude/settings.local.json`:
  - Allow: `Bash(*)`, `Edit(*)`, `Write(*)`, `Read(*)`, `WebFetch(*)`, MCP tools
  - Deny: `rm -rf`, `git push --force`, `git reset --hard`, `git clean -f`
  - Claude-only (Codex/Gemini lack per-command deny)
  - Independent of `--dangerous` (which bypasses everything)
- Also: `sb permissions show`, `sb permissions reset`, `--dry-run`

## Usage

```bash
# Full autonomy (all backends)
sb --dangerous "refactor the auth module"

# Auto-approve with safety net (Claude only)
sb permissions auto           # one-time setup
sb permissions auto --dry-run # preview first
sb permissions show           # view rules
sb permissions reset          # back to prompting
```

## Test plan

- [x] CLI arg parsing tests (2 new)
- [x] Adapter mapping tests (4 new — all backends + negative)
- [x] Permissions command tests (6 new — auto, show, reset, dry-run, merge preservation)
- [x] Build passes clean
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)