### PR TITLE
fix: resolve-binary cache poisoning + gemini tool parsing + timeout (by Wren)

### DIFF
--- a/packages/api/src/services/sessions/codex-runner.test.ts
+++ b/packages/api/src/services/sessions/codex-runner.test.ts
@@ -28,6 +28,10 @@ vi.mock('child_process', async (importOriginal) => {
   };
 });
 
+vi.mock('fs/promises', () => ({
+  access: vi.fn().mockResolvedValue(undefined),
+}));
+
 vi.mock('../../utils/logger.js', () => ({
   logger: {
     info: vi.fn(),

--- a/packages/api/src/services/sessions/gemini-runner.ts
+++ b/packages/api/src/services/sessions/gemini-runner.ts
@@ -411,7 +411,12 @@ export class GeminiRunner implements IClaudeRunner {
 
         if (input && typeof input === 'object') {
           toolCalls.push({
-            toolUseId: typeof obj.id === 'string' ? obj.id : '',
+            toolUseId:
+              typeof obj.id === 'string'
+                ? obj.id
+                : typeof obj.toolCallId === 'string'
+                  ? obj.toolCallId
+                  : '',
             toolName: name,
             input: input as Record<string, unknown>,
           });

--- a/packages/api/src/services/sessions/gemini-runner.ts
+++ b/packages/api/src/services/sessions/gemini-runner.ts
@@ -28,8 +28,10 @@ import { formatInjectedContext } from './context-builder.js';
 import { logger } from '../../utils/logger.js';
 import { resolveBinaryPath, buildSpawnPath } from './resolve-binary.js';
 
-/** Maximum time (ms) to wait for a Gemini CLI subprocess before killing it */
-const PROCESS_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
+/** Maximum time (ms) to wait for a Gemini CLI subprocess before killing it.
+ *  Override with GEMINI_PROCESS_TIMEOUT_MS env var. */
+const PROCESS_TIMEOUT_MS =
+  parseInt(process.env.GEMINI_PROCESS_TIMEOUT_MS || '', 10) || 15 * 60 * 1000; // 15 minutes
 
 /** Idle timeout: no output for this long = stuck */
 const IDLE_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
@@ -221,8 +223,9 @@ export class GeminiRunner implements IClaudeRunner {
           if (!line.trim()) continue;
           try {
             const parsed = JSON.parse(line);
-            this.handleStreamEvent(parsed, responses);
-            this.captureToolCall(parsed, toolCalls);
+            const extracted = this.extractToolData(parsed);
+            responses.push(...extracted.responses);
+            toolCalls.push(...extracted.toolCalls);
 
             // Capture session_id from init event (Gemini emits this on every session)
             if (parsed.type === 'init' && typeof parsed.session_id === 'string') {
@@ -317,8 +320,9 @@ export class GeminiRunner implements IClaudeRunner {
         if (stdoutRemainder.trim()) {
           try {
             const parsed = JSON.parse(stdoutRemainder);
-            this.handleStreamEvent(parsed, responses);
-            this.captureToolCall(parsed, toolCalls);
+            const extracted = this.extractToolData(parsed);
+            responses.push(...extracted.responses);
+            toolCalls.push(...extracted.toolCalls);
             if (parsed.usageMetadata || parsed.usage) {
               const u = parsed.usageMetadata || parsed.usage;
               usage = {
@@ -379,43 +383,76 @@ export class GeminiRunner implements IClaudeRunner {
   }
 
   /**
-   * Capture tool_use events for activity stream logging.
+   * Extract tool calls and send_response calls from a streaming event.
+   *
+   * Uses BFS to find tool call data anywhere in the event structure,
+   * matching the robust approach used by CodexRunner. Gemini's stream-json
+   * format may nest tool info in various structures (functionCall, toolCall,
+   * parts arrays, etc.) — BFS handles all of them.
    */
-  private captureToolCall(event: Record<string, unknown>, toolCalls: ToolCall[]): void {
-    // Handle both Claude-style and Gemini-style tool call events
-    if (event.type === 'tool_use' || event.type === 'toolCall') {
-      toolCalls.push({
-        toolUseId: (event.id as string) || (event.toolCallId as string) || '',
-        toolName: (event.name as string) || (event.toolName as string) || '',
-        input:
-          (event.input as Record<string, unknown>) || (event.args as Record<string, unknown>) || {},
-      });
+  private extractToolData(event: Record<string, unknown>): {
+    responses: ChannelResponse[];
+    toolCalls: ToolCall[];
+  } {
+    const responses: ChannelResponse[] = [];
+    const toolCalls: ToolCall[] = [];
+    const queue: unknown[] = [event];
+
+    while (queue.length > 0) {
+      const current = queue.shift();
+      if (!current || typeof current !== 'object') continue;
+      const obj = current as Record<string, unknown>;
+
+      // Look for a "name" field indicating a tool/function call
+      const name = obj.name;
+      if (typeof name === 'string' && name.length > 0) {
+        const rawInput = obj.input ?? obj.args ?? obj.arguments ?? {};
+        const input = this.normalizeInput(rawInput);
+
+        if (input && typeof input === 'object') {
+          toolCalls.push({
+            toolUseId: typeof obj.id === 'string' ? obj.id : '',
+            toolName: name,
+            input: input as Record<string, unknown>,
+          });
+
+          if (name === 'mcp__pcp__send_response') {
+            const typedInput = input as Record<string, unknown>;
+            const channel = (typedInput.channel as ChannelType) || 'telegram';
+            const conversationId = typedInput.conversationId as string | undefined;
+            const content = typedInput.content as string | undefined;
+            if (channel && conversationId && content) {
+              responses.push({
+                channel,
+                conversationId,
+                content,
+                format: typedInput.format as 'text' | 'markdown' | 'code' | 'json' | undefined,
+                replyToMessageId: typedInput.replyToMessageId as string | undefined,
+                metadata: typedInput.metadata as Record<string, unknown> | undefined,
+              });
+              logger.debug('Captured send_response call from Gemini', { channel, conversationId });
+            }
+          }
+        }
+      }
+
+      for (const value of Object.values(obj)) {
+        if (value && typeof value === 'object') queue.push(value);
+      }
     }
+
+    return { responses, toolCalls };
   }
 
-  /**
-   * Handle a streaming JSON event — capture send_response tool calls.
-   */
-  private handleStreamEvent(event: Record<string, unknown>, responses: ChannelResponse[]): void {
-    // Look for send_response tool calls (same MCP tool as Claude/Codex)
-    const toolName = (event.name as string) || (event.toolName as string);
-    const isToolUse = event.type === 'tool_use' || event.type === 'toolCall';
-
-    if (isToolUse && toolName === 'mcp__pcp__send_response') {
-      const input =
-        (event.input as Record<string, unknown>) || (event.args as Record<string, unknown>) || {};
-      const channel = (input.channel as ChannelType) || 'telegram';
-      const response: ChannelResponse = {
-        channel,
-        conversationId: (input.conversationId as string) || '',
-        content: (input.content as string) || '',
-        format: input.format as 'text' | 'markdown' | 'code' | 'json' | undefined,
-        replyToMessageId: input.replyToMessageId as string | undefined,
-        metadata: input.metadata as Record<string, unknown> | undefined,
-      };
-      responses.push(response);
-      logger.debug('Captured send_response call from Gemini', { response });
+  private normalizeInput(raw: unknown): unknown {
+    if (typeof raw === 'string') {
+      try {
+        return JSON.parse(raw);
+      } catch {
+        return {};
+      }
     }
+    return raw;
   }
 
   /**

--- a/packages/api/src/services/sessions/resolve-binary.ts
+++ b/packages/api/src/services/sessions/resolve-binary.ts
@@ -1,24 +1,51 @@
 /**
  * Binary Path Resolution
  *
- * Resolves CLI binary paths (claude, codex) with fallback to zsh login shell.
+ * Resolves CLI binary paths (claude, codex, gemini) with fallback to zsh login shell.
  * Node's spawn() only searches the current process PATH, which may be a
  * stripped-down bash PATH missing user-installed tools (nvm, homebrew, etc.).
  *
  * Resolution order:
  *   1. Check current process PATH via `which`
  *   2. Fall back to `zsh -ilc 'which <binary>'` to pick up login shell paths
- *   3. Cache resolved paths for the process lifetime
+ *   3. Verify the resolved path actually exists before caching
+ *
+ * Cache policy:
+ *   - Successful resolutions are cached for the process lifetime
+ *   - Failed resolutions are cached for FAILURE_CACHE_TTL_MS then retried
+ *     (handles cases where a binary is installed after server startup)
  */
 
 import { execFile } from 'child_process';
+import { access } from 'fs/promises';
 import { delimiter, dirname, isAbsolute } from 'path';
 import { promisify } from 'util';
 import { logger } from '../../utils/logger.js';
 
 const execFileAsync = promisify(execFile);
 
-const resolvedPaths = new Map<string, string | null>();
+interface CacheEntry {
+  path: string | null;
+  timestamp: number;
+}
+
+const resolvedPaths = new Map<string, CacheEntry>();
+
+/** How long to cache a failed resolution before retrying (5 minutes). */
+const FAILURE_CACHE_TTL_MS = 5 * 60 * 1000;
+
+/**
+ * Verify that a resolved path actually exists on disk.
+ * Guards against stale symlinks, nvm version switches, etc.
+ */
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 /**
  * Resolve a binary name to its full path, with zsh login shell fallback.
@@ -27,18 +54,34 @@ const resolvedPaths = new Map<string, string | null>();
  */
 export async function resolveBinaryPath(binary: string): Promise<string> {
   const cached = resolvedPaths.get(binary);
-  if (cached !== undefined) {
-    return cached ?? binary;
+  if (cached) {
+    if (cached.path) {
+      // Successful resolution — verify it still exists (nvm version switch, etc.)
+      if (await pathExists(cached.path)) {
+        return cached.path;
+      }
+      // Stale cache — path no longer exists, re-resolve
+      logger.warn(`Cached path for ${binary} no longer exists: ${cached.path}. Re-resolving.`);
+      resolvedPaths.delete(binary);
+    } else {
+      // Failed resolution — check if TTL has expired
+      if (Date.now() - cached.timestamp < FAILURE_CACHE_TTL_MS) {
+        return binary;
+      }
+      // TTL expired — retry resolution
+      logger.info(`Retrying resolution for ${binary} (failure cache expired)`);
+      resolvedPaths.delete(binary);
+    }
   }
 
   // 1. Try current process PATH
   try {
     const { stdout } = await execFileAsync('which', [binary], { timeout: 3000 });
-    const path = stdout.trim();
-    if (path) {
-      resolvedPaths.set(binary, path);
-      logger.debug(`Resolved ${binary} from PATH: ${path}`);
-      return path;
+    const resolved = stdout.trim();
+    if (resolved && (await pathExists(resolved))) {
+      resolvedPaths.set(binary, { path: resolved, timestamp: Date.now() });
+      logger.info(`Resolved ${binary} from PATH: ${resolved}`);
+      return resolved;
     }
   } catch {
     // Not found in current PATH
@@ -50,8 +93,8 @@ export async function resolveBinaryPath(binary: string): Promise<string> {
     // zsh -il may print extra lines (nvm "Now using..." etc.) — take the last absolute path
     const lines = stdout.split('\n').filter((l) => l.trim() && l.startsWith('/'));
     const resolved = lines[lines.length - 1];
-    if (resolved) {
-      resolvedPaths.set(binary, resolved);
+    if (resolved && (await pathExists(resolved))) {
+      resolvedPaths.set(binary, { path: resolved, timestamp: Date.now() });
       logger.info(`Resolved ${binary} via zsh login shell: ${resolved}`);
       return resolved;
     }
@@ -59,10 +102,12 @@ export async function resolveBinaryPath(binary: string): Promise<string> {
     // zsh fallback also failed
   }
 
-  // 3. Not found anywhere — cache the miss and warn
-  resolvedPaths.set(binary, null);
-  logger.warn(
-    `Could not resolve ${binary} in PATH or zsh login shell. Spawn will likely fail with ENOENT.`
+  // 3. Not found anywhere — cache with TTL so we retry later
+  resolvedPaths.set(binary, { path: null, timestamp: Date.now() });
+  logger.error(
+    `Could not resolve ${binary} in PATH or zsh login shell. ` +
+      `Will retry in ${FAILURE_CACHE_TTL_MS / 1000}s. ` +
+      `Server PATH: ${(process.env.PATH || '').split(delimiter).slice(0, 5).join(delimiter)}...`
   );
   return binary;
 }


### PR DESCRIPTION
## Summary

Three fixes for agent spawning reliability:

- **resolve-binary cache poisoning**: Failed resolutions were cached permanently (`null` for process lifetime). If the server started before codex was installed or during an nvm version switch, every subsequent spawn attempt would fail forever. Now: failed resolutions expire after 5 minutes and retry. Successful resolutions are verified on disk before reuse — stale symlinks (nvm version switch) trigger re-resolution.

- **Gemini tool call parsing**: The old `captureToolCall` method only checked top-level `event.type === 'tool_use' || 'toolCall'` and read `event.name`, but Gemini's stream-json format nests tool info differently. This caused 7 empty `tool_call` activities (`toolName: ""`, `content: "()"`) in production when Aster reviewed the memory RFC. Ported Codex's robust BFS `extractToolData` approach that finds tool names anywhere in the event structure.

- **Gemini timeout**: Increased hard timeout from 10min to 15min (configurable via `GEMINI_PROCESS_TIMEOUT_MS`). 10min was insufficient for RFC reviews requiring bootstrap + spec read + comment write — Aster hit the timeout exactly (600,012ms) and got killed.

Also fixes pre-existing codex-runner test failure by adding `execFile` and `fs/promises` mocks needed by resolve-binary imports.

## Test plan

- [x] All 1436 tests pass (87 files), including 4 previously failing codex-runner tests
- [x] Type-check passes (only pre-existing TS1479 ESM errors)
- [ ] Verify codex spawns successfully after server restart
- [ ] Verify Gemini tool calls show proper names in mission control after restart

