### PR TITLE
fix: clean stale studio references after rename/remove (by lumen)

### DIFF
--- a/packages/cli/src/commands/studio.test.ts
+++ b/packages/cli/src/commands/studio.test.ts
@@ -4,7 +4,17 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { execSync } from 'child_process';
-import { existsSync, mkdirSync, writeFileSync, rmSync, readFileSync, renameSync } from 'fs';
+import {
+  existsSync,
+  mkdirSync,
+  writeFileSync,
+  rmSync,
+  readFileSync,
+  renameSync,
+  lstatSync,
+  symlinkSync,
+  mkdtempSync,
+} from 'fs';
 import { join, basename, delimiter as pathDelimiter } from 'path';
 import { tmpdir } from 'os';
 import {
@@ -12,6 +22,7 @@ import {
   getWorktreePaths,
   getWorktreeBranchMap,
   removeStudioWorktreeOrFolder,
+  removeExistingLink,
   listStudios,
   getStudioPrefix,
   resolveCopySourceRoot,
@@ -133,6 +144,24 @@ describe('Studio Commands', () => {
 
       const before = getWorktreeBranchMap(realRepo);
       expect(before.has(wtPath)).toBe(true);
+
+      const removedKind = removeStudioWorktreeOrFolder(realRepo, wtPath, true);
+      expect(removedKind).toBe('worktree');
+      expect(existsSync(wtPath)).toBe(false);
+
+      const after = getWorktreeBranchMap(realRepo);
+      expect(after.has(wtPath)).toBe(false);
+    });
+
+    it('treats detached HEAD worktrees as registered and removes via git', () => {
+      const realRepo = git('rev-parse --show-toplevel', TEST_REPO);
+      const parent = join(realRepo, '..');
+      const wtPath = join(parent, 'test-repo--detached');
+      git(`worktree add -b wren/studio/detached "${wtPath}"`, realRepo);
+      git('checkout --detach', wtPath);
+
+      const before = getWorktreeBranchMap(realRepo);
+      expect(before.get(wtPath)).toBe('(detached)');
 
       const removedKind = removeStudioWorktreeOrFolder(realRepo, wtPath, true);
       expect(removedKind).toBe('worktree');
@@ -295,6 +324,18 @@ describe('CLI link path helpers', () => {
     expect(shouldWarnMissingCliBinPath(['/usr/bin', '/bin'].join(pathDelimiter), targets)).toBe(
       true
     );
+  });
+
+  it('removes broken symlinks before re-linking', () => {
+    const tmpLinkDir = mkdtempSync(join(tmpdir(), 'sb-link-test-'));
+    const linkPath = join(tmpLinkDir, 'broken-sb-link');
+    symlinkSync('/tmp/nonexistent-target', linkPath);
+    expect(() => lstatSync(linkPath)).not.toThrow();
+
+    removeExistingLink(linkPath);
+    expect(() => lstatSync(linkPath)).toThrow();
+
+    rmSync(tmpLinkDir, { recursive: true, force: true });
   });
 });
 

--- a/packages/cli/src/commands/studio.test.ts
+++ b/packages/cli/src/commands/studio.test.ts
@@ -10,6 +10,9 @@ import { tmpdir } from 'os';
 import {
   planInit,
   getWorktreePaths,
+  getWorktreeBranchMap,
+  removeStudioWorktreeOrFolder,
+  listStudios,
   getStudioPrefix,
   resolveCopySourceRoot,
   updateIdentityForStudioRename,
@@ -90,6 +93,53 @@ describe('Studio Commands', () => {
       const worktreeList = git('worktree list', TEST_REPO);
       expect(worktreeList).toContain(TEST_REPO);
       expect(worktreeList).toContain(worktreePath);
+    });
+
+    it('should ignore stale prefixed folders in studio list', () => {
+      const realRepo = git('rev-parse --show-toplevel', TEST_REPO);
+      const parent = join(realRepo, '..');
+
+      const validName = 'active';
+      const validPath = join(parent, `test-repo--${validName}`);
+      git(`worktree add -b wren/studio/${validName} "${validPath}"`, realRepo);
+
+      // Simulate stale folder left behind by rename/remove mismatch.
+      const stalePath = join(parent, 'test-repo--stale');
+      mkdirSync(stalePath, { recursive: true });
+
+      const studios = listStudios(realRepo);
+      const names = studios.map((s) => s.name);
+
+      expect(names).toContain(validName);
+      expect(names).not.toContain('stale');
+    });
+
+    it('removes stale non-worktree folders without throwing', () => {
+      const realRepo = git('rev-parse --show-toplevel', TEST_REPO);
+      const parent = join(realRepo, '..');
+      const stalePath = join(parent, 'test-repo--stale');
+      mkdirSync(stalePath, { recursive: true });
+
+      const removedKind = removeStudioWorktreeOrFolder(realRepo, stalePath, true);
+      expect(removedKind).toBe('folder');
+      expect(existsSync(stalePath)).toBe(false);
+    });
+
+    it('removes registered worktrees via git worktree remove', () => {
+      const realRepo = git('rev-parse --show-toplevel', TEST_REPO);
+      const parent = join(realRepo, '..');
+      const wtPath = join(parent, 'test-repo--remove-me');
+      git(`worktree add -b wren/studio/remove-me "${wtPath}"`, realRepo);
+
+      const before = getWorktreeBranchMap(realRepo);
+      expect(before.has(wtPath)).toBe(true);
+
+      const removedKind = removeStudioWorktreeOrFolder(realRepo, wtPath, true);
+      expect(removedKind).toBe('worktree');
+      expect(existsSync(wtPath)).toBe(false);
+
+      const after = getWorktreeBranchMap(realRepo);
+      expect(after.has(wtPath)).toBe(false);
     });
 
     it('should remove worktree', () => {

--- a/packages/cli/src/commands/studio.ts
+++ b/packages/cli/src/commands/studio.ts
@@ -27,6 +27,7 @@ import {
   renameSync,
   cpSync,
   statSync,
+  lstatSync,
   rmSync,
 } from 'fs';
 import {
@@ -221,6 +222,10 @@ function getWorktreeBranchMap(gitRoot: string): Map<string, string> {
       currentPath = resolvePath(line.substring(9));
     } else if (line.startsWith('branch ')) {
       worktrees.set(currentPath, line.substring(7).replace('refs/heads/', ''));
+    } else if (line === 'detached' && currentPath) {
+      // Detached HEAD worktrees don't emit a "branch ..." line in porcelain output,
+      // but they are still registered git worktrees and must be treated as such.
+      worktrees.set(currentPath, '(detached)');
     }
   }
 
@@ -244,6 +249,20 @@ function removeStudioWorktreeOrFolder(
   // Folder exists but is not a registered worktree: clean the stale folder.
   rmSync(normalizedPath, { recursive: true, force: true });
   return 'folder';
+}
+
+function removeExistingLink(linkPath: string): void {
+  try {
+    const stats = lstatSync(linkPath);
+    if (stats.isDirectory()) {
+      throw new Error(`Refusing to overwrite directory at ${linkPath}`);
+    }
+    rmSync(linkPath, { force: true });
+  } catch (error: unknown) {
+    const maybe = error as NodeJS.ErrnoException;
+    if (maybe?.code === 'ENOENT') return;
+    throw error;
+  }
 }
 
 // ============================================================================
@@ -1284,15 +1303,11 @@ async function cliLinkCommand(options: { name?: string; unlink?: boolean }): Pro
     // Create symlink
     mkdirSync(primaryBinDir, { recursive: true });
     mkdirSync(compatBinDir, { recursive: true });
-    const { symlinkSync, unlinkSync } = await import('fs');
+    const { symlinkSync } = await import('fs');
 
-    // Remove existing symlink if present
-    if (existsSync(primaryLinkPath)) {
-      unlinkSync(primaryLinkPath);
-    }
-    if (existsSync(compatLinkPath)) {
-      unlinkSync(compatLinkPath);
-    }
+    // Remove existing paths first (including broken symlinks).
+    removeExistingLink(primaryLinkPath);
+    removeExistingLink(compatLinkPath);
     symlinkSync(cliJs, primaryLinkPath);
     symlinkSync(primaryLinkPath, compatLinkPath);
 
@@ -1335,6 +1350,7 @@ export {
   getWorktreePaths,
   getWorktreeBranchMap,
   removeStudioWorktreeOrFolder,
+  removeExistingLink,
   updateIdentityForStudioRename,
   resolveCopySourceRoot,
   resolveRoleTemplate,

--- a/packages/cli/src/commands/studio.ts
+++ b/packages/cli/src/commands/studio.ts
@@ -27,6 +27,7 @@ import {
   renameSync,
   cpSync,
   statSync,
+  rmSync,
 } from 'fs';
 import {
   join,
@@ -170,25 +171,19 @@ function listStudios(gitRoot: string): StudioInfo[] {
   const parentDir = getStudioParent(gitRoot);
   const studios: StudioInfo[] = [];
 
-  const worktreeOutput = git('worktree list --porcelain', gitRoot);
-  const worktrees = new Map<string, string>();
-
-  let currentPath = '';
-  for (const line of worktreeOutput.split('\n')) {
-    if (line.startsWith('worktree ')) {
-      currentPath = line.substring(9);
-    } else if (line.startsWith('branch ')) {
-      worktrees.set(currentPath, line.substring(7).replace('refs/heads/', ''));
-    }
-  }
+  const worktrees = getWorktreeBranchMap(gitRoot);
 
   const prefix = getStudioPrefix(gitRoot);
   if (existsSync(parentDir)) {
     for (const entry of readdirSync(parentDir)) {
       if (entry.startsWith(prefix)) {
-        const wsPath = join(parentDir, entry);
+        const wsPath = resolvePath(join(parentDir, entry));
         const name = entry.slice(prefix.length);
-        const branch = worktrees.get(wsPath) || 'unknown';
+
+        // Ignore stale folders that match the naming convention but are not
+        // registered as git worktrees.
+        const branch = worktrees.get(wsPath);
+        if (!branch) continue;
 
         let identity: StudioIdentity | undefined;
         const identityPath = join(wsPath, '.pcp', 'identity.json');
@@ -212,19 +207,43 @@ function listStudios(gitRoot: string): StudioInfo[] {
  * Get all worktree paths registered with git (excluding the main worktree).
  */
 function getWorktreePaths(gitRoot: string): string[] {
-  const output = git('worktree list --porcelain', gitRoot);
-  const paths: string[] = [];
+  const worktreeMap = getWorktreeBranchMap(gitRoot);
+  return [...worktreeMap.keys()].filter((path) => path !== resolvePath(gitRoot));
+}
 
-  for (const line of output.split('\n')) {
+function getWorktreeBranchMap(gitRoot: string): Map<string, string> {
+  const worktreeOutput = git('worktree list --porcelain', gitRoot);
+  const worktrees = new Map<string, string>();
+
+  let currentPath = '';
+  for (const line of worktreeOutput.split('\n')) {
     if (line.startsWith('worktree ')) {
-      const path = line.substring(9);
-      if (path !== gitRoot) {
-        paths.push(path);
-      }
+      currentPath = resolvePath(line.substring(9));
+    } else if (line.startsWith('branch ')) {
+      worktrees.set(currentPath, line.substring(7).replace('refs/heads/', ''));
     }
   }
 
-  return paths;
+  return worktrees;
+}
+
+function removeStudioWorktreeOrFolder(
+  gitRoot: string,
+  wsPath: string,
+  force = false
+): 'worktree' | 'folder' {
+  const normalizedPath = resolvePath(wsPath);
+  const worktrees = getWorktreeBranchMap(gitRoot);
+
+  if (worktrees.has(normalizedPath)) {
+    const forceFlag = force ? ' --force' : '';
+    git(`worktree remove "${normalizedPath}"${forceFlag}`, gitRoot);
+    return 'worktree';
+  }
+
+  // Folder exists but is not a registered worktree: clean the stale folder.
+  rmSync(normalizedPath, { recursive: true, force: true });
+  return 'folder';
 }
 
 // ============================================================================
@@ -1014,8 +1033,11 @@ async function removeStudio(name: string): Promise<void> {
       process.exit(1);
     }
 
-    git(`worktree remove "${wsPath}"`, gitRoot);
+    const removedKind = removeStudioWorktreeOrFolder(gitRoot, wsPath);
     spinner.succeed(`Studio removed: ${name}`);
+    if (removedKind === 'folder') {
+      console.log(chalk.dim('  Removed stale folder (not registered as a git worktree).'));
+    }
     console.log(chalk.dim('  Branch kept for PR. Use "sb studio clean" to also delete branch.'));
   } catch (error) {
     spinner.fail(`Failed to remove studio: ${error}`);
@@ -1042,22 +1064,17 @@ async function cleanStudio(name: string): Promise<void> {
       }
     }
 
+    const worktreeMap = getWorktreeBranchMap(gitRoot);
     if (!branch) {
-      // Look up branch from git worktree list
-      const worktreeOutput = git('worktree list --porcelain', gitRoot);
-      let currentPath = '';
-      for (const line of worktreeOutput.split('\n')) {
-        if (line.startsWith('worktree ')) {
-          currentPath = line.substring(9);
-        } else if (line.startsWith('branch ') && currentPath === wsPath) {
-          branch = line.substring(7).replace('refs/heads/', '');
-        }
-      }
+      branch = worktreeMap.get(resolvePath(wsPath));
     }
 
-    if (existsSync(wsPath)) {
+    if (existsSync(wsPath) || worktreeMap.has(resolvePath(wsPath))) {
       spinner.text = 'Removing worktree...';
-      git(`worktree remove "${wsPath}" --force`, gitRoot);
+      const removedKind = removeStudioWorktreeOrFolder(gitRoot, wsPath, true);
+      if (removedKind === 'folder') {
+        console.log(chalk.dim('  Removed stale folder (not registered as a git worktree).'));
+      }
     }
 
     if (branch && branchExists(branch, gitRoot)) {
@@ -1313,8 +1330,11 @@ export {
   findGitRoot,
   getStudioParent,
   getStudioPrefix,
+  listStudios,
   getStudioPath,
   getWorktreePaths,
+  getWorktreeBranchMap,
+  removeStudioWorktreeOrFolder,
   updateIdentityForStudioRename,
   resolveCopySourceRoot,
   resolveRoleTemplate,


### PR DESCRIPTION
## Summary
Fixes `sb studio` stale-reference behavior where renamed/removed studios could leave behind a folder-like entry and `sb studio clean <name>` would fail with:

`fatal: '<path>' is not a working tree`

## What changed
- `listStudios()` now only lists folders that are actually registered git worktrees (prevents stale sibling folders from appearing as studios with `Branch: unknown`).
- Added `getWorktreeBranchMap()` helper to normalize worktree parsing/path matching.
- Added `removeStudioWorktreeOrFolder()` helper:
  - removes via `git worktree remove` when registered
  - falls back to deleting stale folder when not registered
- Updated both `studio remove` and `studio clean` to use the safer helper and print a clear stale-folder message.
- `studio clean` branch lookup now uses normalized worktree map (less brittle path matching).

## Tests
Added coverage in `packages/cli/src/commands/studio.test.ts`:
- ignores stale prefixed folders in `listStudios`
- removes stale non-worktree folders without throwing
- removes registered worktrees via git worktree remove

Ran:
- `npx vitest run packages/cli/src/commands/studio.test.ts`

— Lumen