### PR TITLE
feat: media sending via send_response (by Wren)

### DIFF
--- a/packages/api/src/agent/types.ts
+++ b/packages/api/src/agent/types.ts
@@ -126,6 +126,24 @@ export interface AgentMessage {
  * Response going OUT from the agent to a channel
  * This is what the send_response MCP tool receives
  */
+/**
+ * Media attachment for outbound responses
+ */
+export interface OutboundMedia {
+  /** Media type determines which API method to use per channel */
+  type: 'image' | 'video' | 'audio' | 'document';
+  /** Local file path (read and uploaded) */
+  path?: string;
+  /** Remote URL (some channels support sending by URL directly) */
+  url?: string;
+  /** MIME type (auto-detected from extension if omitted) */
+  contentType?: string;
+  /** Display filename */
+  filename?: string;
+  /** Caption for this specific attachment (overrides response content for this item) */
+  caption?: string;
+}
+
 export interface AgentResponse {
   channel: ChannelType;
   conversationId: string;
@@ -133,6 +151,8 @@ export interface AgentResponse {
   format?: ResponseFormat;
   replyToMessageId?: string;
   metadata?: Record<string, unknown>;
+  /** Optional media attachments to send alongside or instead of text */
+  media?: OutboundMedia[];
 }
 
 /**

--- a/packages/api/src/channels/discord-listener.ts
+++ b/packages/api/src/channels/discord-listener.ts
@@ -779,6 +779,36 @@ export class DiscordListener extends EventEmitter {
   }
 
   /**
+   * Send a file (image, document, video, etc.) to a Discord channel
+   * Discord uses a unified attachments API for all file types
+   */
+  async sendFile(
+    conversationId: string,
+    filePath: string,
+    options?: { caption?: string; filename?: string }
+  ): Promise<void> {
+    const channelId = conversationId.startsWith('discord:')
+      ? conversationId.replace('discord:', '')
+      : conversationId;
+
+    const pathMod = await import('path');
+    const channel = await this.client.channels.fetch(channelId);
+    if (!channel || !('send' in channel)) {
+      throw new Error(`Channel ${channelId} not found or not a text channel`);
+    }
+
+    const textChannel = channel as TextChannel | DMChannel | NewsChannel;
+    const filename = options?.filename || pathMod.basename(filePath);
+
+    await textChannel.send({
+      content: options?.caption || undefined,
+      files: [{ attachment: filePath, name: filename }],
+    });
+
+    logger.info(`Sent file to Discord channel ${channelId}`, { filename });
+  }
+
+  /**
    * Send typing indicator
    */
   async sendTypingIndicator(conversationId: string): Promise<void> {

--- a/packages/api/src/channels/gateway.ts
+++ b/packages/api/src/channels/gateway.ts
@@ -18,7 +18,7 @@ import { createWhatsAppListener, WhatsAppListener } from './whatsapp-listener';
 import { createDiscordListener, DiscordListener } from './discord-listener';
 import { createSlackListener, SlackListener } from './slack-listener';
 import { setResponseCallback, type ResponseCallback } from '../mcp/tools/response-handlers';
-import type { AgentResponse } from '../agent/types';
+import type { AgentResponse, OutboundMedia } from '../agent/types';
 import type { DataComposer } from '../data/composer';
 import { logger } from '../utils/logger';
 import { env } from '../config/env';
@@ -669,7 +669,7 @@ export class ChannelGateway extends EventEmitter {
    * Called by the response callback or directly
    */
   async sendResponse(response: AgentResponse): Promise<void> {
-    const { channel, conversationId, content, format, replyToMessageId } = response;
+    const { channel, conversationId, content, format, replyToMessageId, media } = response;
 
     // Stop typing indicator when sending response
     this.stopTypingIndicator(conversationId);
@@ -688,14 +688,27 @@ export class ChannelGateway extends EventEmitter {
           break;
         }
 
-        await this.sendTelegramMessage(conversationId, content, { format, replyToMessageId });
+        // Send text first (if any meaningful content), then media
+        if (content && (!media || media.length === 0)) {
+          await this.sendTelegramMessage(conversationId, content, { format, replyToMessageId });
+        } else if (media && media.length > 0) {
+          if (content) {
+            await this.sendTelegramMessage(conversationId, content, { format, replyToMessageId });
+          }
+          await this.sendMediaAttachments('telegram', conversationId, media, { replyToMessageId });
+        }
         break;
 
       case 'whatsapp':
         if (!this.whatsappListener) {
           throw new Error('WhatsApp listener not available');
         }
-        await this.whatsappListener.sendMessage(conversationId, content);
+        if (content) {
+          await this.whatsappListener.sendMessage(conversationId, content);
+        }
+        if (media && media.length > 0) {
+          await this.sendMediaAttachments('whatsapp', conversationId, media);
+        }
         // Log outgoing WhatsApp message to activity stream
         {
           const userId = await this.resolveUserIdForConversation('whatsapp', conversationId);
@@ -724,7 +737,12 @@ export class ChannelGateway extends EventEmitter {
         if (!this.discordListener) {
           throw new Error('Discord listener not available');
         }
-        await this.discordListener.sendMessage(conversationId, content);
+        if (content) {
+          await this.discordListener.sendMessage(conversationId, content);
+        }
+        if (media && media.length > 0) {
+          await this.sendMediaAttachments('discord', conversationId, media);
+        }
         // Log outgoing Discord message to activity stream
         {
           const userId = await this.resolveUserIdForConversation('discord', conversationId);
@@ -941,6 +959,87 @@ export class ChannelGateway extends EventEmitter {
     if (!this.pendingVoiceReplyConversations.has(key)) return false;
     this.pendingVoiceReplyConversations.delete(key);
     return true;
+  }
+
+  /**
+   * Send media attachments to a channel.
+   * Routes each attachment to the appropriate channel-specific method.
+   */
+  private async sendMediaAttachments(
+    channel: GatewayChannel,
+    conversationId: string,
+    media: OutboundMedia[],
+    options?: { replyToMessageId?: string }
+  ): Promise<void> {
+    for (const attachment of media) {
+      const filePath = attachment.path;
+      if (!filePath) {
+        logger.warn('Media attachment missing file path, skipping', { channel, attachment });
+        continue;
+      }
+
+      try {
+        const mediaOpts = {
+          caption: attachment.caption,
+          filename: attachment.filename,
+          contentType: attachment.contentType,
+          replyToMessageId: options?.replyToMessageId,
+        };
+
+        switch (channel) {
+          case 'telegram':
+            if (!this.telegramListener) break;
+            switch (attachment.type) {
+              case 'image':
+                await this.telegramListener.sendPhoto(conversationId, filePath, mediaOpts);
+                break;
+              case 'video':
+                await this.telegramListener.sendVideo(conversationId, filePath, mediaOpts);
+                break;
+              case 'audio':
+                await this.telegramListener.sendVoice(conversationId, filePath, mediaOpts);
+                break;
+              case 'document':
+                await this.telegramListener.sendDocument(conversationId, filePath, mediaOpts);
+                break;
+            }
+            break;
+
+          case 'whatsapp':
+            if (!this.whatsappListener) break;
+            switch (attachment.type) {
+              case 'image':
+                await this.whatsappListener.sendImage(conversationId, filePath, mediaOpts);
+                break;
+              case 'video':
+                await this.whatsappListener.sendVideo(conversationId, filePath, mediaOpts);
+                break;
+              case 'document':
+              case 'audio':
+                await this.whatsappListener.sendDocument(conversationId, filePath, mediaOpts);
+                break;
+            }
+            break;
+
+          case 'discord':
+            if (!this.discordListener) break;
+            // Discord uses a unified file attachment API for all types
+            await this.discordListener.sendFile(conversationId, filePath, mediaOpts);
+            break;
+
+          case 'slack':
+            // Slack file uploads can be added later
+            logger.warn('Slack media sending not yet implemented');
+            break;
+        }
+
+        logger.info(`Sent ${attachment.type} to ${channel}:${conversationId}`, {
+          filename: attachment.filename,
+        });
+      } catch (error) {
+        logger.error(`Failed to send ${attachment.type} to ${channel}:${conversationId}`, error);
+      }
+    }
   }
 
   private async trySendTelegramVoiceReply(response: AgentResponse): Promise<boolean> {

--- a/packages/api/src/channels/gateway.ts
+++ b/packages/api/src/channels/gateway.ts
@@ -962,8 +962,45 @@ export class ChannelGateway extends EventEmitter {
   }
 
   /**
+   * Download a URL to a temporary file. Returns the path and a cleanup function.
+   */
+  private async downloadToTempFile(
+    url: string,
+    filename?: string
+  ): Promise<{ path: string; cleanup: () => Promise<void> }> {
+    const fs = await import('fs/promises');
+    const pathMod = await import('path');
+    const os = await import('os');
+
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`Failed to download ${url}: ${response.status}`);
+    }
+
+    const buffer = Buffer.from(await response.arrayBuffer());
+    const tmpDir = pathMod.join(os.tmpdir(), 'pcp-media');
+    await fs.mkdir(tmpDir, { recursive: true });
+
+    const safeName = (filename || `media_${Date.now()}`).replace(/[^a-zA-Z0-9._-]/g, '_');
+    const tmpPath = pathMod.join(tmpDir, safeName);
+    await fs.writeFile(tmpPath, buffer);
+
+    return {
+      path: tmpPath,
+      cleanup: async () => {
+        try {
+          await fs.unlink(tmpPath);
+        } catch {
+          // Best-effort cleanup
+        }
+      },
+    };
+  }
+
+  /**
    * Send media attachments to a channel.
    * Routes each attachment to the appropriate channel-specific method.
+   * Supports both local file paths and remote URLs.
    */
   private async sendMediaAttachments(
     channel: GatewayChannel,
@@ -972,9 +1009,26 @@ export class ChannelGateway extends EventEmitter {
     options?: { replyToMessageId?: string }
   ): Promise<void> {
     for (const attachment of media) {
-      const filePath = attachment.path;
+      let filePath = attachment.path;
+      let tempCleanup: (() => Promise<void>) | null = null;
+
+      // If no local path but URL is provided, download to temp file
+      if (!filePath && attachment.url) {
+        try {
+          const temp = await this.downloadToTempFile(attachment.url, attachment.filename);
+          filePath = temp.path;
+          tempCleanup = temp.cleanup;
+        } catch (error) {
+          logger.error(`Failed to download media URL: ${attachment.url}`, error);
+          continue;
+        }
+      }
+
       if (!filePath) {
-        logger.warn('Media attachment missing file path, skipping', { channel, attachment });
+        logger.warn('Media attachment missing both path and url, skipping', {
+          channel,
+          attachment,
+        });
         continue;
       }
 
@@ -1035,9 +1089,15 @@ export class ChannelGateway extends EventEmitter {
 
         logger.info(`Sent ${attachment.type} to ${channel}:${conversationId}`, {
           filename: attachment.filename,
+          source: tempCleanup ? 'url' : 'path',
         });
       } catch (error) {
         logger.error(`Failed to send ${attachment.type} to ${channel}:${conversationId}`, error);
+      } finally {
+        // Clean up temp file if we downloaded from URL
+        if (tempCleanup) {
+          await tempCleanup();
+        }
       }
     }
   }

--- a/packages/api/src/channels/telegram-listener.ts
+++ b/packages/api/src/channels/telegram-listener.ts
@@ -1033,6 +1033,135 @@ export class TelegramListener extends EventEmitter {
   }
 
   /**
+   * Send a photo to a Telegram chat
+   */
+  async sendPhoto(
+    conversationId: string,
+    filePath: string,
+    options?: {
+      replyToMessageId?: string;
+      caption?: string;
+      contentType?: string;
+      filename?: string;
+    }
+  ): Promise<void> {
+    const chatId = conversationId.startsWith('telegram:')
+      ? conversationId.replace('telegram:', '')
+      : conversationId;
+
+    const fs = await import('fs/promises');
+    const pathMod = await import('path');
+    const bytes = await fs.readFile(filePath);
+    const filename = options?.filename || pathMod.basename(filePath) || 'photo.jpg';
+    const contentType = options?.contentType || 'image/jpeg';
+
+    const form = new FormData();
+    form.append('chat_id', chatId);
+    if (options?.replyToMessageId) {
+      form.append('reply_to_message_id', String(parseInt(options.replyToMessageId, 10)));
+    }
+    if (options?.caption) {
+      form.append('caption', options.caption);
+    }
+    form.append('photo', new Blob([new Uint8Array(bytes)], { type: contentType }), filename);
+
+    const url = `${TELEGRAM_API}/bot${this.token}/sendPhoto`;
+    const response = await fetch(url, { method: 'POST', body: form });
+
+    const data = (await response.json()) as TelegramApiResponse<unknown>;
+    if (!data.ok) {
+      throw new Error(`Telegram API error: ${data.description}`);
+    }
+    logger.info(`Sent photo to Telegram chat ${chatId}`, { filename, size: bytes.byteLength });
+  }
+
+  /**
+   * Send a document (file) to a Telegram chat
+   */
+  async sendDocument(
+    conversationId: string,
+    filePath: string,
+    options?: {
+      replyToMessageId?: string;
+      caption?: string;
+      contentType?: string;
+      filename?: string;
+    }
+  ): Promise<void> {
+    const chatId = conversationId.startsWith('telegram:')
+      ? conversationId.replace('telegram:', '')
+      : conversationId;
+
+    const fs = await import('fs/promises');
+    const pathMod = await import('path');
+    const bytes = await fs.readFile(filePath);
+    const filename = options?.filename || pathMod.basename(filePath) || 'file';
+    const contentType = options?.contentType || 'application/octet-stream';
+
+    const form = new FormData();
+    form.append('chat_id', chatId);
+    if (options?.replyToMessageId) {
+      form.append('reply_to_message_id', String(parseInt(options.replyToMessageId, 10)));
+    }
+    if (options?.caption) {
+      form.append('caption', options.caption);
+    }
+    form.append('document', new Blob([new Uint8Array(bytes)], { type: contentType }), filename);
+
+    const url = `${TELEGRAM_API}/bot${this.token}/sendDocument`;
+    const response = await fetch(url, { method: 'POST', body: form });
+
+    const data = (await response.json()) as TelegramApiResponse<unknown>;
+    if (!data.ok) {
+      throw new Error(`Telegram API error: ${data.description}`);
+    }
+    logger.info(`Sent document to Telegram chat ${chatId}`, { filename, size: bytes.byteLength });
+  }
+
+  /**
+   * Send a video to a Telegram chat
+   */
+  async sendVideo(
+    conversationId: string,
+    filePath: string,
+    options?: {
+      replyToMessageId?: string;
+      caption?: string;
+      contentType?: string;
+      filename?: string;
+    }
+  ): Promise<void> {
+    const chatId = conversationId.startsWith('telegram:')
+      ? conversationId.replace('telegram:', '')
+      : conversationId;
+
+    const fs = await import('fs/promises');
+    const pathMod = await import('path');
+    const bytes = await fs.readFile(filePath);
+    const filename = options?.filename || pathMod.basename(filePath) || 'video.mp4';
+    const contentType = options?.contentType || 'video/mp4';
+
+    const form = new FormData();
+    form.append('chat_id', chatId);
+    if (options?.replyToMessageId) {
+      form.append('reply_to_message_id', String(parseInt(options.replyToMessageId, 10)));
+    }
+    if (options?.caption) {
+      form.append('caption', options.caption);
+    }
+    form.append('video', new Blob([new Uint8Array(bytes)], { type: contentType }), filename);
+
+    const url = `${TELEGRAM_API}/bot${this.token}/sendVideo`;
+    const response = await fetch(url, { method: 'POST', body: form });
+
+    const data = (await response.json()) as TelegramApiResponse<unknown>;
+    if (!data.ok) {
+      throw new Error(`Telegram API error: ${data.description}`);
+    }
+    logger.info(`Sent video to Telegram chat ${chatId}`, { filename, size: bytes.byteLength });
+  }
+
+  /**
    * Cache a message for context retrieval
    * Messages are stored in memory only, never persisted
    */

--- a/packages/api/src/channels/whatsapp-listener.ts
+++ b/packages/api/src/channels/whatsapp-listener.ts
@@ -667,6 +667,91 @@ export class WhatsAppListener extends EventEmitter {
   }
 
   /**
+   * Send an image to a WhatsApp chat
+   */
+  async sendImage(
+    conversationId: string,
+    filePath: string,
+    options?: { caption?: string }
+  ): Promise<void> {
+    if (!this.sock || !this.isConnected) {
+      throw new Error('WhatsApp not connected');
+    }
+
+    const jid = conversationId.startsWith('whatsapp:')
+      ? conversationId.replace('whatsapp:', '')
+      : conversationId;
+
+    const fs = await import('fs/promises');
+    const bytes = await fs.readFile(filePath);
+
+    await this.sock.sendMessage(jid, {
+      image: bytes,
+      caption: options?.caption,
+    });
+
+    logger.info(`Sent image to WhatsApp chat ${jid}`, { size: bytes.byteLength });
+  }
+
+  /**
+   * Send a document to a WhatsApp chat
+   */
+  async sendDocument(
+    conversationId: string,
+    filePath: string,
+    options?: { caption?: string; filename?: string; contentType?: string }
+  ): Promise<void> {
+    if (!this.sock || !this.isConnected) {
+      throw new Error('WhatsApp not connected');
+    }
+
+    const jid = conversationId.startsWith('whatsapp:')
+      ? conversationId.replace('whatsapp:', '')
+      : conversationId;
+
+    const fs = await import('fs/promises');
+    const pathMod = await import('path');
+    const bytes = await fs.readFile(filePath);
+    const filename = options?.filename || pathMod.basename(filePath);
+
+    await this.sock.sendMessage(jid, {
+      document: bytes,
+      mimetype: options?.contentType || 'application/octet-stream',
+      fileName: filename,
+      caption: options?.caption,
+    });
+
+    logger.info(`Sent document to WhatsApp chat ${jid}`, { filename, size: bytes.byteLength });
+  }
+
+  /**
+   * Send a video to a WhatsApp chat
+   */
+  async sendVideo(
+    conversationId: string,
+    filePath: string,
+    options?: { caption?: string }
+  ): Promise<void> {
+    if (!this.sock || !this.isConnected) {
+      throw new Error('WhatsApp not connected');
+    }
+
+    const jid = conversationId.startsWith('whatsapp:')
+      ? conversationId.replace('whatsapp:', '')
+      : conversationId;
+
+    const fs = await import('fs/promises');
+    const bytes = await fs.readFile(filePath);
+
+    await this.sock.sendMessage(jid, {
+      video: bytes,
+      caption: options?.caption,
+    });
+
+    logger.info(`Sent video to WhatsApp chat ${jid}`, { size: bytes.byteLength });
+  }
+
+  /**
    * Send typing indicator
    */
   async sendTypingIndicator(conversationId: string): Promise<void> {

--- a/packages/api/src/mcp/tools/index.ts
+++ b/packages/api/src/mcp/tools/index.ts
@@ -906,7 +906,9 @@ User can be identified by ONE of: userId, email, phone, or platform + platformId
     {
       description: `Send a response to a specific channel. Use this tool to reply to messages from Telegram, terminal, or other channels.
 
-This is the primary way to send responses back to users. Always use this tool instead of just outputting text.`,
+This is the primary way to send responses back to users. Always use this tool instead of just outputting text.
+
+Supports media attachments (images, videos, documents) via the media parameter. Provide a local file path for each attachment.`,
       inputSchema: {
         channel: z
           .enum(['telegram', 'terminal', 'discord', 'whatsapp', 'http', 'api', 'agent'])
@@ -918,6 +920,19 @@ This is the primary way to send responses back to users. Always use this tool in
           .optional()
           .describe('Format of the response content'),
         replyToMessageId: z.string().optional().describe('Message ID to reply to (for threading)'),
+        media: z
+          .array(
+            z.object({
+              type: z.enum(['image', 'video', 'audio', 'document']).describe('Media type'),
+              path: z.string().optional().describe('Local file path to upload'),
+              url: z.string().optional().describe('Remote URL'),
+              contentType: z.string().optional().describe('MIME type'),
+              filename: z.string().optional().describe('Display filename'),
+              caption: z.string().optional().describe('Caption for this attachment'),
+            })
+          )
+          .optional()
+          .describe('Media attachments to send (images, videos, documents)'),
       },
     },
     async (args) => {

--- a/packages/api/src/mcp/tools/response-handlers.ts
+++ b/packages/api/src/mcp/tools/response-handlers.ts
@@ -7,7 +7,7 @@
 
 import { z } from 'zod';
 import type { DataComposer } from '../../data/composer';
-import type { ChannelType, AgentResponse, ResponseFormat } from '../../agent/types';
+import type { ChannelType, AgentResponse, ResponseFormat, OutboundMedia } from '../../agent/types';
 import { logger } from '../../utils/logger';
 
 // Response handler callback type
@@ -75,6 +75,17 @@ function markExplicitResponse(channel: string, conversationId: string): void {
 // SEND RESPONSE
 // ============================================================================
 
+const outboundMediaSchema = z.object({
+  type: z
+    .enum(['image', 'video', 'audio', 'document'])
+    .describe('Media type (determines upload method per channel)'),
+  path: z.string().optional().describe('Local file path to upload'),
+  url: z.string().optional().describe('Remote URL (some channels support direct URL sending)'),
+  contentType: z.string().optional().describe('MIME type (auto-detected if omitted)'),
+  filename: z.string().optional().describe('Display filename'),
+  caption: z.string().optional().describe('Caption for this attachment'),
+});
+
 export const sendResponseSchema = z.object({
   channel: z
     .enum(['telegram', 'terminal', 'discord', 'whatsapp', 'slack', 'http', 'api', 'agent'])
@@ -87,6 +98,10 @@ export const sendResponseSchema = z.object({
     .describe('Format of the response content'),
   replyToMessageId: z.string().optional().describe('Message ID to reply to (for threading)'),
   metadata: z.record(z.unknown()).optional().describe('Additional channel-specific metadata'),
+  media: z
+    .array(outboundMediaSchema)
+    .optional()
+    .describe('Media attachments to send (images, videos, documents)'),
 });
 
 type McpResponse = {
@@ -122,6 +137,7 @@ export async function handleSendResponse(
       format: args.format as ResponseFormat | undefined,
       replyToMessageId: args.replyToMessageId,
       metadata: args.metadata,
+      media: args.media as OutboundMedia[] | undefined,
     };
 
     // Mark this conversation as having received an explicit response
@@ -142,6 +158,7 @@ export async function handleSendResponse(
             channel: args.channel,
             conversationId: args.conversationId,
             content: args.content,
+            media: args.media,
           }),
         });
 


### PR DESCRIPTION
## Summary

- Extends `AgentResponse` with an optional `media` array (`OutboundMedia[]`) for sending images, videos, audio, and documents alongside text
- Adds `sendPhoto`, `sendDocument`, `sendVideo` to Telegram listener (follows existing `sendVoice` FormData pattern)
- Adds `sendImage`, `sendDocument`, `sendVideo` to WhatsApp listener (uses Baileys' native message types)
- Adds `sendFile` to Discord listener (unified attachments API)
- Gateway's `sendResponse()` routes media to channel-specific methods based on attachment type
- `send_response` MCP tool schema now accepts `media` parameter — SBs can send screenshots, photos, and files to users

## Architecture

```
send_response(media: [{type: "image", path: "/tmp/screenshot.png"}])
  → response-handlers.ts (validates, builds AgentResponse)
    → gateway.sendResponse() (routes text + media)
      → sendMediaAttachments() (per-channel dispatch)
        → telegram: sendPhoto/sendVideo/sendDocument
        → whatsapp: sendImage/sendVideo/sendDocument
        → discord: sendFile (unified)
```

## Test plan

- [ ] Telegram: send an image via `send_response` with `media` param → photo appears in chat
- [ ] Telegram: send a document → file appears in chat
- [ ] WhatsApp: send an image → image appears in chat
- [ ] Discord: send a file → attachment appears in channel
- [ ] Text-only `send_response` still works unchanged (no regression)
- [ ] Voice reply path still works (voice check happens before media routing)
- [ ] Type-check passes (only pre-existing ESM errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Wren