### PR TITLE
feat: env var overrides for runner process timeouts (by Wren)

### DIFF
--- a/packages/api/src/services/sessions/claude-runner.ts
+++ b/packages/api/src/services/sessions/claude-runner.ts
@@ -20,8 +20,10 @@ import { formatInjectedContext } from './context-builder.js';
 import { logger } from '../../utils/logger.js';
 import { resolveBinaryPath, buildSpawnPath } from './resolve-binary.js';
 
-/** Maximum time (ms) to wait for a Claude Code subprocess before killing it */
-const PROCESS_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
+/** Maximum time (ms) to wait for a Claude Code subprocess before killing it.
+ *  Override with CLAUDE_PROCESS_TIMEOUT_MS env var. */
+const PROCESS_TIMEOUT_MS =
+  parseInt(process.env.CLAUDE_PROCESS_TIMEOUT_MS || '', 10) || 30 * 60 * 1000; // 30 minutes
 
 /**
  * Parse usage stats from Claude Code stream output.

--- a/packages/api/src/services/sessions/codex-runner.ts
+++ b/packages/api/src/services/sessions/codex-runner.ts
@@ -23,7 +23,10 @@ import { formatInjectedContext } from './context-builder.js';
 import { logger } from '../../utils/logger.js';
 import { resolveBinaryPath, buildSpawnPath } from './resolve-binary.js';
 
-const PROCESS_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
+/** Maximum time (ms) to wait for a Codex CLI subprocess before killing it.
+ *  Override with CODEX_PROCESS_TIMEOUT_MS env var. */
+const PROCESS_TIMEOUT_MS =
+  parseInt(process.env.CODEX_PROCESS_TIMEOUT_MS || '', 10) || 30 * 60 * 1000; // 30 minutes
 const DIAGNOSTIC_MAX_CHARS = 4000;
 const DIAGNOSTIC_MAX_LINES = 20;
 


### PR DESCRIPTION
## Summary

- Add `CLAUDE_PROCESS_TIMEOUT_MS` env var override for Claude runner hard timeout
- Add `CODEX_PROCESS_TIMEOUT_MS` env var override for Codex runner hard timeout
- Matches Gemini's existing `GEMINI_PROCESS_TIMEOUT_MS` pattern

All three runners now support env var overrides for the 30-minute default hard timeout.

## Test plan

- [x] Env var parsing matches Gemini's pattern (`parseInt || default`)
- [ ] Setting `CLAUDE_PROCESS_TIMEOUT_MS=60000` uses 60s timeout
- [ ] Unset env var falls back to 30min default

🤖 Generated with [Claude Code](https://claude.com/claude-code)