### PR TITLE
fix: increase hard timeout to 30min for all runners (by Wren)

### DIFF
--- a/packages/api/src/services/sessions/claude-runner.ts
+++ b/packages/api/src/services/sessions/claude-runner.ts
@@ -21,7 +21,7 @@ import { logger } from '../../utils/logger.js';
 import { resolveBinaryPath, buildSpawnPath } from './resolve-binary.js';
 
 /** Maximum time (ms) to wait for a Claude Code subprocess before killing it */
-const PROCESS_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
+const PROCESS_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
 
 /**
  * Parse usage stats from Claude Code stream output.

--- a/packages/api/src/services/sessions/codex-runner.ts
+++ b/packages/api/src/services/sessions/codex-runner.ts
@@ -23,7 +23,7 @@ import { formatInjectedContext } from './context-builder.js';
 import { logger } from '../../utils/logger.js';
 import { resolveBinaryPath, buildSpawnPath } from './resolve-binary.js';
 
-const PROCESS_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
+const PROCESS_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
 const DIAGNOSTIC_MAX_CHARS = 4000;
 const DIAGNOSTIC_MAX_LINES = 20;
 

--- a/packages/api/src/services/sessions/gemini-runner.ts
+++ b/packages/api/src/services/sessions/gemini-runner.ts
@@ -31,7 +31,7 @@ import { resolveBinaryPath, buildSpawnPath } from './resolve-binary.js';
 /** Maximum time (ms) to wait for a Gemini CLI subprocess before killing it.
  *  Override with GEMINI_PROCESS_TIMEOUT_MS env var. */
 const PROCESS_TIMEOUT_MS =
-  parseInt(process.env.GEMINI_PROCESS_TIMEOUT_MS || '', 10) || 15 * 60 * 1000; // 15 minutes
+  parseInt(process.env.GEMINI_PROCESS_TIMEOUT_MS || '', 10) || 30 * 60 * 1000; // 30 minutes
 
 /** Idle timeout: no output for this long = stuck */
 const IDLE_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes


### PR DESCRIPTION
## Summary

Bumps the hard process timeout from 10min to 30min for all three runners (Claude, Codex, Gemini).

The idle timeout (5min no output = stuck) is the real safety net against hung processes. The hard timeout is just an absolute ceiling to prevent runaway costs. 10min was too aggressive for complex implementation tasks — meaningful work can easily take 15-30 minutes.

| Runner | Before | After | Idle timeout |
|--------|--------|-------|-------------|
| Claude | 10 min | **30 min** | 5 min |
| Codex | 10 min | **30 min** | none |
| Gemini | 15 min | **30 min** | 5 min |

## Test plan

- [x] One-line constant change per file, no logic changes
