### PR TITLE
feat: polish studio repo-root display + dashboard status badges (by Lumen)

### DIFF
--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -3737,6 +3737,7 @@ router.get('/sessions', async (req: Request, res: Response) => {
         id: string;
         branch: string | null;
         baseBranch: string | null;
+        repoRoot: string | null;
         purpose: string | null;
         workType: string | null;
         status: string;
@@ -3750,6 +3751,7 @@ router.get('/sessions', async (req: Request, res: Response) => {
         id: string;
         branch: string | null;
         baseBranch: string | null;
+        repoRoot: string | null;
         purpose: string | null;
         workType: string | null;
         status: string;
@@ -3767,7 +3769,7 @@ router.get('/sessions', async (req: Request, res: Response) => {
     if (studioIds.length > 0) {
       const { data: studios } = await supabase
         .from('studios')
-        .select('id, branch, base_branch, purpose, work_type, status, worktree_path')
+        .select('id, branch, base_branch, repo_root, purpose, work_type, status, worktree_path')
         .in('id', studioIds);
 
       for (const studio of studios || []) {
@@ -3775,6 +3777,7 @@ router.get('/sessions', async (req: Request, res: Response) => {
           id: studio.id,
           branch: studio.branch,
           baseBranch: studio.base_branch,
+          repoRoot: studio.repo_root,
           purpose: studio.purpose,
           workType: studio.work_type,
           status: studio.status,
@@ -3788,7 +3791,9 @@ router.get('/sessions', async (req: Request, res: Response) => {
     if (sessionIds.length > 0) {
       const { data: linkedWorkspaces } = await supabase
         .from('studios')
-        .select('id, session_id, branch, base_branch, purpose, work_type, status, worktree_path')
+        .select(
+          'id, session_id, branch, base_branch, repo_root, purpose, work_type, status, worktree_path'
+        )
         .in('session_id', sessionIds);
 
       for (const ws of linkedWorkspaces || []) {
@@ -3797,6 +3802,7 @@ router.get('/sessions', async (req: Request, res: Response) => {
             id: ws.id,
             branch: ws.branch,
             baseBranch: ws.base_branch,
+            repoRoot: ws.repo_root,
             purpose: ws.purpose,
             workType: ws.work_type,
             status: ws.status,
@@ -3960,6 +3966,7 @@ router.get('/studios', async (req: Request, res: Response) => {
       agent_id: string | null;
       branch: string;
       base_branch: string | null;
+      repo_root: string | null;
       purpose: string | null;
       work_type: string | null;
       worktree_path: string;
@@ -3973,7 +3980,7 @@ router.get('/studios', async (req: Request, res: Response) => {
       const { data: scopedStudios } = await supabase
         .from('studios')
         .select(
-          'id, agent_id, branch, base_branch, purpose, work_type, worktree_path, slug, status, updated_at, created_at'
+          'id, agent_id, branch, base_branch, repo_root, purpose, work_type, worktree_path, slug, status, updated_at, created_at'
         )
         .eq('user_id', authReq.pcpUserId)
         .in('identity_id', identityIds)
@@ -4049,6 +4056,7 @@ router.get('/studios', async (req: Request, res: Response) => {
           id: s.id,
           branch: s.branch,
           baseBranch: s.base_branch,
+          repoRoot: s.repo_root,
           purpose: s.purpose,
           workType: s.work_type,
           worktreePath: s.worktree_path,

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -3759,11 +3759,22 @@ router.get('/sessions', async (req: Request, res: Response) => {
         repoName: string | null;
       }
     >();
-    const deriveRepoName = (worktreePath: string | null | undefined): string | null => {
+    const deriveRepoName = (
+      repoRoot: string | null | undefined,
+      worktreePath: string | null | undefined
+    ): string | null => {
+      if (repoRoot) {
+        const normalizedRoot = repoRoot.replace(/\/+$/, '');
+        const rootBasename = path.basename(normalizedRoot);
+        return rootBasename || normalizedRoot;
+      }
+
       if (!worktreePath) return null;
       const normalizedPath = worktreePath.replace(/\/+$/, '');
-      const basename = path.basename(normalizedPath);
-      return basename || null;
+      const worktreeFolder = path.basename(normalizedPath);
+      const separatorIdx = worktreeFolder.lastIndexOf('--');
+      if (separatorIdx === -1) return null;
+      return worktreeFolder.slice(0, separatorIdx) || null;
     };
 
     if (studioIds.length > 0) {
@@ -3782,7 +3793,7 @@ router.get('/sessions', async (req: Request, res: Response) => {
           workType: studio.work_type,
           status: studio.status,
           worktreePath: studio.worktree_path,
-          repoName: deriveRepoName(studio.worktree_path),
+          repoName: deriveRepoName(studio.repo_root, studio.worktree_path),
         });
       }
     }
@@ -3807,7 +3818,7 @@ router.get('/sessions', async (req: Request, res: Response) => {
             workType: ws.work_type,
             status: ws.status,
             worktreePath: ws.worktree_path,
-            repoName: deriveRepoName(ws.worktree_path),
+            repoName: deriveRepoName(ws.repo_root, ws.worktree_path),
           });
         }
       }

--- a/packages/web/src/app/(dashboard)/page.tsx
+++ b/packages/web/src/app/(dashboard)/page.tsx
@@ -14,6 +14,7 @@ interface StudioInfo {
   id: string;
   branch: string;
   baseBranch: string | null;
+  repoRoot: string | null;
   purpose: string | null;
   workType: string | null;
   worktreePath: string | null;
@@ -99,6 +100,20 @@ function getStudioSlug(worktreePath: string | null): string | null {
   const dashDashIdx = folder.indexOf('--');
   if (dashDashIdx === -1) return null;
   return folder.slice(dashDashIdx + 2);
+}
+
+function getRepoName(repoRoot: string | null, worktreePath: string | null): string | null {
+  if (repoRoot) {
+    const normalized = repoRoot.replace(/\/+$/, '');
+    const parts = normalized.split('/');
+    return parts[parts.length - 1] || normalized;
+  }
+
+  // Fallback: infer from worktree folder "<repo>--<slug>"
+  const folder = worktreePath?.split('/').pop() || '';
+  const dashDashIdx = folder.indexOf('--');
+  if (dashDashIdx === -1) return null;
+  return folder.slice(0, dashDashIdx) || null;
 }
 
 function getStudioStatusColor(status: string): string {
@@ -251,6 +266,7 @@ export default function DashboardPage() {
                     <div className="divide-y">
                       {agent.studios.map((studio) => {
                         const slug = studio.slug || getStudioSlug(studio.worktreePath);
+                        const repoName = getRepoName(studio.repoRoot, studio.worktreePath);
                         return (
                           <div key={studio.id} className="flex items-center gap-4 px-5 py-3">
                             <div className="flex items-center gap-3 flex-1 min-w-0">
@@ -262,6 +278,14 @@ export default function DashboardPage() {
                                   {slug || studio.branch}
                                 </span>
                               </div>
+                              {repoName && (
+                                <span
+                                  className="text-xs text-gray-400"
+                                  title={studio.repoRoot || undefined}
+                                >
+                                  {repoName}
+                                </span>
+                              )}
                               {studio.purpose && (
                                 <span className="text-xs text-gray-400 truncate">
                                   {studio.purpose}

--- a/packages/web/src/app/(dashboard)/page.tsx
+++ b/packages/web/src/app/(dashboard)/page.tsx
@@ -6,7 +6,7 @@ import { MessageSquare, GitBranch, ArrowRight, Monitor, FolderGit2 } from 'lucid
 import Link from 'next/link';
 import { useApiQuery } from '@/lib/api';
 import clsx from 'clsx';
-import { getAgentGradient } from '@/lib/utils';
+import { deriveRepoName, deriveStudioSlugFromWorktreePath, getAgentGradient } from '@/lib/utils';
 
 // ─── Types ───
 
@@ -70,7 +70,7 @@ function getAgentStatusBadge(
 ): {
   label: string;
   badgeClass: string;
-} {
+} | null {
   // Phase-level overrides (blocked is a phase concern)
   if (phase?.startsWith('blocked'))
     return { label: 'Blocked', badgeClass: 'bg-amber-100 text-amber-700' };
@@ -85,35 +85,10 @@ function getAgentStatusBadge(
   // Backward compat: check old runtime:* phase values
   if (phase === 'runtime:generating')
     return { label: 'Running', badgeClass: 'bg-blue-100 text-blue-700' };
-  if (phase === 'runtime:idle') return { label: 'Idle', badgeClass: 'bg-green-100 text-green-700' };
-  if (phase) return { label: 'Idle', badgeClass: 'bg-green-100 text-green-700' };
+  if (phase === 'runtime:idle') return null;
+  if (phase) return null;
 
-  return { label: 'Offline', badgeClass: 'bg-gray-100 text-gray-500' };
-}
-
-function getStudioSlug(worktreePath: string | null): string | null {
-  if (!worktreePath) return null;
-  // Worktree folder names follow the pattern: <repo>--<slug>
-  // e.g. /path/to/personal-context-protocol--wren → "wren"
-  // e.g. /path/to/personal-context-protocol--lumen--lumen-alpha → "lumen--lumen-alpha"
-  const folder = worktreePath.split('/').pop() || '';
-  const dashDashIdx = folder.indexOf('--');
-  if (dashDashIdx === -1) return null;
-  return folder.slice(dashDashIdx + 2);
-}
-
-function getRepoName(repoRoot: string | null, worktreePath: string | null): string | null {
-  if (repoRoot) {
-    const normalized = repoRoot.replace(/\/+$/, '');
-    const parts = normalized.split('/');
-    return parts[parts.length - 1] || normalized;
-  }
-
-  // Fallback: infer from worktree folder "<repo>--<slug>"
-  const folder = worktreePath?.split('/').pop() || '';
-  const dashDashIdx = folder.indexOf('--');
-  if (dashDashIdx === -1) return null;
-  return folder.slice(0, dashDashIdx) || null;
+  return null;
 }
 
 function getStudioStatusColor(status: string): string {
@@ -231,9 +206,11 @@ export default function DashboardPage() {
                       <div className="flex items-center gap-2">
                         <h3 className="font-semibold text-gray-900">{agent.agentName}</h3>
                         <span className="text-xs text-gray-400">@{agent.agentId}</span>
-                        <Badge className={clsx('text-[11px]', status.badgeClass)}>
-                          {status.label}
-                        </Badge>
+                        {status && (
+                          <Badge className={clsx('text-[11px]', status.badgeClass)}>
+                            {status.label}
+                          </Badge>
+                        )}
                       </div>
                       <div className="flex items-center gap-2 mt-0.5">
                         {agent.agentRole && (
@@ -265,8 +242,9 @@ export default function DashboardPage() {
                   ) : (
                     <div className="divide-y">
                       {agent.studios.map((studio) => {
-                        const slug = studio.slug || getStudioSlug(studio.worktreePath);
-                        const repoName = getRepoName(studio.repoRoot, studio.worktreePath);
+                        const slug =
+                          studio.slug || deriveStudioSlugFromWorktreePath(studio.worktreePath);
+                        const repoName = deriveRepoName(studio.repoRoot, studio.worktreePath);
                         return (
                           <div key={studio.id} className="flex items-center gap-4 px-5 py-3">
                             <div className="flex items-center gap-3 flex-1 min-w-0">
@@ -298,18 +276,18 @@ export default function DashboardPage() {
                               )}
                             </div>
                             <div className="flex items-center gap-3 shrink-0">
-                              <Badge
-                                className={clsx(
-                                  'text-[11px] font-medium border',
-                                  studio.status === 'active'
-                                    ? 'bg-green-50 text-green-700 border-green-200 hover:bg-green-50'
-                                    : studio.status === 'idle'
+                              {studio.status !== 'active' && (
+                                <Badge
+                                  className={clsx(
+                                    'text-[11px] font-medium border',
+                                    studio.status === 'idle'
                                       ? 'bg-gray-50 text-gray-500 border-gray-200 hover:bg-gray-50'
                                       : 'bg-gray-50 text-gray-400 border-gray-200 hover:bg-gray-50'
-                                )}
-                              >
-                                {studio.status}
-                              </Badge>
+                                  )}
+                                >
+                                  {studio.status}
+                                </Badge>
+                              )}
                               <span className="text-xs text-gray-400">
                                 {formatRelativeTime(studio.updatedAt)}
                               </span>

--- a/packages/web/src/app/(dashboard)/sessions/page.tsx
+++ b/packages/web/src/app/(dashboard)/sessions/page.tsx
@@ -17,7 +17,6 @@ import {
 } from 'lucide-react';
 import { useApiQuery } from '@/lib/api';
 import clsx from 'clsx';
-import { deriveRepoName } from '@/lib/utils';
 
 interface SessionWorkspace {
   id: string;
@@ -188,9 +187,7 @@ function SessionCard({ session }: { session: Session }) {
   const [expanded, setExpanded] = useState(false);
   const state = getSessionState(session);
   const phaseLabel = session.currentPhase;
-  const repoName =
-    session.studio?.repoName ||
-    deriveRepoName(session.studio?.repoRoot || null, session.studio?.worktreePath);
+  const repoName = session.studio?.repoName;
 
   return (
     <div className={clsx('rounded-lg border p-4', state.cardClass)}>

--- a/packages/web/src/app/(dashboard)/sessions/page.tsx
+++ b/packages/web/src/app/(dashboard)/sessions/page.tsx
@@ -22,6 +22,7 @@ interface SessionWorkspace {
   id: string;
   branch: string | null;
   baseBranch: string | null;
+  repoRoot: string | null;
   purpose: string | null;
   workType: string | null;
   status: string;
@@ -182,10 +183,18 @@ function getSessionState(session: Session): {
   };
 }
 
+function getRepoName(repoRoot: string | null): string | null {
+  if (!repoRoot) return null;
+  const normalized = repoRoot.replace(/\/+$/, '');
+  const parts = normalized.split('/');
+  return parts[parts.length - 1] || normalized;
+}
+
 function SessionCard({ session }: { session: Session }) {
   const [expanded, setExpanded] = useState(false);
   const state = getSessionState(session);
   const phaseLabel = session.currentPhase;
+  const repoName = session.studio?.repoName || getRepoName(session.studio?.repoRoot || null);
 
   return (
     <div className={clsx('rounded-lg border p-4', state.cardClass)}>
@@ -214,10 +223,13 @@ function SessionCard({ session }: { session: Session }) {
           {/* Workspace info */}
           {session.studio && (
             <div className="flex items-center gap-3 mt-2 text-xs text-gray-500">
-              {session.studio.repoName && (
-                <span className="flex items-center gap-1">
+              {repoName && (
+                <span
+                  className="flex items-center gap-1"
+                  title={session.studio.repoRoot || undefined}
+                >
                   <FolderGit2 className="h-3 w-3" />
-                  {session.studio.repoName}
+                  {repoName}
                 </span>
               )}
               <span className="flex items-center gap-1">
@@ -358,6 +370,12 @@ function SessionCard({ session }: { session: Session }) {
                     <div>
                       <span className="text-gray-400">Base: </span>
                       <code className="font-mono">{session.studio.baseBranch}</code>
+                    </div>
+                  )}
+                  {session.studio.repoRoot && (
+                    <div className="sm:col-span-2">
+                      <span className="text-gray-400">Repo root: </span>
+                      <code className="font-mono break-all">{session.studio.repoRoot}</code>
                     </div>
                   )}
                   {session.studio.purpose && (

--- a/packages/web/src/app/(dashboard)/sessions/page.tsx
+++ b/packages/web/src/app/(dashboard)/sessions/page.tsx
@@ -17,6 +17,7 @@ import {
 } from 'lucide-react';
 import { useApiQuery } from '@/lib/api';
 import clsx from 'clsx';
+import { deriveRepoName } from '@/lib/utils';
 
 interface SessionWorkspace {
   id: string;
@@ -183,18 +184,13 @@ function getSessionState(session: Session): {
   };
 }
 
-function getRepoName(repoRoot: string | null): string | null {
-  if (!repoRoot) return null;
-  const normalized = repoRoot.replace(/\/+$/, '');
-  const parts = normalized.split('/');
-  return parts[parts.length - 1] || normalized;
-}
-
 function SessionCard({ session }: { session: Session }) {
   const [expanded, setExpanded] = useState(false);
   const state = getSessionState(session);
   const phaseLabel = session.currentPhase;
-  const repoName = session.studio?.repoName || getRepoName(session.studio?.repoRoot || null);
+  const repoName =
+    session.studio?.repoName ||
+    deriveRepoName(session.studio?.repoRoot || null, session.studio?.worktreePath);
 
   return (
     <div className={clsx('rounded-lg border p-4', state.cardClass)}>

--- a/packages/web/src/lib/utils.ts
+++ b/packages/web/src/lib/utils.ts
@@ -30,12 +30,12 @@ export function getAgentGradient(agentId: string): string {
 
 /**
  * Parse studio slug from worktree folder convention: "<repo>--<slug>".
- * Uses the last "--" so repo names containing "--" still resolve correctly.
+ * Uses the first "--" because the slug itself may include "--".
  */
 export function deriveStudioSlugFromWorktreePath(worktreePath: string | null): string | null {
   if (!worktreePath) return null;
   const folder = worktreePath.split('/').pop() || '';
-  const separatorIdx = folder.lastIndexOf('--');
+  const separatorIdx = folder.indexOf('--');
   if (separatorIdx === -1) return null;
   return folder.slice(separatorIdx + 2) || null;
 }

--- a/packages/web/src/lib/utils.ts
+++ b/packages/web/src/lib/utils.ts
@@ -27,3 +27,35 @@ export function getAgentGradient(agentId: string): string {
   }
   return SB_GRADIENTS[Math.abs(hash) % SB_GRADIENTS.length];
 }
+
+/**
+ * Parse studio slug from worktree folder convention: "<repo>--<slug>".
+ * Uses the last "--" so repo names containing "--" still resolve correctly.
+ */
+export function deriveStudioSlugFromWorktreePath(worktreePath: string | null): string | null {
+  if (!worktreePath) return null;
+  const folder = worktreePath.split('/').pop() || '';
+  const separatorIdx = folder.lastIndexOf('--');
+  if (separatorIdx === -1) return null;
+  return folder.slice(separatorIdx + 2) || null;
+}
+
+/**
+ * Derive repo display name from repoRoot with worktree fallback.
+ * Fallback also supports repo names containing "--" via lastIndexOf.
+ */
+export function deriveRepoName(
+  repoRoot: string | null,
+  worktreePath?: string | null
+): string | null {
+  if (repoRoot) {
+    const normalized = repoRoot.replace(/\/+$/, '');
+    const parts = normalized.split('/');
+    return parts[parts.length - 1] || normalized;
+  }
+
+  const folder = worktreePath?.split('/').pop() || '';
+  const separatorIdx = folder.lastIndexOf('--');
+  if (separatorIdx === -1) return null;
+  return folder.slice(0, separatorIdx) || null;
+}


### PR DESCRIPTION
## Summary
Consolidates the studio repo-root UI work on top of latest `main` and addresses Wren’s review notes from #166.

## What changed
- keeps repo-root/studio metadata surfaced in admin sessions payload
- hardens repo-name derivation in API + web:
  - prefer `repo_root` basename when present
  - fallback to worktree convention using **last** `--` split so repo names containing `--` still work
- removes noisy dashboard status chips:
  - no default `Offline` agent badge
  - hide redundant `active` studio badge (keep non-active statuses)
- uses shared web helpers (`deriveRepoName`, `deriveStudioSlugFromWorktreePath`) so dashboard/sessions stay consistent

## Validation
- `npx vitest run packages/api/src/routes/admin-endpoints.test.ts`
- `yarn workspace @personal-context/web type-check`

## Context
Supersedes the earlier open branches/PRs for this feature line (#166, #177) with a clean, rebased version.