### PR TITLE
feat: improve session candidate sync + table output (by Lumen)

### DIFF
--- a/packages/api/src/services/sessions/codex-runner.test.ts
+++ b/packages/api/src/services/sessions/codex-runner.test.ts
@@ -1,9 +1,32 @@
 import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { EventEmitter } from 'events';
 
-vi.mock('child_process', () => ({
-  spawn: vi.fn(),
-}));
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>();
+  return {
+    ...actual,
+    spawn: vi.fn(),
+    execFile: vi.fn(
+      (
+        file: string,
+        args: string[] | undefined,
+        options: unknown,
+        callback?: (error: Error | null, stdout: string, stderr: string) => void
+      ) => {
+        const cb =
+          typeof options === 'function'
+            ? (options as (error: Error | null, stdout: string, stderr: string) => void)
+            : callback;
+        if (typeof cb !== 'function') return;
+        if (file === 'which' || file === 'zsh') {
+          cb(null, '/usr/bin/codex\n', '');
+          return;
+        }
+        cb(new Error(`mock execFile unsupported for ${file}`), '', '');
+      }
+    ),
+  };
+});
 
 vi.mock('../../utils/logger.js', () => ({
   logger: {
@@ -150,7 +173,7 @@ describe('CodexRunner', () => {
     const [, , options] = (spawn as Mock).mock.calls[0] as [
       string,
       string[],
-      { env?: Record<string, string> }
+      { env?: Record<string, string> },
     ];
     expect(options.env?.PCP_ACCESS_TOKEN).toBe('test-pcp-token');
   });

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { extractArgs, isBackendInteractiveSubcommand } from './cli.js';
+import {
+  buildInteractiveSubcommandArgs,
+  extractArgs,
+  isBackendInteractiveSubcommand,
+} from './cli.js';
 
 describe('isBackendInteractiveSubcommand', () => {
   it('matches codex resume with session id', () => {
@@ -12,14 +16,8 @@ describe('isBackendInteractiveSubcommand', () => {
     expect(isBackendInteractiveSubcommand('codex', ['resume'])).toBe(true);
   });
 
-  it('matches codex resume behind other positional args', () => {
-    expect(
-      isBackendInteractiveSubcommand('codex', [
-        'mcp',
-        'resume',
-        '019c44fd-68f6-7332-9eda-2dc7c8afcedf',
-      ])
-    ).toBe(true);
+  it('does not match codex resume when it is not the first positional token', () => {
+    expect(isBackendInteractiveSubcommand('codex', ['mcp', 'resume'])).toBe(false);
   });
 
   it('does not match non-codex backends', () => {
@@ -29,6 +27,16 @@ describe('isBackendInteractiveSubcommand', () => {
 
   it('does not match empty prompt parts', () => {
     expect(isBackendInteractiveSubcommand('codex', [])).toBe(false);
+  });
+});
+
+describe('buildInteractiveSubcommandArgs', () => {
+  it('keeps positional subcommand tokens before passthrough flags', () => {
+    expect(buildInteractiveSubcommandArgs(['--full-auto'], ['resume', '019c91d2'])).toEqual([
+      'resume',
+      '019c91d2',
+      '--full-auto',
+    ]);
   });
 });
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -96,8 +96,18 @@ interface ParsedArgs {
  */
 export function isBackendInteractiveSubcommand(backend: string, promptParts: string[]): boolean {
   if (backend !== 'codex' || promptParts.length === 0) return false;
-  const CODEX_INTERACTIVE_SUBCOMMANDS = ['resume'];
-  return promptParts.some((part) => CODEX_INTERACTIVE_SUBCOMMANDS.includes(part));
+  return promptParts[0]?.toLowerCase() === 'resume';
+}
+
+/**
+ * For interactive backend subcommands, positional tokens are the actual subcommand
+ * invocation and must stay first (e.g. `codex resume <id> --full-auto`).
+ */
+export function buildInteractiveSubcommandArgs(
+  passthroughArgs: string[],
+  promptParts: string[]
+): string[] {
+  return [...promptParts, ...passthroughArgs];
 }
 
 export function extractArgs(argv: string[]): ParsedArgs {
@@ -229,12 +239,13 @@ program
     );
 
     if (isInteractiveSubcommand) {
+      const interactiveArgs = buildInteractiveSubcommandArgs(passthroughArgs, promptParts);
       sbDebugLog('sb', 'run_interactive_subcommand', {
         backend: resolvedOptions.backend,
-        passthroughArgs: [...passthroughArgs, ...promptParts],
+        passthroughArgs: interactiveArgs,
       });
       // Move positional args to passthrough so the backend receives them as subcommand args
-      await runClaudeInteractive(resolvedOptions, [...passthroughArgs, ...promptParts]);
+      await runClaudeInteractive(resolvedOptions, interactiveArgs);
     } else if (!prompt && !passthroughArgs.length && !process.stdin.isTTY) {
       // Piped stdin — read it as the prompt
       let stdinData = '';

--- a/packages/cli/src/commands/claude.test.ts
+++ b/packages/cli/src/commands/claude.test.ts
@@ -752,10 +752,64 @@ describe('resolveCapturedBackendSessionIdFromRuntime', () => {
         cwd: tempRepo,
         backend: 'claude',
         pcpSessionId: 'pcp-session-1',
-        knownLocalSessionIds: new Set([oldSessionId]),
+        knownLocalSessionSnapshot: new Map([[oldSessionId, '2026-03-04T00:00:00.000Z']]),
       });
 
       expect(resolved).toBe(newSessionId);
+    } finally {
+      if (oldHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = oldHome;
+      }
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to modified existing local backend session when no new local id appears', () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), 'sb-claude-runtime-'));
+    const tempHome = join(tempRoot, 'home');
+    const tempRepo = join(tempRoot, 'repo');
+    mkdirSync(tempHome, { recursive: true });
+    mkdirSync(tempRepo, { recursive: true });
+
+    const projectDirName = tempRepo.replace(/[\\/]/g, '-');
+    const projectKeyDir = join(tempHome, '.claude', 'projects', projectDirName);
+    mkdirSync(projectKeyDir, { recursive: true });
+
+    const oldHome = process.env.HOME;
+    process.env.HOME = tempHome;
+
+    try {
+      const existingSessionId = '33333333-3333-4333-8333-333333333333';
+      const sessionPath = join(projectKeyDir, `${existingSessionId}.jsonl`);
+      writeFileSync(
+        sessionPath,
+        JSON.stringify({
+          type: 'progress',
+          sessionId: existingSessionId,
+          timestamp: '2026-03-04T00:00:00.000Z',
+        }) + '\n'
+      );
+
+      const beforeModified = '2000-01-01T00:00:00.000Z';
+      writeFileSync(
+        sessionPath,
+        JSON.stringify({
+          type: 'progress',
+          sessionId: existingSessionId,
+          timestamp: '2026-03-04T00:02:00.000Z',
+        }) + '\n'
+      );
+
+      const resolved = resolveCapturedBackendSessionIdFromRuntime({
+        cwd: tempRepo,
+        backend: 'claude',
+        pcpSessionId: 'pcp-session-1',
+        knownLocalSessionSnapshot: new Map([[existingSessionId, beforeModified]]),
+      });
+
+      expect(resolved).toBe(existingSessionId);
     } finally {
       if (oldHome === undefined) {
         delete process.env.HOME;

--- a/packages/cli/src/commands/claude.test.ts
+++ b/packages/cli/src/commands/claude.test.ts
@@ -39,7 +39,11 @@ describe('hasBackendSessionOverride', () => {
 
   it('does not treat plain prompt text as resume override', () => {
     expect(hasBackendSessionOverride('codex', [], ['resume this bug'])).toBe(false);
-    expect(hasBackendSessionOverride('codex', [], ['resume'])).toBe(false);
+    expect(hasBackendSessionOverride('codex', [], ['summarize', 'resume'])).toBe(false);
+  });
+
+  it('treats codex resume prompt without explicit session id as override', () => {
+    expect(hasBackendSessionOverride('codex', [], ['resume'])).toBe(true);
   });
 
   it('treats codex resume passthrough args as override', () => {

--- a/packages/cli/src/commands/claude.test.ts
+++ b/packages/cli/src/commands/claude.test.ts
@@ -8,6 +8,7 @@ import {
   filterUntrackedLocalBackendSessions,
   filterPcpSessionsForContext,
   filterUntrackedLocalClaudeSessions,
+  buildSessionPickerLabel,
   getClaudeLocalSessionsForProject,
   getKnownClaudeSessionIds,
   getCodexLocalSessionsForProject,
@@ -83,6 +84,20 @@ describe('renderSessionCandidatesTable', () => {
     expect(lines[2]).toContain('new');
     expect(lines[3]).toContain('pcp:12345678');
     expect(lines[3].length).toBe(lines[2].length);
+  });
+});
+
+describe('buildSessionPickerLabel', () => {
+  it('renders two lines when preview is present', () => {
+    const label = buildSessionPickerLabel({
+      primary: 'Resume PCP c4ec2f5e',
+      details: ['runtime:idle', '2m ago'],
+      preview: 'lumen: latest assistant message preview here',
+    });
+
+    expect(label).toContain('\n');
+    expect(label).toContain('↳');
+    expect(label).toContain('Resume PCP c4ec2f5e');
   });
 });
 

--- a/packages/cli/src/commands/claude.test.ts
+++ b/packages/cli/src/commands/claude.test.ts
@@ -56,6 +56,13 @@ describe('hasBackendSessionOverride', () => {
     expect(hasBackendSessionOverride('claude', ['--resume', 'abc123'])).toBe(true);
     expect(hasBackendSessionOverride('gemini', ['--session-id', 'abc123'])).toBe(true);
   });
+
+  it('treats backend resume flags as overrides even without explicit ids', () => {
+    expect(hasBackendSessionOverride('claude', ['--resume'])).toBe(true);
+    expect(hasBackendSessionOverride('claude', ['-r'])).toBe(true);
+    expect(hasBackendSessionOverride('gemini', ['--resume'])).toBe(true);
+    expect(hasBackendSessionOverride('gemini', ['-r'])).toBe(true);
+  });
 });
 
 describe('renderSessionCandidatesTable', () => {

--- a/packages/cli/src/commands/claude.test.ts
+++ b/packages/cli/src/commands/claude.test.ts
@@ -90,14 +90,15 @@ describe('renderSessionCandidatesTable', () => {
 describe('buildSessionPickerLabel', () => {
   it('renders two lines when preview is present', () => {
     const label = buildSessionPickerLabel({
-      primary: 'Resume PCP c4ec2f5e',
+      primary: 'PCP c4ec2f5e',
       details: ['runtime:idle', '2m ago'],
       preview: 'lumen: latest assistant message preview here',
     });
 
     expect(label).toContain('\n');
     expect(label).toContain('↳');
-    expect(label).toContain('Resume PCP c4ec2f5e');
+    expect(label).toContain('PCP c4ec2f5e');
+    expect(label).toContain('|');
   });
 });
 

--- a/packages/cli/src/commands/claude.test.ts
+++ b/packages/cli/src/commands/claude.test.ts
@@ -12,6 +12,7 @@ import {
   getKnownClaudeSessionIds,
   getCodexLocalSessionsForProject,
   hasBackendSessionOverride,
+  renderSessionCandidatesTable,
   resolveCapturedBackendSessionIdFromRuntime,
   resolveAdoptableLocalBackendSessionId,
   resolveBackendSessionIdForResume,
@@ -49,6 +50,39 @@ describe('hasBackendSessionOverride', () => {
     expect(hasBackendSessionOverride('codex', ['--resume', 'abc123'])).toBe(true);
     expect(hasBackendSessionOverride('claude', ['--resume', 'abc123'])).toBe(true);
     expect(hasBackendSessionOverride('gemini', ['--session-id', 'abc123'])).toBe(true);
+  });
+});
+
+describe('renderSessionCandidatesTable', () => {
+  it('renders headers and aligned rows with truncation', () => {
+    const lines = renderSessionCandidatesTable([
+      {
+        type: 'new',
+        choice: 'new',
+        updated: '-',
+        phase: '-',
+        thread: '-',
+        link: '-',
+        preview: 'Start new session',
+      },
+      {
+        type: 'pcp',
+        choice: 'pcp:12345678',
+        updated: '3/7/2026, 1:23:45 PM',
+        phase: 'runtime:idle',
+        thread: 'pr:182',
+        link: 'Claude 48650142',
+        preview:
+          'lumen: Resumed ✅ Quick checkpoint: Open PRs #149, #147, #126 and more detail that should be truncated in the table row output.',
+      },
+    ]);
+
+    expect(lines[0]).toContain('TYPE');
+    expect(lines[0]).toContain('CHOICE');
+    expect(lines[0]).toContain('PREVIEW');
+    expect(lines[2]).toContain('new');
+    expect(lines[3]).toContain('pcp:12345678');
+    expect(lines[3].length).toBe(lines[2].length);
   });
 });
 

--- a/packages/cli/src/commands/claude.test.ts
+++ b/packages/cli/src/commands/claude.test.ts
@@ -49,6 +49,8 @@ describe('hasBackendSessionOverride', () => {
   it('treats codex resume passthrough args as override', () => {
     expect(hasBackendSessionOverride('codex', ['resume'])).toBe(true);
     expect(hasBackendSessionOverride('codex', ['resume', '--latest'])).toBe(true);
+    expect(hasBackendSessionOverride('codex', ['--full-auto', 'resume', '019c1234'])).toBe(true);
+    expect(hasBackendSessionOverride('codex', ['foo', 'resume'])).toBe(false);
   });
 
   it('still respects flag-based resume overrides', () => {

--- a/packages/cli/src/commands/claude.test.ts
+++ b/packages/cli/src/commands/claude.test.ts
@@ -90,15 +90,14 @@ describe('renderSessionCandidatesTable', () => {
 describe('buildSessionPickerLabel', () => {
   it('renders two lines when preview is present', () => {
     const label = buildSessionPickerLabel({
-      primary: 'PCP c4ec2f5e',
-      details: ['runtime:idle', '2m ago'],
+      metaLine: 'PCP        c4ec2f5e   runtime:idle         main         2m ago',
       preview: 'lumen: latest assistant message preview here',
     });
 
     expect(label).toContain('\n');
     expect(label).toContain('↳');
-    expect(label).toContain('PCP c4ec2f5e');
-    expect(label).toContain('|');
+    expect(label).toContain('PCP');
+    expect(label).toContain('c4ec2f5e');
   });
 });
 

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -19,7 +19,7 @@ import {
   realpathSync,
   statSync,
 } from 'fs';
-import { join, resolve as resolvePath } from 'path';
+import { basename, dirname, join, resolve as resolvePath } from 'path';
 import { homedir } from 'os';
 import { getBackend, resolveAgentId } from '../backends/index.js';
 import { classifyError } from '@personal-context/shared';
@@ -59,6 +59,7 @@ interface PcpSessionSummary {
   id: string;
   studioId?: string | null;
   threadKey?: string | null;
+  context?: string | null;
   currentPhase?: string | null;
   lifecycle?: string | null;
   status?: string | null;
@@ -772,26 +773,61 @@ function findLatestPcpReplTranscriptForSession(
   sessionId: string,
   cwd = process.cwd()
 ): string | undefined {
-  const dir = join(cwd, '.pcp', 'runtime', 'repl');
-  if (!existsSync(dir)) return undefined;
+  const searchRoots = new Set<string>([cwd]);
+  const worktreesDir = join(cwd, '.worktrees');
+  if (existsSync(worktreesDir)) {
+    try {
+      for (const entry of readdirSync(worktreesDir, { withFileTypes: true })) {
+        if (!entry.isDirectory()) continue;
+        searchRoots.add(join(worktreesDir, entry.name));
+      }
+    } catch {
+      // Ignore unreadable .worktrees directory
+    }
+  }
+
+  const cwdBase = basename(cwd);
+  const repoPrefix = cwdBase.split('--')[0] || cwdBase;
+  const parentDir = dirname(cwd);
+  if (existsSync(parentDir)) {
+    try {
+      for (const entry of readdirSync(parentDir, { withFileTypes: true })) {
+        if (!entry.isDirectory()) continue;
+        if (entry.name !== repoPrefix && !entry.name.startsWith(`${repoPrefix}--`)) continue;
+        searchRoots.add(join(parentDir, entry.name));
+      }
+    } catch {
+      // Ignore unreadable sibling directories
+    }
+  }
+
   const prefix = `${sessionId}-`;
-  const candidates = readdirSync(dir)
-    .filter((entry) => entry.startsWith(prefix) && entry.endsWith('.jsonl'))
-    .map((entry) => join(dir, entry))
-    .filter((fullPath) => {
-      try {
-        return statSync(fullPath).isFile();
-      } catch {
-        return false;
+  const candidates: string[] = [];
+  for (const root of searchRoots) {
+    const dir = join(root, '.pcp', 'runtime', 'repl');
+    if (!existsSync(dir)) continue;
+    try {
+      for (const entry of readdirSync(dir)) {
+        if (!entry.startsWith(prefix) || !entry.endsWith('.jsonl')) continue;
+        const fullPath = join(dir, entry);
+        try {
+          if (statSync(fullPath).isFile()) candidates.push(fullPath);
+        } catch {
+          // Ignore unreadable candidate files
+        }
       }
-    })
-    .sort((a, b) => {
-      try {
-        return statSync(b).mtimeMs - statSync(a).mtimeMs;
-      } catch {
-        return 0;
-      }
-    });
+    } catch {
+      // Ignore unreadable repl directories
+    }
+  }
+
+  candidates.sort((a, b) => {
+    try {
+      return statSync(b).mtimeMs - statSync(a).mtimeMs;
+    } catch {
+      return 0;
+    }
+  });
   return candidates[0];
 }
 
@@ -2351,6 +2387,7 @@ async function ensurePcpSessionContext(
         id: session.id,
         threadKey: session.threadKey || null,
         phase: getSessionPhaseLabel(session) || null,
+        contextPreview: session.context || null,
         startedAt: session.startedAt || null,
         backendSessionId: linkedBackendSessionId || null,
         linkedLocalModified:
@@ -2421,7 +2458,8 @@ async function ensurePcpSessionContext(
           link: session.backendSessionId
             ? `${backendLabel} ${session.backendSessionId.slice(0, 8)}`
             : '-',
-          preview: session.linkedLocalPreview || session.pcpPreview || '-',
+          preview:
+            session.linkedLocalPreview || session.pcpPreview || session.contextPreview || '-',
         })),
         ...localCandidates.map((localSession) => ({
           type: localSession.linkedPcpSessionId ? 'local+pcp' : 'local',
@@ -2503,7 +2541,7 @@ async function ensurePcpSessionContext(
       const backendLabel = backend[0].toUpperCase() + backend.slice(1);
       const preview = pcpPreviewBySessionId.get(session.id);
       const phaseLabel = getSessionPhaseLabel(session);
-      const pickerPreview = linkedPreviewText || preview;
+      const pickerPreview = linkedPreviewText || preview || session.context || undefined;
       choices.push({
         name: buildSessionPickerLabel({
           primary: `Resume PCP ${session.id.slice(0, 8)}`,
@@ -2551,9 +2589,11 @@ async function ensurePcpSessionContext(
 
     try {
       const { select } = await import('@inquirer/prompts');
+      const pageSize = Math.max(12, Math.min(30, (process.stdout.rows || 28) - 6));
       const selection = await select({
         message: `Session for ${agentId}/${backend}`,
         choices,
+        pageSize,
       });
       if (selection === '__new__') {
         chosen = await startNewPcpSession();

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -2645,7 +2645,6 @@ async function ensurePcpSessionContext(
             state: stateTokens.join(' · '),
             branch: pickerPreview || branchLabel,
           }),
-          preview: branchLabel !== '-' ? `branch ${branchLabel}` : undefined,
         }),
         value,
       });
@@ -2670,7 +2669,6 @@ async function ensurePcpSessionContext(
             state: linkedPcpSession ? `linked pcp:${linkedPcpSession.id.slice(0, 8)}` : 'local',
             branch: previewText || localSession.gitBranch || '-',
           }),
-          preview: localSession.gitBranch ? `branch ${localSession.gitBranch}` : undefined,
         }),
         value,
       });

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -142,7 +142,7 @@ function getPickerLabelMaxWidth(): number {
   return Math.max(72, Math.min(140, columns - 12));
 }
 
-function buildSessionPickerLabel(options: {
+export function buildSessionPickerLabel(options: {
   primary: string;
   details?: Array<string | null | undefined>;
   preview?: string | null;
@@ -150,10 +150,12 @@ function buildSessionPickerLabel(options: {
   const maxWidth = getPickerLabelMaxWidth();
   const detailText = (options.details || []).filter(Boolean).join(' · ');
   const base = detailText ? `${options.primary} — ${detailText}` : options.primary;
-  if (!options.preview) return truncateText(base, maxWidth);
+  const firstLine = truncateText(base, maxWidth);
+  if (!options.preview) return firstLine;
 
-  const previewBudget = Math.max(24, maxWidth - base.length - 3);
-  return truncateText(`${base} — ${truncateText(options.preview, previewBudget)}`, maxWidth);
+  const previewWidth = Math.max(36, maxWidth - 4);
+  const previewLine = `  ↳ ${truncateText(options.preview, previewWidth)}`;
+  return `${firstLine}\n${previewLine}`;
 }
 
 export function renderSessionCandidatesTable(rows: SessionCandidateTableRow[]): string[] {

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -1873,11 +1873,7 @@ export function hasBackendSessionOverride(
 ): boolean {
   const lowered = passthroughArgs.map((arg) => arg.toLowerCase());
   const has = (flag: string) => lowered.includes(flag.toLowerCase());
-  const isCodexResumePrompt =
-    backend === 'codex' &&
-    promptParts[0]?.toLowerCase() === 'resume' &&
-    Boolean(promptParts[1]) &&
-    !promptParts[1]?.startsWith('-');
+  const isCodexResumePrompt = backend === 'codex' && promptParts[0]?.toLowerCase() === 'resume';
   const isCodexResumePassthrough =
     backend === 'codex' && passthroughArgs[0]?.toLowerCase() === 'resume';
 

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -149,8 +149,8 @@ export function buildSessionPickerLabel(options: {
   preview?: string | null;
 }): string {
   const maxWidth = getPickerLabelMaxWidth();
-  const detailText = (options.details || []).filter(Boolean).join(' · ');
-  const base = detailText ? `${options.primary} — ${detailText}` : options.primary;
+  const detailText = (options.details || []).filter(Boolean).join(' | ');
+  const base = detailText ? `${options.primary} | ${detailText}` : options.primary;
   const firstLine = truncateText(base, maxWidth);
   if (!options.preview) return firstLine;
 
@@ -2544,7 +2544,7 @@ async function ensurePcpSessionContext(
       const pickerPreview = linkedPreviewText || preview || session.context || undefined;
       choices.push({
         name: buildSessionPickerLabel({
-          primary: `Resume PCP ${session.id.slice(0, 8)}`,
+          primary: `PCP ${session.id.slice(0, 8)}`,
           details: [
             session.threadKey ? `thread ${truncateText(session.threadKey, 24)}` : null,
             phaseLabel || null,
@@ -2573,8 +2573,8 @@ async function ensurePcpSessionContext(
         name: buildSessionPickerLabel({
           primary:
             localSession.backend === 'claude'
-              ? `Resume Claude local ${localSession.sessionId.slice(0, 8)}`
-              : `Resume ${backendLabel} local ${localSession.sessionId.slice(0, 8)}`,
+              ? `Claude local ${localSession.sessionId.slice(0, 8)}`
+              : `${backendLabel} local ${localSession.sessionId.slice(0, 8)}`,
           details: [
             linkedPcpSession ? `linked pcp:${linkedPcpSession.id.slice(0, 8)}` : null,
             localSession.gitBranch ? `branch ${truncateText(localSession.gitBranch, 22)}` : null,

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -137,10 +137,16 @@ function padSessionCandidateCell(value: string, width: number): string {
   return truncateText(value || '-', width).padEnd(width, ' ');
 }
 
+function truncatePickerLine(value: string, max = 120): string {
+  if (!value) return '';
+  if (value.length <= max) return value;
+  return `${value.slice(0, max - 1)}…`;
+}
+
 function getPickerLabelMaxWidth(): number {
   const columns = process.stdout.columns;
   if (!columns || columns <= 0) return 110;
-  return Math.max(72, Math.min(140, columns - 12));
+  return Math.max(88, Math.min(200, columns - 8));
 }
 
 interface PickerMetaLineInput {
@@ -153,13 +159,13 @@ interface PickerMetaLineInput {
 
 function buildPickerMetaLine(input: PickerMetaLineInput): string {
   const maxWidth = getPickerLabelMaxWidth();
-  const sourceWidth = 10;
+  const sourceWidth = 12;
   const idWidth = 9;
   const ageWidth = 8;
   const separator = '  ';
   const fixed = sourceWidth + idWidth + ageWidth + separator.length * 4;
   const flexible = Math.max(34, maxWidth - fixed);
-  let stateWidth = Math.max(18, Math.floor(flexible * 0.62));
+  let stateWidth = Math.max(16, Math.floor(flexible * 0.45));
   let branchWidth = Math.max(12, flexible - stateWidth);
   if (stateWidth + branchWidth > flexible) {
     branchWidth = Math.max(12, flexible - stateWidth);
@@ -182,7 +188,7 @@ export function buildSessionPickerLabel(options: {
   preview?: string | null;
 }): string {
   const maxWidth = getPickerLabelMaxWidth();
-  const firstLine = truncateText(options.metaLine, maxWidth);
+  const firstLine = truncatePickerLine(options.metaLine, maxWidth);
   if (!options.preview) return firstLine;
 
   const previewWidth = Math.max(36, maxWidth - 4);

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -170,20 +170,16 @@ interface PickerMetaLineInput {
 
 function buildPickerMetaLine(input: PickerMetaLineInput): string {
   const maxWidth = getPickerLabelMaxWidth();
-  const sourceWidth = 12;
-  const idWidth = 9;
-  const whenWidth = 16;
+  const sourceWidth = 7;
+  const idWidth = 8;
+  const whenWidth = 14;
   const separator = '  ';
   const fixed = sourceWidth + idWidth + whenWidth + separator.length * 4;
   const flexible = Math.max(34, maxWidth - fixed);
-  let stateWidth = Math.max(16, Math.floor(flexible * 0.45));
-  let branchWidth = Math.max(12, flexible - stateWidth);
-  if (stateWidth + branchWidth > flexible) {
-    branchWidth = Math.max(12, flexible - stateWidth);
-  }
-  if (stateWidth + branchWidth > flexible) {
-    stateWidth = Math.max(18, flexible - branchWidth);
-  }
+  let stateWidth = Math.max(12, Math.floor(flexible * 0.3));
+  let branchWidth = Math.max(20, flexible - stateWidth);
+  if (stateWidth + branchWidth > flexible) stateWidth = Math.max(12, flexible - branchWidth);
+  if (stateWidth + branchWidth > flexible) branchWidth = Math.max(20, flexible - stateWidth);
 
   return [
     padSessionCandidateCell(input.source, sourceWidth),
@@ -208,17 +204,29 @@ export function buildSessionPickerLabel(options: {
 }
 
 export function renderSessionCandidatesTable(rows: SessionCandidateTableRow[]): string[] {
+  const terminalWidth = process.stdout.columns || 220;
+  const separator = '  ';
+  const fixedColumns: Array<{
+    key: keyof SessionCandidateTableRow;
+    header: string;
+    width: number;
+  }> = [
+    { key: 'type', header: 'TYPE', width: 7 },
+    { key: 'choice', header: 'CHOICE', width: 14 },
+    { key: 'updated', header: 'UPDATED', width: 18 },
+    { key: 'phase', header: 'PHASE', width: 16 },
+    { key: 'thread', header: 'THREAD', width: 14 },
+    { key: 'link', header: 'LINK', width: 16 },
+  ];
+  const fixedWidth =
+    fixedColumns.reduce((sum, column) => sum + column.width, 0) +
+    separator.length * fixedColumns.length;
+  const previewWidth = Math.max(36, terminalWidth - fixedWidth);
   const columns: Array<{ key: keyof SessionCandidateTableRow; header: string; width: number }> = [
-    { key: 'type', header: 'TYPE', width: 8 },
-    { key: 'choice', header: 'CHOICE', width: 20 },
-    { key: 'updated', header: 'UPDATED', width: 22 },
-    { key: 'phase', header: 'PHASE', width: 18 },
-    { key: 'thread', header: 'THREAD', width: 18 },
-    { key: 'link', header: 'LINK', width: 22 },
-    { key: 'preview', header: 'PREVIEW', width: 120 },
+    ...fixedColumns,
+    { key: 'preview', header: 'PREVIEW', width: previewWidth },
   ];
 
-  const separator = '  ';
   const header = columns
     .map((column) => padSessionCandidateCell(column.header, column.width))
     .join(separator);

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -93,10 +93,57 @@ interface SessionPreviewSummary {
   ts?: string;
 }
 
+interface SessionCandidateTableRow {
+  type: string;
+  choice: string;
+  updated: string;
+  phase: string;
+  thread: string;
+  link: string;
+  preview: string;
+}
+
 function toEpochMs(value: string | undefined): number | undefined {
   if (!value) return undefined;
   const ms = new Date(value).getTime();
   return Number.isFinite(ms) ? ms : undefined;
+}
+
+function formatCandidateTimestamp(value: string | null | undefined): string {
+  if (!value) return '-';
+  const ms = Date.parse(value);
+  if (!Number.isFinite(ms)) return '-';
+  return new Date(ms).toLocaleString();
+}
+
+function padSessionCandidateCell(value: string, width: number): string {
+  return truncateText(value || '-', width).padEnd(width, ' ');
+}
+
+export function renderSessionCandidatesTable(rows: SessionCandidateTableRow[]): string[] {
+  const columns: Array<{ key: keyof SessionCandidateTableRow; header: string; width: number }> = [
+    { key: 'type', header: 'TYPE', width: 8 },
+    { key: 'choice', header: 'CHOICE', width: 20 },
+    { key: 'updated', header: 'UPDATED', width: 22 },
+    { key: 'phase', header: 'PHASE', width: 18 },
+    { key: 'thread', header: 'THREAD', width: 18 },
+    { key: 'link', header: 'LINK', width: 22 },
+    { key: 'preview', header: 'PREVIEW', width: 120 },
+  ];
+
+  const separator = '  ';
+  const header = columns
+    .map((column) => padSessionCandidateCell(column.header, column.width))
+    .join(separator);
+  const divider = columns.map((column) => '-'.repeat(column.width)).join(separator);
+
+  const lines = rows.map((row) =>
+    columns
+      .map((column) => padSessionCandidateCell(row[column.key] || '-', column.width))
+      .join(separator)
+  );
+
+  return [header, divider, ...lines];
 }
 
 export function resolveAdoptableLocalBackendSessionId(options: {
@@ -1952,7 +1999,9 @@ async function ensurePcpSessionContext(
   const email = config?.email;
   const cwd = process.cwd();
   const { studioId, identityId } = getIdentityContextFromIdentityJson(cwd);
-  const localBackendSessions = getBackendLocalSessionsForProject(backend, cwd, 20);
+  const localSessionLimit = options.listCandidates || options.listCandidatesJson ? 120 : 40;
+  const pcpSessionLimit = options.listCandidates || options.listCandidatesJson ? 80 : 40;
+  const localBackendSessions = getBackendLocalSessionsForProject(backend, cwd, localSessionLimit);
   const localBackendSessionIds = new Set(localBackendSessions.map((session) => session.sessionId));
   const knownBackendSessionIds =
     backend === 'claude' ? getKnownClaudeSessionIds() : localBackendSessionIds;
@@ -2004,7 +2053,7 @@ async function ensurePcpSessionContext(
         email,
         agentId,
         ...(studioId ? { studioId } : {}),
-        limit: 20,
+        limit: pcpSessionLimit,
       });
       activeSessions = filterPcpSessionsForContext(
         (listed.sessions || []).filter((s) => isSessionResumable(s)),
@@ -2064,6 +2113,16 @@ async function ensurePcpSessionContext(
     localBackendSessions,
     activeSessions
   );
+  const pcpSessionByBackendSessionId = new Map<string, PcpSessionSummary>();
+  for (const session of activeSessions) {
+    const backendSessionId = getSessionBackendId(session);
+    if (!backendSessionId || pcpSessionByBackendSessionId.has(backendSessionId)) continue;
+    pcpSessionByBackendSessionId.set(backendSessionId, session);
+  }
+  const displayLocalBackendSessions =
+    options.listCandidates || options.listCandidatesJson
+      ? localBackendSessions
+      : untrackedLocalBackendSessions;
   const existingSessionIds = new Set(activeSessions.map((session) => session.id));
   const pcpPreviewBySessionId = new Map<string, string>();
   for (const session of activeSessions) {
@@ -2085,7 +2144,7 @@ async function ensurePcpSessionContext(
   };
   const localSelection = (selection: string): string | undefined => {
     const value = selection.replace(/^__local__:/, '').replace(/^local:/, '');
-    const found = untrackedLocalBackendSessions.find(
+    const found = localBackendSessions.find(
       (session) => session.sessionId === value || session.sessionId.startsWith(value)
     );
     return found?.sessionId;
@@ -2105,7 +2164,7 @@ async function ensurePcpSessionContext(
             email,
             agentId,
             ...(studioId ? { studioId } : {}),
-            limit: 20,
+            limit: pcpSessionLimit,
           },
           { callerProfile: 'runtime' }
         );
@@ -2254,6 +2313,7 @@ async function ensurePcpSessionContext(
         id: session.id,
         threadKey: session.threadKey || null,
         phase: getSessionPhaseLabel(session) || null,
+        startedAt: session.startedAt || null,
         backendSessionId: linkedBackendSessionId || null,
         linkedLocalModified:
           linkedLocalSession?.latestPromptAt || linkedLocalSession?.modified || null,
@@ -2261,14 +2321,21 @@ async function ensurePcpSessionContext(
         pcpPreview: pcpPreviewBySessionId.get(session.id) || null,
       };
     });
-    const localCandidates = untrackedLocalBackendSessions.map((session) => ({
-      type: 'local' as const,
-      id: session.sessionId,
-      modified: session.latestPromptAt || session.modified,
-      preview:
-        withAgentPreviewSpeaker(session.latestPrompt || session.firstPrompt, agentId) || null,
-      gitBranch: session.gitBranch || null,
-    }));
+    const localCandidates = displayLocalBackendSessions.map((session) => {
+      const linkedPcpSession = pcpSessionByBackendSessionId.get(session.sessionId);
+      const preview =
+        withAgentPreviewSpeaker(session.latestPrompt || session.firstPrompt, agentId) || null;
+      return {
+        type: 'local' as const,
+        id: session.sessionId,
+        modified: session.latestPromptAt || session.modified,
+        preview,
+        gitBranch: session.gitBranch || null,
+        linkedPcpSessionId: linkedPcpSession?.id || null,
+        linkedPcpPhase: linkedPcpSession ? getSessionPhaseLabel(linkedPcpSession) || null : null,
+        selectable: !linkedPcpSession,
+      };
+    });
 
     if (options.listCandidatesJson) {
       console.log(
@@ -2279,6 +2346,15 @@ async function ensurePcpSessionContext(
             cwd,
             pcpAvailable,
             pcpUnavailableReason: pcpUnavailableReason || null,
+            limits: {
+              local: localSessionLimit,
+              pcp: pcpSessionLimit,
+            },
+            counts: {
+              pcp: pcpCandidates.length,
+              local: localCandidates.length,
+              localSelectable: localCandidates.filter((candidate) => candidate.selectable).length,
+            },
             candidates: [{ type: 'new' as const }, ...pcpCandidates, ...localCandidates],
           },
           null,
@@ -2287,29 +2363,52 @@ async function ensurePcpSessionContext(
       );
     } else {
       console.log(chalk.bold(`\nSession candidates for ${agentId}/${backend}:`));
-      console.log(chalk.dim('  new'));
-      for (const session of pcpCandidates) {
-        const backendLabel = backend[0].toUpperCase() + backend.slice(1);
-        const linkedPreview = session.linkedLocalPreview
-          ? ` — ${truncateText(session.linkedLocalPreview)}`
-          : '';
-        const linkedWhen = session.linkedLocalModified
-          ? ` (${new Date(session.linkedLocalModified).toLocaleString()})`
-          : '';
-        const pcpPreview = session.pcpPreview ? ` — ${truncateText(session.pcpPreview, 120)}` : '';
-        console.log(
-          chalk.dim(
-            `  pcp:${session.id}${session.threadKey ? ` (${session.threadKey})` : ''}${session.phase ? ` — ${session.phase}` : ''}${session.backendSessionId ? ` · tracks ${backendLabel} ${session.backendSessionId.slice(0, 8)}` : ''}${linkedWhen}${linkedPreview}${pcpPreview}`
-          )
-        );
+      const backendLabel = backend[0].toUpperCase() + backend.slice(1);
+      const rows: SessionCandidateTableRow[] = [
+        {
+          type: 'new',
+          choice: 'new',
+          updated: '-',
+          phase: '-',
+          thread: '-',
+          link: '-',
+          preview: pcpAvailable ? 'Start new session' : 'Start new backend session',
+        },
+        ...pcpCandidates.map((session) => ({
+          type: 'pcp',
+          choice: `pcp:${session.id.slice(0, 8)}`,
+          updated: formatCandidateTimestamp(session.linkedLocalModified || session.startedAt),
+          phase: session.phase || '-',
+          thread: session.threadKey || '-',
+          link: session.backendSessionId
+            ? `${backendLabel} ${session.backendSessionId.slice(0, 8)}`
+            : '-',
+          preview: session.linkedLocalPreview || session.pcpPreview || '-',
+        })),
+        ...localCandidates.map((localSession) => ({
+          type: localSession.linkedPcpSessionId ? 'local+pcp' : 'local',
+          choice: `local:${localSession.id.slice(0, 8)}`,
+          updated: formatCandidateTimestamp(localSession.modified),
+          phase: localSession.linkedPcpPhase || '-',
+          thread: '-',
+          link: localSession.linkedPcpSessionId
+            ? `pcp:${localSession.linkedPcpSessionId.slice(0, 8)}`
+            : localSession.gitBranch || '-',
+          preview: localSession.preview || '-',
+        })),
+      ];
+      const [header, divider, ...body] = renderSessionCandidatesTable(rows);
+      if (header) console.log(chalk.bold(`  ${header}`));
+      if (divider) console.log(chalk.dim(`  ${divider}`));
+      for (const line of body) {
+        console.log(chalk.dim(`  ${line}`));
       }
-      for (const localSession of localCandidates) {
-        console.log(
-          chalk.dim(
-            `  local:${localSession.id}${localSession.preview ? ` — ${truncateText(localSession.preview)}` : ''}`
-          )
-        );
-      }
+      const selectableLocals = localCandidates.filter((candidate) => candidate.selectable).length;
+      console.log(
+        chalk.dim(
+          `\n  Local sessions: ${localCandidates.length} (${selectableLocals} selectable, ${localCandidates.length - selectableLocals} already linked to PCP)`
+        )
+      );
       console.log('');
     }
     if (!normalizedSelectionOverride) {
@@ -2328,8 +2427,13 @@ async function ensurePcpSessionContext(
     } else if (selection.startsWith('local:') || selection.startsWith('__local__:')) {
       selectedLocalBackendSessionId = localSelection(selection);
       if (selectedLocalBackendSessionId && pcpAvailable) {
-        chosen = await startNewPcpSession();
-        createdNewPcpSession = Boolean(chosen?.id);
+        const linkedPcpSession = pcpSessionByBackendSessionId.get(selectedLocalBackendSessionId);
+        if (linkedPcpSession) {
+          chosen = linkedPcpSession;
+        } else {
+          chosen = await startNewPcpSession();
+          createdNewPcpSession = Boolean(chosen?.id);
+        }
       }
     } else {
       console.error(
@@ -2404,8 +2508,13 @@ async function ensurePcpSessionContext(
       } else if (selection.startsWith('__local__:')) {
         selectedLocalBackendSessionId = sessionChoiceByValue.get(selection);
         if (selectedLocalBackendSessionId && pcpAvailable) {
-          chosen = await startNewPcpSession();
-          createdNewPcpSession = Boolean(chosen?.id);
+          const linkedPcpSession = pcpSessionByBackendSessionId.get(selectedLocalBackendSessionId);
+          if (linkedPcpSession) {
+            chosen = linkedPcpSession;
+          } else {
+            chosen = await startNewPcpSession();
+            createdNewPcpSession = Boolean(chosen?.id);
+          }
         }
       }
     } catch (err) {

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -1084,7 +1084,7 @@ export function resolveCapturedBackendSessionIdFromRuntime(options: {
   runtimeLinkId?: string;
   agentId?: string;
   studioId?: string;
-  knownLocalSessionIds?: Set<string>;
+  knownLocalSessionSnapshot?: Map<string, string>;
   fallbackBackendSessionId?: string;
 }): string | undefined {
   const {
@@ -1094,7 +1094,7 @@ export function resolveCapturedBackendSessionIdFromRuntime(options: {
     runtimeLinkId,
     agentId,
     studioId,
-    knownLocalSessionIds,
+    knownLocalSessionSnapshot,
     fallbackBackendSessionId,
   } = options;
 
@@ -1132,12 +1132,19 @@ export function resolveCapturedBackendSessionIdFromRuntime(options: {
     if (currentSessionId) return currentSessionId;
   }
 
-  if (knownLocalSessionIds && knownLocalSessionIds.size > 0) {
+  if (knownLocalSessionSnapshot && knownLocalSessionSnapshot.size > 0) {
     const postRunLocalSessions = getBackendLocalSessionsForProject(backend, cwd, 50);
     const newLocalSession = postRunLocalSessions.find(
-      (session) => !knownLocalSessionIds.has(session.sessionId)
+      (session) => !knownLocalSessionSnapshot.has(session.sessionId)
     );
     if (newLocalSession?.sessionId) return newLocalSession.sessionId;
+
+    const updatedExistingSession = postRunLocalSessions.find((session) => {
+      const previousModified = knownLocalSessionSnapshot.get(session.sessionId);
+      if (!previousModified) return false;
+      return previousModified !== session.modified;
+    });
+    if (updatedExistingSession?.sessionId) return updatedExistingSession.sessionId;
   }
 
   return resolveFromRecord(scopedRecords[0]) || fallbackBackendSessionId;
@@ -2238,9 +2245,24 @@ async function ensurePcpSessionContext(
     localBackendSessions,
     activeSessions
   );
+  const runtimeSessionsForBackend = listRuntimeSessions(cwd, backend);
+  const runtimeBackendSessionIdByPcpSessionId = new Map<string, string>();
+  const runtimeBranchByPcpSessionId = new Map<string, string>();
+  for (const session of runtimeSessionsForBackend) {
+    if (
+      session.backendSessionId &&
+      !runtimeBackendSessionIdByPcpSessionId.has(session.pcpSessionId)
+    ) {
+      runtimeBackendSessionIdByPcpSessionId.set(session.pcpSessionId, session.backendSessionId);
+    }
+    if (session.gitBranch && !runtimeBranchByPcpSessionId.has(session.pcpSessionId)) {
+      runtimeBranchByPcpSessionId.set(session.pcpSessionId, session.gitBranch);
+    }
+  }
   const pcpSessionByBackendSessionId = new Map<string, PcpSessionSummary>();
   for (const session of activeSessions) {
-    const backendSessionId = getSessionBackendId(session);
+    const backendSessionId =
+      getSessionBackendId(session) || runtimeBackendSessionIdByPcpSessionId.get(session.id);
     if (!backendSessionId || pcpSessionByBackendSessionId.has(backendSessionId)) continue;
     pcpSessionByBackendSessionId.set(backendSessionId, session);
   }
@@ -2302,7 +2324,9 @@ async function ensurePcpSessionContext(
         const scopedActive =
           backend === 'claude'
             ? listedActive.filter((session) => {
-                const linkedBackendSessionId = getSessionBackendId(session);
+                const linkedBackendSessionId =
+                  getSessionBackendId(session) ||
+                  runtimeBackendSessionIdByPcpSessionId.get(session.id);
                 if (!linkedBackendSessionId) return true;
                 return knownBackendSessionIds.has(linkedBackendSessionId);
               })
@@ -2423,14 +2447,10 @@ async function ensurePcpSessionContext(
   const localBySessionId = new Map(
     localBackendSessions.map((session) => [session.sessionId, session])
   );
-  const runtimeBranchByPcpSessionId = new Map(
-    listRuntimeSessions(cwd, backend)
-      .filter((session) => Boolean(session.gitBranch))
-      .map((session) => [session.pcpSessionId, session.gitBranch as string])
-  );
   if (options.listCandidates || options.listCandidatesJson) {
     const pcpCandidates = activeSessions.map((session) => {
-      const linkedBackendSessionId = getSessionBackendId(session);
+      const linkedBackendSessionId =
+        getSessionBackendId(session) || runtimeBackendSessionIdByPcpSessionId.get(session.id);
       const linkedLocalSession = linkedBackendSessionId
         ? localBySessionId.get(linkedBackendSessionId)
         : undefined;
@@ -2585,7 +2605,8 @@ async function ensurePcpSessionContext(
 
     for (const session of activeSessions) {
       const value = `__pcp__:${session.id}`;
-      const linkedBackendSessionId = getSessionBackendId(session);
+      const linkedBackendSessionId =
+        getSessionBackendId(session) || runtimeBackendSessionIdByPcpSessionId.get(session.id);
       const linkedLocalSession = linkedBackendSessionId
         ? localBySessionId.get(linkedBackendSessionId)
         : undefined;
@@ -2917,11 +2938,12 @@ export async function runClaude(
   };
   const executionStartedAt = Date.now();
   const backendStartActivityId = await logBackendExecutionStart(executionContext);
-  const knownLocalSessionIds = options.session
-    ? new Set(
-        getBackendLocalSessionsForProject(options.backend, process.cwd(), 50).map(
-          (session) => session.sessionId
-        )
+  const knownLocalSessionSnapshot = options.session
+    ? new Map(
+        getBackendLocalSessionsForProject(options.backend, process.cwd(), 50).map((session) => [
+          session.sessionId,
+          session.modified,
+        ])
       )
     : undefined;
   let capturedBackendSessionId = sessionContext.backendSessionId;
@@ -2988,7 +3010,7 @@ export async function runClaude(
         runtimeLinkId,
         agentId,
         studioId,
-        knownLocalSessionIds,
+        knownLocalSessionSnapshot,
         fallbackBackendSessionId: capturedBackendSessionId,
       });
     }
@@ -3088,11 +3110,12 @@ export async function runClaudeInteractive(
     verbose: options.verbose,
     pcpSessionId: sessionContext.pcpSessionId,
   });
-  const knownLocalSessionIds = options.session
-    ? new Set(
-        getBackendLocalSessionsForProject(options.backend, process.cwd(), 50).map(
-          (session) => session.sessionId
-        )
+  const knownLocalSessionSnapshot = options.session
+    ? new Map(
+        getBackendLocalSessionsForProject(options.backend, process.cwd(), 50).map((session) => [
+          session.sessionId,
+          session.modified,
+        ])
       )
     : undefined;
   const maxAttempts = sessionContext.backendSessionId ? 2 : 1;
@@ -3164,7 +3187,7 @@ export async function runClaudeInteractive(
           runtimeLinkId,
           agentId,
           studioId,
-          knownLocalSessionIds,
+          knownLocalSessionSnapshot,
           fallbackBackendSessionId: finalCapturedBackendSessionId,
         });
 

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -116,8 +116,44 @@ function formatCandidateTimestamp(value: string | null | undefined): string {
   return new Date(ms).toLocaleString();
 }
 
+function formatRelativeCandidateTime(value: string | null | undefined): string {
+  if (!value) return '-';
+  const ms = Date.parse(value);
+  if (!Number.isFinite(ms)) return '-';
+  const diffMs = Math.max(0, Date.now() - ms);
+  const minute = 60 * 1000;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+
+  if (diffMs < minute) return 'just now';
+  if (diffMs < hour) return `${Math.floor(diffMs / minute)}m ago`;
+  if (diffMs < day) return `${Math.floor(diffMs / hour)}h ago`;
+  if (diffMs < 7 * day) return `${Math.floor(diffMs / day)}d ago`;
+  return new Date(ms).toLocaleDateString();
+}
+
 function padSessionCandidateCell(value: string, width: number): string {
   return truncateText(value || '-', width).padEnd(width, ' ');
+}
+
+function getPickerLabelMaxWidth(): number {
+  const columns = process.stdout.columns;
+  if (!columns || columns <= 0) return 110;
+  return Math.max(72, Math.min(140, columns - 12));
+}
+
+function buildSessionPickerLabel(options: {
+  primary: string;
+  details?: Array<string | null | undefined>;
+  preview?: string | null;
+}): string {
+  const maxWidth = getPickerLabelMaxWidth();
+  const detailText = (options.details || []).filter(Boolean).join(' · ');
+  const base = detailText ? `${options.primary} — ${detailText}` : options.primary;
+  if (!options.preview) return truncateText(base, maxWidth);
+
+  const previewBudget = Math.max(24, maxWidth - base.length - 3);
+  return truncateText(`${base} — ${truncateText(options.preview, previewBudget)}`, maxWidth);
 }
 
 export function renderSessionCandidatesTable(rows: SessionCandidateTableRow[]): string[] {
@@ -2461,33 +2497,51 @@ async function ensurePcpSessionContext(
         linkedLocalSession?.latestPrompt || linkedLocalSession?.firstPrompt,
         agentId
       );
-      const linkedPreview = linkedPreviewText ? ` — ${truncateText(linkedPreviewText)}` : '';
       const linkedAt = linkedLocalSession?.latestPromptAt || linkedLocalSession?.modified;
-      const linkedWhen = linkedAt ? ` (${new Date(linkedAt).toLocaleString()})` : '';
       const backendLabel = backend[0].toUpperCase() + backend.slice(1);
       const preview = pcpPreviewBySessionId.get(session.id);
       const phaseLabel = getSessionPhaseLabel(session);
+      const pickerPreview = linkedPreviewText || preview;
       choices.push({
-        name: `Resume PCP ${session.id.slice(0, 8)}${session.threadKey ? ` (${session.threadKey})` : ''}${phaseLabel ? ` — ${phaseLabel}` : ''}${linkedBackendSessionId ? ` · tracks ${backendLabel} ${linkedBackendSessionId.slice(0, 8)}` : ''}${linkedWhen}${linkedPreview}${preview ? ` — ${truncateText(preview, 120)}` : ''}`,
+        name: buildSessionPickerLabel({
+          primary: `Resume PCP ${session.id.slice(0, 8)}`,
+          details: [
+            session.threadKey ? `thread ${truncateText(session.threadKey, 24)}` : null,
+            phaseLabel || null,
+            linkedBackendSessionId
+              ? `tracks ${backendLabel} ${linkedBackendSessionId.slice(0, 8)}`
+              : null,
+            formatRelativeCandidateTime(linkedAt || session.startedAt),
+          ],
+          preview: pickerPreview,
+        }),
         value,
       });
       sessionChoiceByValue.set(value, session.id);
     }
 
-    for (const localSession of untrackedLocalBackendSessions) {
+    for (const localSession of displayLocalBackendSessions) {
       const value = `__local__:${localSession.sessionId}`;
       const previewText = withAgentPreviewSpeaker(
         localSession.latestPrompt || localSession.firstPrompt,
         agentId
       );
-      const preview = previewText ? ` — ${truncateText(previewText)}` : '';
       const previewAt = localSession.latestPromptAt || localSession.modified;
       const backendLabel = localSession.backend[0].toUpperCase() + localSession.backend.slice(1);
+      const linkedPcpSession = pcpSessionByBackendSessionId.get(localSession.sessionId);
       choices.push({
-        name:
-          localSession.backend === 'claude'
-            ? `Resume Claude local ${localSession.sessionId.slice(0, 8)} (${new Date(previewAt).toLocaleString()})${preview}`
-            : `Resume ${backendLabel} local ${localSession.sessionId.slice(0, 8)} (${new Date(previewAt).toLocaleString()})${preview}`,
+        name: buildSessionPickerLabel({
+          primary:
+            localSession.backend === 'claude'
+              ? `Resume Claude local ${localSession.sessionId.slice(0, 8)}`
+              : `Resume ${backendLabel} local ${localSession.sessionId.slice(0, 8)}`,
+          details: [
+            linkedPcpSession ? `linked pcp:${linkedPcpSession.id.slice(0, 8)}` : null,
+            localSession.gitBranch ? `branch ${truncateText(localSession.gitBranch, 22)}` : null,
+            formatRelativeCandidateTime(previewAt),
+          ],
+          preview: previewText,
+        }),
         value,
       });
       sessionChoiceByValue.set(value, localSession.sessionId);

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -1874,8 +1874,11 @@ export function hasBackendSessionOverride(
   const lowered = passthroughArgs.map((arg) => arg.toLowerCase());
   const has = (flag: string) => lowered.includes(flag.toLowerCase());
   const isCodexResumePrompt = backend === 'codex' && promptParts[0]?.toLowerCase() === 'resume';
+  const codexResumeIndex = passthroughArgs.findIndex((arg) => arg.toLowerCase() === 'resume');
   const isCodexResumePassthrough =
-    backend === 'codex' && passthroughArgs[0]?.toLowerCase() === 'resume';
+    backend === 'codex' &&
+    codexResumeIndex >= 0 &&
+    passthroughArgs.slice(0, codexResumeIndex).every((arg) => arg.startsWith('-'));
 
   if (isCodexResumePrompt || isCodexResumePassthrough) return true;
 
@@ -2615,6 +2618,11 @@ async function ensurePcpSessionContext(
       const preview = pcpPreviewBySessionId.get(session.id);
       const phaseLabel = getSessionPhaseLabel(session);
       const pickerPreview = linkedPreviewText || preview || session.context || undefined;
+      const branchLabel =
+        linkedLocalSession?.gitBranch ||
+        runtimeBranchByPcpSessionId.get(session.id) ||
+        session.studio?.branch ||
+        '-';
       const stateTokens = [
         phaseLabel || 'runtime:active',
         session.threadKey ? `thread ${truncateText(session.threadKey, 20)}` : null,
@@ -2627,13 +2635,9 @@ async function ensurePcpSessionContext(
             id: session.id.slice(0, 8),
             when: formatPickerTimestamp(linkedAt || session.startedAt),
             state: stateTokens.join(' · '),
-            branch:
-              linkedLocalSession?.gitBranch ||
-              runtimeBranchByPcpSessionId.get(session.id) ||
-              session.studio?.branch ||
-              '-',
+            branch: pickerPreview || branchLabel,
           }),
-          preview: pickerPreview,
+          preview: branchLabel !== '-' ? `branch ${branchLabel}` : undefined,
         }),
         value,
       });
@@ -2652,15 +2656,13 @@ async function ensurePcpSessionContext(
       choices.push({
         name: buildSessionPickerLabel({
           metaLine: buildPickerMetaLine({
-            source: `${backendLabel} local`,
+            source: backendLabel,
             id: localSession.sessionId.slice(0, 8),
             when: formatPickerTimestamp(previewAt),
-            state: linkedPcpSession
-              ? `linked pcp:${linkedPcpSession.id.slice(0, 8)}`
-              : 'local-only',
-            branch: localSession.gitBranch || '-',
+            state: linkedPcpSession ? `linked pcp:${linkedPcpSession.id.slice(0, 8)}` : 'local',
+            branch: previewText || localSession.gitBranch || '-',
           }),
-          preview: previewText,
+          preview: localSession.gitBranch ? `branch ${localSession.gitBranch}` : undefined,
         }),
         value,
       });

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -58,6 +58,7 @@ interface BootstrapContextResult {
 interface PcpSessionSummary {
   id: string;
   studioId?: string | null;
+  studio?: { branch?: string | null } | null;
   threadKey?: string | null;
   context?: string | null;
   currentPhase?: string | null;
@@ -117,20 +118,30 @@ function formatCandidateTimestamp(value: string | null | undefined): string {
   return new Date(ms).toLocaleString();
 }
 
-function formatRelativeCandidateTime(value: string | null | undefined): string {
+function formatPickerTimestamp(value: string | null | undefined): string {
   if (!value) return '-';
   const ms = Date.parse(value);
   if (!Number.isFinite(ms)) return '-';
-  const diffMs = Math.max(0, Date.now() - ms);
-  const minute = 60 * 1000;
-  const hour = 60 * minute;
-  const day = 24 * hour;
+  return new Date(ms).toLocaleString([], {
+    month: 'numeric',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
 
-  if (diffMs < minute) return 'just now';
-  if (diffMs < hour) return `${Math.floor(diffMs / minute)}m ago`;
-  if (diffMs < day) return `${Math.floor(diffMs / hour)}h ago`;
-  if (diffMs < 7 * day) return `${Math.floor(diffMs / day)}d ago`;
-  return new Date(ms).toLocaleDateString();
+function getCurrentGitBranch(cwd = process.cwd()): string | undefined {
+  try {
+    const result = spawnSync('git', ['-C', cwd, 'rev-parse', '--abbrev-ref', 'HEAD'], {
+      encoding: 'utf-8',
+    });
+    if (result.status !== 0) return undefined;
+    const value = result.stdout.trim();
+    if (!value || value === 'HEAD') return undefined;
+    return value;
+  } catch {
+    return undefined;
+  }
 }
 
 function padSessionCandidateCell(value: string, width: number): string {
@@ -152,18 +163,18 @@ function getPickerLabelMaxWidth(): number {
 interface PickerMetaLineInput {
   source: string;
   id: string;
+  when: string;
   state: string;
   branch: string;
-  age: string;
 }
 
 function buildPickerMetaLine(input: PickerMetaLineInput): string {
   const maxWidth = getPickerLabelMaxWidth();
   const sourceWidth = 12;
   const idWidth = 9;
-  const ageWidth = 8;
+  const whenWidth = 16;
   const separator = '  ';
-  const fixed = sourceWidth + idWidth + ageWidth + separator.length * 4;
+  const fixed = sourceWidth + idWidth + whenWidth + separator.length * 4;
   const flexible = Math.max(34, maxWidth - fixed);
   let stateWidth = Math.max(16, Math.floor(flexible * 0.45));
   let branchWidth = Math.max(12, flexible - stateWidth);
@@ -177,9 +188,9 @@ function buildPickerMetaLine(input: PickerMetaLineInput): string {
   return [
     padSessionCandidateCell(input.source, sourceWidth),
     padSessionCandidateCell(input.id, idWidth),
+    padSessionCandidateCell(input.when, whenWidth),
     padSessionCandidateCell(input.state, stateWidth),
     padSessionCandidateCell(input.branch, branchWidth),
-    padSessionCandidateCell(input.age, ageWidth),
   ].join(separator);
 }
 
@@ -2061,6 +2072,7 @@ async function persistBackendSessionLink(options: {
   email?: string;
 }): Promise<void> {
   if (!options.pcpSessionId || !options.backendSessionId) return;
+  const gitBranch = getCurrentGitBranch(process.cwd());
 
   upsertRuntimeSession(process.cwd(), {
     pcpSessionId: options.pcpSessionId,
@@ -2070,6 +2082,7 @@ async function persistBackendSessionLink(options: {
     ...(options.studioId ? { studioId: options.studioId } : {}),
     ...(options.runtimeLinkId ? { runtimeLinkId: options.runtimeLinkId } : {}),
     backendSessionId: options.backendSessionId,
+    ...(gitBranch ? { gitBranch } : {}),
     updatedAt: new Date().toISOString(),
   });
 
@@ -2110,6 +2123,7 @@ async function ensurePcpSessionContext(
   const email = config?.email;
   const cwd = process.cwd();
   const { studioId, identityId } = getIdentityContextFromIdentityJson(cwd);
+  const currentGitBranch = getCurrentGitBranch(cwd);
   const localSessionLimit = options.listCandidates || options.listCandidatesJson ? 120 : 40;
   const pcpSessionLimit = options.listCandidates || options.listCandidatesJson ? 80 : 40;
   const localBackendSessions = getBackendLocalSessionsForProject(backend, cwd, localSessionLimit);
@@ -2409,6 +2423,11 @@ async function ensurePcpSessionContext(
   const localBySessionId = new Map(
     localBackendSessions.map((session) => [session.sessionId, session])
   );
+  const runtimeBranchByPcpSessionId = new Map(
+    listRuntimeSessions(cwd, backend)
+      .filter((session) => Boolean(session.gitBranch))
+      .map((session) => [session.pcpSessionId, session.gitBranch as string])
+  );
   if (options.listCandidates || options.listCandidatesJson) {
     const pcpCandidates = activeSessions.map((session) => {
       const linkedBackendSessionId = getSessionBackendId(session);
@@ -2589,9 +2608,13 @@ async function ensurePcpSessionContext(
           metaLine: buildPickerMetaLine({
             source: 'PCP',
             id: session.id.slice(0, 8),
+            when: formatPickerTimestamp(linkedAt || session.startedAt),
             state: stateTokens.join(' · '),
-            branch: linkedLocalSession?.gitBranch || '-',
-            age: formatRelativeCandidateTime(linkedAt || session.startedAt),
+            branch:
+              linkedLocalSession?.gitBranch ||
+              runtimeBranchByPcpSessionId.get(session.id) ||
+              session.studio?.branch ||
+              '-',
           }),
           preview: pickerPreview,
         }),
@@ -2614,11 +2637,11 @@ async function ensurePcpSessionContext(
           metaLine: buildPickerMetaLine({
             source: `${backendLabel} local`,
             id: localSession.sessionId.slice(0, 8),
+            when: formatPickerTimestamp(previewAt),
             state: linkedPcpSession
               ? `linked pcp:${linkedPcpSession.id.slice(0, 8)}`
               : 'local-only',
             branch: localSession.gitBranch || '-',
-            age: formatRelativeCandidateTime(previewAt),
           }),
           preview: previewText,
         }),
@@ -2736,6 +2759,7 @@ async function ensurePcpSessionContext(
     ...(studioId ? { studioId } : {}),
     ...(chosen.threadKey ? { threadKey: chosen.threadKey } : {}),
     ...(effectiveBackendSessionId ? { backendSessionId: effectiveBackendSessionId } : {}),
+    ...(currentGitBranch ? { gitBranch: currentGitBranch } : {}),
     startedAt: chosen.startedAt,
   });
   setCurrentRuntimeSession(cwd, chosen.id, backend, {
@@ -2819,6 +2843,7 @@ export async function runClaude(
       )
     : {};
   const runtimeLinkId = options.session ? randomUUID() : undefined;
+  const currentGitBranch = getCurrentGitBranch(process.cwd());
   const { studioId, identityId } = getIdentityContextFromIdentityJson(process.cwd());
 
   if (sessionContext.pcpSessionId && runtimeLinkId) {
@@ -2832,6 +2857,7 @@ export async function runClaude(
       ...(sessionContext.backendSessionId
         ? { backendSessionId: sessionContext.backendSessionId }
         : {}),
+      ...(currentGitBranch ? { gitBranch: currentGitBranch } : {}),
       updatedAt: new Date().toISOString(),
     });
   }
@@ -3024,6 +3050,7 @@ export async function runClaudeInteractive(
       )
     : {};
   const runtimeLinkId = options.session ? randomUUID() : undefined;
+  const currentGitBranch = getCurrentGitBranch(process.cwd());
   const { studioId, identityId } = getIdentityContextFromIdentityJson(process.cwd());
 
   if (sessionContext.pcpSessionId && runtimeLinkId) {
@@ -3037,6 +3064,7 @@ export async function runClaudeInteractive(
       ...(sessionContext.backendSessionId
         ? { backendSessionId: sessionContext.backendSessionId }
         : {}),
+      ...(currentGitBranch ? { gitBranch: currentGitBranch } : {}),
       updatedAt: new Date().toISOString(),
     });
   }

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -143,15 +143,46 @@ function getPickerLabelMaxWidth(): number {
   return Math.max(72, Math.min(140, columns - 12));
 }
 
+interface PickerMetaLineInput {
+  source: string;
+  id: string;
+  state: string;
+  branch: string;
+  age: string;
+}
+
+function buildPickerMetaLine(input: PickerMetaLineInput): string {
+  const maxWidth = getPickerLabelMaxWidth();
+  const sourceWidth = 10;
+  const idWidth = 9;
+  const ageWidth = 8;
+  const separator = '  ';
+  const fixed = sourceWidth + idWidth + ageWidth + separator.length * 4;
+  const flexible = Math.max(34, maxWidth - fixed);
+  let stateWidth = Math.max(18, Math.floor(flexible * 0.62));
+  let branchWidth = Math.max(12, flexible - stateWidth);
+  if (stateWidth + branchWidth > flexible) {
+    branchWidth = Math.max(12, flexible - stateWidth);
+  }
+  if (stateWidth + branchWidth > flexible) {
+    stateWidth = Math.max(18, flexible - branchWidth);
+  }
+
+  return [
+    padSessionCandidateCell(input.source, sourceWidth),
+    padSessionCandidateCell(input.id, idWidth),
+    padSessionCandidateCell(input.state, stateWidth),
+    padSessionCandidateCell(input.branch, branchWidth),
+    padSessionCandidateCell(input.age, ageWidth),
+  ].join(separator);
+}
+
 export function buildSessionPickerLabel(options: {
-  primary: string;
-  details?: Array<string | null | undefined>;
+  metaLine: string;
   preview?: string | null;
 }): string {
   const maxWidth = getPickerLabelMaxWidth();
-  const detailText = (options.details || []).filter(Boolean).join(' | ');
-  const base = detailText ? `${options.primary} | ${detailText}` : options.primary;
-  const firstLine = truncateText(base, maxWidth);
+  const firstLine = truncateText(options.metaLine, maxWidth);
   if (!options.preview) return firstLine;
 
   const previewWidth = Math.max(36, maxWidth - 4);
@@ -2542,17 +2573,20 @@ async function ensurePcpSessionContext(
       const preview = pcpPreviewBySessionId.get(session.id);
       const phaseLabel = getSessionPhaseLabel(session);
       const pickerPreview = linkedPreviewText || preview || session.context || undefined;
+      const stateTokens = [
+        phaseLabel || 'runtime:active',
+        session.threadKey ? `thread ${truncateText(session.threadKey, 20)}` : null,
+        linkedBackendSessionId ? `${backendLabel} ${linkedBackendSessionId.slice(0, 8)}` : null,
+      ].filter(Boolean) as string[];
       choices.push({
         name: buildSessionPickerLabel({
-          primary: `PCP ${session.id.slice(0, 8)}`,
-          details: [
-            session.threadKey ? `thread ${truncateText(session.threadKey, 24)}` : null,
-            phaseLabel || null,
-            linkedBackendSessionId
-              ? `tracks ${backendLabel} ${linkedBackendSessionId.slice(0, 8)}`
-              : null,
-            formatRelativeCandidateTime(linkedAt || session.startedAt),
-          ],
+          metaLine: buildPickerMetaLine({
+            source: 'PCP',
+            id: session.id.slice(0, 8),
+            state: stateTokens.join(' · '),
+            branch: linkedLocalSession?.gitBranch || '-',
+            age: formatRelativeCandidateTime(linkedAt || session.startedAt),
+          }),
           preview: pickerPreview,
         }),
         value,
@@ -2571,15 +2605,15 @@ async function ensurePcpSessionContext(
       const linkedPcpSession = pcpSessionByBackendSessionId.get(localSession.sessionId);
       choices.push({
         name: buildSessionPickerLabel({
-          primary:
-            localSession.backend === 'claude'
-              ? `Claude local ${localSession.sessionId.slice(0, 8)}`
-              : `${backendLabel} local ${localSession.sessionId.slice(0, 8)}`,
-          details: [
-            linkedPcpSession ? `linked pcp:${linkedPcpSession.id.slice(0, 8)}` : null,
-            localSession.gitBranch ? `branch ${truncateText(localSession.gitBranch, 22)}` : null,
-            formatRelativeCandidateTime(previewAt),
-          ],
+          metaLine: buildPickerMetaLine({
+            source: `${backendLabel} local`,
+            id: localSession.sessionId.slice(0, 8),
+            state: linkedPcpSession
+              ? `linked pcp:${linkedPcpSession.id.slice(0, 8)}`
+              : 'local-only',
+            branch: localSession.gitBranch || '-',
+            age: formatRelativeCandidateTime(previewAt),
+          }),
           preview: previewText,
         }),
         value,

--- a/packages/cli/src/session/runtime.ts
+++ b/packages/cli/src/session/runtime.ts
@@ -8,6 +8,7 @@ export interface RuntimeSessionRecord {
   identityId?: string;
   studioId?: string;
   threadKey?: string;
+  gitBranch?: string;
   runtimeLinkId?: string;
   backendSessionId?: string;
   backendSessionIds?: string[];
@@ -111,7 +112,10 @@ export function upsertRuntimeSession(
       s.studioId === next.studioId
   );
 
-  const mergeSessionIds = (existing?: RuntimeSessionRecord, incoming?: RuntimeSessionRecord): string[] => {
+  const mergeSessionIds = (
+    existing?: RuntimeSessionRecord,
+    incoming?: RuntimeSessionRecord
+  ): string[] => {
     const ids = new Set<string>();
 
     const add = (value: unknown): void => {


### PR DESCRIPTION
## Summary
- improve session candidate parity by increasing local/PCP candidate fetch limits
- enrich candidate data with local↔PCP linkage metadata (including selectable status)
- make `local:<id>` selection reuse linked PCP session when one exists
- replace compact `--session-candidates` text output with a columnar table + headers

## Testing
- `npx vitest run packages/cli/src/commands/claude.test.ts packages/cli/src/cli.test.ts`

## Notes
- JSON output now also includes `limits` and `counts` metadata to aid rendering/debugging.
