### PR TITLE
feat: skill MCP servers + sb skills sync + bundled Playwright (by Wren)

### DIFF
--- a/packages/api/src/mcp/tools/skill-handlers.ts
+++ b/packages/api/src/mcp/tools/skill-handlers.ts
@@ -103,6 +103,7 @@ export async function handleListSkills(
         triggers: s.triggers,
         functionCount: s.functionCount,
         capabilities: s.capabilities,
+        ...(s.mcp ? { mcp: s.mcp } : {}),
       };
 
       // Include full content for guides when requested (for hook injection)
@@ -166,6 +167,7 @@ export async function handleGetSkill(
             content: matchDetail.skillContent || 'No skill documentation available.',
             functions: matchDetail.manifest.functions,
             triggers: matchDetail.manifest.triggers,
+            ...(matchDetail.manifest.mcp ? { mcp: matchDetail.manifest.mcp } : {}),
           });
         }
       }
@@ -191,6 +193,7 @@ export async function handleGetSkill(
       content: detail.skillContent || 'No skill documentation available.',
       functions: detail.manifest.functions,
       triggers: detail.manifest.triggers,
+      ...(detail.manifest.mcp ? { mcp: detail.manifest.mcp } : {}),
     });
   } catch (error) {
     logger.error('Error in get_skill:', error);

--- a/packages/api/src/services/sessions/codex-runner.test.ts
+++ b/packages/api/src/services/sessions/codex-runner.test.ts
@@ -5,6 +5,11 @@ vi.mock('child_process', () => ({
   spawn: vi.fn(),
 }));
 
+vi.mock('./resolve-binary.js', () => ({
+  resolveBinaryPath: vi.fn().mockResolvedValue('codex'),
+  buildSpawnPath: vi.fn().mockReturnValue(process.env.PATH || ''),
+}));
+
 vi.mock('../../utils/logger.js', () => ({
   logger: {
     info: vi.fn(),
@@ -150,7 +155,7 @@ describe('CodexRunner', () => {
     const [, , options] = (spawn as Mock).mock.calls[0] as [
       string,
       string[],
-      { env?: Record<string, string> }
+      { env?: Record<string, string> },
     ];
     expect(options.env?.PCP_ACCESS_TOKEN).toBe('test-pcp-token');
   });

--- a/packages/api/src/services/sessions/resolve-binary.test.ts
+++ b/packages/api/src/services/sessions/resolve-binary.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { delimiter } from 'path';
+
+// Mock child_process with a callback-compatible execFile
+const mockExecFile = vi.fn();
+vi.mock('child_process', () => ({
+  execFile: mockExecFile,
+}));
+
+vi.mock('../../utils/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+// Dynamic import so mocks are in place before module loads
+const { resolveBinaryPath, buildSpawnPath } = await import('./resolve-binary.js');
+
+// Helper: make mockExecFile behave like Node's callback-style execFile
+function mockWhichResult(stdout: string) {
+  mockExecFile.mockImplementation(
+    (
+      _cmd: string,
+      _args: string[],
+      _opts: unknown,
+      cb?: (err: Error | null, result: { stdout: string; stderr: string }) => void
+    ) => {
+      // promisify calls with (cmd, args, opts, callback)
+      if (typeof cb === 'function') {
+        cb(null, { stdout, stderr: '' });
+      }
+    }
+  );
+}
+
+function mockWhichError() {
+  mockExecFile.mockImplementation(
+    (_cmd: string, _args: string[], _opts: unknown, cb?: (err: Error | null) => void) => {
+      if (typeof cb === 'function') {
+        cb(new Error('not found'));
+      }
+    }
+  );
+}
+
+describe('resolveBinaryPath', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Clear the module-level cache between tests by re-importing would be ideal,
+    // but we can test the caching behavior by resolving different binary names
+  });
+
+  it('resolves a binary found via which', async () => {
+    mockWhichResult('/usr/local/bin/test-binary\n');
+    const result = await resolveBinaryPath('test-binary-' + Date.now());
+    expect(result).toBe('/usr/local/bin/test-binary');
+    expect(mockExecFile).toHaveBeenCalledWith(
+      'which',
+      [expect.stringContaining('test-binary')],
+      expect.any(Object),
+      expect.any(Function)
+    );
+  });
+
+  it('falls back to zsh login shell when which fails', async () => {
+    let callCount = 0;
+    mockExecFile.mockImplementation(
+      (
+        cmd: string,
+        _args: string[],
+        _opts: unknown,
+        cb?: (err: Error | null, result?: { stdout: string; stderr: string }) => void
+      ) => {
+        callCount++;
+        if (typeof cb !== 'function') return;
+        if (callCount === 1) {
+          // First call (which) fails
+          cb(new Error('not found'));
+        } else {
+          // Second call (zsh -ilc) succeeds
+          cb(null, { stdout: 'Now using node v22\n/opt/homebrew/bin/zsh-binary\n', stderr: '' });
+        }
+      }
+    );
+
+    const result = await resolveBinaryPath('zsh-binary-' + Date.now());
+    expect(result).toBe('/opt/homebrew/bin/zsh-binary');
+    expect(mockExecFile).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns bare binary name when both resolution methods fail', async () => {
+    mockWhichError();
+    const name = 'nonexistent-binary-' + Date.now();
+    const result = await resolveBinaryPath(name);
+    expect(result).toBe(name);
+  });
+
+  it('returns cached result on subsequent calls', async () => {
+    const name = 'cached-binary-' + Date.now();
+    mockWhichResult('/usr/bin/cached-binary\n');
+
+    const first = await resolveBinaryPath(name);
+    const second = await resolveBinaryPath(name);
+
+    expect(first).toBe('/usr/bin/cached-binary');
+    expect(second).toBe('/usr/bin/cached-binary');
+    // execFile should only be called once (first call), second hits cache
+    // (may be called twice due to which + zsh fallback, but not 4 times)
+    expect(mockExecFile.mock.calls.filter((c) => c[1]?.includes(name))).toHaveLength(1);
+  });
+});
+
+describe('buildSpawnPath', () => {
+  it('prepends binary directory to PATH', () => {
+    const original = process.env.PATH;
+    process.env.PATH = '/usr/bin:/usr/local/bin';
+    const result = buildSpawnPath('/opt/homebrew/bin/claude');
+    expect(result).toBe(`/opt/homebrew/bin${delimiter}/usr/bin:/usr/local/bin`);
+    process.env.PATH = original;
+  });
+
+  it('does not duplicate existing directory', () => {
+    const original = process.env.PATH;
+    process.env.PATH = `/usr/bin${delimiter}/opt/homebrew/bin`;
+    const result = buildSpawnPath('/opt/homebrew/bin/claude');
+    expect(result).toBe(process.env.PATH);
+    process.env.PATH = original;
+  });
+
+  it('returns current PATH for non-absolute (bare) binary names', () => {
+    const original = process.env.PATH;
+    process.env.PATH = '/usr/bin:/usr/local/bin';
+    const result = buildSpawnPath('codex');
+    expect(result).toBe('/usr/bin:/usr/local/bin');
+    process.env.PATH = original;
+  });
+
+  it('returns just the binary directory when PATH is empty', () => {
+    const original = process.env.PATH;
+    process.env.PATH = '';
+    const result = buildSpawnPath('/opt/homebrew/bin/claude');
+    expect(result).toBe('/opt/homebrew/bin');
+    process.env.PATH = original;
+  });
+});

--- a/packages/api/src/services/sessions/resolve-binary.test.ts
+++ b/packages/api/src/services/sessions/resolve-binary.test.ts
@@ -7,6 +7,12 @@ vi.mock('child_process', () => ({
   execFile: mockExecFile,
 }));
 
+// Mock fs/promises for pathExists
+const mockAccess = vi.fn();
+vi.mock('fs/promises', () => ({
+  access: mockAccess,
+}));
+
 vi.mock('../../utils/logger.js', () => ({
   logger: {
     info: vi.fn(),
@@ -19,7 +25,7 @@ vi.mock('../../utils/logger.js', () => ({
 // Dynamic import so mocks are in place before module loads
 const { resolveBinaryPath, buildSpawnPath } = await import('./resolve-binary.js');
 
-// Helper: make mockExecFile behave like Node's callback-style execFile
+// Helper: make mockExecFile resolve with stdout
 function mockWhichResult(stdout: string) {
   mockExecFile.mockImplementation(
     (
@@ -28,7 +34,6 @@ function mockWhichResult(stdout: string) {
       _opts: unknown,
       cb?: (err: Error | null, result: { stdout: string; stderr: string }) => void
     ) => {
-      // promisify calls with (cmd, args, opts, callback)
       if (typeof cb === 'function') {
         cb(null, { stdout, stderr: '' });
       }
@@ -49,17 +54,18 @@ function mockWhichError() {
 describe('resolveBinaryPath', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // Clear the module-level cache between tests by re-importing would be ideal,
-    // but we can test the caching behavior by resolving different binary names
+    // Default: pathExists returns true for any path
+    mockAccess.mockResolvedValue(undefined);
   });
 
   it('resolves a binary found via which', async () => {
     mockWhichResult('/usr/local/bin/test-binary\n');
-    const result = await resolveBinaryPath('test-binary-' + Date.now());
+    const name = 'test-binary-' + Date.now();
+    const result = await resolveBinaryPath(name);
     expect(result).toBe('/usr/local/bin/test-binary');
     expect(mockExecFile).toHaveBeenCalledWith(
       'which',
-      [expect.stringContaining('test-binary')],
+      [name],
       expect.any(Object),
       expect.any(Function)
     );
@@ -69,7 +75,7 @@ describe('resolveBinaryPath', () => {
     let callCount = 0;
     mockExecFile.mockImplementation(
       (
-        cmd: string,
+        _cmd: string,
         _args: string[],
         _opts: unknown,
         cb?: (err: Error | null, result?: { stdout: string; stderr: string }) => void
@@ -77,11 +83,12 @@ describe('resolveBinaryPath', () => {
         callCount++;
         if (typeof cb !== 'function') return;
         if (callCount === 1) {
-          // First call (which) fails
           cb(new Error('not found'));
         } else {
-          // Second call (zsh -ilc) succeeds
-          cb(null, { stdout: 'Now using node v22\n/opt/homebrew/bin/zsh-binary\n', stderr: '' });
+          cb(null, {
+            stdout: 'Now using node v22\n/opt/homebrew/bin/zsh-binary\n',
+            stderr: '',
+          });
         }
       }
     );
@@ -98,6 +105,16 @@ describe('resolveBinaryPath', () => {
     expect(result).toBe(name);
   });
 
+  it('rejects resolved path that does not exist on disk', async () => {
+    mockWhichResult('/usr/local/bin/ghost-binary\n');
+    mockAccess.mockRejectedValue(new Error('ENOENT'));
+
+    const name = 'ghost-binary-' + Date.now();
+    const result = await resolveBinaryPath(name);
+    // Both which and zsh paths fail pathExists, so bare name returned
+    expect(result).toBe(name);
+  });
+
   it('returns cached result on subsequent calls', async () => {
     const name = 'cached-binary-' + Date.now();
     mockWhichResult('/usr/bin/cached-binary\n');
@@ -107,9 +124,8 @@ describe('resolveBinaryPath', () => {
 
     expect(first).toBe('/usr/bin/cached-binary');
     expect(second).toBe('/usr/bin/cached-binary');
-    // execFile should only be called once (first call), second hits cache
-    // (may be called twice due to which + zsh fallback, but not 4 times)
-    expect(mockExecFile.mock.calls.filter((c) => c[1]?.includes(name))).toHaveLength(1);
+    // execFile should only be called for the first resolution
+    expect(mockExecFile.mock.calls.filter((c: string[][]) => c[1]?.includes(name))).toHaveLength(1);
   });
 });
 

--- a/packages/api/src/skills/builtin/playwright-mcp/SKILL.md
+++ b/packages/api/src/skills/builtin/playwright-mcp/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: playwright-mcp
+description: Browser automation via Playwright MCP server. Navigate websites, interact with elements, extract data, and take screenshots.
+type: cli
+triggers:
+  keywords:
+    - playwright
+    - browser
+    - screenshot
+    - scrape
+    - webpage
+    - DOM
+    - web test
+    - headless
+    - navigate
+metadata:
+  openclaw:
+    emoji: '🎭'
+    os: [linux, darwin, win32]
+    requires:
+      anyBins: [npx, playwright-mcp]
+    install:
+      - id: npm-playwright-mcp
+        kind: npm
+        package: '@playwright/mcp'
+        bins: [playwright-mcp]
+        label: Install Playwright MCP
+mcp:
+  name: playwright
+  command: npx
+  args: ['@playwright/mcp', '--headless']
+  env: {}
+---
+
+# Playwright MCP
+
+Browser automation powered by the [Playwright MCP server](https://www.npmjs.com/package/@playwright/mcp). Gives you full browser control via MCP tools.
+
+## Setup
+
+The MCP server is auto-configured by `sb` when this skill is active. To install Playwright browsers (first time only):
+
+```bash
+npx playwright install chromium
+```
+
+## Available Tools
+
+Once the MCP server is running, you have these tools:
+
+| Tool                    | What it does                  |
+| ----------------------- | ----------------------------- |
+| `browser_navigate`      | Open a URL                    |
+| `browser_click`         | Click an element              |
+| `browser_type`          | Type text into an input       |
+| `browser_select_option` | Choose from a dropdown        |
+| `browser_get_text`      | Extract text content          |
+| `browser_evaluate`      | Run JavaScript on the page    |
+| `browser_snapshot`      | Get accessible page structure |
+| `browser_press`         | Press a keyboard key          |
+| `browser_choose_file`   | Upload a file                 |
+| `browser_close`         | Close the browser             |
+
+## Common Patterns
+
+### Navigate and extract data
+
+```
+browser_navigate → browser_get_text or browser_evaluate
+```
+
+### Fill and submit a form
+
+```
+browser_navigate → browser_type (fields) → browser_click (submit) → browser_get_text (result)
+```
+
+### Screenshot a page
+
+```
+browser_navigate → browser_snapshot
+```
+
+## Options
+
+The MCP server defaults to headless Chromium. Override via skill config or passthrough:
+
+- `--browser firefox|webkit` — different browser engine
+- `--headless=false` — show the browser window
+- `--viewport-size 1920x1080` — set viewport dimensions
+- `--save-video 1280x720` — record video
+- `--output-dir ./playwright-output` — save artifacts

--- a/packages/api/src/skills/loader.ts
+++ b/packages/api/src/skills/loader.ts
@@ -153,6 +153,8 @@ function frontmatterToManifest(
     guide: frontmatter.guide as SkillManifest['guide'],
 
     entry: frontmatter.entry as string,
+
+    mcp: frontmatter.mcp as SkillManifest['mcp'],
   };
 }
 

--- a/packages/api/src/skills/service.ts
+++ b/packages/api/src/skills/service.ts
@@ -66,6 +66,7 @@ function toSummary(skill: LoadedSkill, userSettings?: UserSkillSettings): SkillS
     functionCount: skill.manifest.functions?.length,
     capabilities: skill.manifest.capabilities,
     eligibility: skill.eligibility,
+    ...(skill.manifest.mcp ? { mcp: skill.manifest.mcp } : {}),
   };
 }
 

--- a/packages/api/src/skills/types.ts
+++ b/packages/api/src/skills/types.ts
@@ -144,6 +144,14 @@ export interface SkillManifest {
 
   /** Entry point file (SKILL.md for documentation) */
   entry?: string;
+
+  /** MCP server provided by this skill (stdio transport) */
+  mcp?: {
+    name: string;
+    command: string;
+    args: string[];
+    env?: Record<string, string>;
+  };
 }
 
 // ============================================================================
@@ -235,6 +243,7 @@ export interface SkillSummary {
   functionCount?: number;
   capabilities?: SkillManifest['capabilities'];
   eligibility: EligibilityResult;
+  mcp?: SkillManifest['mcp'];
 }
 
 export interface SkillDetail extends SkillSummary {

--- a/packages/cli/src/backends/claude.ts
+++ b/packages/cli/src/backends/claude.ts
@@ -5,9 +5,8 @@
  * MCP config via --mcp-config <path>
  */
 
-import { existsSync } from 'fs';
-import { join } from 'path';
 import { buildIdentityPrompt } from './identity.js';
+import { buildMergedMcpConfig } from '../lib/skill-mcp.js';
 import type { BackendAdapter, BackendConfig, PreparedBackend } from './types.js';
 
 export class ClaudeAdapter implements BackendAdapter {
@@ -41,10 +40,10 @@ export class ClaudeAdapter implements BackendAdapter {
       args.push('--session-id', config.backendSessionSeedId);
     }
 
-    // MCP config (if present in CWD)
-    const mcpConfig = join(process.cwd(), '.mcp.json');
-    if (existsSync(mcpConfig)) {
-      args.push('--mcp-config', mcpConfig);
+    // MCP config: merge project .mcp.json with skill-provided MCP servers
+    const { mcpConfigPath, cleanup: mcpCleanup } = buildMergedMcpConfig(process.cwd());
+    if (mcpConfigPath) {
+      args.push('--mcp-config', mcpConfigPath);
     }
 
     // Auto-approve: skip all permission prompts
@@ -62,7 +61,7 @@ export class ClaudeAdapter implements BackendAdapter {
         AGENT_ID: config.agentId,
         ...(config.pcpSessionId ? { PCP_SESSION_ID: config.pcpSessionId } : {}),
       },
-      cleanup: () => {}, // No temp file, no cleanup needed
+      cleanup: mcpCleanup,
     };
   }
 }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -32,6 +32,7 @@ import { registerDoctorCommand } from './commands/doctor.js';
 import { registerMissionCommand } from './commands/mission.js';
 import { registerStatusCommand } from './commands/status.js';
 import { registerPermissionsCommands } from './commands/permissions.js';
+import { registerSkillsCommands } from './commands/skills.js';
 import { runClaude, runClaudeInteractive } from './commands/claude.js';
 import { resolveBackend } from './backends/index.js';
 import { initSbDebug, sbDebugLog } from './lib/sb-debug.js';
@@ -280,6 +281,7 @@ registerDoctorCommand(program);
 registerMissionCommand(program);
 registerStatusCommand(program);
 registerPermissionsCommands(program);
+registerSkillsCommands(program);
 
 // ============================================================================
 // Subcommand detection

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -16,6 +16,7 @@ import { homedir } from 'os';
 import { installHooks } from './hooks.js';
 import { syncMcpConfig } from './mcp.js';
 import { loadAuth, decodeJwtPayload, isTokenExpired } from '../auth/tokens.js';
+import { callPcpTool } from '../lib/pcp-mcp.js';
 
 // ============================================================================
 // Helpers
@@ -226,6 +227,25 @@ async function initCommand(options: { force?: boolean }): Promise<void> {
             : chalk.yellow(step.status);
     const detail = step.detail ? chalk.dim(` (${step.detail})`) : '';
     console.log(`  ${icon} ${step.label}: ${statusText}${detail}`);
+  }
+
+  // Async step: sync MCP-providing skills from PCP server (best-effort)
+  try {
+    const result = await callPcpTool<{
+      success: boolean;
+      skills: Array<{ name: string; mcp?: { name: string; command: string; args: string[] } }>;
+    }>('list_skills', {});
+    if (result.success && result.skills) {
+      const mcpSkills = result.skills.filter((s) => s.mcp);
+      if (mcpSkills.length > 0) {
+        console.log(
+          chalk.dim(`\n  ${mcpSkills.length} MCP-providing skill(s) available on server.`)
+        );
+        console.log(chalk.dim('  Run `sb skills sync` to install them locally.'));
+      }
+    }
+  } catch {
+    // Server not reachable — skip skill hint
   }
 
   console.log(chalk.dim('\nDone.'));

--- a/packages/cli/src/commands/skills.ts
+++ b/packages/cli/src/commands/skills.ts
@@ -2,10 +2,12 @@
  * Skills Commands
  *
  * Manage PCP skills: discover, list, and sync across studios/worktrees.
+ * Writes to ALL backend skill directories so skills show up natively in
+ * Claude Code (/skills), Codex, and Gemini — not just PCP's discovery.
  *
  * Commands:
  *   skills list    Show discovered skills (local + server)
- *   skills sync    Sync MCP-providing skills to local dirs + inject into backend configs
+ *   skills sync    Sync skills from PCP server to all backend configs
  */
 
 import { Command } from 'commander';
@@ -63,6 +65,21 @@ interface McpJsonConfig {
 }
 
 // ============================================================================
+// Constants
+// ============================================================================
+
+/**
+ * Home-level skill directories for each backend.
+ * Writing here means skills persist across ALL projects/studios.
+ */
+const HOME_SKILL_DIRS = [
+  join(homedir(), '.pcp', 'skills'), // PCP discovery (sb chat, buildMergedMcpConfig)
+  join(homedir(), '.claude', 'skills'), // Claude Code native (/skills)
+  join(homedir(), '.codex', 'skills'), // Codex native
+  join(homedir(), '.gemini', 'skills'), // Gemini native
+];
+
+// ============================================================================
 // Helpers
 // ============================================================================
 
@@ -81,9 +98,6 @@ function getWorktrees(): string[] {
   }
 }
 
-/**
- * Reconstruct a SKILL.md file from get_skill response data.
- */
 function buildSkillMd(skill: GetSkillResponse): string {
   const frontmatter: Record<string, unknown> = {
     name: skill.skillName,
@@ -137,10 +151,6 @@ function serializeYaml(obj: unknown, indent: number): string {
   return String(obj);
 }
 
-/**
- * Inject skill MCP servers into a project's .mcp.json.
- * Does not override existing servers. Returns names of servers added.
- */
 function injectMcpServers(
   mcpJsonPath: string,
   skills: ServerSkill[]
@@ -181,6 +191,23 @@ function injectMcpServers(
   }
 
   return { added, existed };
+}
+
+/**
+ * Write a SKILL.md to a directory, return true if written (false if skipped).
+ */
+function writeSkillToDir(dir: string, skillName: string, content: string): boolean {
+  const skillDir = join(dir, skillName);
+  const skillFile = join(skillDir, 'SKILL.md');
+
+  if (existsSync(skillFile)) {
+    const existing = readFileSync(skillFile, 'utf-8');
+    if (existing === content) return false;
+  }
+
+  mkdirSync(skillDir, { recursive: true });
+  writeFileSync(skillFile, content);
+  return true;
 }
 
 // ============================================================================
@@ -247,7 +274,6 @@ async function listCommand(): Promise<void> {
 
 interface SyncOptions {
   all?: boolean;
-  workspace?: boolean;
 }
 
 async function syncCommand(options: SyncOptions): Promise<void> {
@@ -280,29 +306,15 @@ async function syncCommand(options: SyncOptions): Promise<void> {
 
   console.log(chalk.dim(`  Found ${mcpSkills.length} MCP-providing skill(s) on server\n`));
 
-  // ---- Step 1: Write SKILL.md files to ~/.pcp/skills/ ----
-  const skillTargets: Array<{ dir: string; label: string }> = [
-    { dir: join(homedir(), '.pcp', 'skills'), label: '~/.pcp/skills' },
-  ];
+  // ---- Step 1: Write SKILL.md to all backend skill dirs (home-level) ----
+  // This is the core of "one sync, skills everywhere":
+  //   ~/.pcp/skills/    → PCP discovery (sb chat, buildMergedMcpConfig)
+  //   ~/.claude/skills/ → Claude Code native (/skills)
+  //   ~/.codex/skills/  → Codex native
+  //   ~/.gemini/skills/ → Gemini native
 
-  if (options.workspace) {
-    skillTargets.push({
-      dir: join(cwd, '.pcp', 'skills'),
-      label: '.pcp/skills (workspace)',
-    });
-  }
-
-  if (options.all) {
-    for (const wt of getWorktrees()) {
-      const wtDir = join(wt, '.pcp', 'skills');
-      if (!skillTargets.some((t) => t.dir === wtDir)) {
-        skillTargets.push({ dir: wtDir, label: `.pcp/skills (${wt})` });
-      }
-    }
-  }
-
-  let skillsSynced = 0;
-  let skillsSkipped = 0;
+  let written = 0;
+  let skipped = 0;
 
   for (const skill of mcpSkills) {
     let detail: GetSkillResponse;
@@ -320,22 +332,14 @@ async function syncCommand(options: SyncOptions): Promise<void> {
     if (!detail.mcp && skill.mcp) detail.mcp = skill.mcp;
     const skillMd = buildSkillMd(detail);
 
-    for (const target of skillTargets) {
-      const skillDir = join(target.dir, skill.name);
-      const skillFile = join(skillDir, 'SKILL.md');
-
-      if (existsSync(skillFile)) {
-        const existing = readFileSync(skillFile, 'utf-8');
-        if (existing === skillMd) {
-          skillsSkipped++;
-          continue;
-        }
+    for (const dir of HOME_SKILL_DIRS) {
+      if (writeSkillToDir(dir, skill.name, skillMd)) {
+        written++;
+        const shortDir = dir.replace(homedir(), '~');
+        console.log(chalk.green(`  + ${skill.name}`), chalk.dim(`→ ${shortDir}/`));
+      } else {
+        skipped++;
       }
-
-      mkdirSync(skillDir, { recursive: true });
-      writeFileSync(skillFile, skillMd);
-      skillsSynced++;
-      console.log(chalk.green(`  + ${skill.name} SKILL.md`), chalk.dim(`→ ${target.label}`));
     }
   }
 
@@ -354,14 +358,14 @@ async function syncCommand(options: SyncOptions): Promise<void> {
     const mcpPath = join(targetDir, '.mcp.json');
     if (!existsSync(mcpPath)) continue;
 
-    const { added, existed } = injectMcpServers(mcpPath, mcpSkills);
+    const { added } = injectMcpServers(mcpPath, mcpSkills);
     if (added.length > 0) {
       const label = targetDir === cwd ? '.mcp.json' : `.mcp.json (${targetDir})`;
       console.log(chalk.green(`  + ${added.join(', ')}`), chalk.dim(`→ ${label}`));
     }
   }
 
-  // ---- Step 3: Sync to Codex/Gemini backend configs ----
+  // ---- Step 3: Sync to Codex/Gemini backend configs (from .mcp.json) ----
   const syncTargets = options.all ? getWorktrees() : [cwd];
   for (const targetDir of syncTargets) {
     if (!existsSync(join(targetDir, '.mcp.json'))) continue;
@@ -376,14 +380,13 @@ async function syncCommand(options: SyncOptions): Promise<void> {
   }
 
   // ---- Summary ----
-  const total = skillsSynced;
-  if (total === 0 && skillsSkipped > 0) {
+  if (written === 0 && skipped > 0) {
     console.log(chalk.dim(`\n  All skill(s) already up to date.`));
-  } else if (total > 0) {
-    console.log('');
   }
 
-  console.log(chalk.dim('Done. MCP servers available to all backends.\n'));
+  console.log(
+    chalk.dim('\nDone. Skills available to all backends (claude /skills, codex, gemini).\n')
+  );
 }
 
 // ============================================================================
@@ -398,7 +401,6 @@ export function registerSkillsCommands(program: Command): void {
   skills
     .command('sync')
     .description('Sync MCP-providing skills from PCP server to all backend configs')
-    .option('--workspace', 'Also sync to workspace .pcp/skills/ (current directory)')
-    .option('--all', 'Sync to all git worktrees')
+    .option('--all', 'Also sync .mcp.json + backend configs across all git worktrees')
     .action(syncCommand);
 }

--- a/packages/cli/src/commands/skills.ts
+++ b/packages/cli/src/commands/skills.ts
@@ -5,7 +5,7 @@
  *
  * Commands:
  *   skills list    Show discovered skills (local + server)
- *   skills sync    Sync MCP-providing skills to local directories
+ *   skills sync    Sync MCP-providing skills to local dirs + inject into backend configs
  */
 
 import { Command } from 'commander';
@@ -14,9 +14,10 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
 import { execSync } from 'child_process';
-import { discoverSkills, loadSkillInstruction } from '../repl/skills.js';
+import { discoverSkills } from '../repl/skills.js';
 import { parseSkillMcpConfig } from '../lib/skill-mcp.js';
 import { callPcpTool } from '../lib/pcp-mcp.js';
+import { syncMcpConfig } from './mcp.js';
 
 // ============================================================================
 // Types
@@ -45,6 +46,20 @@ interface GetSkillResponse {
   content: string;
   mcp?: ServerSkill['mcp'];
   triggers?: { keywords?: string[] };
+}
+
+interface McpJsonConfig {
+  mcpServers: Record<
+    string,
+    {
+      type?: string;
+      command?: string;
+      args?: string[];
+      url?: string;
+      env?: Record<string, string>;
+      headers?: Record<string, string>;
+    }
+  >;
 }
 
 // ============================================================================
@@ -86,7 +101,6 @@ function buildSkillMd(skill: GetSkillResponse): string {
     frontmatter.mcp = skill.mcp;
   }
 
-  // Simple YAML serialization for the frontmatter
   const yamlLines = serializeYaml(frontmatter, 0);
   return `---\n${yamlLines}---\n\n${skill.content}\n`;
 }
@@ -97,7 +111,6 @@ function serializeYaml(obj: unknown, indent: number): string {
 
   if (Array.isArray(obj)) {
     if (obj.length === 0) return '[]\n';
-    // Use inline format for simple string arrays
     if (obj.every((v) => typeof v === 'string')) {
       const items = obj.map((v) => JSON.stringify(v)).join(', ');
       return `[${items}]\n`;
@@ -124,6 +137,52 @@ function serializeYaml(obj: unknown, indent: number): string {
   return String(obj);
 }
 
+/**
+ * Inject skill MCP servers into a project's .mcp.json.
+ * Does not override existing servers. Returns names of servers added.
+ */
+function injectMcpServers(
+  mcpJsonPath: string,
+  skills: ServerSkill[]
+): { added: string[]; existed: string[] } {
+  let config: McpJsonConfig = { mcpServers: {} };
+  if (existsSync(mcpJsonPath)) {
+    try {
+      config = JSON.parse(readFileSync(mcpJsonPath, 'utf-8'));
+      if (!config.mcpServers) config.mcpServers = {};
+    } catch {
+      config = { mcpServers: {} };
+    }
+  }
+
+  const added: string[] = [];
+  const existed: string[] = [];
+
+  for (const skill of skills) {
+    if (!skill.mcp) continue;
+    const serverName = skill.mcp.name;
+
+    if (config.mcpServers[serverName]) {
+      existed.push(serverName);
+      continue;
+    }
+
+    config.mcpServers[serverName] = {
+      type: 'stdio',
+      command: skill.mcp.command,
+      args: skill.mcp.args,
+      ...(skill.mcp.env && Object.keys(skill.mcp.env).length > 0 ? { env: skill.mcp.env } : {}),
+    };
+    added.push(serverName);
+  }
+
+  if (added.length > 0) {
+    writeFileSync(mcpJsonPath, JSON.stringify(config, null, 2) + '\n');
+  }
+
+  return { added, existed };
+}
+
 // ============================================================================
 // List Command
 // ============================================================================
@@ -132,7 +191,6 @@ async function listCommand(): Promise<void> {
   const cwd = process.cwd();
   const localSkills = discoverSkills(cwd);
 
-  // Check which local skills provide MCP servers
   const withMcp = localSkills.map((skill) => {
     const mcp = parseSkillMcpConfig(skill.path);
     return { ...skill, mcp };
@@ -193,6 +251,7 @@ interface SyncOptions {
 }
 
 async function syncCommand(options: SyncOptions): Promise<void> {
+  const cwd = process.cwd();
   console.log(chalk.bold('\nSyncing skills from PCP server...\n'));
 
   // Fetch all skills from server
@@ -207,51 +266,43 @@ async function syncCommand(options: SyncOptions): Promise<void> {
       process.exit(1);
     }
     serverSkills = result.skills;
-  } catch (error) {
+  } catch {
     console.error(chalk.red('Cannot reach PCP server.'));
     console.error(chalk.dim('Ensure the server is running (yarn dev) and try again.'));
     process.exit(1);
   }
 
-  // Filter to skills with MCP configs
   const mcpSkills = serverSkills.filter((s) => s.mcp);
   if (mcpSkills.length === 0) {
     console.log(chalk.dim('  No MCP-providing skills found on server.'));
     return;
   }
 
-  console.log(chalk.dim(`  Found ${mcpSkills.length} MCP-providing skill(s) on server`));
+  console.log(chalk.dim(`  Found ${mcpSkills.length} MCP-providing skill(s) on server\n`));
 
-  // Determine target directories
-  const targets: Array<{ dir: string; label: string }> = [];
-
-  // Always sync to ~/.pcp/skills/ (managed tier — available to all SBs)
-  targets.push({
-    dir: join(homedir(), '.pcp', 'skills'),
-    label: '~/.pcp/skills',
-  });
+  // ---- Step 1: Write SKILL.md files to ~/.pcp/skills/ ----
+  const skillTargets: Array<{ dir: string; label: string }> = [
+    { dir: join(homedir(), '.pcp', 'skills'), label: '~/.pcp/skills' },
+  ];
 
   if (options.workspace) {
-    targets.push({
-      dir: join(process.cwd(), '.pcp', 'skills'),
+    skillTargets.push({
+      dir: join(cwd, '.pcp', 'skills'),
       label: '.pcp/skills (workspace)',
     });
   }
 
   if (options.all) {
-    const worktrees = getWorktrees();
-    for (const wt of worktrees) {
-      const wtSkillsDir = join(wt, '.pcp', 'skills');
-      // Avoid duplicating cwd
-      if (!targets.some((t) => t.dir === wtSkillsDir)) {
-        targets.push({ dir: wtSkillsDir, label: `.pcp/skills (${wt})` });
+    for (const wt of getWorktrees()) {
+      const wtDir = join(wt, '.pcp', 'skills');
+      if (!skillTargets.some((t) => t.dir === wtDir)) {
+        skillTargets.push({ dir: wtDir, label: `.pcp/skills (${wt})` });
       }
     }
   }
 
-  // Fetch full skill content for each MCP skill
-  let synced = 0;
-  let skipped = 0;
+  let skillsSynced = 0;
+  let skillsSkipped = 0;
 
   for (const skill of mcpSkills) {
     let detail: GetSkillResponse;
@@ -266,40 +317,73 @@ async function syncCommand(options: SyncOptions): Promise<void> {
       continue;
     }
 
-    // Ensure mcp field is on the detail
-    if (!detail.mcp && skill.mcp) {
-      detail.mcp = skill.mcp;
-    }
-
+    if (!detail.mcp && skill.mcp) detail.mcp = skill.mcp;
     const skillMd = buildSkillMd(detail);
 
-    for (const target of targets) {
+    for (const target of skillTargets) {
       const skillDir = join(target.dir, skill.name);
       const skillFile = join(skillDir, 'SKILL.md');
 
-      // Skip if already exists and content matches
       if (existsSync(skillFile)) {
         const existing = readFileSync(skillFile, 'utf-8');
         if (existing === skillMd) {
-          skipped++;
+          skillsSkipped++;
           continue;
         }
       }
 
       mkdirSync(skillDir, { recursive: true });
       writeFileSync(skillFile, skillMd);
-      synced++;
-      console.log(chalk.green(`  + ${skill.name}`), chalk.dim(`→ ${target.label}`));
+      skillsSynced++;
+      console.log(chalk.green(`  + ${skill.name} SKILL.md`), chalk.dim(`→ ${target.label}`));
     }
   }
 
-  if (synced === 0 && skipped > 0) {
-    console.log(chalk.dim(`\n  All ${skipped} skill(s) already up to date.`));
-  } else if (synced > 0) {
-    console.log(chalk.dim(`\n  Synced ${synced} skill(s), ${skipped} already up to date.`));
+  // ---- Step 2: Inject MCP servers into .mcp.json ----
+  const mcpTargets: string[] = [cwd];
+
+  if (options.all) {
+    for (const wt of getWorktrees()) {
+      if (wt !== cwd && existsSync(join(wt, '.mcp.json'))) {
+        mcpTargets.push(wt);
+      }
+    }
   }
 
-  console.log(chalk.dim('Done.\n'));
+  for (const targetDir of mcpTargets) {
+    const mcpPath = join(targetDir, '.mcp.json');
+    if (!existsSync(mcpPath)) continue;
+
+    const { added, existed } = injectMcpServers(mcpPath, mcpSkills);
+    if (added.length > 0) {
+      const label = targetDir === cwd ? '.mcp.json' : `.mcp.json (${targetDir})`;
+      console.log(chalk.green(`  + ${added.join(', ')}`), chalk.dim(`→ ${label}`));
+    }
+  }
+
+  // ---- Step 3: Sync to Codex/Gemini backend configs ----
+  const syncTargets = options.all ? getWorktrees() : [cwd];
+  for (const targetDir of syncTargets) {
+    if (!existsSync(join(targetDir, '.mcp.json'))) continue;
+    const result = syncMcpConfig(targetDir);
+    const synced: string[] = [];
+    if (result.codex) synced.push('.codex/config.toml');
+    if (result.gemini) synced.push('.gemini/settings.json');
+    if (synced.length > 0) {
+      const label = targetDir === cwd ? '' : ` (${targetDir})`;
+      console.log(chalk.green(`  + backend configs${label}:`), chalk.dim(synced.join(', ')));
+    }
+  }
+
+  // ---- Summary ----
+  const total = skillsSynced;
+  if (total === 0 && skillsSkipped > 0) {
+    console.log(chalk.dim(`\n  All skill(s) already up to date.`));
+  } else if (total > 0) {
+    console.log('');
+  }
+
+  console.log(chalk.dim('Done. MCP servers available to all backends.\n'));
 }
 
 // ============================================================================
@@ -313,7 +397,7 @@ export function registerSkillsCommands(program: Command): void {
 
   skills
     .command('sync')
-    .description('Sync MCP-providing skills from PCP server to local directories')
+    .description('Sync MCP-providing skills from PCP server to all backend configs')
     .option('--workspace', 'Also sync to workspace .pcp/skills/ (current directory)')
     .option('--all', 'Sync to all git worktrees')
     .action(syncCommand);

--- a/packages/cli/src/commands/skills.ts
+++ b/packages/cli/src/commands/skills.ts
@@ -1,0 +1,320 @@
+/**
+ * Skills Commands
+ *
+ * Manage PCP skills: discover, list, and sync across studios/worktrees.
+ *
+ * Commands:
+ *   skills list    Show discovered skills (local + server)
+ *   skills sync    Sync MCP-providing skills to local directories
+ */
+
+import { Command } from 'commander';
+import chalk from 'chalk';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+import { execSync } from 'child_process';
+import { discoverSkills, loadSkillInstruction } from '../repl/skills.js';
+import { parseSkillMcpConfig } from '../lib/skill-mcp.js';
+import { callPcpTool } from '../lib/pcp-mcp.js';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface ServerSkill {
+  name: string;
+  displayName?: string;
+  type: string;
+  description: string;
+  version?: string;
+  mcp?: {
+    name: string;
+    command: string;
+    args: string[];
+    env?: Record<string, string>;
+  };
+}
+
+interface GetSkillResponse {
+  success: boolean;
+  skillName: string;
+  type: string;
+  version: string;
+  description: string;
+  content: string;
+  mcp?: ServerSkill['mcp'];
+  triggers?: { keywords?: string[] };
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function getWorktrees(): string[] {
+  try {
+    const output = execSync('git worktree list --porcelain', {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    return output
+      .split('\n')
+      .filter((line) => line.startsWith('worktree '))
+      .map((line) => line.slice('worktree '.length));
+  } catch {
+    return [process.cwd()];
+  }
+}
+
+/**
+ * Reconstruct a SKILL.md file from get_skill response data.
+ */
+function buildSkillMd(skill: GetSkillResponse): string {
+  const frontmatter: Record<string, unknown> = {
+    name: skill.skillName,
+    description: skill.description,
+    type: skill.type,
+  };
+
+  if (skill.version) frontmatter.version = skill.version;
+
+  if (skill.triggers?.keywords) {
+    frontmatter.triggers = { keywords: skill.triggers.keywords };
+  }
+
+  if (skill.mcp) {
+    frontmatter.mcp = skill.mcp;
+  }
+
+  // Simple YAML serialization for the frontmatter
+  const yamlLines = serializeYaml(frontmatter, 0);
+  return `---\n${yamlLines}---\n\n${skill.content}\n`;
+}
+
+function serializeYaml(obj: unknown, indent: number): string {
+  const prefix = '  '.repeat(indent);
+  if (obj === null || obj === undefined) return '';
+
+  if (Array.isArray(obj)) {
+    if (obj.length === 0) return '[]\n';
+    // Use inline format for simple string arrays
+    if (obj.every((v) => typeof v === 'string')) {
+      const items = obj.map((v) => JSON.stringify(v)).join(', ');
+      return `[${items}]\n`;
+    }
+    return obj.map((v) => `${prefix}- ${String(v)}`).join('\n') + '\n';
+  }
+
+  if (typeof obj === 'object') {
+    const entries = Object.entries(obj as Record<string, unknown>);
+    if (entries.length === 0) return '{}\n';
+    return entries
+      .map(([key, val]) => {
+        if (typeof val === 'object' && val !== null && !Array.isArray(val)) {
+          const nested = serializeYaml(val, indent + 1);
+          return `${prefix}${key}:\n${nested}`;
+        }
+        const serialized = serializeYaml(val, indent).trimEnd();
+        return `${prefix}${key}: ${serialized}\n`;
+      })
+      .join('');
+  }
+
+  if (typeof obj === 'string') return obj;
+  return String(obj);
+}
+
+// ============================================================================
+// List Command
+// ============================================================================
+
+async function listCommand(): Promise<void> {
+  const cwd = process.cwd();
+  const localSkills = discoverSkills(cwd);
+
+  // Check which local skills provide MCP servers
+  const withMcp = localSkills.map((skill) => {
+    const mcp = parseSkillMcpConfig(skill.path);
+    return { ...skill, mcp };
+  });
+
+  console.log(chalk.bold(`\nLocal Skills (${localSkills.length} discovered)\n`));
+
+  if (localSkills.length === 0) {
+    console.log(chalk.dim('  No local skills found.'));
+    console.log(
+      chalk.dim(
+        '  Skills are discovered from .pcp/skills/, .claude/skills/, .codex/skills/, .gemini/skills/'
+      )
+    );
+    console.log(chalk.dim('  Run `sb skills sync` to install skills from PCP server.\n'));
+    return;
+  }
+
+  for (const skill of withMcp) {
+    const mcpBadge = skill.mcp ? chalk.cyan(' [MCP]') : '';
+    const sourceBadge = chalk.dim(` (${skill.source})`);
+    console.log(`  ${skill.name}${mcpBadge}${sourceBadge}`);
+  }
+
+  // Try to show server skills too
+  try {
+    const result = await callPcpTool<{ success: boolean; skills: ServerSkill[] }>(
+      'list_skills',
+      {}
+    );
+    if (result.success && result.skills) {
+      const serverMcp = result.skills.filter((s) => s.mcp);
+      const localNames = new Set(localSkills.map((s) => s.name));
+      const serverOnly = serverMcp.filter((s) => !localNames.has(s.name));
+
+      if (serverOnly.length > 0) {
+        console.log(chalk.bold(`\nServer Skills with MCP (not installed locally)`));
+        for (const skill of serverOnly) {
+          console.log(
+            `  ${skill.name} ${chalk.cyan('[MCP]')} ${chalk.dim(`— ${skill.description}`)}`
+          );
+        }
+        console.log(chalk.dim('\n  Run `sb skills sync` to install these locally.\n'));
+      }
+    }
+  } catch {
+    console.log(chalk.dim('\n  (PCP server not reachable — showing local skills only)\n'));
+  }
+}
+
+// ============================================================================
+// Sync Command
+// ============================================================================
+
+interface SyncOptions {
+  all?: boolean;
+  workspace?: boolean;
+}
+
+async function syncCommand(options: SyncOptions): Promise<void> {
+  console.log(chalk.bold('\nSyncing skills from PCP server...\n'));
+
+  // Fetch all skills from server
+  let serverSkills: ServerSkill[];
+  try {
+    const result = await callPcpTool<{ success: boolean; skills: ServerSkill[] }>(
+      'list_skills',
+      {}
+    );
+    if (!result.success || !result.skills) {
+      console.error(chalk.red('Failed to fetch skills from PCP server.'));
+      process.exit(1);
+    }
+    serverSkills = result.skills;
+  } catch (error) {
+    console.error(chalk.red('Cannot reach PCP server.'));
+    console.error(chalk.dim('Ensure the server is running (yarn dev) and try again.'));
+    process.exit(1);
+  }
+
+  // Filter to skills with MCP configs
+  const mcpSkills = serverSkills.filter((s) => s.mcp);
+  if (mcpSkills.length === 0) {
+    console.log(chalk.dim('  No MCP-providing skills found on server.'));
+    return;
+  }
+
+  console.log(chalk.dim(`  Found ${mcpSkills.length} MCP-providing skill(s) on server`));
+
+  // Determine target directories
+  const targets: Array<{ dir: string; label: string }> = [];
+
+  // Always sync to ~/.pcp/skills/ (managed tier — available to all SBs)
+  targets.push({
+    dir: join(homedir(), '.pcp', 'skills'),
+    label: '~/.pcp/skills',
+  });
+
+  if (options.workspace) {
+    targets.push({
+      dir: join(process.cwd(), '.pcp', 'skills'),
+      label: '.pcp/skills (workspace)',
+    });
+  }
+
+  if (options.all) {
+    const worktrees = getWorktrees();
+    for (const wt of worktrees) {
+      const wtSkillsDir = join(wt, '.pcp', 'skills');
+      // Avoid duplicating cwd
+      if (!targets.some((t) => t.dir === wtSkillsDir)) {
+        targets.push({ dir: wtSkillsDir, label: `.pcp/skills (${wt})` });
+      }
+    }
+  }
+
+  // Fetch full skill content for each MCP skill
+  let synced = 0;
+  let skipped = 0;
+
+  for (const skill of mcpSkills) {
+    let detail: GetSkillResponse;
+    try {
+      detail = await callPcpTool<GetSkillResponse>('get_skill', { skillName: skill.name });
+      if (!detail.success) {
+        console.log(chalk.yellow(`  ! ${skill.name}: failed to fetch details`));
+        continue;
+      }
+    } catch {
+      console.log(chalk.yellow(`  ! ${skill.name}: failed to fetch details`));
+      continue;
+    }
+
+    // Ensure mcp field is on the detail
+    if (!detail.mcp && skill.mcp) {
+      detail.mcp = skill.mcp;
+    }
+
+    const skillMd = buildSkillMd(detail);
+
+    for (const target of targets) {
+      const skillDir = join(target.dir, skill.name);
+      const skillFile = join(skillDir, 'SKILL.md');
+
+      // Skip if already exists and content matches
+      if (existsSync(skillFile)) {
+        const existing = readFileSync(skillFile, 'utf-8');
+        if (existing === skillMd) {
+          skipped++;
+          continue;
+        }
+      }
+
+      mkdirSync(skillDir, { recursive: true });
+      writeFileSync(skillFile, skillMd);
+      synced++;
+      console.log(chalk.green(`  + ${skill.name}`), chalk.dim(`→ ${target.label}`));
+    }
+  }
+
+  if (synced === 0 && skipped > 0) {
+    console.log(chalk.dim(`\n  All ${skipped} skill(s) already up to date.`));
+  } else if (synced > 0) {
+    console.log(chalk.dim(`\n  Synced ${synced} skill(s), ${skipped} already up to date.`));
+  }
+
+  console.log(chalk.dim('Done.\n'));
+}
+
+// ============================================================================
+// Register
+// ============================================================================
+
+export function registerSkillsCommands(program: Command): void {
+  const skills = program.command('skills').description('Manage PCP skills');
+
+  skills.command('list').description('List discovered skills (local + server)').action(listCommand);
+
+  skills
+    .command('sync')
+    .description('Sync MCP-providing skills from PCP server to local directories')
+    .option('--workspace', 'Also sync to workspace .pcp/skills/ (current directory)')
+    .option('--all', 'Sync to all git worktrees')
+    .action(syncCommand);
+}

--- a/packages/cli/src/commands/skills.ts
+++ b/packages/cli/src/commands/skills.ts
@@ -12,7 +12,15 @@
 
 import { Command } from 'commander';
 import chalk from 'chalk';
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  symlinkSync,
+  unlinkSync,
+  writeFileSync,
+} from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
 import { execSync } from 'child_process';
@@ -68,15 +76,18 @@ interface McpJsonConfig {
 // Constants
 // ============================================================================
 
+/** Canonical skill directory — single source of truth */
+const PCP_SKILLS_DIR = join(homedir(), '.pcp', 'skills');
+
 /**
- * Home-level skill directories for each backend.
- * Writing here means skills persist across ALL projects/studios.
+ * Backend skill directories that get symlinks pointing to PCP_SKILLS_DIR.
+ * This makes skills show up in each backend's native discovery:
+ *   Claude Code: /skills   Codex: native   Gemini: native
  */
-const HOME_SKILL_DIRS = [
-  join(homedir(), '.pcp', 'skills'), // PCP discovery (sb chat, buildMergedMcpConfig)
-  join(homedir(), '.claude', 'skills'), // Claude Code native (/skills)
-  join(homedir(), '.codex', 'skills'), // Codex native
-  join(homedir(), '.gemini', 'skills'), // Gemini native
+const BACKEND_SKILL_DIRS = [
+  join(homedir(), '.claude', 'skills'),
+  join(homedir(), '.codex', 'skills'),
+  join(homedir(), '.gemini', 'skills'),
 ];
 
 // ============================================================================
@@ -194,10 +205,11 @@ function injectMcpServers(
 }
 
 /**
- * Write a SKILL.md to a directory, return true if written (false if skipped).
+ * Write a SKILL.md to the canonical PCP skills dir.
+ * Returns true if written (false if content unchanged).
  */
-function writeSkillToDir(dir: string, skillName: string, content: string): boolean {
-  const skillDir = join(dir, skillName);
+function writeCanonicalSkill(skillName: string, content: string): boolean {
+  const skillDir = join(PCP_SKILLS_DIR, skillName);
   const skillFile = join(skillDir, 'SKILL.md');
 
   if (existsSync(skillFile)) {
@@ -208,6 +220,48 @@ function writeSkillToDir(dir: string, skillName: string, content: string): boole
   mkdirSync(skillDir, { recursive: true });
   writeFileSync(skillFile, content);
   return true;
+}
+
+/**
+ * Create a symlink from a backend skill dir to the canonical PCP skill dir.
+ * Returns 'created' | 'exists' | 'updated' (if symlink target changed).
+ */
+function ensureSkillSymlink(
+  backendDir: string,
+  skillName: string
+): 'created' | 'exists' | 'updated' {
+  const linkPath = join(backendDir, skillName);
+  const targetPath = join(PCP_SKILLS_DIR, skillName);
+
+  mkdirSync(backendDir, { recursive: true });
+
+  if (existsSync(linkPath)) {
+    try {
+      const stat = lstatSync(linkPath);
+      if (stat.isSymbolicLink()) {
+        // Already a symlink — check if target matches
+        const currentTarget = readFileSync(linkPath + '/SKILL.md', 'utf-8');
+        const canonicalContent = readFileSync(join(targetPath, 'SKILL.md'), 'utf-8');
+        if (currentTarget === canonicalContent) return 'exists';
+        // Stale symlink — remove and recreate
+        unlinkSync(linkPath);
+      } else {
+        // Real directory — remove it and replace with symlink
+        // (safe: we just wrote the canonical version)
+        execSync(`rm -rf ${JSON.stringify(linkPath)}`, { stdio: 'ignore' });
+      }
+    } catch {
+      // If we can't stat it, remove and recreate
+      try {
+        unlinkSync(linkPath);
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+
+  symlinkSync(targetPath, linkPath);
+  return 'created';
 }
 
 // ============================================================================
@@ -306,14 +360,14 @@ async function syncCommand(options: SyncOptions): Promise<void> {
 
   console.log(chalk.dim(`  Found ${mcpSkills.length} MCP-providing skill(s) on server\n`));
 
-  // ---- Step 1: Write SKILL.md to all backend skill dirs (home-level) ----
-  // This is the core of "one sync, skills everywhere":
-  //   ~/.pcp/skills/    → PCP discovery (sb chat, buildMergedMcpConfig)
-  //   ~/.claude/skills/ → Claude Code native (/skills)
-  //   ~/.codex/skills/  → Codex native
-  //   ~/.gemini/skills/ → Gemini native
+  // ---- Step 1: Write canonical SKILL.md + symlink to backend dirs ----
+  // ~/.pcp/skills/<name>/SKILL.md is the single source of truth.
+  // ~/.claude/skills/<name> → ~/.pcp/skills/<name>  (symlink)
+  // ~/.codex/skills/<name>  → ~/.pcp/skills/<name>  (symlink)
+  // ~/.gemini/skills/<name> → ~/.pcp/skills/<name>  (symlink)
 
   let written = 0;
+  let linked = 0;
   let skipped = 0;
 
   for (const skill of mcpSkills) {
@@ -332,13 +386,21 @@ async function syncCommand(options: SyncOptions): Promise<void> {
     if (!detail.mcp && skill.mcp) detail.mcp = skill.mcp;
     const skillMd = buildSkillMd(detail);
 
-    for (const dir of HOME_SKILL_DIRS) {
-      if (writeSkillToDir(dir, skill.name, skillMd)) {
-        written++;
-        const shortDir = dir.replace(homedir(), '~');
-        console.log(chalk.green(`  + ${skill.name}`), chalk.dim(`→ ${shortDir}/`));
-      } else {
-        skipped++;
+    // Write canonical copy
+    if (writeCanonicalSkill(skill.name, skillMd)) {
+      written++;
+      console.log(chalk.green(`  + ${skill.name}`), chalk.dim('→ ~/.pcp/skills/'));
+    } else {
+      skipped++;
+    }
+
+    // Symlink from each backend dir
+    for (const backendDir of BACKEND_SKILL_DIRS) {
+      const result = ensureSkillSymlink(backendDir, skill.name);
+      if (result === 'created' || result === 'updated') {
+        linked++;
+        const shortDir = backendDir.replace(homedir(), '~');
+        console.log(chalk.green(`  ↳ ${skill.name}`), chalk.dim(`→ ${shortDir}/ (symlink)`));
       }
     }
   }
@@ -380,7 +442,7 @@ async function syncCommand(options: SyncOptions): Promise<void> {
   }
 
   // ---- Summary ----
-  if (written === 0 && skipped > 0) {
+  if (written === 0 && linked === 0 && skipped > 0) {
     console.log(chalk.dim(`\n  All skill(s) already up to date.`));
   }
 

--- a/packages/cli/src/lib/skill-mcp.test.ts
+++ b/packages/cli/src/lib/skill-mcp.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { parseSkillMcpConfig, discoverSkillMcpServers, buildMergedMcpConfig } from './skill-mcp.js';
+
+describe('parseSkillMcpConfig', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'skill-mcp-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('parses mcp config from skill frontmatter', () => {
+    const skillDir = join(tmpDir, 'my-skill');
+    mkdirSync(skillDir);
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      `---
+name: my-skill
+description: Test skill
+mcp:
+  name: my-server
+  command: npx
+  args: ["@my/mcp-server", "--headless"]
+  env: {}
+---
+
+# My Skill
+`
+    );
+
+    const result = parseSkillMcpConfig(skillDir);
+    expect(result).not.toBeNull();
+    expect(result!.name).toBe('my-server');
+    expect(result!.command).toBe('npx');
+    expect(result!.args).toEqual(['@my/mcp-server', '--headless']);
+  });
+
+  it('returns null for skills without mcp config', () => {
+    const skillDir = join(tmpDir, 'no-mcp');
+    mkdirSync(skillDir);
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      `---
+name: no-mcp
+description: No MCP server
+type: guide
+---
+
+# Guide
+`
+    );
+
+    expect(parseSkillMcpConfig(skillDir)).toBeNull();
+  });
+
+  it('returns null for missing SKILL.md', () => {
+    expect(parseSkillMcpConfig(join(tmpDir, 'nonexistent'))).toBeNull();
+  });
+});
+
+describe('buildMergedMcpConfig', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'merged-mcp-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns project .mcp.json when no skill servers exist', () => {
+    writeFileSync(
+      join(tmpDir, '.mcp.json'),
+      JSON.stringify({
+        mcpServers: {
+          pcp: { type: 'http', url: 'http://localhost:3001/mcp' },
+        },
+      })
+    );
+
+    const { mcpConfigPath, cleanup } = buildMergedMcpConfig(tmpDir);
+    try {
+      // Returns original path, not a temp file
+      expect(mcpConfigPath).toBe(join(tmpDir, '.mcp.json'));
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('returns null when no .mcp.json and no skill servers', () => {
+    const { mcpConfigPath, cleanup } = buildMergedMcpConfig(tmpDir);
+    try {
+      expect(mcpConfigPath).toBeNull();
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('merges skill MCP servers into project config', () => {
+    // Create a skill with MCP config in .pcp/skills/
+    const skillDir = join(tmpDir, '.pcp', 'skills', 'playwright-mcp');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      `---
+name: playwright-mcp
+description: Browser automation
+mcp:
+  name: playwright
+  command: npx
+  args: ["@playwright/mcp", "--headless"]
+  env: {}
+---
+
+# Playwright
+`
+    );
+
+    // Create project .mcp.json
+    writeFileSync(
+      join(tmpDir, '.mcp.json'),
+      JSON.stringify({
+        mcpServers: {
+          pcp: { type: 'http', url: 'http://localhost:3001/mcp' },
+        },
+      })
+    );
+
+    const { mcpConfigPath, cleanup } = buildMergedMcpConfig(tmpDir);
+    try {
+      expect(mcpConfigPath).not.toBeNull();
+      // Should be a temp file, not the original
+      expect(mcpConfigPath).not.toBe(join(tmpDir, '.mcp.json'));
+
+      const merged = JSON.parse(readFileSync(mcpConfigPath!, 'utf-8'));
+      expect(merged.mcpServers.pcp).toBeDefined();
+      expect(merged.mcpServers.playwright).toBeDefined();
+      expect(merged.mcpServers.playwright.type).toBe('stdio');
+      expect(merged.mcpServers.playwright.command).toBe('npx');
+      expect(merged.mcpServers.playwright.args).toEqual(['@playwright/mcp', '--headless']);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('does not override existing MCP servers', () => {
+    const skillDir = join(tmpDir, '.pcp', 'skills', 'pcp-override');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      `---
+name: pcp-override
+description: Should not override
+mcp:
+  name: pcp
+  command: fake
+  args: ["--bad"]
+  env: {}
+---
+
+# Override attempt
+`
+    );
+
+    writeFileSync(
+      join(tmpDir, '.mcp.json'),
+      JSON.stringify({
+        mcpServers: {
+          pcp: { type: 'http', url: 'http://localhost:3001/mcp' },
+        },
+      })
+    );
+
+    const { mcpConfigPath, cleanup } = buildMergedMcpConfig(tmpDir);
+    try {
+      const merged = JSON.parse(readFileSync(mcpConfigPath!, 'utf-8'));
+      // Original pcp config preserved, not overridden by skill
+      expect(merged.mcpServers.pcp.type).toBe('http');
+      expect(merged.mcpServers.pcp.url).toBe('http://localhost:3001/mcp');
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/packages/cli/src/lib/skill-mcp.ts
+++ b/packages/cli/src/lib/skill-mcp.ts
@@ -47,25 +47,56 @@ export function parseSkillMcpConfig(skillPath: string): SkillMcpServer | null {
 
   const name = mcpBlock.match(/^\s*name:\s*(.+)/m)?.[1]?.trim();
   const command = mcpBlock.match(/^\s*command:\s*(.+)/m)?.[1]?.trim();
-  const argsMatch = mcpBlock.match(/^\s*args:\s*\[([^\]]*)\]/m);
 
   if (!name || !command) return null;
 
-  const args = argsMatch
-    ? argsMatch[1]
-        .split(',')
-        .map((a) => a.trim().replace(/^["']|["']$/g, ''))
-        .filter(Boolean)
-    : [];
+  // Parse args — inline [a, b] or block-style list (- a\n- b)
+  let args: string[] = [];
+  const argsInlineMatch = mcpBlock.match(/^\s*args:\s*\[([^\]]*)\]/m);
+  if (argsInlineMatch) {
+    args = argsInlineMatch[1]
+      .split(',')
+      .map((a) => a.trim().replace(/^["']|["']$/g, ''))
+      .filter(Boolean);
+  } else {
+    // Block-style: args:\n    - value1\n    - value2
+    const argsBlockMatch = mcpBlock.match(/^\s*args:\s*\n((?:\s+-\s+.+\n?)*)/m);
+    if (argsBlockMatch) {
+      args = argsBlockMatch[1]
+        .split('\n')
+        .map((line) =>
+          line
+            .replace(/^\s*-\s+/, '')
+            .trim()
+            .replace(/^["']|["']$/g, '')
+        )
+        .filter(Boolean);
+    }
+  }
 
-  // Parse env if present
-  const envMatch = mcpBlock.match(/^\s*env:\s*\{([^}]*)\}/m);
+  // Parse env — inline {K: V} or block-style (K: V\n K2: V2)
   const env: Record<string, string> = {};
-  if (envMatch && envMatch[1].trim()) {
-    envMatch[1].split(',').forEach((pair) => {
+  const envInlineMatch = mcpBlock.match(/^\s*env:\s*\{([^}]*)\}/m);
+  if (envInlineMatch && envInlineMatch[1].trim()) {
+    envInlineMatch[1].split(',').forEach((pair) => {
       const [k, v] = pair.split(':').map((s) => s.trim().replace(/^["']|["']$/g, ''));
       if (k && v) env[k] = v;
     });
+  } else {
+    // Block-style: env:\n    KEY: VALUE
+    const envBlockMatch = mcpBlock.match(/^\s*env:\s*\n((?:\s+\w+:.+\n?)*)/m);
+    if (envBlockMatch) {
+      envBlockMatch[1].split('\n').forEach((line) => {
+        const colonIdx = line.indexOf(':');
+        if (colonIdx === -1) return;
+        const k = line.slice(0, colonIdx).trim();
+        const v = line
+          .slice(colonIdx + 1)
+          .trim()
+          .replace(/^["']|["']$/g, '');
+        if (k && v) env[k] = v;
+      });
+    }
   }
 
   return { name, command, args, env: Object.keys(env).length > 0 ? env : undefined };
@@ -129,7 +160,8 @@ export function buildMergedMcpConfig(cwd: string): {
   let config: McpJsonConfig = { mcpServers: {} };
   if (existsSync(projectMcpPath)) {
     try {
-      config = JSON.parse(readFileSync(projectMcpPath, 'utf-8'));
+      const parsed = JSON.parse(readFileSync(projectMcpPath, 'utf-8'));
+      config = { mcpServers: {}, ...parsed };
     } catch {
       config = { mcpServers: {} };
     }

--- a/packages/cli/src/lib/skill-mcp.ts
+++ b/packages/cli/src/lib/skill-mcp.ts
@@ -1,0 +1,166 @@
+/**
+ * Skill MCP Config Extraction
+ *
+ * Reads skills that provide MCP servers (via `mcp` field in YAML frontmatter)
+ * and merges them into a temporary .mcp.json for the backend to consume.
+ */
+
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { discoverSkills } from '../repl/skills.js';
+
+export interface SkillMcpServer {
+  name: string;
+  command: string;
+  args: string[];
+  env?: Record<string, string>;
+}
+
+/**
+ * Parse the `mcp` field from a skill's YAML frontmatter.
+ * Returns null if the skill doesn't provide an MCP server.
+ */
+export function parseSkillMcpConfig(skillPath: string): SkillMcpServer | null {
+  const skillFile = join(skillPath, 'SKILL.md');
+  if (!existsSync(skillFile)) return null;
+
+  const content = readFileSync(skillFile, 'utf-8');
+
+  // Extract YAML frontmatter between --- delimiters
+  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) return null;
+
+  const frontmatter = match[1];
+
+  // Simple YAML parsing for the mcp block — avoids adding a yaml dependency.
+  // Looks for:
+  //   mcp:
+  //     name: <string>
+  //     command: <string>
+  //     args: [...]
+  //     env: {}
+  const mcpMatch = frontmatter.match(/^mcp:\s*\n((?:  .+\n)*)/m);
+  if (!mcpMatch) return null;
+
+  const mcpBlock = mcpMatch[1];
+
+  const name = mcpBlock.match(/^\s*name:\s*(.+)/m)?.[1]?.trim();
+  const command = mcpBlock.match(/^\s*command:\s*(.+)/m)?.[1]?.trim();
+  const argsMatch = mcpBlock.match(/^\s*args:\s*\[([^\]]*)\]/m);
+
+  if (!name || !command) return null;
+
+  const args = argsMatch
+    ? argsMatch[1]
+        .split(',')
+        .map((a) => a.trim().replace(/^["']|["']$/g, ''))
+        .filter(Boolean)
+    : [];
+
+  // Parse env if present
+  const envMatch = mcpBlock.match(/^\s*env:\s*\{([^}]*)\}/m);
+  const env: Record<string, string> = {};
+  if (envMatch && envMatch[1].trim()) {
+    envMatch[1].split(',').forEach((pair) => {
+      const [k, v] = pair.split(':').map((s) => s.trim().replace(/^["']|["']$/g, ''));
+      if (k && v) env[k] = v;
+    });
+  }
+
+  return { name, command, args, env: Object.keys(env).length > 0 ? env : undefined };
+}
+
+/**
+ * Discover all skills that provide MCP servers.
+ */
+export function discoverSkillMcpServers(cwd: string): SkillMcpServer[] {
+  const skills = discoverSkills(cwd);
+  const servers: SkillMcpServer[] = [];
+
+  for (const skill of skills) {
+    const mcpConfig = parseSkillMcpConfig(skill.path);
+    if (mcpConfig) {
+      servers.push(mcpConfig);
+    }
+  }
+
+  return servers;
+}
+
+interface McpJsonConfig {
+  mcpServers: Record<
+    string,
+    {
+      type?: string;
+      command?: string;
+      args?: string[];
+      url?: string;
+      env?: Record<string, string>;
+      headers?: Record<string, string>;
+    }
+  >;
+}
+
+/**
+ * Build a merged MCP config that includes both the project's .mcp.json
+ * and any skill-provided MCP servers. Returns the path to a temp file
+ * and a cleanup function.
+ *
+ * If no skill MCP servers are found, returns the original .mcp.json path
+ * (no temp file needed).
+ */
+export function buildMergedMcpConfig(cwd: string): {
+  mcpConfigPath: string | null;
+  cleanup: () => void;
+} {
+  const projectMcpPath = join(cwd, '.mcp.json');
+  const skillServers = discoverSkillMcpServers(cwd);
+
+  // No skill MCP servers — just use the project config as-is
+  if (skillServers.length === 0) {
+    return {
+      mcpConfigPath: existsSync(projectMcpPath) ? projectMcpPath : null,
+      cleanup: () => {},
+    };
+  }
+
+  // Load existing project config
+  let config: McpJsonConfig = { mcpServers: {} };
+  if (existsSync(projectMcpPath)) {
+    try {
+      config = JSON.parse(readFileSync(projectMcpPath, 'utf-8'));
+    } catch {
+      config = { mcpServers: {} };
+    }
+  }
+
+  // Merge skill-provided servers (don't override existing ones)
+  for (const server of skillServers) {
+    if (!config.mcpServers[server.name]) {
+      config.mcpServers[server.name] = {
+        type: 'stdio',
+        command: server.command,
+        args: server.args,
+        ...(server.env ? { env: server.env } : {}),
+      };
+    }
+  }
+
+  // Write merged config to temp file
+  const tmpDir = join(tmpdir(), 'sb-mcp');
+  mkdirSync(tmpDir, { recursive: true });
+  const tmpPath = join(tmpDir, `mcp-${process.pid}.json`);
+  writeFileSync(tmpPath, JSON.stringify(config, null, 2));
+
+  return {
+    mcpConfigPath: tmpPath,
+    cleanup: () => {
+      try {
+        unlinkSync(tmpPath);
+      } catch {
+        // Best-effort cleanup
+      }
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Skills can now provide MCP servers (via `mcp` field in YAML frontmatter), and `sb skills sync` makes them available to **all backends natively** — not just sb-wrapped sessions.

### What this PR does

1. **`mcp` field in SkillManifest** — Skills declare MCP servers in frontmatter. Flows through `list_skills`/`get_skill` API responses.

2. **Bundled Playwright skill** — Ships as a builtin with MCP server config (`npx @playwright/mcp --headless`). Gives all SBs browser automation out of the box.

3. **`sb skills sync`** — Fetches MCP-providing skills from PCP server and:
   - Writes `SKILL.md` to `~/.pcp/skills/` (managed tier, discoverable by all agents)
   - Injects MCP servers into `.mcp.json` (Claude reads this natively)
   - Runs `syncMcpConfig` to update `.codex/config.toml` + `.gemini/settings.json`
   - `--all` flag syncs across all worktrees
   - Never overrides existing MCP server entries

4. **`sb skills list`** — Shows local + server skills, flags MCP providers

5. **Runtime merge for `sb` sessions** — `buildMergedMcpConfig()` discovers skill MCP servers from local dirs and merges into a temp config at launch time (Claude adapter wired, Codex/Gemini have placeholders)

6. **`sb init` hint** — After setup, hints about available MCP skills

### Architecture: how skills reach each backend

```
PCP Server (builtin skills)
    │
    ▼
sb skills sync ─────┬──→ ~/.pcp/skills/<name>/SKILL.md  (local discovery)
                    ├──→ .mcp.json                       (Claude native)
                    ├──→ .codex/config.toml              (Codex native)
                    └──→ .gemini/settings.json           (Gemini native)
```

After sync, skills work in:
- `sb -a wren -b claude` (merged config at launch)
- `claude` directly (reads .mcp.json)
- `codex` directly (reads .codex/config.toml)
- `gemini` directly (reads .gemini/settings.json)

### Files changed

| File | Change |
|------|--------|
| `packages/api/src/skills/types.ts` | Add `mcp` to `SkillManifest` + `SkillSummary` |
| `packages/api/src/skills/loader.ts` | Extract `mcp` from frontmatter |
| `packages/api/src/skills/service.ts` | Include `mcp` in summary |
| `packages/api/src/mcp/tools/skill-handlers.ts` | Include `mcp` in list/get responses |
| `packages/api/src/skills/builtin/playwright-mcp/SKILL.md` | NEW — bundled skill |
| `packages/cli/src/commands/skills.ts` | NEW — `sb skills list/sync` |
| `packages/cli/src/lib/skill-mcp.ts` | NEW — MCP config parser + merger |
| `packages/cli/src/lib/skill-mcp.test.ts` | NEW — 7 tests |
| `packages/cli/src/backends/claude.ts` | Use `buildMergedMcpConfig()` |
| `packages/cli/src/commands/init.ts` | Hint about MCP skills |
| `packages/cli/src/cli.ts` | Register skills commands |

## Test plan
- [x] `npx vitest run packages/cli/src/lib/skill-mcp.test.ts` — 7 tests pass
- [x] `npx vitest run packages/cli/src/backends/` — 14 adapter tests pass
- [x] `npx vitest run packages/api/src/skills/` — 43 skill tests pass
- [ ] Manual: `sb skills sync` with server running → writes to ~/.pcp/skills/ + .mcp.json
- [ ] Manual: `sb skills list` shows Playwright with [MCP] badge
- [ ] Manual: `claude` session after sync has Playwright MCP server available

🤖 Generated with [Claude Code](https://claude.com/claude-code)