### PR TITLE
fix: harden sb chat backend tool gating paths (by lumen)

### DIFF
--- a/packages/cli/TESTS.md
+++ b/packages/cli/TESTS.md
@@ -64,6 +64,30 @@ yarn workspace @personal-context/cli test -- src/commands/hooks.test.ts
 yarn workspace @personal-context/cli test -- src/lib/pcp-mcp.test.ts
 ```
 
+## Optional local smoke tests (not CI)
+
+For real-backend validation of `sb chat` local tool routing (`pcp-tool` → sb runtime execution),
+run:
+
+```bash
+yarn workspace @personal-context/cli test:smoke:live
+```
+
+The smoke runner:
+
+- requires a live PCP API server (`PCP_SERVER_URL`, default `http://localhost:3101`)
+- uses real backend CLIs (claude/codex/gemini) if installed
+- checks for `local tool get_inbox` in output as proof that tool execution happened in sb runtime
+
+Environment overrides:
+
+```bash
+SB_SMOKE_AGENT=lumen \
+SB_SMOKE_BACKENDS="claude codex gemini" \
+PCP_SERVER_URL=http://localhost:3101 \
+yarn workspace @personal-context/cli test:smoke:live
+```
+
 ## Logging
 
 - Use `--sb-debug` for runtime tracing.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -17,6 +17,7 @@
     "uninstall:cli": "rm -f \"$HOME/.pcp/bin/sb\" \"$HOME/.local/bin/sb\" && echo \"Unlinked: $HOME/.pcp/bin/sb and $HOME/.local/bin/sb\"",
     "type-check": "tsc --noEmit",
     "test": "yarn workspace @personal-context/shared build && vitest run",
+    "test:smoke:live": "bash ./scripts/smoke-chat-live.sh",
     "test:watch": "vitest",
     "clean": "rm -rf dist"
   },

