### PR TITLE
feat: show studio repo root in dashboard/session views (by Lumen)

### DIFF
--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -3737,6 +3737,7 @@ router.get('/sessions', async (req: Request, res: Response) => {
         id: string;
         branch: string | null;
         baseBranch: string | null;
+        repoRoot: string | null;
         purpose: string | null;
         workType: string | null;
         status: string;
@@ -3750,6 +3751,7 @@ router.get('/sessions', async (req: Request, res: Response) => {
         id: string;
         branch: string | null;
         baseBranch: string | null;
+        repoRoot: string | null;
         purpose: string | null;
         workType: string | null;
         status: string;
@@ -3767,7 +3769,7 @@ router.get('/sessions', async (req: Request, res: Response) => {
     if (studioIds.length > 0) {
       const { data: studios } = await supabase
         .from('studios')
-        .select('id, branch, base_branch, purpose, work_type, status, worktree_path')
+        .select('id, branch, base_branch, repo_root, purpose, work_type, status, worktree_path')
         .in('id', studioIds);
 
       for (const studio of studios || []) {
@@ -3775,6 +3777,7 @@ router.get('/sessions', async (req: Request, res: Response) => {
           id: studio.id,
           branch: studio.branch,
           baseBranch: studio.base_branch,
+          repoRoot: studio.repo_root,
           purpose: studio.purpose,
           workType: studio.work_type,
           status: studio.status,
@@ -3788,7 +3791,9 @@ router.get('/sessions', async (req: Request, res: Response) => {
     if (sessionIds.length > 0) {
       const { data: linkedWorkspaces } = await supabase
         .from('studios')
-        .select('id, session_id, branch, base_branch, purpose, work_type, status, worktree_path')
+        .select(
+          'id, session_id, branch, base_branch, repo_root, purpose, work_type, status, worktree_path'
+        )
         .in('session_id', sessionIds);
 
       for (const ws of linkedWorkspaces || []) {
@@ -3797,6 +3802,7 @@ router.get('/sessions', async (req: Request, res: Response) => {
             id: ws.id,
             branch: ws.branch,
             baseBranch: ws.base_branch,
+            repoRoot: ws.repo_root,
             purpose: ws.purpose,
             workType: ws.work_type,
             status: ws.status,
@@ -3960,6 +3966,7 @@ router.get('/studios', async (req: Request, res: Response) => {
       agent_id: string | null;
       branch: string;
       base_branch: string | null;
+      repo_root: string | null;
       purpose: string | null;
       work_type: string | null;
       worktree_path: string;
@@ -3973,7 +3980,7 @@ router.get('/studios', async (req: Request, res: Response) => {
       const { data: scopedStudios } = await supabase
         .from('studios')
         .select(
-          'id, agent_id, branch, base_branch, purpose, work_type, worktree_path, slug, status, updated_at, created_at'
+          'id, agent_id, branch, base_branch, repo_root, purpose, work_type, worktree_path, slug, status, updated_at, created_at'
         )
         .eq('user_id', authReq.pcpUserId)
         .in('identity_id', identityIds)
@@ -4049,6 +4056,7 @@ router.get('/studios', async (req: Request, res: Response) => {
           id: s.id,
           branch: s.branch,
           baseBranch: s.base_branch,
+          repoRoot: s.repo_root,
           purpose: s.purpose,
           workType: s.work_type,
           worktreePath: s.worktree_path,

--- a/packages/web/src/app/(dashboard)/page.tsx
+++ b/packages/web/src/app/(dashboard)/page.tsx
@@ -14,6 +14,7 @@ interface StudioInfo {
   id: string;
   branch: string;
   baseBranch: string | null;
+  repoRoot: string | null;
   purpose: string | null;
   workType: string | null;
   worktreePath: string | null;
@@ -99,6 +100,20 @@ function getStudioSlug(worktreePath: string | null): string | null {
   const dashDashIdx = folder.indexOf('--');
   if (dashDashIdx === -1) return null;
   return folder.slice(dashDashIdx + 2);
+}
+
+function getRepoName(repoRoot: string | null, worktreePath: string | null): string | null {
+  if (repoRoot) {
+    const normalized = repoRoot.replace(/\/+$/, '');
+    const parts = normalized.split('/');
+    return parts[parts.length - 1] || normalized;
+  }
+
+  // Fallback: infer from worktree folder "<repo>--<slug>"
+  const folder = worktreePath?.split('/').pop() || '';
+  const dashDashIdx = folder.indexOf('--');
+  if (dashDashIdx === -1) return null;
+  return folder.slice(0, dashDashIdx) || null;
 }
 
 function getStudioStatusColor(status: string): string {
@@ -251,6 +266,7 @@ export default function DashboardPage() {
                     <div className="divide-y">
                       {agent.studios.map((studio) => {
                         const slug = studio.slug || getStudioSlug(studio.worktreePath);
+                        const repoName = getRepoName(studio.repoRoot, studio.worktreePath);
                         return (
                           <div key={studio.id} className="flex items-center gap-4 px-5 py-3">
                             <div className="flex items-center gap-3 flex-1 min-w-0">
@@ -262,6 +278,14 @@ export default function DashboardPage() {
                                   {slug || studio.branch}
                                 </span>
                               </div>
+                              {repoName && (
+                                <span
+                                  className="text-xs text-gray-400"
+                                  title={studio.repoRoot || undefined}
+                                >
+                                  {repoName}
+                                </span>
+                              )}
                               {studio.purpose && (
                                 <span className="text-xs text-gray-400 truncate">
                                   {studio.purpose}

--- a/packages/web/src/app/(dashboard)/sessions/page.tsx
+++ b/packages/web/src/app/(dashboard)/sessions/page.tsx
@@ -22,6 +22,7 @@ interface SessionWorkspace {
   id: string;
   branch: string | null;
   baseBranch: string | null;
+  repoRoot: string | null;
   purpose: string | null;
   workType: string | null;
   status: string;
@@ -182,10 +183,18 @@ function getSessionState(session: Session): {
   };
 }
 
+function getRepoName(repoRoot: string | null): string | null {
+  if (!repoRoot) return null;
+  const normalized = repoRoot.replace(/\/+$/, '');
+  const parts = normalized.split('/');
+  return parts[parts.length - 1] || normalized;
+}
+
 function SessionCard({ session }: { session: Session }) {
   const [expanded, setExpanded] = useState(false);
   const state = getSessionState(session);
   const phaseLabel = session.currentPhase;
+  const repoName = session.studio?.repoName || getRepoName(session.studio?.repoRoot || null);
 
   return (
     <div className={clsx('rounded-lg border p-4', state.cardClass)}>
@@ -214,10 +223,13 @@ function SessionCard({ session }: { session: Session }) {
           {/* Workspace info */}
           {session.studio && (
             <div className="flex items-center gap-3 mt-2 text-xs text-gray-500">
-              {session.studio.repoName && (
-                <span className="flex items-center gap-1">
+              {repoName && (
+                <span
+                  className="flex items-center gap-1"
+                  title={session.studio.repoRoot || undefined}
+                >
                   <FolderGit2 className="h-3 w-3" />
-                  {session.studio.repoName}
+                  {repoName}
                 </span>
               )}
               <span className="flex items-center gap-1">
@@ -358,6 +370,12 @@ function SessionCard({ session }: { session: Session }) {
                     <div>
                       <span className="text-gray-400">Base: </span>
                       <code className="font-mono">{session.studio.baseBranch}</code>
+                    </div>
+                  )}
+                  {session.studio.repoRoot && (
+                    <div className="sm:col-span-2">
+                      <span className="text-gray-400">Repo root: </span>
+                      <code className="font-mono break-all">{session.studio.repoRoot}</code>
                     </div>
                   )}
                   {session.studio.purpose && (


### PR DESCRIPTION
## Summary
- restore studio repo-root visibility in dashboard and sessions on top of latest `main`
- include `repo_root` in admin sessions studio selects while preserving current `studio` response shape
- show repo name + repo root path in sessions/detail UI with studio-based typing

## Validation
- `npx vitest run packages/api/src/routes/admin-endpoints.test.ts`
- `yarn workspace @personal-context/web type-check`