### PR TITLE
fix: guard against nonexistent studio worktree path in spawn cwd (by Wren)

### DIFF
--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -667,7 +667,7 @@ When you complete a task_request, mark it as completed using update_inbox_messag
     }
 
     if (!result.success) {
-      logger.error(`[Trigger] SessionService failed for ${targetAgentId}:`, result.error);
+      logger.error(`[Trigger] SessionService failed for ${targetAgentId}: ${result.error}`);
       throw new Error(result.error || 'SessionService processing failed');
     }
 

--- a/packages/api/src/services/sessions/session-service.ts
+++ b/packages/api/src/services/sessions/session-service.ts
@@ -9,6 +9,7 @@
  */
 
 import { randomUUID } from 'crypto';
+import { access } from 'fs/promises';
 import { SupabaseClient } from '@supabase/supabase-js';
 import jwt from 'jsonwebtoken';
 import type { Database } from '../../data/supabase/types.js';
@@ -870,7 +871,20 @@ export class SessionService implements ISessionService {
       .maybeSingle();
 
     if (studio?.worktree_path) {
-      return studio.worktree_path;
+      const pathExists = await access(studio.worktree_path)
+        .then(() => true)
+        .catch(() => false);
+      if (pathExists) {
+        return studio.worktree_path;
+      }
+      logger.warn('Studio worktree path does not exist; falling back to default', {
+        userId,
+        agentId,
+        studioId,
+        worktreePath: studio.worktree_path,
+        defaultWorkingDirectory: this.config.defaultWorkingDirectory,
+      });
+      return this.config.defaultWorkingDirectory;
     }
 
     logger.warn('Studio not found for session; using default working directory', {


### PR DESCRIPTION
## Summary

- `resolveWorkingDirectory()` now validates that `studio.worktree_path` exists on disk (async `fs.access`) before returning it — falls back to `defaultWorkingDirectory` with a clear warning if the path is gone
- Fixes misleading "spawn codex ENOENT" errors that were actually caused by a nonexistent `cwd`, not a missing binary (Node's `spawn()` blames the binary path when the cwd doesn't exist)
- Fixes character-by-character error serialization in trigger failure logging (string passed as second arg to structured logger was being spread as `{"0":"F","1":"a",...}`)

**Root cause:** `lumen-alpha` studio is marked `active` in the DB but its worktree (`...--lumen-alpha`) doesn't exist on disk. Any session routed there would fail. Latent bug since `resolveWorkingDirectory` was added in `cdb202c` (Feb 17) — it never validated paths.

## Test plan

- [x] 909 API tests pass
- [ ] Restart server, trigger Lumen — should fall back to repo root with warning instead of ENOENT
- [ ] Verify warning log shows the stale worktree path clearly

Generated with [Claude Code](https://claude.com/claude-code)