--- a/packages/cli/scripts/smoke-chat-live.sh
+++ b/packages/cli/scripts/smoke-chat-live.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Optional local smoke test (NOT CI):
+# Verifies that sb chat local tool routing can execute get_inbox via sb runtime
+# across configured backends.
+#
+# Prerequisites:
+# - Local PCP API server running (default: http://localhost:3101)
+# - Authenticated backend CLIs (claude/codex/gemini)
+# - Built CLI in this package (dist/cli.js)
+#
+# Tunables:
+#   SB_SMOKE_AGENT=lumen
+#   SB_SMOKE_BACKENDS="claude codex gemini"
+#   SB_SMOKE_BIN="node dist/cli.js"
+#   PCP_SERVER_URL=http://localhost:3101
+
+AGENT="${SB_SMOKE_AGENT:-lumen}"
+BACKENDS="${SB_SMOKE_BACKENDS:-claude codex gemini}"
+SB_BIN="${SB_SMOKE_BIN:-node dist/cli.js}"
+PCP_URL="${PCP_SERVER_URL:-http://localhost:3101}"
+
+if [[ ! -f "dist/cli.js" ]]; then
+  echo "dist/cli.js not found. Run: yarn workspace @personal-context/cli build"
+  exit 1
+fi
+
+prompt_for_backend() {
+  local agent="$1"
+  cat <<EOF
+Emit exactly one fenced pcp-tool block and nothing else:
+\`\`\`pcp-tool
+{"tool":"get_inbox","args":{"agentId":"${agent}","status":"unread","limit":1}}
+\`\`\`
+EOF
+}
+
+failures=0
+
+echo "Running sb-chat live smoke test"
+echo "  agent:    ${AGENT}"
+echo "  backends: ${BACKENDS}"
+echo "  pcp:      ${PCP_URL}"
+echo ""
+
+for backend in ${BACKENDS}; do
+  if ! command -v "${backend}" >/dev/null 2>&1; then
+    echo "SKIP ${backend}: binary not found in PATH"
+    continue
+  fi
+
+  echo "==> ${backend}"
+  prompt="$(prompt_for_backend "${AGENT}")"
+
+  set +e
+  output="$(
+    PCP_SERVER_URL="${PCP_URL}" \
+      ${SB_BIN} chat \
+      -a "${AGENT}" \
+      -b "${backend}" \
+      --tool-routing local \
+      --sb-strict-tools \
+      --non-interactive \
+      --message "${prompt}" \
+      --poll-seconds 999 \
+      --verbose \
+      2>&1
+  )"
+  rc=$?
+  set -e
+
+  if [[ ${rc} -ne 0 ]]; then
+    echo "FAIL ${backend}: sb chat exited ${rc}"
+    echo "${output}" | tail -n 40
+    failures=$((failures + 1))
+    continue
+  fi
+
+  if ! grep -q "local tool get_inbox" <<<"${output}"; then
+    echo "FAIL ${backend}: no sb local tool execution marker found"
+    echo "${output}" | tail -n 60
+    failures=$((failures + 1))
+    continue
+  fi
+
+  echo "PASS ${backend}"
+done
+
+echo ""
+if [[ ${failures} -gt 0 ]]; then
+  echo "Smoke test failed (${failures} backend(s) failed)."
+  exit 1
+fi
+
+echo "Smoke test passed."

--- a/packages/cli/scripts/smoke-chat-live.sh
+++ b/packages/cli/scripts/smoke-chat-live.sh
@@ -14,11 +14,15 @@ set -euo pipefail
 #   SB_SMOKE_AGENT=lumen
 #   SB_SMOKE_BACKENDS="claude codex gemini"
 #   SB_SMOKE_BIN="node dist/cli.js"
+#   SB_SMOKE_TIMEOUT_SECONDS=20
+#   SB_SMOKE_DEBUG_FILE=/tmp/sb-chat-smoke-debug.log
 #   PCP_SERVER_URL=http://localhost:3101
 
 AGENT="${SB_SMOKE_AGENT:-lumen}"
 BACKENDS="${SB_SMOKE_BACKENDS:-claude codex gemini}"
 SB_BIN="${SB_SMOKE_BIN:-node dist/cli.js}"
+TIMEOUT_SECONDS="${SB_SMOKE_TIMEOUT_SECONDS:-20}"
+DEBUG_FILE="${SB_SMOKE_DEBUG_FILE:-/tmp/sb-chat-smoke-debug.log}"
 PCP_URL="${PCP_SERVER_URL:-http://localhost:3101}"
 
 if [[ ! -f "dist/cli.js" ]]; then
@@ -42,6 +46,8 @@ echo "Running sb-chat live smoke test"
 echo "  agent:    ${AGENT}"
 echo "  backends: ${BACKENDS}"
 echo "  pcp:      ${PCP_URL}"
+echo "  timeout:  ${TIMEOUT_SECONDS}s"
+echo "  debug:    ${DEBUG_FILE}"
 echo ""
 
 for backend in ${BACKENDS}; do
@@ -56,11 +62,14 @@ for backend in ${BACKENDS}; do
   set +e
   output="$(
     PCP_SERVER_URL="${PCP_URL}" \
+      SB_DEBUG_FILE="${DEBUG_FILE}" \
       ${SB_BIN} chat \
       -a "${AGENT}" \
       -b "${backend}" \
       --tool-routing local \
       --sb-strict-tools \
+      --backend-timeout-seconds "${TIMEOUT_SECONDS}" \
+      --sb-debug \
       --non-interactive \
       --message "${prompt}" \
       --poll-seconds 999 \
@@ -77,11 +86,15 @@ for backend in ${BACKENDS}; do
     continue
   fi
 
-  if ! grep -q "local tool get_inbox" <<<"${output}"; then
-    echo "FAIL ${backend}: no sb local tool execution marker found"
+  if ! grep -Eq "local tool get_inbox|Local tool error \\(get_inbox\\)|local tool call emitted; see tool results above" <<<"${output}"; then
+    echo "FAIL ${backend}: no sb local tool routing marker found"
     echo "${output}" | tail -n 60
     failures=$((failures + 1))
     continue
+  fi
+
+  if grep -q "Local tool error (get_inbox)" <<<"${output}"; then
+    echo "WARN ${backend}: local tool call was routed but PCP call failed (check PCP_SERVER_URL/auth)"
   fi
 
   echo "PASS ${backend}"

--- a/packages/cli/src/backends/adapters.test.ts
+++ b/packages/cli/src/backends/adapters.test.ts
@@ -67,6 +67,30 @@ describe('backend adapters session resume wiring', () => {
     }
   });
 
+  it('places codex passthrough args after exec subcommand', () => {
+    const adapter = new CodexAdapter();
+    const prepared = adapter.prepare({
+      agentId: 'lumen',
+      model: undefined,
+      promptParts: ['exec', 'do work'],
+      passthroughArgs: ['--sandbox', 'read-only', '--skip-git-repo-check'],
+    });
+
+    try {
+      const execIndex = prepared.args.indexOf('exec');
+      expect(execIndex).toBeGreaterThanOrEqual(0);
+      expect(prepared.args.slice(execIndex, execIndex + 5)).toEqual([
+        'exec',
+        '--sandbox',
+        'read-only',
+        '--skip-git-repo-check',
+        'do work',
+      ]);
+    } finally {
+      prepared.cleanup();
+    }
+  });
+
   it('injects startup context into codex model instructions file when provided', () => {
     const adapter = new CodexAdapter();
     const prepared = adapter.prepare({

--- a/packages/cli/src/backends/codex.ts
+++ b/packages/cli/src/backends/codex.ts
@@ -44,13 +44,26 @@ export class CodexAdapter implements BackendAdapter {
       args.push('--dangerously-bypass-approvals-and-sandbox');
     }
 
-    // Passthrough flags
-    args.push(...config.passthroughArgs);
-
     // Positional args spread individually so subcommands work
     // e.g. "sb -b codex mcp login supabase" → codex ... mcp login supabase
-    if (config.promptParts.length > 0) {
-      args.push(...config.promptParts);
+    //
+    // Codex has subcommand-scoped flags (notably for `exec`) such as:
+    //   --skip-git-repo-check, --color, --json
+    // Those must come AFTER `exec`, not before it.
+    //
+    // Preserve general behavior for non-exec prompt parts, but when promptParts
+    // starts with `exec`, place passthrough args immediately after `exec`.
+    const promptParts = config.promptParts || [];
+    if (promptParts.length > 0 && promptParts[0]?.toLowerCase() === 'exec') {
+      args.push(promptParts[0]);
+      args.push(...config.passthroughArgs);
+      args.push(...promptParts.slice(1));
+    } else {
+      // Passthrough flags
+      args.push(...config.passthroughArgs);
+      if (promptParts.length > 0) {
+        args.push(...promptParts);
+      }
     }
 
     return {

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -27,6 +27,11 @@ import {
   updateConfigEmail,
   CLIENT_ID,
 } from '../auth/tokens.js';
+import {
+  getBackendAuthStatus,
+  runBackendInteractiveLogin,
+  type BackendAuthBackend,
+} from '../lib/backend-auth.js';
 
 // ============================================================================
 // Helpers
@@ -361,6 +366,91 @@ async function delegateCommand(options: { agent: string }): Promise<void> {
   );
 }
 
+const AUTH_BACKENDS: BackendAuthBackend[] = ['claude', 'codex', 'gemini'];
+
+function parseBackendName(value?: string): BackendAuthBackend | null {
+  if (!value) return null;
+  const normalized = value.trim().toLowerCase();
+  if (normalized === 'claude' || normalized === 'codex' || normalized === 'gemini') {
+    return normalized;
+  }
+  return null;
+}
+
+async function backendStatusCommand(options: { backend?: string }): Promise<void> {
+  const selected = parseBackendName(options.backend);
+  if (options.backend && !selected) {
+    console.log(chalk.red(`Unknown backend: ${options.backend}`));
+    console.log(chalk.dim('Valid: claude, codex, gemini'));
+    process.exitCode = 1;
+    return;
+  }
+
+  const targets = selected ? [selected] : AUTH_BACKENDS;
+  console.log(chalk.bold('\nBackend Auth Status\n'));
+  for (const backend of targets) {
+    const status = await getBackendAuthStatus(backend);
+    const state = status.authenticated
+      ? chalk.green('authenticated')
+      : chalk.yellow('unauthenticated');
+    console.log(`  ${chalk.bold(backend)}: ${state} ${chalk.dim(`(${status.detail})`)}`);
+    console.log(chalk.dim(`    source: ${status.credentialSource}`));
+    if (!status.authenticated && status.loginCommand) {
+      console.log(chalk.dim(`    login:  ${status.loginCommand}`));
+    }
+  }
+  console.log('');
+}
+
+async function backendLoginCommand(options: { backend: string }): Promise<void> {
+  const backend = parseBackendName(options.backend);
+  if (!backend) {
+    console.log(chalk.red(`Unknown backend: ${options.backend}`));
+    console.log(chalk.dim('Valid: claude, codex, gemini'));
+    process.exitCode = 1;
+    return;
+  }
+
+  const before = await getBackendAuthStatus(backend);
+  if (before.authenticated) {
+    console.log(chalk.green(`${backend} already authenticated (${before.detail})`));
+    return;
+  }
+
+  if (!before.canInteractiveLogin || !before.loginCommand) {
+    console.log(chalk.yellow(`${backend} login must be completed in backend CLI.`));
+    console.log(chalk.dim(`Status: ${before.detail}`));
+    if (backend === 'gemini') {
+      console.log(
+        chalk.dim('Run `gemini` and complete authentication, then re-run this status check.')
+      );
+    }
+    return;
+  }
+
+  if (!process.stdin.isTTY || !process.stdout.isTTY) {
+    console.log(chalk.yellow('backend login requires interactive TTY.'));
+    console.log(chalk.dim(`Run interactively: ${before.loginCommand}`));
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(chalk.dim(`Launching: ${before.loginCommand}`));
+  const exitCode = await runBackendInteractiveLogin(backend);
+  if (exitCode !== 0) {
+    console.log(chalk.red(`${before.loginCommand} exited with ${exitCode}`));
+    process.exitCode = exitCode;
+    return;
+  }
+  const after = await getBackendAuthStatus(backend);
+  if (!after.authenticated) {
+    console.log(chalk.red(`${backend} still unauthenticated (${after.detail})`));
+    process.exitCode = 1;
+    return;
+  }
+  console.log(chalk.green(`${backend} authenticated (${after.detail})`));
+}
+
 // ============================================================================
 // Register
 // ============================================================================
@@ -383,4 +473,20 @@ export function registerAuthCommands(program: Command): void {
     .description('Mint and store an SB-scoped delegated MCP token')
     .requiredOption('-a, --agent <agentId>', 'SB agentId (e.g. wren, lumen, aster)')
     .action(delegateCommand);
+
+  const backend = auth
+    .command('backend')
+    .description('Manage backend CLI authentication status/login');
+
+  backend
+    .command('status')
+    .description('Show backend CLI auth status')
+    .option('-b, --backend <name>', 'Backend (claude, codex, gemini)')
+    .action(backendStatusCommand);
+
+  backend
+    .command('login')
+    .description('Run backend CLI login flow (interactive when supported)')
+    .requiredOption('-b, --backend <name>', 'Backend (claude, codex, gemini)')
+    .action(backendLoginCommand);
 }

--- a/packages/cli/src/commands/chat.integration.test.ts
+++ b/packages/cli/src/commands/chat.integration.test.ts
@@ -1308,6 +1308,33 @@ describe('runChat integration', () => {
     expect(backendRequest.passthroughArgs).toEqual([]);
   });
 
+  it('applies strict codex hardening args in local routing when --sb-strict-tools is set', async () => {
+    testState.inputs = ['codex strict local turn', '/quit'];
+
+    await runChat({
+      agent: 'lumen',
+      backend: 'codex',
+      toolRouting: 'local',
+      sbStrictTools: true,
+      pollSeconds: '999',
+    });
+
+    expect(testState.runBackendImpl).toHaveBeenCalledTimes(1);
+    const backendRequest = testState.runBackendImpl.mock.calls[0][0] as {
+      passthroughArgs: string[];
+      prompt: string;
+    };
+    expect(backendRequest.passthroughArgs).toEqual([
+      '--sandbox',
+      'read-only',
+      '--ask-for-approval',
+      'never',
+      '--config',
+      'mcp_servers={}',
+    ]);
+    expect(backendRequest.prompt).toContain('Strict tools mode: ON.');
+  });
+
   it('handles non-interactive local tool blocks without readline crashes', async () => {
     testState.runBackendImpl.mockResolvedValue({
       success: true,

--- a/packages/cli/src/commands/chat.integration.test.ts
+++ b/packages/cli/src/commands/chat.integration.test.ts
@@ -1291,6 +1291,98 @@ describe('runChat integration', () => {
     expect(localToolCall).toBeTruthy();
   });
 
+  it('executes local pcp-tool blocks with gemini backend via sb runtime', async () => {
+    testState.runBackendImpl.mockResolvedValue({
+      success: true,
+      stdout:
+        '```pcp-tool\n{"tool":"get_inbox","args":{"agentId":"lumen","status":"unread","limit":2}}\n```',
+      stderr: '',
+      exitCode: 0,
+      durationMs: 5,
+      command: 'mock',
+    });
+    testState.callToolImpl.mockImplementation(
+      async (tool: string, args?: Record<string, unknown>) => {
+        switch (tool) {
+          case 'bootstrap':
+            return { user: { timezone: 'America/Los_Angeles' } };
+          case 'start_session':
+            return { session: { id: 'sess-1' } };
+          case 'get_inbox':
+            return { messages: [], echo: args || {} };
+          case 'update_session_phase':
+          case 'end_session':
+            return { success: true };
+          default:
+            return { success: true };
+        }
+      }
+    );
+
+    testState.inputs = ['run local gemini tool routing', '/quit'];
+    await runChat({
+      agent: 'lumen',
+      backend: 'gemini',
+      toolRouting: 'local',
+      pollSeconds: '999',
+    });
+
+    const backendRequest = testState.runBackendImpl.mock.calls[0][0] as {
+      passthroughArgs: string[];
+    };
+    expect(backendRequest.passthroughArgs).toEqual(['--allowed-tools', '']);
+    const localToolCall = testState.pcpCalls.find(
+      (call) => call.tool === 'get_inbox' && call.args.limit === 2
+    );
+    expect(localToolCall).toBeTruthy();
+  });
+
+  it('executes local pcp-tool blocks with codex backend via sb runtime', async () => {
+    testState.runBackendImpl.mockResolvedValue({
+      success: true,
+      stdout:
+        '```pcp-tool\n{"tool":"get_inbox","args":{"agentId":"lumen","status":"unread","limit":3}}\n```',
+      stderr: '',
+      exitCode: 0,
+      durationMs: 5,
+      command: 'mock',
+    });
+    testState.callToolImpl.mockImplementation(
+      async (tool: string, args?: Record<string, unknown>) => {
+        switch (tool) {
+          case 'bootstrap':
+            return { user: { timezone: 'America/Los_Angeles' } };
+          case 'start_session':
+            return { session: { id: 'sess-1' } };
+          case 'get_inbox':
+            return { messages: [], echo: args || {} };
+          case 'update_session_phase':
+          case 'end_session':
+            return { success: true };
+          default:
+            return { success: true };
+        }
+      }
+    );
+
+    testState.inputs = ['run local codex tool routing', '/quit'];
+    await runChat({
+      agent: 'lumen',
+      backend: 'codex',
+      toolRouting: 'local',
+      pollSeconds: '999',
+    });
+
+    const backendRequest = testState.runBackendImpl.mock.calls[0][0] as {
+      passthroughArgs: string[];
+    };
+    expect(backendRequest.passthroughArgs).toEqual([]);
+    const localToolCall = testState.pcpCalls.find(
+      (call) => call.tool === 'get_inbox' && call.args.limit === 3
+    );
+    expect(localToolCall).toBeTruthy();
+  });
+
   it('does not pass unsupported --allowedTools passthrough to codex backend', async () => {
     testState.inputs = ['codex local turn', '/quit'];
 

--- a/packages/cli/src/commands/chat.integration.test.ts
+++ b/packages/cli/src/commands/chat.integration.test.ts
@@ -1291,6 +1291,52 @@ describe('runChat integration', () => {
     expect(localToolCall).toBeTruthy();
   });
 
+  it('does not pass unsupported --allowedTools passthrough to codex backend', async () => {
+    testState.inputs = ['codex local turn', '/quit'];
+
+    await runChat({
+      agent: 'lumen',
+      backend: 'codex',
+      toolRouting: 'local',
+      pollSeconds: '999',
+    });
+
+    expect(testState.runBackendImpl).toHaveBeenCalledTimes(1);
+    const backendRequest = testState.runBackendImpl.mock.calls[0][0] as {
+      passthroughArgs: string[];
+    };
+    expect(backendRequest.passthroughArgs).toEqual([]);
+  });
+
+  it('handles non-interactive local tool blocks without readline crashes', async () => {
+    testState.runBackendImpl.mockResolvedValue({
+      success: true,
+      stdout:
+        '```pcp-tool\n{"tool":"send_to_inbox","args":{"recipientAgentId":"wren","content":"ping"}}\n```',
+      stderr: '',
+      exitCode: 0,
+      durationMs: 5,
+      command: 'mock',
+    });
+
+    await expect(
+      runChat({
+        agent: 'lumen',
+        backend: 'claude',
+        nonInteractive: true,
+        message: 'one shot',
+        toolRouting: 'local',
+        pollSeconds: '999',
+      })
+    ).resolves.toBeUndefined();
+
+    // In non-interactive mode there is no readline prompt, so this tool call must be denied
+    // instead of crashing from an uninitialized readline reference.
+    expect(testState.pcpCalls.some((call) => call.tool === 'send_to_inbox')).toBe(false);
+    const logText = stripAnsi(logSpy.mock.calls.flat().join('\n'));
+    expect(logText).toContain('Local tool denied (send_to_inbox)');
+  });
+
   it('exits gracefully on double ctrl+c', async () => {
     testState.inputs = ['__ABORT__', '__ABORT__'];
 

--- a/packages/cli/src/commands/chat.integration.test.ts
+++ b/packages/cli/src/commands/chat.integration.test.ts
@@ -1417,10 +1417,21 @@ describe('runChat integration', () => {
       prompt: string;
     };
     expect(backendRequest.passthroughArgs).toEqual([
+      '--color',
+      'never',
       '--sandbox',
       'read-only',
-      '--ask-for-approval',
-      'never',
+      '--skip-git-repo-check',
+      '--config',
+      'features.apps=false',
+      '--config',
+      'mcp_servers.pcp.enabled=false',
+      '--config',
+      'mcp_servers.next-devtools.enabled=false',
+      '--config',
+      'mcp_servers.github.enabled=false',
+      '--config',
+      'mcp_servers.supabase.enabled=false',
       '--config',
       'mcp_servers={}',
     ]);
@@ -1454,6 +1465,39 @@ describe('runChat integration', () => {
     expect(testState.pcpCalls.some((call) => call.tool === 'send_to_inbox')).toBe(false);
     const logText = stripAnsi(logSpy.mock.calls.flat().join('\n'));
     expect(logText).toContain('Local tool denied (send_to_inbox)');
+  });
+
+  it('applies default backend timeout for non-interactive turns', async () => {
+    await runChat({
+      agent: 'lumen',
+      backend: 'codex',
+      nonInteractive: true,
+      message: 'one shot timeout default',
+      pollSeconds: '999',
+    });
+
+    expect(testState.runBackendImpl).toHaveBeenCalledTimes(1);
+    const backendRequest = testState.runBackendImpl.mock.calls[0][0] as {
+      timeoutMs?: number;
+    };
+    expect(backendRequest.timeoutMs).toBe(120_000);
+  });
+
+  it('applies explicit --backend-timeout-seconds override', async () => {
+    await runChat({
+      agent: 'lumen',
+      backend: 'codex',
+      nonInteractive: true,
+      message: 'one shot timeout override',
+      backendTimeoutSeconds: '7',
+      pollSeconds: '999',
+    });
+
+    expect(testState.runBackendImpl).toHaveBeenCalledTimes(1);
+    const backendRequest = testState.runBackendImpl.mock.calls[0][0] as {
+      timeoutMs?: number;
+    };
+    expect(backendRequest.timeoutMs).toBe(7_000);
   });
 
   it('exits gracefully on double ctrl+c', async () => {

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -73,6 +73,7 @@ type ChatOptions = {
   message?: string;
   nonInteractive?: boolean;
   tailTranscript?: string;
+  sbStrictTools?: boolean;
   verbose?: boolean;
   fullscreen?: boolean;
 };
@@ -113,6 +114,7 @@ interface ChatRuntime {
   transcriptPath: string;
   activeSkills: SkillInstruction[];
   bootstrapContext?: string;
+  strictTools: boolean;
 }
 
 interface SessionSummary {
@@ -151,7 +153,8 @@ type BackendToolGateSnapshot = {
 function buildBackendToolPassthrough(
   backend: string,
   toolRouting: 'backend' | 'local',
-  gate: BackendToolGateSnapshot
+  gate: BackendToolGateSnapshot,
+  strictTools: boolean
 ): { passthroughArgs: string[]; warning?: string } {
   const shouldDisableBackendTools = toolRouting !== 'backend' || gate.mode === 'off';
 
@@ -175,14 +178,30 @@ function buildBackendToolPassthrough(
     return { passthroughArgs: ['--allowed-tools', gate.allowedTools.join(',')] };
   }
 
-  if (backend === 'codex' && (shouldDisableBackendTools || gate.mode === 'backend')) {
-    return {
-      passthroughArgs: [],
-      warning:
-        toolRouting === 'local'
-          ? 'Codex CLI has no allowlist passthrough flag; relying on sb local-tool routing prompt guard.'
-          : 'Codex CLI has no allowlist passthrough flag; backend tool gating is not enforced by CLI flags.',
-    };
+  if (backend === 'codex') {
+    if (toolRouting === 'local' && strictTools) {
+      return {
+        passthroughArgs: [
+          '--sandbox',
+          'read-only',
+          '--ask-for-approval',
+          'never',
+          '--config',
+          'mcp_servers={}',
+        ],
+        warning:
+          'Codex strict-tools mode enabled: forcing read-only sandbox, no approval prompts, and disabling backend MCP servers.',
+      };
+    }
+    if (shouldDisableBackendTools || gate.mode === 'backend') {
+      return {
+        passthroughArgs: [],
+        warning:
+          toolRouting === 'local'
+            ? 'Codex CLI has no allowlist passthrough flag; relying on sb local-tool routing prompt guard.'
+            : 'Codex CLI has no allowlist passthrough flag; backend tool gating is not enforced by CLI flags.',
+      };
+    }
   }
 
   return { passthroughArgs: [] };
@@ -1621,6 +1640,7 @@ function buildPromptEnvelope(
     `Current backend: ${runtime.backend}${runtime.model ? ` (${runtime.model})` : ''}.`,
     `Tool mode: ${runtime.toolMode}.`,
     `Tool routing: ${runtime.toolRouting}.`,
+    runtime.strictTools ? 'Strict tools mode: ON.' : '',
     toolInstruction,
     runtime.activeSkills.length > 0
       ? `Active skills: ${runtime.activeSkills.map((skill) => skill.name).join(', ')}`
@@ -1690,6 +1710,7 @@ export async function runChat(options: ChatOptions): Promise<void> {
     awayMode: false,
     transcriptPath: ensureRuntimeTranscriptPath(),
     activeSkills: [],
+    strictTools: options.sbStrictTools ?? false,
   };
   const approvalManager = new ApprovalRequestManager();
   const policyPathFromEnv = process.env.PCP_TOOL_POLICY_PATH?.trim();
@@ -2446,7 +2467,8 @@ export async function runChat(options: ChatOptions): Promise<void> {
     const passthroughPlan = buildBackendToolPassthrough(
       runtime.backend,
       runtime.toolRouting,
-      backendGate
+      backendGate,
+      runtime.strictTools
     );
     const passthroughArgs = passthroughPlan.passthroughArgs;
 
@@ -4225,6 +4247,10 @@ export function registerChatCommand(program: Command): void {
       .option('--auto-run', 'Automatically execute backend turns for new inbox task messages')
       .option('--message <text>', 'Single-turn message for non-interactive mode')
       .option('--non-interactive', 'Run one turn and exit (requires --message)')
+      .option(
+        '--sb-strict-tools',
+        'Harden backend-native tooling (Codex: disable MCP servers + force read-only sandbox in local routing)'
+      )
       .option(
         '--tail-transcript <pathOrSession>',
         'Tail transcript output by file path or session id'

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -15,6 +15,12 @@ import {
 import { isAbsolute, join } from 'path';
 import { readIdentityJson, resolveAgentId } from '../backends/identity.js';
 import { PcpClient } from '../lib/pcp-client.js';
+import { initSbDebug, sbDebugLog } from '../lib/sb-debug.js';
+import {
+  getBackendAuthStatus,
+  runBackendInteractiveLogin,
+  type BackendAuthBackend,
+} from '../lib/backend-auth.js';
 import { runBackendTurn } from '../repl/backend-runner.js';
 import { ContextLedger, estimateTokens } from '../repl/context-ledger.js';
 import { parseSlashCommand } from '../repl/slash.js';
@@ -72,8 +78,10 @@ type ChatOptions = {
   profile?: string;
   message?: string;
   nonInteractive?: boolean;
+  backendTimeoutSeconds?: string;
   tailTranscript?: string;
   sbStrictTools?: boolean;
+  sbDebug?: boolean;
   verbose?: boolean;
   fullscreen?: boolean;
 };
@@ -115,6 +123,7 @@ interface ChatRuntime {
   activeSkills: SkillInstruction[];
   bootstrapContext?: string;
   strictTools: boolean;
+  backendTurnTimeoutMs?: number;
 }
 
 interface SessionSummary {
@@ -142,6 +151,90 @@ interface ActivitySummary {
   agentId?: string;
   sessionId?: string;
   createdAt?: string;
+}
+
+function isBackendAuthBackend(value: string): value is BackendAuthBackend {
+  return value === 'claude' || value === 'codex' || value === 'gemini';
+}
+
+async function ensureBackendAuthReady(
+  backend: string,
+  mode: { nonInteractive: boolean; hasMessage: boolean; verbose: boolean }
+): Promise<void> {
+  if (process.env.SB_SKIP_BACKEND_AUTH_CHECK === '1' || process.env.VITEST) {
+    return;
+  }
+  if (!isBackendAuthBackend(backend)) return;
+
+  const status = await getBackendAuthStatus(backend);
+  sbDebugLog('chat', 'backend_auth_status', {
+    backend,
+    authenticated: status.authenticated,
+    detail: status.detail,
+    canInteractiveLogin: status.canInteractiveLogin,
+    loginCommand: status.loginCommand || null,
+    mode,
+  });
+  if (status.authenticated) {
+    if (mode.verbose) {
+      console.log(chalk.dim(`Backend auth: ${backend} (${status.detail})`));
+    }
+    return;
+  }
+
+  const guidance = `Backend ${backend} is not authenticated (${status.detail}).`;
+  const loginHint =
+    status.loginCommand ||
+    (backend === 'gemini' ? 'Start `gemini` once and complete login in the Gemini CLI' : null);
+
+  if (mode.nonInteractive || mode.hasMessage) {
+    sbDebugLog('chat', 'backend_auth_required_non_interactive', {
+      backend,
+      detail: status.detail,
+      loginCommand: loginHint || null,
+      mode,
+    });
+    throw new Error(
+      `${guidance}${loginHint ? `\nRun: ${loginHint}` : '\nAuthenticate backend CLI and retry.'}`
+    );
+  }
+
+  console.log(chalk.yellow(`⚠ ${guidance}`));
+  if (!status.canInteractiveLogin || !status.loginCommand) {
+    if (loginHint) console.log(chalk.dim(`  Run: ${loginHint}`));
+    return;
+  }
+  if (!input.isTTY || !output.isTTY) {
+    console.log(chalk.dim(`  Run: ${status.loginCommand}`));
+    return;
+  }
+
+  const prompt = createInterface({ input, output });
+  try {
+    const answer = (
+      await prompt.question(chalk.cyan(`Run ${status.loginCommand} now? [Y/n] `))
+    ).trim();
+    if (answer && !['y', 'yes'].includes(answer.toLowerCase())) {
+      console.log(chalk.dim(`  Skipping login. Run manually: ${status.loginCommand}`));
+      return;
+    }
+  } finally {
+    prompt.close();
+  }
+
+  const exitCode = await runBackendInteractiveLogin(backend);
+  if (exitCode !== 0) {
+    throw new Error(
+      `Backend ${backend} login exited with code ${exitCode}. Run \`${status.loginCommand}\` and retry.`
+    );
+  }
+  const recheck = await getBackendAuthStatus(backend);
+  if (!recheck.authenticated) {
+    throw new Error(
+      `Backend ${backend} still appears unauthenticated (${recheck.detail}). Run \`${status.loginCommand}\` and retry.`
+    );
+  }
+  console.log(chalk.green(`✓ Backend ${backend} authenticated (${recheck.detail})`));
 }
 
 type BackendToolGateSnapshot = {
@@ -182,15 +275,29 @@ function buildBackendToolPassthrough(
     if (toolRouting === 'local' && strictTools) {
       return {
         passthroughArgs: [
+          // Keep Codex execution deterministic in one-shot mode.
+          // NOTE: for Codex `exec`, these are subcommand options and therefore
+          // must be placed after `exec` (adapter handles ordering).
+          '--color',
+          'never',
           '--sandbox',
           'read-only',
-          '--ask-for-approval',
-          'never',
+          '--skip-git-repo-check',
+          '--config',
+          'features.apps=false',
+          '--config',
+          'mcp_servers.pcp.enabled=false',
+          '--config',
+          'mcp_servers.next-devtools.enabled=false',
+          '--config',
+          'mcp_servers.github.enabled=false',
+          '--config',
+          'mcp_servers.supabase.enabled=false',
           '--config',
           'mcp_servers={}',
         ],
         warning:
-          'Codex strict-tools mode enabled: forcing read-only sandbox, no approval prompts, and disabling backend MCP servers.',
+          'Codex strict-tools mode enabled: forcing read-only sandbox, no color UI, and disabling known backend MCP servers.',
       };
     }
     if (shouldDisableBackendTools || gate.mode === 'backend') {
@@ -1665,6 +1772,16 @@ function buildPromptEnvelope(
 }
 
 export async function runChat(options: ChatOptions): Promise<void> {
+  const debugFile = initSbDebug({
+    enabled: options.sbDebug,
+    context: {
+      command: 'chat',
+      argv: process.argv.slice(2),
+      backend: options.backend,
+      agent: options.agent,
+    },
+  });
+
   if (options.tailTranscript) {
     await tailTranscript(options.tailTranscript);
     return;
@@ -1685,6 +1802,16 @@ export async function runChat(options: ChatOptions): Promise<void> {
     options.maxContextTokens || String(initialBackendTokenWindow),
     10
   );
+  const parsedBackendTimeoutSeconds =
+    options.backendTimeoutSeconds !== undefined
+      ? Number.parseInt(options.backendTimeoutSeconds, 10)
+      : Number.NaN;
+  const backendTurnTimeoutMs =
+    Number.isFinite(parsedBackendTimeoutSeconds) && parsedBackendTimeoutSeconds > 0
+      ? parsedBackendTimeoutSeconds * 1000
+      : options.nonInteractive
+        ? 120_000
+        : undefined;
 
   const runtime: ChatRuntime = {
     backend: initialBackend,
@@ -1711,7 +1838,13 @@ export async function runChat(options: ChatOptions): Promise<void> {
     transcriptPath: ensureRuntimeTranscriptPath(),
     activeSkills: [],
     strictTools: options.sbStrictTools ?? false,
+    backendTurnTimeoutMs,
   };
+  await ensureBackendAuthReady(runtime.backend, {
+    nonInteractive: Boolean(options.nonInteractive),
+    hasMessage: Boolean(options.message?.trim()),
+    verbose: runtime.verbose,
+  });
   const approvalManager = new ApprovalRequestManager();
   const policyPathFromEnv = process.env.PCP_TOOL_POLICY_PATH?.trim();
   const toolPolicy = new ToolPolicyState(
@@ -2486,6 +2619,19 @@ export async function runChat(options: ChatOptions): Promise<void> {
     if (passthroughPlan.warning && runtime.verbose) {
       printLine(chalk.yellow(passthroughPlan.warning));
     }
+    sbDebugLog(
+      'chat',
+      'backend_turn_start',
+      {
+        backend: runtime.backend,
+        sessionId: runtime.sessionId || null,
+        toolRouting: runtime.toolRouting,
+        toolMode: backendGate.mode,
+        passthroughArgs,
+        timeoutMs: runtime.backendTurnTimeoutMs ?? null,
+      },
+      debugFile ? { force: true, file: debugFile } : undefined
+    );
 
     // Ink handles waiting via its own component; legacy uses animated indicator
     const stopWaiting = inkRepl
@@ -2529,11 +2675,26 @@ export async function runChat(options: ChatOptions): Promise<void> {
       prompt,
       verbose: runtime.verbose,
       passthroughArgs,
+      timeoutMs: runtime.backendTurnTimeoutMs,
     }).finally(() => {
       process.off('SIGINT', onSigintDuringTurn);
       turnDurationSeconds = Math.max(0, Math.round((Date.now() - turnStartedAt) / 1000));
       stopWaiting();
     });
+    sbDebugLog(
+      'chat',
+      'backend_turn_result',
+      {
+        backend: runtime.backend,
+        sessionId: runtime.sessionId || null,
+        success: runResult.success,
+        exitCode: runResult.exitCode,
+        durationMs: runResult.durationMs,
+        command: runResult.command,
+        stderrPreview: runResult.stderr.slice(0, 500),
+      },
+      debugFile ? { force: true, file: debugFile } : undefined
+    );
 
     // Log backend CLI turn completion to activity stream
     if (runtime.sessionId) {
@@ -4247,6 +4408,11 @@ export function registerChatCommand(program: Command): void {
       .option('--auto-run', 'Automatically execute backend turns for new inbox task messages')
       .option('--message <text>', 'Single-turn message for non-interactive mode')
       .option('--non-interactive', 'Run one turn and exit (requires --message)')
+      .option(
+        '--backend-timeout-seconds <n>',
+        'Backend turn timeout in seconds (default: 120 for --non-interactive, otherwise 1200)'
+      )
+      .option('--sb-debug', 'Enable sb debug logging for chat runtime')
       .option(
         '--sb-strict-tools',
         'Harden backend-native tooling (Codex: disable MCP servers + force read-only sandbox in local routing)'

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -142,6 +142,52 @@ interface ActivitySummary {
   createdAt?: string;
 }
 
+type BackendToolGateSnapshot = {
+  mode: ToolMode;
+  allowedTools: string[];
+  unresolvedPatterns: string[];
+};
+
+function buildBackendToolPassthrough(
+  backend: string,
+  toolRouting: 'backend' | 'local',
+  gate: BackendToolGateSnapshot
+): { passthroughArgs: string[]; warning?: string } {
+  const shouldDisableBackendTools = toolRouting !== 'backend' || gate.mode === 'off';
+
+  if (backend === 'claude') {
+    if (shouldDisableBackendTools) {
+      return { passthroughArgs: ['--allowedTools', ''] };
+    }
+    if (gate.mode === 'privileged') {
+      return { passthroughArgs: [] };
+    }
+    return { passthroughArgs: ['--allowedTools', gate.allowedTools.join(',')] };
+  }
+
+  if (backend === 'gemini') {
+    if (shouldDisableBackendTools) {
+      return { passthroughArgs: ['--allowed-tools', ''] };
+    }
+    if (gate.mode === 'privileged') {
+      return { passthroughArgs: [] };
+    }
+    return { passthroughArgs: ['--allowed-tools', gate.allowedTools.join(',')] };
+  }
+
+  if (backend === 'codex' && (shouldDisableBackendTools || gate.mode === 'backend')) {
+    return {
+      passthroughArgs: [],
+      warning:
+        toolRouting === 'local'
+          ? 'Codex CLI has no allowlist passthrough flag; relying on sb local-tool routing prompt guard.'
+          : 'Codex CLI has no allowlist passthrough flag; backend tool gating is not enforced by CLI flags.',
+    };
+  }
+
+  return { passthroughArgs: [] };
+}
+
 interface DelegationState {
   token: string;
   payload: DelegationTokenPayload;
@@ -1559,6 +1605,15 @@ function buildPromptEnvelope(
     includeSources: true,
   });
 
+  const toolInstruction =
+    runtime.toolRouting === 'local'
+      ? 'Backend-native tool calling is disabled for this run. If you need PCP tool access, emit fenced blocks in this exact format: ```pcp-tool {"tool":"tool_name","args":{}} ``` and continue with your plain-text answer.'
+      : runtime.toolMode === 'off'
+        ? 'Do not call backend-native tools. Provide reasoning and instructions only.'
+        : runtime.toolMode === 'privileged'
+          ? 'Backend-native tools are enabled and external actions are allowed when needed.'
+          : '';
+
   return [
     `You are ${agentId}.`,
     'You are running inside sb chat (first-class PCP REPL).',
@@ -1566,15 +1621,7 @@ function buildPromptEnvelope(
     `Current backend: ${runtime.backend}${runtime.model ? ` (${runtime.model})` : ''}.`,
     `Tool mode: ${runtime.toolMode}.`,
     `Tool routing: ${runtime.toolRouting}.`,
-    runtime.toolMode === 'off'
-      ? 'Do not call backend-native tools. Provide reasoning and instructions only.'
-      : '',
-    runtime.toolMode === 'privileged'
-      ? 'Backend-native tools are enabled and external actions are allowed when needed.'
-      : '',
-    runtime.toolRouting === 'local'
-      ? 'Backend-native tool calling is disabled for this run. If you need PCP tool access, emit fenced blocks in this exact format: ```pcp-tool {"tool":"tool_name","args":{}} ``` and continue with your plain-text answer.'
-      : '',
+    toolInstruction,
     runtime.activeSkills.length > 0
       ? `Active skills: ${runtime.activeSkills.map((skill) => skill.name).join(', ')}`
       : '',
@@ -2396,14 +2443,12 @@ export async function runChat(options: ChatOptions): Promise<void> {
     const prompt = buildPromptEnvelope(agentId, runtime, ledger, raw);
     const turnStartedAt = Date.now();
     const backendGate = toolPolicy.getBackendToolGate();
-    const passthroughArgs =
-      runtime.toolRouting !== 'backend'
-        ? ['--allowedTools', '']
-        : backendGate.mode === 'off'
-          ? ['--allowedTools', '']
-          : backendGate.mode === 'privileged'
-            ? []
-            : ['--allowedTools', backendGate.allowedTools.join(',')];
+    const passthroughPlan = buildBackendToolPassthrough(
+      runtime.backend,
+      runtime.toolRouting,
+      backendGate
+    );
+    const passthroughArgs = passthroughPlan.passthroughArgs;
 
     if (runtime.toolRouting === 'backend' && backendGate.mode === 'backend' && runtime.verbose) {
       printLine(
@@ -2415,6 +2460,9 @@ export async function runChat(options: ChatOptions): Promise<void> {
           }`
         )
       );
+    }
+    if (passthroughPlan.warning && runtime.verbose) {
+      printLine(chalk.yellow(passthroughPlan.warning));
     }
 
     // Ink handles waiting via its own component; legacy uses animated indicator
@@ -2663,6 +2711,8 @@ export async function runChat(options: ChatOptions): Promise<void> {
     }
   };
 
+  let rl: ReturnType<typeof createInterface> | null = null;
+
   let turnQueue: Promise<void> = Promise.resolve();
   let pendingTurns = 0;
   let lastStatusSummary = '';
@@ -2766,7 +2816,6 @@ export async function runChat(options: ChatOptions): Promise<void> {
   // ── Mount the REPL input layer (Ink or legacy readline) ──
 
   let readlineClosed = false;
-  let rl: ReturnType<typeof createInterface> | null = null;
   let keepRunning = true;
   let lastUsageTotal: number | undefined;
   let lastCtrlCAt = 0;

--- a/packages/cli/src/lib/backend-auth.test.ts
+++ b/packages/cli/src/lib/backend-auth.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { parseClaudeAuthStatusOutput, parseCodexLoginStatusOutput } from './backend-auth.js';
+
+describe('backend auth parsing', () => {
+  it('parses claude logged in json', () => {
+    const parsed = parseClaudeAuthStatusOutput(
+      JSON.stringify({
+        loggedIn: true,
+        authMethod: 'oauthAccount',
+      })
+    );
+    expect(parsed.authenticated).toBe(true);
+    expect(parsed.detail).toContain('logged in');
+  });
+
+  it('parses claude logged out json', () => {
+    const parsed = parseClaudeAuthStatusOutput(
+      JSON.stringify({
+        loggedIn: false,
+        authMethod: 'none',
+      })
+    );
+    expect(parsed.authenticated).toBe(false);
+    expect(parsed.detail).toContain('not logged in');
+  });
+
+  it('parses codex logged in text output', () => {
+    const parsed = parseCodexLoginStatusOutput('Logged in using ChatGPT');
+    expect(parsed.authenticated).toBe(true);
+    expect(parsed.detail).toContain('Logged in');
+  });
+
+  it('parses codex logged out text output', () => {
+    const parsed = parseCodexLoginStatusOutput('Not logged in');
+    expect(parsed.authenticated).toBe(false);
+    expect(parsed.detail).toContain('Not logged in');
+  });
+});

--- a/packages/cli/src/lib/backend-auth.ts
+++ b/packages/cli/src/lib/backend-auth.ts
@@ -1,0 +1,252 @@
+import { spawn } from 'child_process';
+import { homedir } from 'os';
+import { join } from 'path';
+import { existsSync, readFileSync } from 'fs';
+
+export type BackendAuthBackend = 'claude' | 'codex' | 'gemini';
+
+export type BackendAuthStatus = {
+  backend: BackendAuthBackend;
+  authenticated: boolean;
+  detail: string;
+  loginCommand: string | null;
+  loginArgs: string[];
+  canInteractiveLogin: boolean;
+  credentialSource: string;
+};
+
+type CommandResult = {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  timedOut: boolean;
+};
+
+const AUTH_CHECK_TIMEOUT_MS = 5000;
+
+async function runCommand(
+  binary: string,
+  args: string[],
+  timeoutMs = AUTH_CHECK_TIMEOUT_MS
+): Promise<CommandResult> {
+  return await new Promise((resolve) => {
+    const child = spawn(binary, args, {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: process.env,
+    });
+
+    let stdout = '';
+    let stderr = '';
+    let done = false;
+    let timedOut = false;
+
+    child.stdout?.setEncoding('utf8');
+    child.stderr?.setEncoding('utf8');
+    child.stdout?.on('data', (chunk) => {
+      stdout += String(chunk);
+    });
+    child.stderr?.on('data', (chunk) => {
+      stderr += String(chunk);
+    });
+
+    const finish = (exitCode: number) => {
+      if (done) return;
+      done = true;
+      resolve({
+        exitCode,
+        stdout: stdout.trim(),
+        stderr: stderr.trim(),
+        timedOut,
+      });
+    };
+
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill('SIGTERM');
+      finish(124);
+    }, timeoutMs);
+    timer.unref();
+
+    child.on('error', (error) => {
+      clearTimeout(timer);
+      stderr = `${stderr}\n${String(error)}`.trim();
+      finish(1);
+    });
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      finish(code ?? 1);
+    });
+  });
+}
+
+export function parseClaudeAuthStatusOutput(output: string): {
+  authenticated: boolean;
+  detail: string;
+} {
+  try {
+    const parsed = JSON.parse(output) as { loggedIn?: unknown; authMethod?: unknown };
+    if (parsed.loggedIn === true) {
+      return {
+        authenticated: true,
+        detail:
+          typeof parsed.authMethod === 'string' && parsed.authMethod.trim()
+            ? `logged in (${parsed.authMethod})`
+            : 'logged in',
+      };
+    }
+    return { authenticated: false, detail: 'not logged in' };
+  } catch {
+    if (/logged\s*in/i.test(output)) {
+      return { authenticated: true, detail: 'logged in' };
+    }
+    return { authenticated: false, detail: output || 'unable to parse auth status' };
+  }
+}
+
+export function parseCodexLoginStatusOutput(output: string): {
+  authenticated: boolean;
+  detail: string;
+} {
+  const lines = output
+    .split(/\r?\n/g)
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  const notLoggedLine = lines.find((line) => /not\s+logged\s+in/i.test(line));
+  if (notLoggedLine) {
+    return {
+      authenticated: false,
+      detail: notLoggedLine,
+    };
+  }
+  const loggedLine = lines.find((line) => /logged in/i.test(line));
+  if (loggedLine) {
+    return { authenticated: true, detail: loggedLine };
+  }
+  return {
+    authenticated: false,
+    detail: lines[0] || 'not logged in',
+  };
+}
+
+function readGeminiAuthFile(now = Date.now()): { authenticated: boolean; detail: string } {
+  if (process.env.GEMINI_API_KEY || process.env.GOOGLE_API_KEY) {
+    return { authenticated: true, detail: 'using API key from environment' };
+  }
+  const credsPath = join(homedir(), '.gemini', 'oauth_creds.json');
+  if (!existsSync(credsPath)) {
+    return { authenticated: false, detail: 'oauth creds not found (~/.gemini/oauth_creds.json)' };
+  }
+  try {
+    const raw = JSON.parse(readFileSync(credsPath, 'utf8')) as {
+      access_token?: unknown;
+      expiry_date?: unknown;
+    };
+    if (typeof raw.access_token !== 'string' || !raw.access_token.trim()) {
+      return { authenticated: false, detail: 'oauth creds missing access token' };
+    }
+    if (typeof raw.expiry_date === 'number' && Number.isFinite(raw.expiry_date)) {
+      if (raw.expiry_date <= now) {
+        return { authenticated: false, detail: 'oauth creds expired' };
+      }
+      return { authenticated: true, detail: 'oauth creds available' };
+    }
+    return { authenticated: true, detail: 'oauth creds available' };
+  } catch {
+    return { authenticated: false, detail: 'oauth creds unreadable' };
+  }
+}
+
+export async function getBackendAuthStatus(
+  backend: BackendAuthBackend
+): Promise<BackendAuthStatus> {
+  switch (backend) {
+    case 'claude': {
+      const result = await runCommand('claude', ['auth', 'status']);
+      if (result.timedOut) {
+        return {
+          backend,
+          authenticated: false,
+          detail: 'auth status check timed out',
+          loginCommand: 'claude auth login',
+          loginArgs: ['auth', 'login'],
+          canInteractiveLogin: true,
+          credentialSource:
+            'Claude CLI auth store (keychain and/or ~/.claude/.credentials.json) via `claude auth status`',
+        };
+      }
+      const parsed = parseClaudeAuthStatusOutput(result.stdout || result.stderr);
+      return {
+        backend,
+        authenticated: result.exitCode === 0 && parsed.authenticated,
+        detail: parsed.detail,
+        loginCommand: 'claude auth login',
+        loginArgs: ['auth', 'login'],
+        canInteractiveLogin: true,
+        credentialSource:
+          'Claude CLI auth store (keychain and/or ~/.claude/.credentials.json) via `claude auth status`',
+      };
+    }
+    case 'codex': {
+      const result = await runCommand('codex', ['login', 'status']);
+      if (result.timedOut) {
+        return {
+          backend,
+          authenticated: false,
+          detail: 'login status check timed out',
+          loginCommand: 'codex login',
+          loginArgs: ['login'],
+          canInteractiveLogin: true,
+          credentialSource: '~/.codex/auth.json and/or keychain via `codex login status`',
+        };
+      }
+      const parsed = parseCodexLoginStatusOutput(result.stdout || result.stderr);
+      return {
+        backend,
+        authenticated: result.exitCode === 0 && parsed.authenticated,
+        detail: parsed.detail,
+        loginCommand: 'codex login',
+        loginArgs: ['login'],
+        canInteractiveLogin: true,
+        credentialSource: '~/.codex/auth.json and/or keychain via `codex login status`',
+      };
+    }
+    case 'gemini': {
+      const parsed = readGeminiAuthFile();
+      return {
+        backend,
+        authenticated: parsed.authenticated,
+        detail: parsed.detail,
+        loginCommand: null,
+        loginArgs: [],
+        canInteractiveLogin: false,
+        credentialSource: '~/.gemini/oauth_creds.json or GEMINI_API_KEY/GOOGLE_API_KEY',
+      };
+    }
+    default: {
+      return {
+        backend,
+        authenticated: true,
+        detail: 'auth check not required',
+        loginCommand: null,
+        loginArgs: [],
+        canInteractiveLogin: false,
+        credentialSource: 'n/a',
+      };
+    }
+  }
+}
+
+export async function runBackendInteractiveLogin(backend: BackendAuthBackend): Promise<number> {
+  const status = await getBackendAuthStatus(backend);
+  if (!status.loginArgs.length) return 1;
+
+  return await new Promise((resolve) => {
+    const child = spawn(backend, status.loginArgs, {
+      stdio: 'inherit',
+      env: process.env,
+    });
+    child.on('error', () => resolve(1));
+    child.on('close', (code) => resolve(code ?? 1));
+  });
+}

--- a/packages/cli/src/repl/backend-runner.test.ts
+++ b/packages/cli/src/repl/backend-runner.test.ts
@@ -1,0 +1,96 @@
+import { EventEmitter } from 'events';
+import { describe, expect, it, vi } from 'vitest';
+
+const state = vi.hoisted(() => ({
+  prepareCalls: [] as Array<{ backend: string; promptParts: string[] }>,
+}));
+
+const spawnMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../backends/index.js', () => ({
+  getBackend: (backend: string) => ({
+    name: backend,
+    binary: 'mock-backend',
+    prepare: (config: { promptParts: string[] }) => {
+      state.prepareCalls.push({ backend, promptParts: [...config.promptParts] });
+      return {
+        binary: 'mock-backend',
+        args: [...config.promptParts],
+        env: {},
+        cleanup: () => undefined,
+      };
+    },
+  }),
+}));
+
+vi.mock('child_process', () => ({
+  spawn: spawnMock,
+}));
+
+import { runBackendTurn } from './backend-runner.js';
+
+function createMockChild(exitCode = 0): EventEmitter & {
+  stdout: EventEmitter & { setEncoding: (encoding: string) => void };
+  stderr: EventEmitter & { setEncoding: (encoding: string) => void };
+} {
+  const stdout = new EventEmitter() as EventEmitter & {
+    setEncoding: (encoding: string) => void;
+  };
+  stdout.setEncoding = () => undefined;
+
+  const stderr = new EventEmitter() as EventEmitter & {
+    setEncoding: (encoding: string) => void;
+  };
+  stderr.setEncoding = () => undefined;
+
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter & { setEncoding: (encoding: string) => void };
+    stderr: EventEmitter & { setEncoding: (encoding: string) => void };
+  };
+  child.stdout = stdout;
+  child.stderr = stderr;
+
+  queueMicrotask(() => {
+    child.emit('close', exitCode);
+  });
+
+  return child;
+}
+
+describe('runBackendTurn', () => {
+  it('uses codex exec mode for non-interactive turns', async () => {
+    state.prepareCalls = [];
+    spawnMock.mockImplementation(() => createMockChild(0));
+
+    await runBackendTurn({
+      backend: 'codex',
+      agentId: 'lumen',
+      prompt: 'ping',
+    });
+
+    expect(state.prepareCalls[0]).toEqual({ backend: 'codex', promptParts: ['exec', 'ping'] });
+    expect(spawnMock).toHaveBeenCalledWith(
+      'mock-backend',
+      ['exec', 'ping'],
+      expect.objectContaining({ stdio: ['ignore', 'pipe', 'pipe'] })
+    );
+  });
+
+  it('keeps existing one-shot prompt flow for non-codex backends', async () => {
+    state.prepareCalls = [];
+    spawnMock.mockImplementation(() => createMockChild(0));
+
+    await runBackendTurn({
+      backend: 'claude',
+      agentId: 'wren',
+      prompt: 'ping',
+    });
+
+    expect(state.prepareCalls[0]).toEqual({ backend: 'claude', promptParts: ['ping'] });
+    expect(spawnMock).toHaveBeenCalledWith(
+      'mock-backend',
+      ['ping'],
+      expect.objectContaining({ stdio: ['ignore', 'pipe', 'pipe'] })
+    );
+  });
+});

--- a/packages/cli/src/repl/backend-runner.ts
+++ b/packages/cli/src/repl/backend-runner.ts
@@ -24,11 +24,14 @@ export interface BackendRunResult {
 
 export async function runBackendTurn(request: BackendRunRequest): Promise<BackendRunResult> {
   const adapter = getBackend(request.backend);
+  // Codex requires `exec` for one-shot/non-interactive turns.
+  // Plain `codex <prompt>` enters interactive mode and can fail in non-TTY flows.
+  const promptParts = request.backend === 'codex' ? ['exec', request.prompt] : [request.prompt];
   const prepared = adapter.prepare({
     agentId: request.agentId,
     model: request.model,
     prompt: request.prompt,
-    promptParts: [request.prompt],
+    promptParts,
     passthroughArgs: request.passthroughArgs || [],
   });
 


### PR DESCRIPTION
## Product objective
Ensure `sb chat` is the single tool-policy authority when used as the backend runtime wrapper, so SBs can call approved tools reliably and consistently across backends.

Concretely:
- approved tools should execute through sb's policy pipeline
- blocked/unapproved tools should be denied by sb policy (not backend-native policy)
- behavior should be predictable across Claude, Codex, and Gemini despite CLI differences

## Summary
- fix sb chat non-interactive local-tool flow crashing with rl TDZ
- backend-aware passthrough:
  - Claude uses `--allowedTools`
  - Gemini uses `--allowed-tools`
  - Codex skips unsupported allowlist flags
- add `--sb-strict-tools` hardening mode for Codex local routing:
  - `--sandbox read-only`
  - `--ask-for-approval never`
  - `--config mcp_servers={}`
- local routing instruction now takes precedence (no contradictory privileged+local text)
- add integration tests proving local sb runtime tool execution path for Claude, Gemini, and Codex
- add optional local live smoke harness (`yarn workspace @personal-context/cli test:smoke:live`) documented in `packages/cli/TESTS.md` (not CI)

## Validation
- npx vitest run --config vitest.config.ts src/commands/chat.integration.test.ts (packages/cli)
- yarn workspace @personal-context/cli type-check
- yarn workspace @personal-context/cli test