### PR TITLE
feat: unified studio routing (by Wren)

### DIFF
--- a/packages/api/src/data/supabase/types.ts
+++ b/packages/api/src/data/supabase/types.ts
@@ -133,6 +133,7 @@ export type Database = {
           relationships: Json | null;
           role: string;
           soul: string | null;
+          studio_hint: string | null;
           updated_at: string | null;
           user_id: string;
           values: Json | null;
@@ -152,6 +153,7 @@ export type Database = {
           relationships?: Json | null;
           role: string;
           soul?: string | null;
+          studio_hint?: string | null;
           updated_at?: string | null;
           user_id: string;
           values?: Json | null;
@@ -171,6 +173,7 @@ export type Database = {
           relationships?: Json | null;
           role?: string;
           soul?: string | null;
+          studio_hint?: string | null;
           updated_at?: string | null;
           user_id?: string;
           values?: Json | null;
@@ -1908,6 +1911,7 @@ export type Database = {
           next_run_at: string;
           run_count: number | null;
           status: string;
+          studio_hint: string | null;
           title: string;
           updated_at: string | null;
           user_id: string;
@@ -1926,6 +1930,7 @@ export type Database = {
           next_run_at: string;
           run_count?: number | null;
           status?: string;
+          studio_hint?: string | null;
           title: string;
           updated_at?: string | null;
           user_id: string;
@@ -1944,6 +1949,7 @@ export type Database = {
           next_run_at?: string;
           run_count?: number | null;
           status?: string;
+          studio_hint?: string | null;
           title?: string;
           updated_at?: string | null;
           user_id?: string;

--- a/packages/api/src/mcp/tools/reminder-handlers.ts
+++ b/packages/api/src/mcp/tools/reminder-handlers.ts
@@ -149,6 +149,12 @@ export const createReminderSchema = z.object({
     .positive()
     .optional()
     .describe('Maximum number of times to run (for recurring reminders)'),
+  studioHint: z
+    .string()
+    .optional()
+    .describe(
+      'Studio to run this reminder in (e.g., "home", "main", studio name). Overrides the agent\'s default. If omitted, inherits from agent identity.'
+    ),
 });
 
 export async function handleCreateReminder(
@@ -269,6 +275,7 @@ export async function handleCreateReminder(
         cron_expression: args.cronExpression || null,
         next_run_at: nextRunAt.toISOString(),
         max_runs: args.maxRuns || null,
+        studio_hint: args.studioHint || null,
         status: 'active',
       })
       .select()
@@ -290,6 +297,7 @@ export async function handleCreateReminder(
         deliveryTarget: data.delivery_target,
         cronExpression: data.cron_expression,
         nextRunAt: data.next_run_at,
+        studioHint: data.studio_hint,
         status: data.status,
         isRecurring: !!data.cron_expression,
       },
@@ -394,6 +402,7 @@ export async function handleListReminders(
       cronExpression: r.cron_expression,
       nextRunAt: r.next_run_at,
       lastRunAt: r.last_run_at,
+      studioHint: r.studio_hint,
       status: r.status,
       runCount: r.run_count,
       maxRuns: r.max_runs,
@@ -459,6 +468,12 @@ export const updateReminderSchema = z.object({
     .describe('New cron expression (set to null to make one-time)'),
   nextRunAt: z.string().datetime().optional().describe('Reschedule to specific time'),
   status: z.enum(['active', 'paused']).optional().describe('Pause or resume the reminder'),
+  studioHint: z
+    .string()
+    .optional()
+    .describe(
+      'Studio to run this reminder in. Set to override agent default, or empty string to clear override.'
+    ),
 });
 
 export async function handleUpdateReminder(
@@ -509,6 +524,7 @@ export async function handleUpdateReminder(
     if (args.cronExpression !== undefined) updates.cron_expression = args.cronExpression || null;
     if (args.nextRunAt !== undefined) updates.next_run_at = args.nextRunAt;
     if (args.status !== undefined) updates.status = args.status;
+    if (args.studioHint !== undefined) updates.studio_hint = args.studioHint || null;
 
     if (Object.keys(updates).length === 0) {
       return mcpResponse({ success: false, error: 'No updates provided' }, true);
@@ -533,6 +549,7 @@ export async function handleUpdateReminder(
         description: data.description,
         cronExpression: data.cron_expression,
         nextRunAt: data.next_run_at,
+        studioHint: data.studio_hint,
         status: data.status,
       },
     });

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -1621,7 +1621,8 @@ router.get('/routing/agents/:agentId', async (req: Request, res: Response) => {
         status,
         run_count,
         max_runs,
-        identity_id
+        identity_id,
+        studio_hint
       `
       )
       .eq('user_id', authReq.pcpUserId)
@@ -1692,6 +1693,7 @@ router.get('/routing/agents/:agentId', async (req: Request, res: Response) => {
         runCount: reminder.run_count,
         maxRuns: reminder.max_runs,
         identityId: reminder.identity_id,
+        studioHint: reminder.studio_hint ?? null,
       })),
     });
   } catch (error) {
@@ -2047,6 +2049,57 @@ router.patch('/routing/identities/:identityId', async (req: Request, res: Respon
   } catch (error) {
     logger.error('Failed to update identity studio_hint:', error);
     res.status(500).json(errorJson('Failed to update identity', error));
+  }
+});
+
+/**
+ * PATCH /api/admin/routing/reminders/:reminderId
+ * Update a reminder's studio_hint override.
+ */
+router.patch('/routing/reminders/:reminderId', async (req: Request, res: Response) => {
+  try {
+    const authReq = req as AdminAuthRequest;
+    const { reminderId } = req.params;
+    const { studioHint } = req.body;
+
+    // studioHint can be a string (set override) or null (clear override, inherit from agent)
+    if (studioHint !== null && (typeof studioHint !== 'string' || !studioHint.trim())) {
+      res.status(400).json({ error: 'studioHint must be a non-empty string or null (to clear)' });
+      return;
+    }
+
+    const supabase = createClient(env.SUPABASE_URL, env.SUPABASE_SECRET_KEY, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+
+    // Verify reminder belongs to user
+    const { data: reminder, error: fetchError } = await supabase
+      .from('scheduled_reminders')
+      .select('id')
+      .eq('id', reminderId)
+      .eq('user_id', authReq.pcpUserId)
+      .single();
+
+    if (fetchError || !reminder) {
+      res.status(404).json({ error: 'Reminder not found' });
+      return;
+    }
+
+    const { error: updateError } = await supabase
+      .from('scheduled_reminders')
+      .update({ studio_hint: studioHint ? studioHint.trim() : null })
+      .eq('id', reminderId);
+
+    if (updateError) {
+      logger.error('Failed to update reminder studio_hint:', updateError);
+      res.status(500).json(errorJson('Failed to update reminder', updateError));
+      return;
+    }
+
+    res.json({ success: true, reminderId, studioHint: studioHint ? studioHint.trim() : null });
+  } catch (error) {
+    logger.error('Failed to update reminder studio_hint:', error);
+    res.status(500).json(errorJson('Failed to update reminder', error));
   }
 });
 

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -1458,7 +1458,7 @@ router.get('/routing', async (req: Request, res: Response) => {
 
     const { data: identitiesData, error: identitiesError } = await supabase
       .from('agent_identities')
-      .select('id, agent_id, name, role, backend')
+      .select('id, agent_id, name, role, backend, studio_hint')
       .eq('user_id', authReq.pcpUserId)
       .eq('workspace_id', authReq.pcpWorkspaceId)
       .order('agent_id', { ascending: true });
@@ -1533,6 +1533,7 @@ router.get('/routing', async (req: Request, res: Response) => {
         name: identity.name,
         role: identity.role,
         backend: identity.backend,
+        studioHint: identity.studio_hint || 'home',
       })),
       routes,
     });
@@ -1996,6 +1997,57 @@ router.delete('/routing/routes/:routeId', async (req: Request, res: Response) =>
 });
 
 /**
+ * PATCH /api/admin/routing/identities/:identityId
+ * Update an agent identity's studio_hint (home studio).
+ */
+router.patch('/routing/identities/:identityId', async (req: Request, res: Response) => {
+  try {
+    const authReq = req as AdminAuthRequest;
+    const { identityId } = req.params;
+    const { studioHint } = req.body;
+
+    if (typeof studioHint !== 'string' || !studioHint.trim()) {
+      res.status(400).json({ error: 'studioHint is required (non-empty string)' });
+      return;
+    }
+
+    const supabase = createClient(env.SUPABASE_URL, env.SUPABASE_SECRET_KEY, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+
+    // Verify identity belongs to user + workspace
+    const { data: identity, error: fetchError } = await supabase
+      .from('agent_identities')
+      .select('id, agent_id')
+      .eq('id', identityId)
+      .eq('user_id', authReq.pcpUserId)
+      .eq('workspace_id', authReq.pcpWorkspaceId)
+      .single();
+
+    if (fetchError || !identity) {
+      res.status(404).json({ error: 'Identity not found' });
+      return;
+    }
+
+    const { error: updateError } = await supabase
+      .from('agent_identities')
+      .update({ studio_hint: studioHint.trim() })
+      .eq('id', identityId);
+
+    if (updateError) {
+      logger.error('Failed to update identity studio_hint:', updateError);
+      res.status(500).json(errorJson('Failed to update identity', updateError));
+      return;
+    }
+
+    res.json({ success: true, identityId, studioHint: studioHint.trim() });
+  } catch (error) {
+    logger.error('Failed to update identity studio_hint:', error);
+    res.status(500).json(errorJson('Failed to update identity', error));
+  }
+});
+
+/**
  * GET /api/admin/reminders
  * List reminders for the active user (admin view)
  */
@@ -2032,6 +2084,7 @@ router.get('/reminders', async (req: Request, res: Response) => {
         status: r.status,
         runCount: r.run_count,
         maxRuns: r.max_runs,
+        studioHint: r.studio_hint ?? null,
         agentId: r.agent_identities?.agent_id ?? null,
         agentName: r.agent_identities?.name ?? null,
         createdAt: r.created_at,

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -1557,7 +1557,9 @@ router.get('/routing/agents/:agentId', async (req: Request, res: Response) => {
 
     const { data: identity, error: identityError } = await supabase
       .from('agent_identities')
-      .select('id, agent_id, name, role, description, backend, workspace_id, updated_at')
+      .select(
+        'id, agent_id, name, role, description, backend, studio_hint, workspace_id, updated_at'
+      )
       .eq('user_id', authReq.pcpUserId)
       .eq('workspace_id', authReq.pcpWorkspaceId)
       .eq('agent_id', agentId)
@@ -1667,6 +1669,7 @@ router.get('/routing/agents/:agentId', async (req: Request, res: Response) => {
         role: identity.role,
         description: identity.description,
         backend: identity.backend,
+        studioHint: identity.studio_hint || 'home',
         updatedAt: identity.updated_at,
       },
       studios: (studiosData || []).map((s) => ({

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -380,11 +380,24 @@ async function startServer(config: ServerConfig = {}): Promise<void> {
       }
     }
 
-    // Resolve studioHint from channel_routes for the delivery channel + target
-    // delivery_target is the chat/conversation ID (e.g., Telegram chat ID)
-    // This enables per-chat routing for multi-user scenarios
+    // Resolve studioHint via cascade:
+    //   1. reminder.studio_hint (direct override)
+    //   2. channel_routes.studio_hint (matched by delivery channel)
+    //   3. agent_identities.studio_hint (agent's home studio)
+    //   4. 'home' (hardcoded fallback)
     let reminderStudioHint: string | null = null;
-    if (dataComposer && reminder.delivery_channel) {
+
+    // Check reminder-level override first
+    if (reminder.studio_hint) {
+      reminderStudioHint = reminder.studio_hint;
+      logger.debug(`[Heartbeat] Using reminder-level studioHint`, {
+        studioHint: reminderStudioHint,
+        reminderId: reminder.id,
+      });
+    }
+
+    // Fallback to channel_routes
+    if (!reminderStudioHint && dataComposer && reminder.delivery_channel) {
       const route = await resolveRouteAgentId(
         dataComposer.getClient(),
         userId,
@@ -400,6 +413,28 @@ async function startServer(config: ServerConfig = {}): Promise<void> {
           deliveryTarget: reminder.delivery_target,
         });
       }
+    }
+
+    // Fallback to agent identity's home studio
+    if (!reminderStudioHint && reminder.identity_id && dataComposer) {
+      const { data: identity } = await dataComposer
+        .getClient()
+        .from('agent_identities')
+        .select('studio_hint')
+        .eq('id', reminder.identity_id)
+        .single();
+      if (identity?.studio_hint) {
+        reminderStudioHint = identity.studio_hint;
+        logger.debug(`[Heartbeat] Using agent home studio`, {
+          studioHint: reminderStudioHint,
+          identityId: reminder.identity_id,
+        });
+      }
+    }
+
+    // Final fallback
+    if (!reminderStudioHint) {
+      reminderStudioHint = 'home';
     }
 
     const reminderContent = `[HEARTBEAT REMINDER]

--- a/packages/api/src/services/heartbeat.ts
+++ b/packages/api/src/services/heartbeat.ts
@@ -32,6 +32,7 @@ export interface DueReminder {
   next_run_at: string;
   run_count: number;
   max_runs: number | null;
+  studio_hint: string | null;
 }
 
 interface HeartbeatConfig {
@@ -317,6 +318,7 @@ export async function createReminder(params: {
   runAt?: Date;
   maxRuns?: number;
   identityId?: string;
+  studioHint?: string;
   metadata?: Json;
 }): Promise<{ id: string } | null> {
   if (!supabase) {
@@ -344,6 +346,7 @@ export async function createReminder(params: {
       next_run_at: nextRunAt.toISOString(),
       max_runs: params.maxRuns || null,
       identity_id: params.identityId || null,
+      studio_hint: params.studioHint || null,
       metadata: params.metadata ?? {},
     })
     .select('id')

--- a/packages/web/src/app/(dashboard)/routing/[agentId]/page.tsx
+++ b/packages/web/src/app/(dashboard)/routing/[agentId]/page.tsx
@@ -15,6 +15,7 @@ import {
   Pencil,
   Check,
   X,
+  Info,
 } from 'lucide-react';
 import { apiDelete, apiPatch, useApiPost, useApiQuery, useQueryClient } from '@/lib/api';
 import { Badge } from '@/components/ui/badge';
@@ -54,6 +55,7 @@ interface AgentReminder {
   runCount: number;
   maxRuns: number | null;
   identityId: string | null;
+  studioHint: string | null;
 }
 
 interface AgentStudio {
@@ -103,7 +105,6 @@ function formatTime(value: string | null): string {
 function buildStudioOptions(studios: AgentStudio[]): { value: string; label: string }[] {
   const options: { value: string; label: string }[] = [{ value: 'main', label: 'Main' }];
   for (const s of studios) {
-    // Skip if this IS the main branch studio (already covered by "Main" option)
     if (s.branch === 'main') continue;
     options.push({ value: s.name, label: s.name });
   }
@@ -128,6 +129,14 @@ function initialFormFromRoute(route: AgentRoute): RouteFormState {
   };
 }
 
+const STATUS_COLORS: Record<string, string> = {
+  active: 'bg-green-100 text-green-700',
+  paused: 'bg-amber-100 text-amber-700',
+  completed: 'bg-gray-100 text-gray-600',
+  cancelled: 'bg-gray-100 text-gray-500',
+  failed: 'bg-red-100 text-red-700',
+};
+
 export default function AgentRoutingPage() {
   const params = useParams<{ agentId: string }>();
   const agentId = decodeURIComponent(params?.agentId || '');
@@ -136,13 +145,15 @@ export default function AgentRoutingPage() {
   const { data, isLoading, error } = useApiQuery<AgentRoutingResponse>(
     ['routing-agent', agentId],
     `/api/admin/routing/agents/${encodeURIComponent(agentId)}`,
-    {
-      enabled: !!agentId,
-    }
+    { enabled: !!agentId }
   );
 
   const studios = data?.studios ?? [];
   const studioOptions = useMemo(() => buildStudioOptions(studios), [studios]);
+  const studioOptionsWithInherit = useMemo(
+    () => [{ value: '', label: 'Inherit from default' }, ...studioOptions],
+    [studioOptions]
+  );
 
   // Home studio editing
   const [editingHomeStudio, setEditingHomeStudio] = useState(false);
@@ -155,6 +166,19 @@ export default function AgentRoutingPage() {
       queryClient.invalidateQueries({ queryKey: ['routing'] });
       queryClient.invalidateQueries({ queryKey: ['routing-agent', agentId] });
       setEditingHomeStudio(false);
+    },
+  });
+
+  // Reminder studio editing
+  const [editingReminderId, setEditingReminderId] = useState<string | null>(null);
+  const [reminderStudioValue, setReminderStudioValue] = useState('');
+
+  const updateReminderStudioMutation = useMutation({
+    mutationFn: ({ reminderId, studioHint }: { reminderId: string; studioHint: string | null }) =>
+      apiPatch(`/api/admin/routing/reminders/${reminderId}`, { studioHint }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['routing-agent', agentId] });
+      setEditingReminderId(null);
     },
   });
 
@@ -220,13 +244,15 @@ export default function AgentRoutingPage() {
     createRouteMutation.error?.message ||
     updateRouteMutation.error?.message ||
     deleteRouteMutation.error?.message ||
-    updateHomeStudioMutation.error?.message;
+    updateHomeStudioMutation.error?.message ||
+    updateReminderStudioMutation.error?.message;
 
   const selectClassName =
     'flex h-9 w-full rounded-md border border-input bg-background px-3 py-2 text-sm';
 
   return (
     <div>
+      {/* Header */}
       <div className="flex items-center justify-between gap-4">
         <div>
           <Button variant="ghost" size="sm" asChild className="mb-2 px-0">
@@ -242,73 +268,11 @@ export default function AgentRoutingPage() {
             {data?.agent?.role || 'Configure channel route scope and routing behavior for this SB.'}
           </p>
         </div>
-        <div className="flex items-center gap-3 shrink-0">
-          {data?.agent && (
-            <div className="text-right">
-              <div className="text-xs text-gray-400 mb-1">Home studio</div>
-              {editingHomeStudio ? (
-                <div className="flex items-center gap-1">
-                  <select
-                    className="h-8 rounded-md border border-input bg-background px-2 text-sm"
-                    value={homeStudioValue}
-                    onChange={(event) => setHomeStudioValue(event.target.value)}
-                  >
-                    {studioOptions.map((opt) => (
-                      <option key={opt.value} value={opt.value}>
-                        {opt.label}
-                      </option>
-                    ))}
-                    {/* Always include 'home' as an option */}
-                    {!studioOptions.some((o) => o.value === 'home') && (
-                      <option value="home">home</option>
-                    )}
-                  </select>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="h-8 w-8 p-0"
-                    disabled={updateHomeStudioMutation.isPending}
-                    onClick={() =>
-                      updateHomeStudioMutation.mutate({
-                        identityId: data.agent.id,
-                        studioHint: homeStudioValue,
-                      })
-                    }
-                  >
-                    <Check className="h-4 w-4 text-green-600" />
-                  </Button>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="h-8 w-8 p-0"
-                    onClick={() => setEditingHomeStudio(false)}
-                  >
-                    <X className="h-4 w-4 text-gray-400" />
-                  </Button>
-                </div>
-              ) : (
-                <button
-                  className="flex items-center gap-1.5 text-sm text-gray-700 hover:text-gray-900 group cursor-pointer"
-                  onClick={() => {
-                    setHomeStudioValue(data.agent.studioHint || 'home');
-                    setEditingHomeStudio(true);
-                  }}
-                >
-                  <Home className="h-3.5 w-3.5 text-gray-500" />
-                  <span className="font-medium">
-                    {studioHintLabel(data.agent.studioHint, studios)}
-                  </span>
-                  <Pencil className="h-3 w-3 text-gray-400 opacity-0 group-hover:opacity-100 transition-opacity" />
-                </button>
-              )}
-            </div>
-          )}
-          {data?.agent?.backend && (
-            <Badge variant="secondary" className="text-sm">
-              {data.agent.backend}
-            </Badge>
-          )}
-        </div>
+        {data?.agent?.backend && (
+          <Badge variant="secondary" className="text-sm shrink-0">
+            {data.agent.backend}
+          </Badge>
+        )}
       </div>
 
       {data && !data.heartbeatProcessingEnabled && (
@@ -324,127 +288,87 @@ export default function AgentRoutingPage() {
         </div>
       )}
 
-      <Card className="mt-6">
-        <CardHeader>
-          <CardTitle>Add route for {data?.agent?.name || agentId}</CardTitle>
-          <CardDescription>
-            Start broad (platform only) then narrow to account/chat when needed.
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <form
-            className="space-y-4"
-            onSubmit={(event) => {
-              event.preventDefault();
-              if (!data?.agent?.id) return;
-              createRouteMutation.mutate({
-                identityId: data.agent.id,
-                platform: newRoute.platform,
-                platformAccountId: newRoute.platformAccountId || null,
-                chatId: newRoute.chatId || null,
-                studioHint: newRoute.studioHint || null,
-                isActive: newRoute.isActive,
-              });
-            }}
-          >
-            <div className="grid gap-4 md:grid-cols-2">
-              <div className="space-y-2">
-                <label className="text-sm font-medium">Platform</label>
-                <select
-                  className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-                  value={newRoute.platform}
-                  onChange={(event) =>
-                    setNewRoute((previous) => ({
-                      ...previous,
-                      platform: event.target.value,
-                    }))
-                  }
-                >
-                  {PLATFORM_OPTIONS.map((platform) => (
-                    <option key={platform} value={platform}>
-                      {formatPlatform(platform)}
-                    </option>
-                  ))}
-                </select>
-              </div>
-              <div className="space-y-2">
-                <label className="text-sm font-medium">Studio</label>
-                <select
-                  className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
-                  value={newRoute.studioHint}
-                  onChange={(event) =>
-                    setNewRoute((previous) => ({
-                      ...previous,
-                      studioHint: event.target.value,
-                    }))
-                  }
-                >
-                  {studioOptions.map((opt) => (
-                    <option key={opt.value} value={opt.value}>
-                      {opt.label}
-                    </option>
-                  ))}
-                </select>
-              </div>
-            </div>
-            <div className="grid gap-4 md:grid-cols-2">
-              <div className="space-y-2">
-                <label className="text-sm font-medium">Platform account</label>
-                <Input
-                  placeholder="myra_help_bot or +14155551234"
-                  value={newRoute.platformAccountId}
-                  onChange={(event) =>
-                    setNewRoute((previous) => ({
-                      ...previous,
-                      platformAccountId: event.target.value,
-                    }))
-                  }
-                />
-              </div>
-              <div className="space-y-2">
-                <label className="text-sm font-medium">Chat ID</label>
-                <Input
-                  placeholder="chat/thread identifier"
-                  value={newRoute.chatId}
-                  onChange={(event) =>
-                    setNewRoute((previous) => ({
-                      ...previous,
-                      chatId: event.target.value,
-                    }))
-                  }
-                />
-              </div>
-            </div>
-
-            <div className="flex items-center justify-between">
-              <label className="flex items-center gap-2 text-sm">
-                <input
-                  type="checkbox"
-                  checked={newRoute.isActive}
-                  onChange={(event) =>
-                    setNewRoute((previous) => ({
-                      ...previous,
-                      isActive: event.target.checked,
-                    }))
-                  }
-                />
-                Route active
-              </label>
-              <Button type="submit" disabled={createRouteMutation.isPending}>
-                <Plus className="mr-2 h-4 w-4" />
-                {createRouteMutation.isPending ? 'Creating...' : 'Add route'}
-              </Button>
-            </div>
-          </form>
-        </CardContent>
-      </Card>
-
+      {/* Routes card — with default studio at top */}
       <Card className="mt-6">
         <CardHeader>
           <CardTitle>Routes</CardTitle>
-          <CardDescription>Edit or disable route scopes for this SB.</CardDescription>
+          <CardDescription>
+            Channel routes determine which studio handles messages from each platform.
+          </CardDescription>
         </CardHeader>
         <CardContent>
+          {/* Default studio selector */}
+          {data?.agent && (
+            <div className="mb-6 rounded-lg border border-indigo-100 bg-indigo-50/50 p-4">
+              <div className="flex items-center justify-between">
+                <div className="flex items-start gap-3">
+                  <Home className="mt-0.5 h-5 w-5 text-indigo-500 shrink-0" />
+                  <div>
+                    <div className="font-medium text-gray-900">Default studio</div>
+                    <p className="mt-0.5 text-sm text-gray-500">
+                      Used for all messages unless a specific route overrides it below.
+                    </p>
+                  </div>
+                </div>
+                <div className="shrink-0 ml-4">
+                  {editingHomeStudio ? (
+                    <div className="flex items-center gap-1.5">
+                      <select
+                        className="h-9 rounded-md border border-input bg-white px-3 text-sm font-medium"
+                        value={homeStudioValue}
+                        onChange={(event) => setHomeStudioValue(event.target.value)}
+                      >
+                        {studioOptions.map((opt) => (
+                          <option key={opt.value} value={opt.value}>
+                            {opt.label}
+                          </option>
+                        ))}
+                        {!studioOptions.some((o) => o.value === 'home') && (
+                          <option value="home">home</option>
+                        )}
+                      </select>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="h-9 w-9 p-0 border-green-200 hover:bg-green-50"
+                        disabled={updateHomeStudioMutation.isPending}
+                        onClick={() =>
+                          updateHomeStudioMutation.mutate({
+                            identityId: data.agent.id,
+                            studioHint: homeStudioValue,
+                          })
+                        }
+                      >
+                        <Check className="h-4 w-4 text-green-600" />
+                      </Button>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="h-9 w-9 p-0"
+                        onClick={() => setEditingHomeStudio(false)}
+                      >
+                        <X className="h-4 w-4 text-gray-400" />
+                      </Button>
+                    </div>
+                  ) : (
+                    <button
+                      className="flex items-center gap-2 rounded-md border border-gray-200 bg-white px-3 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 hover:border-gray-300 transition-colors cursor-pointer group"
+                      onClick={() => {
+                        setHomeStudioValue(data.agent.studioHint || 'home');
+                        setEditingHomeStudio(true);
+                      }}
+                    >
+                      <GitBranch className="h-4 w-4 text-indigo-500" />
+                      {studioHintLabel(data.agent.studioHint, studios)}
+                      <Pencil className="h-3 w-3 text-gray-400 opacity-0 group-hover:opacity-100 transition-opacity" />
+                    </button>
+                  )}
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Route list */}
           {isLoading ? (
             <p className="text-gray-500">Loading...</p>
           ) : !data || data.routes.length === 0 ? (
@@ -485,10 +409,14 @@ export default function AgentRoutingPage() {
                         <div className="font-mono text-xs">{route.chatId || 'All chats'}</div>
                       </div>
                       <div>
-                        <div className="text-gray-500">Studio</div>
+                        <div className="text-gray-500">Studio override</div>
                         <div className="flex items-center gap-1 text-xs">
                           <GitBranch className="h-3 w-3 text-gray-400" />
-                          {studioHintLabel(route.studioHint, studios)}
+                          {route.studioHint ? (
+                            studioHintLabel(route.studioHint, studios)
+                          ) : (
+                            <span className="text-gray-400 italic">Uses default</span>
+                          )}
                         </div>
                       </div>
                     </div>
@@ -538,6 +466,7 @@ export default function AgentRoutingPage() {
                               }))
                             }
                           >
+                            <option value="">Uses default</option>
                             {studioOptions.map((opt) => (
                               <option key={opt.value} value={opt.value}>
                                 {opt.label}
@@ -647,41 +576,228 @@ export default function AgentRoutingPage() {
         </CardContent>
       </Card>
 
+      {/* Scheduled reminders — with studio overrides */}
       <Card className="mt-6">
         <CardHeader>
-          <CardTitle>Scheduled reminders for this SB</CardTitle>
-          <CardDescription>Identity-bound reminders that will route to this agent.</CardDescription>
+          <CardTitle>Scheduled reminders</CardTitle>
+          <CardDescription>
+            Reminders bound to this SB. Each can override the default studio for targeted execution.
+          </CardDescription>
         </CardHeader>
         <CardContent>
           {!data || data.reminders.length === 0 ? (
             <p className="text-sm text-gray-500">No reminders assigned to this SB.</p>
           ) : (
             <div className="space-y-3">
-              {data.reminders.map((reminder) => (
-                <div key={reminder.id} className="rounded-md border p-3">
-                  <div className="flex items-center justify-between gap-3">
-                    <div>
-                      <div className="font-medium text-gray-900">{reminder.title}</div>
-                      <div className="text-xs text-gray-500 mt-1">
-                        {formatPlatform(reminder.deliveryChannel)}
-                        {reminder.deliveryTarget ? ` \u2192 ${reminder.deliveryTarget}` : ''}
+              {data.reminders.map((reminder) => {
+                const isEditingStudio = editingReminderId === reminder.id;
+                return (
+                  <div key={reminder.id} className="rounded-lg border p-4">
+                    <div className="flex items-center justify-between gap-3">
+                      <div className="min-w-0">
+                        <div className="font-medium text-gray-900 truncate">{reminder.title}</div>
+                        <div className="text-xs text-gray-500 mt-1">
+                          {formatPlatform(reminder.deliveryChannel)}
+                          {reminder.deliveryTarget ? ` \u2192 ${reminder.deliveryTarget}` : ''}
+                        </div>
                       </div>
+                      <Badge className={STATUS_COLORS[reminder.status] || 'bg-gray-100'}>
+                        {reminder.status}
+                      </Badge>
                     </div>
-                    <Badge variant="outline">{reminder.status}</Badge>
-                  </div>
-                  <div className="mt-2 grid gap-2 md:grid-cols-2 text-xs text-gray-600">
-                    <div className="flex items-center gap-1">
-                      <Bell className="h-3 w-3" />
-                      Next: {formatTime(reminder.nextRunAt)}
+
+                    <div className="mt-3 grid gap-3 md:grid-cols-2 lg:grid-cols-4 text-xs text-gray-600">
+                      <div className="flex items-center gap-1">
+                        <Bell className="h-3 w-3" />
+                        Next: {formatTime(reminder.nextRunAt)}
+                      </div>
+                      <div>Runs: {reminder.runCount}</div>
+                      {reminder.cronExpression && <div>Cron: {reminder.cronExpression}</div>}
+                      {reminder.lastRunAt && <div>Last: {formatTime(reminder.lastRunAt)}</div>}
                     </div>
-                    <div>Runs: {reminder.runCount}</div>
-                    {reminder.cronExpression && <div>Cron: {reminder.cronExpression}</div>}
-                    {reminder.lastRunAt && <div>Last: {formatTime(reminder.lastRunAt)}</div>}
+
+                    {/* Studio override row */}
+                    <div className="mt-3 flex items-center gap-2 pt-3 border-t border-gray-100">
+                      <GitBranch className="h-3.5 w-3.5 text-gray-400 shrink-0" />
+                      <span className="text-xs text-gray-500 shrink-0">Studio:</span>
+                      {isEditingStudio ? (
+                        <div className="flex items-center gap-1.5">
+                          <select
+                            className="h-7 rounded border border-input bg-white px-2 text-xs"
+                            value={reminderStudioValue}
+                            onChange={(event) => setReminderStudioValue(event.target.value)}
+                          >
+                            {studioOptionsWithInherit.map((opt) => (
+                              <option key={opt.value} value={opt.value}>
+                                {opt.label}
+                              </option>
+                            ))}
+                          </select>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="h-7 w-7 p-0"
+                            disabled={updateReminderStudioMutation.isPending}
+                            onClick={() =>
+                              updateReminderStudioMutation.mutate({
+                                reminderId: reminder.id,
+                                studioHint: reminderStudioValue || null,
+                              })
+                            }
+                          >
+                            <Check className="h-3.5 w-3.5 text-green-600" />
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="h-7 w-7 p-0"
+                            onClick={() => setEditingReminderId(null)}
+                          >
+                            <X className="h-3.5 w-3.5 text-gray-400" />
+                          </Button>
+                        </div>
+                      ) : (
+                        <button
+                          className="flex items-center gap-1 text-xs text-gray-700 hover:text-gray-900 group cursor-pointer"
+                          onClick={() => {
+                            setReminderStudioValue(reminder.studioHint || '');
+                            setEditingReminderId(reminder.id);
+                          }}
+                        >
+                          {reminder.studioHint ? (
+                            <span className="font-medium">
+                              {studioHintLabel(reminder.studioHint, studios)}
+                            </span>
+                          ) : (
+                            <span className="text-gray-400 italic">Inherits default</span>
+                          )}
+                          <Pencil className="h-2.5 w-2.5 text-gray-400 opacity-0 group-hover:opacity-100 transition-opacity" />
+                        </button>
+                      )}
+                    </div>
                   </div>
-                </div>
-              ))}
+                );
+              })}
             </div>
           )}
+        </CardContent>
+      </Card>
+
+      {/* Add route — moved below existing routes */}
+      <Card className="mt-6">
+        <CardHeader>
+          <CardTitle>Add route for {data?.agent?.name || agentId}</CardTitle>
+          <CardDescription>
+            Start broad (platform only) then narrow to account/chat when needed. Leave studio empty
+            to use the default above.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form
+            className="space-y-4"
+            onSubmit={(event) => {
+              event.preventDefault();
+              if (!data?.agent?.id) return;
+              createRouteMutation.mutate({
+                identityId: data.agent.id,
+                platform: newRoute.platform,
+                platformAccountId: newRoute.platformAccountId || null,
+                chatId: newRoute.chatId || null,
+                studioHint: newRoute.studioHint || null,
+                isActive: newRoute.isActive,
+              });
+            }}
+          >
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-2">
+                <label className="text-sm font-medium">Platform</label>
+                <select
+                  className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                  value={newRoute.platform}
+                  onChange={(event) =>
+                    setNewRoute((previous) => ({
+                      ...previous,
+                      platform: event.target.value,
+                    }))
+                  }
+                >
+                  {PLATFORM_OPTIONS.map((platform) => (
+                    <option key={platform} value={platform}>
+                      {formatPlatform(platform)}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="space-y-2">
+                <label className="text-sm font-medium">Studio override</label>
+                <select
+                  className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                  value={newRoute.studioHint}
+                  onChange={(event) =>
+                    setNewRoute((previous) => ({
+                      ...previous,
+                      studioHint: event.target.value,
+                    }))
+                  }
+                >
+                  <option value="">Uses default</option>
+                  {studioOptions.map((opt) => (
+                    <option key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-2">
+                <label className="text-sm font-medium">Platform account</label>
+                <Input
+                  placeholder="myra_help_bot or +14155551234"
+                  value={newRoute.platformAccountId}
+                  onChange={(event) =>
+                    setNewRoute((previous) => ({
+                      ...previous,
+                      platformAccountId: event.target.value,
+                    }))
+                  }
+                />
+              </div>
+              <div className="space-y-2">
+                <label className="text-sm font-medium">Chat ID</label>
+                <Input
+                  placeholder="chat/thread identifier"
+                  value={newRoute.chatId}
+                  onChange={(event) =>
+                    setNewRoute((previous) => ({
+                      ...previous,
+                      chatId: event.target.value,
+                    }))
+                  }
+                />
+              </div>
+            </div>
+
+            <div className="flex items-center justify-between">
+              <label className="flex items-center gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  checked={newRoute.isActive}
+                  onChange={(event) =>
+                    setNewRoute((previous) => ({
+                      ...previous,
+                      isActive: event.target.checked,
+                    }))
+                  }
+                />
+                Route active
+              </label>
+              <Button type="submit" disabled={createRouteMutation.isPending}>
+                <Plus className="mr-2 h-4 w-4" />
+                {createRouteMutation.isPending ? 'Creating...' : 'Add route'}
+              </Button>
+            </div>
+          </form>
         </CardContent>
       </Card>
     </div>

--- a/packages/web/src/app/(dashboard)/routing/[agentId]/page.tsx
+++ b/packages/web/src/app/(dashboard)/routing/[agentId]/page.tsx
@@ -299,71 +299,65 @@ export default function AgentRoutingPage() {
         <CardContent>
           {/* Default studio selector */}
           {data?.agent && (
-            <div className="mb-6 rounded-lg border border-indigo-100 bg-indigo-50/50 p-4">
-              <div className="flex items-center justify-between">
-                <div className="flex items-start gap-3">
-                  <Home className="mt-0.5 h-5 w-5 text-indigo-500 shrink-0" />
-                  <div>
-                    <div className="font-medium text-gray-900">Default studio</div>
-                    <p className="mt-0.5 text-sm text-gray-500">
-                      Used for all messages unless a specific route overrides it below.
-                    </p>
-                  </div>
-                </div>
-                <div className="shrink-0 ml-4">
-                  {editingHomeStudio ? (
-                    <div className="flex items-center gap-1.5">
-                      <select
-                        className="h-9 rounded-md border border-input bg-white px-3 text-sm font-medium"
-                        value={homeStudioValue}
-                        onChange={(event) => setHomeStudioValue(event.target.value)}
-                      >
-                        {studioOptions.map((opt) => (
-                          <option key={opt.value} value={opt.value}>
-                            {opt.label}
-                          </option>
-                        ))}
-                        {!studioOptions.some((o) => o.value === 'home') && (
-                          <option value="home">home</option>
-                        )}
-                      </select>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        className="h-9 w-9 p-0 border-green-200 hover:bg-green-50"
-                        disabled={updateHomeStudioMutation.isPending}
-                        onClick={() =>
-                          updateHomeStudioMutation.mutate({
-                            identityId: data.agent.id,
-                            studioHint: homeStudioValue,
-                          })
-                        }
-                      >
-                        <Check className="h-4 w-4 text-green-600" />
-                      </Button>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        className="h-9 w-9 p-0"
-                        onClick={() => setEditingHomeStudio(false)}
-                      >
-                        <X className="h-4 w-4 text-gray-400" />
-                      </Button>
-                    </div>
-                  ) : (
-                    <button
-                      className="flex items-center gap-2 rounded-md border border-gray-200 bg-white px-3 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 hover:border-gray-300 transition-colors cursor-pointer group"
-                      onClick={() => {
-                        setHomeStudioValue(data.agent.studioHint || 'home');
-                        setEditingHomeStudio(true);
-                      }}
+            <div className="mb-6 flex items-center justify-between border-b border-gray-100 pb-4">
+              <div className="flex items-center gap-2.5 text-sm text-gray-500">
+                <Home className="h-4 w-4 text-gray-400" />
+                <span>Default studio</span>
+                <span className="text-gray-300">&mdash;</span>
+                <span className="text-gray-400">used unless a route or reminder overrides it</span>
+              </div>
+              <div className="shrink-0 ml-4">
+                {editingHomeStudio ? (
+                  <div className="flex items-center gap-1.5">
+                    <select
+                      className="h-8 rounded-md border border-input bg-background px-2.5 text-sm"
+                      value={homeStudioValue}
+                      onChange={(event) => setHomeStudioValue(event.target.value)}
                     >
-                      <GitBranch className="h-4 w-4 text-indigo-500" />
-                      {studioHintLabel(data.agent.studioHint, studios)}
-                      <Pencil className="h-3 w-3 text-gray-400 opacity-0 group-hover:opacity-100 transition-opacity" />
-                    </button>
-                  )}
-                </div>
+                      {studioOptions.map((opt) => (
+                        <option key={opt.value} value={opt.value}>
+                          {opt.label}
+                        </option>
+                      ))}
+                      {!studioOptions.some((o) => o.value === 'home') && (
+                        <option value="home">home</option>
+                      )}
+                    </select>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-8 w-8 p-0"
+                      disabled={updateHomeStudioMutation.isPending}
+                      onClick={() =>
+                        updateHomeStudioMutation.mutate({
+                          identityId: data.agent.id,
+                          studioHint: homeStudioValue,
+                        })
+                      }
+                    >
+                      <Check className="h-4 w-4 text-green-600" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-8 w-8 p-0"
+                      onClick={() => setEditingHomeStudio(false)}
+                    >
+                      <X className="h-4 w-4 text-gray-400" />
+                    </Button>
+                  </div>
+                ) : (
+                  <button
+                    className="inline-flex items-center gap-2 rounded-md border border-gray-200 px-2.5 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 hover:border-gray-300 transition-colors cursor-pointer"
+                    onClick={() => {
+                      setHomeStudioValue(data.agent.studioHint || 'home');
+                      setEditingHomeStudio(true);
+                    }}
+                  >
+                    {studioHintLabel(data.agent.studioHint, studios)}
+                    <Pencil className="h-3 w-3 text-gray-400" />
+                  </button>
+                )}
               </div>
             </div>
           )}
@@ -658,7 +652,7 @@ export default function AgentRoutingPage() {
                         </div>
                       ) : (
                         <button
-                          className="flex items-center gap-1 text-xs text-gray-700 hover:text-gray-900 group cursor-pointer"
+                          className="inline-flex items-center gap-1.5 rounded-md border border-transparent px-2 py-0.5 text-xs text-gray-700 hover:border-gray-200 hover:bg-gray-50 transition-all cursor-pointer"
                           onClick={() => {
                             setReminderStudioValue(reminder.studioHint || '');
                             setEditingReminderId(reminder.id);
@@ -671,7 +665,7 @@ export default function AgentRoutingPage() {
                           ) : (
                             <span className="text-gray-400 italic">Inherits default</span>
                           )}
-                          <Pencil className="h-2.5 w-2.5 text-gray-400 opacity-0 group-hover:opacity-100 transition-opacity" />
+                          <Pencil className="h-3 w-3 text-gray-400" />
                         </button>
                       )}
                     </div>

--- a/packages/web/src/app/(dashboard)/routing/[agentId]/page.tsx
+++ b/packages/web/src/app/(dashboard)/routing/[agentId]/page.tsx
@@ -186,7 +186,7 @@ export default function AgentRoutingPage() {
     platform: 'telegram',
     platformAccountId: '',
     chatId: '',
-    studioHint: 'main',
+    studioHint: '',
     isActive: true,
   });
   const [editingRouteId, setEditingRouteId] = useState<string | null>(null);
@@ -215,7 +215,7 @@ export default function AgentRoutingPage() {
           platform: 'telegram',
           platformAccountId: '',
           chatId: '',
-          studioHint: 'main',
+          studioHint: '',
           isActive: true,
         });
       },

--- a/packages/web/src/app/(dashboard)/routing/[agentId]/page.tsx
+++ b/packages/web/src/app/(dashboard)/routing/[agentId]/page.tsx
@@ -4,7 +4,18 @@ import Link from 'next/link';
 import { useEffect, useMemo, useState } from 'react';
 import { useParams } from 'next/navigation';
 import { useMutation } from '@tanstack/react-query';
-import { ArrowLeft, Bell, Save, Trash2, Plus, GitBranch } from 'lucide-react';
+import {
+  ArrowLeft,
+  Bell,
+  Save,
+  Trash2,
+  Plus,
+  GitBranch,
+  Home,
+  Pencil,
+  Check,
+  X,
+} from 'lucide-react';
 import { apiDelete, apiPatch, useApiPost, useApiQuery, useQueryClient } from '@/lib/api';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -61,6 +72,7 @@ interface AgentRoutingResponse {
     role: string;
     description: string | null;
     backend: string | null;
+    studioHint: string;
     updatedAt: string;
   };
   studios: AgentStudio[];
@@ -89,9 +101,7 @@ function formatTime(value: string | null): string {
 }
 
 function buildStudioOptions(studios: AgentStudio[]): { value: string; label: string }[] {
-  const options: { value: string; label: string }[] = [
-    { value: 'main', label: 'Main' },
-  ];
+  const options: { value: string; label: string }[] = [{ value: 'main', label: 'Main' }];
   for (const s of studios) {
     // Skip if this IS the main branch studio (already covered by "Main" option)
     if (s.branch === 'main') continue;
@@ -133,6 +143,20 @@ export default function AgentRoutingPage() {
 
   const studios = data?.studios ?? [];
   const studioOptions = useMemo(() => buildStudioOptions(studios), [studios]);
+
+  // Home studio editing
+  const [editingHomeStudio, setEditingHomeStudio] = useState(false);
+  const [homeStudioValue, setHomeStudioValue] = useState('');
+
+  const updateHomeStudioMutation = useMutation({
+    mutationFn: ({ identityId, studioHint }: { identityId: string; studioHint: string }) =>
+      apiPatch(`/api/admin/routing/identities/${identityId}`, { studioHint }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['routing'] });
+      queryClient.invalidateQueries({ queryKey: ['routing-agent', agentId] });
+      setEditingHomeStudio(false);
+    },
+  });
 
   const [newRoute, setNewRoute] = useState<RouteFormState>({
     platform: 'telegram',
@@ -195,7 +219,8 @@ export default function AgentRoutingPage() {
   const mutationError =
     createRouteMutation.error?.message ||
     updateRouteMutation.error?.message ||
-    deleteRouteMutation.error?.message;
+    deleteRouteMutation.error?.message ||
+    updateHomeStudioMutation.error?.message;
 
   const selectClassName =
     'flex h-9 w-full rounded-md border border-input bg-background px-3 py-2 text-sm';
@@ -217,11 +242,73 @@ export default function AgentRoutingPage() {
             {data?.agent?.role || 'Configure channel route scope and routing behavior for this SB.'}
           </p>
         </div>
-        {data?.agent?.backend && (
-          <Badge variant="secondary" className="text-sm">
-            {data.agent.backend}
-          </Badge>
-        )}
+        <div className="flex items-center gap-3 shrink-0">
+          {data?.agent && (
+            <div className="text-right">
+              <div className="text-xs text-gray-400 mb-1">Home studio</div>
+              {editingHomeStudio ? (
+                <div className="flex items-center gap-1">
+                  <select
+                    className="h-8 rounded-md border border-input bg-background px-2 text-sm"
+                    value={homeStudioValue}
+                    onChange={(event) => setHomeStudioValue(event.target.value)}
+                  >
+                    {studioOptions.map((opt) => (
+                      <option key={opt.value} value={opt.value}>
+                        {opt.label}
+                      </option>
+                    ))}
+                    {/* Always include 'home' as an option */}
+                    {!studioOptions.some((o) => o.value === 'home') && (
+                      <option value="home">home</option>
+                    )}
+                  </select>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-8 w-8 p-0"
+                    disabled={updateHomeStudioMutation.isPending}
+                    onClick={() =>
+                      updateHomeStudioMutation.mutate({
+                        identityId: data.agent.id,
+                        studioHint: homeStudioValue,
+                      })
+                    }
+                  >
+                    <Check className="h-4 w-4 text-green-600" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-8 w-8 p-0"
+                    onClick={() => setEditingHomeStudio(false)}
+                  >
+                    <X className="h-4 w-4 text-gray-400" />
+                  </Button>
+                </div>
+              ) : (
+                <button
+                  className="flex items-center gap-1.5 text-sm text-gray-700 hover:text-gray-900 group cursor-pointer"
+                  onClick={() => {
+                    setHomeStudioValue(data.agent.studioHint || 'home');
+                    setEditingHomeStudio(true);
+                  }}
+                >
+                  <Home className="h-3.5 w-3.5 text-gray-500" />
+                  <span className="font-medium">
+                    {studioHintLabel(data.agent.studioHint, studios)}
+                  </span>
+                  <Pencil className="h-3 w-3 text-gray-400 opacity-0 group-hover:opacity-100 transition-opacity" />
+                </button>
+              )}
+            </div>
+          )}
+          {data?.agent?.backend && (
+            <Badge variant="secondary" className="text-sm">
+              {data.agent.backend}
+            </Badge>
+          )}
+        </div>
       </div>
 
       {data && !data.heartbeatProcessingEnabled && (
@@ -389,7 +476,9 @@ export default function AgentRoutingPage() {
                     <div className="mt-3 grid gap-3 md:grid-cols-3 text-sm">
                       <div>
                         <div className="text-gray-500">Account</div>
-                        <div className="font-mono text-xs">{route.platformAccountId || 'All accounts'}</div>
+                        <div className="font-mono text-xs">
+                          {route.platformAccountId || 'All accounts'}
+                        </div>
                       </div>
                       <div>
                         <div className="text-gray-500">Chat</div>

--- a/packages/web/src/app/(dashboard)/routing/page.tsx
+++ b/packages/web/src/app/(dashboard)/routing/page.tsx
@@ -10,6 +10,7 @@ import {
   AlertTriangle,
   ChevronRight,
   Globe,
+  Home,
   MessageCircle,
   Send,
   Hash,
@@ -32,6 +33,7 @@ interface RoutingIdentity {
   name: string;
   role: string;
   backend: string | null;
+  studioHint: string;
 }
 
 interface RoutingRoute {
@@ -79,6 +81,7 @@ interface SBGroup {
   agentName: string;
   agentRole: string | null;
   identityId: string;
+  studioHint: string;
   routes: RoutingRoute[];
   totalReminders: number;
   activeRoutes: number;
@@ -192,17 +195,28 @@ export default function RoutingPage() {
     unassignedReminderCount: 0,
   };
 
+  // Build identity lookup for studioHint
+  const identityMap = useMemo(() => {
+    const map = new Map<string, RoutingIdentity>();
+    for (const identity of identities) {
+      map.set(identity.id, identity);
+    }
+    return map;
+  }, [identities]);
+
   // Group routes by SB
   const sbGroups = useMemo<SBGroup[]>(() => {
     const groups = new Map<string, SBGroup>();
     for (const route of routes) {
       const key = route.agentId || route.identityId;
       if (!groups.has(key)) {
+        const identity = identityMap.get(route.identityId);
         groups.set(key, {
           agentId: route.agentId || 'unknown',
           agentName: route.agentName || route.agentId || 'Unknown agent',
           agentRole: route.agentRole || null,
           identityId: route.identityId,
+          studioHint: identity?.studioHint || 'home',
           routes: [],
           totalReminders: 0,
           activeRoutes: 0,
@@ -421,6 +435,13 @@ export default function RoutingPage() {
                     )}
                   </div>
                   <div className="flex items-center gap-4 shrink-0">
+                    <div className="text-right">
+                      <div className="text-xs text-gray-400">Home</div>
+                      <div className="flex items-center gap-1 justify-end">
+                        <Home className="h-3.5 w-3.5 text-gray-500" />
+                        <span className="font-medium text-gray-700">{group.studioHint}</span>
+                      </div>
+                    </div>
                     <div className="text-right">
                       <div className="text-xs text-gray-400">Reminders</div>
                       <div className="flex items-center gap-1 justify-end">

--- a/supabase/migrations/20260307053439_studio_hint_routing.sql
+++ b/supabase/migrations/20260307053439_studio_hint_routing.sql
@@ -9,15 +9,17 @@ ALTER TABLE agent_identities
   ADD COLUMN IF NOT EXISTS studio_hint text DEFAULT 'home';
 
 -- Backfill: any identity that already has routes with studio_hint set,
--- inherit the most common one as their default.
+-- inherit the most recently updated one as their default.
 UPDATE agent_identities ai
-SET studio_hint = sub.most_common
+SET studio_hint = sub.latest_hint
 FROM (
-  SELECT cr.identity_id, cr.studio_hint AS most_common
+  SELECT DISTINCT ON (cr.identity_id)
+    cr.identity_id,
+    cr.studio_hint AS latest_hint
   FROM channel_routes cr
   WHERE cr.studio_hint IS NOT NULL
     AND cr.is_active = true
-  ORDER BY cr.updated_at DESC
+  ORDER BY cr.identity_id, cr.updated_at DESC
 ) sub
 WHERE ai.id = sub.identity_id
   AND ai.studio_hint = 'home';

--- a/supabase/migrations/20260307053439_studio_hint_routing.sql
+++ b/supabase/migrations/20260307053439_studio_hint_routing.sql
@@ -1,0 +1,32 @@
+-- Studio Hint Routing
+--
+-- Every SB gets a "home" studio via agent_identities.studio_hint.
+-- Reminders can override to a specific studio via scheduled_reminders.studio_hint.
+-- Resolution cascade: work-specific → agent home → 'home'.
+
+-- 1. Agent identity home studio (default: 'home')
+ALTER TABLE agent_identities
+  ADD COLUMN IF NOT EXISTS studio_hint text DEFAULT 'home';
+
+-- Backfill: any identity that already has routes with studio_hint set,
+-- inherit the most common one as their default.
+UPDATE agent_identities ai
+SET studio_hint = sub.most_common
+FROM (
+  SELECT cr.identity_id, cr.studio_hint AS most_common
+  FROM channel_routes cr
+  WHERE cr.studio_hint IS NOT NULL
+    AND cr.is_active = true
+  ORDER BY cr.updated_at DESC
+) sub
+WHERE ai.id = sub.identity_id
+  AND ai.studio_hint = 'home';
+
+-- 2. Reminder studio override (nullable — inherits from agent when null)
+ALTER TABLE scheduled_reminders
+  ADD COLUMN IF NOT EXISTS studio_hint text;
+
+-- 3. Index for routing lookups
+CREATE INDEX IF NOT EXISTS idx_agent_identities_studio_hint
+  ON agent_identities (studio_hint)
+  WHERE studio_hint IS NOT NULL;


### PR DESCRIPTION
## Summary

Every SB gets a **home studio** via `agent_identities.studio_hint` (default: `'home'`). Reminders can override to a specific studio. Resolution cascade: work-specific → agent home → `'home'`.

- **Migration**: `studio_hint` on `agent_identities` (default `'home'`) + `scheduled_reminders` (nullable override)
- **Heartbeat**: 3-tier studio resolution — reminder.studio_hint → channel_routes.studio_hint → agent_identities.studio_hint → `'home'`
- **MCP tools**: `create_reminder` / `update_reminder` accept `studioHint` parameter
- **Admin API**: `GET /routing` returns `studioHint` per identity; new `PATCH /routing/identities/:id` to edit home studio
- **Frontend**: routing page shows "Home" studio badge per SB

Spec: `pcp://specs/studio-routing`

## Test plan

- [ ] Verify migration applies cleanly (already applied to prod DB)
- [ ] Create reminder with `studioHint` via MCP — confirm it persists
- [ ] Heartbeat processes reminder with studio_hint — confirm cascade resolves correctly
- [ ] Routing page shows "Home: home" per SB when API is rebuilt
- [ ] PATCH identity studio_hint via admin API — verify it updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)