### PR TITLE
feat: save_team_constitution / get_team_constitution MCP tools (by Wren)

### DIFF
--- a/packages/api/src/mcp/tools/index.ts
+++ b/packages/api/src/mcp/tools/index.ts
@@ -110,6 +110,13 @@ import {
 } from './user-identity-handlers';
 
 import {
+  handleSaveTeamConstitution,
+  handleGetTeamConstitution,
+  saveTeamConstitutionSchema,
+  getTeamConstitutionSchema,
+} from './team-constitution-handlers';
+
+import {
   handleCreateReminder,
   handleListReminders,
   handleUpdateReminder,
@@ -2577,9 +2584,9 @@ User can be identified by ONE of: userId, email, phone, or platform + platformId
     {
       description: `Save or update shared user-level documents. These are shared across all agents for a user.
 
-- userProfile: About-you document content (legacy alias: userProfileMd)
-- sharedValues: Shared values document content (legacy alias: sharedValuesMd)
-- process: Shared collaboration process document content (legacy alias: processMd)
+- userProfile: USER.md — about the organic human (background, preferences, relationship). This is the primary use of this tool.
+- sharedValues: [Prefer save_team_constitution] VALUES.md — shared principles (legacy path, still works)
+- process: [Prefer save_team_constitution] PROCESS.md — team operational process (legacy path, still works)
 
 User can be identified by ONE of: userId, email, phone, or platform + platformId`,
       inputSchema: saveUserIdentitySchema,
@@ -2608,7 +2615,7 @@ User can be identified by ONE of: userId, email, phone, or platform + platformId
   server.registerTool(
     'get_user_identity',
     {
-      description: `Get shared user-level documents (about-you, shared values, process).
+      description: `Get shared user-level documents. Returns USER.md (about the organic human), plus VALUES.md and PROCESS.md (prefer get_team_constitution for those).
 
 User can be identified by ONE of: userId, email, phone, or platform + platformId`,
       inputSchema: getUserIdentitySchema,
@@ -2676,6 +2683,76 @@ User can be identified by ONE of: userId, email, phone, or platform + platformId
         return await handleRestoreUserIdentity(args, dataComposer);
       } catch (error) {
         logger.error('Error in restore_user_identity:', error);
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                success: false,
+                error: error instanceof Error ? error.message : 'Unknown error',
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // =====================================================
+  // TEAM CONSTITUTION TOOLS (workspace-level VALUES.md, PROCESS.md)
+  // =====================================================
+
+  server.registerTool(
+    'save_team_constitution',
+    {
+      description: `Update team constitution documents. These are workspace-level shared documents that affect ALL SBs.
+
+- sharedValues: VALUES.md — shared principles, core truths, boundaries, identity philosophy
+- process: PROCESS.md — team operational process (sessions, memory, handoff, PR conventions)
+
+⚠️ CONSTITUTION-LEVEL: Changes are versioned and affect every SB's bootstrap context.
+Prefer this over save_user_identity for values/process updates.
+
+User can be identified by ONE of: userId, email, phone, or platform + platformId`,
+      inputSchema: saveTeamConstitutionSchema,
+    },
+    async (args) => {
+      try {
+        return await handleSaveTeamConstitution(args, dataComposer);
+      } catch (error) {
+        logger.error('Error in save_team_constitution:', error);
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                success: false,
+                error: error instanceof Error ? error.message : 'Unknown error',
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  server.registerTool(
+    'get_team_constitution',
+    {
+      description: `Get team constitution documents (VALUES.md, PROCESS.md) from workspace storage.
+
+Returns the canonical workspace-level versions. Falls back to user_identity if workspace columns are empty.
+
+User can be identified by ONE of: userId, email, phone, or platform + platformId`,
+      inputSchema: getTeamConstitutionSchema,
+    },
+    async (args) => {
+      try {
+        return await handleGetTeamConstitution(args, dataComposer);
+      } catch (error) {
+        logger.error('Error in get_team_constitution:', error);
         return {
           content: [
             {

--- a/packages/api/src/mcp/tools/team-constitution-handlers.ts
+++ b/packages/api/src/mcp/tools/team-constitution-handlers.ts
@@ -153,18 +153,13 @@ export async function handleSaveTeamConstitution(args: unknown, dataComposer: Da
   if (existing) {
     await supabase.from('user_identity').update(identityUpdate).eq('id', existing.id);
   } else {
-    // No workspace-scoped user_identity row yet — try global
-    const { data: global } = await supabase
-      .from('user_identity')
-      .select('id')
-      .eq('user_id', user.id)
-      .is('workspace_id', null)
-      .single();
-
-    if (global) {
-      await supabase.from('user_identity').update(identityUpdate).eq('id', global.id);
-    }
-    // If no user_identity exists at all, skip — workspace is canonical
+    // No workspace-scoped row — insert one for history tracking
+    await supabase.from('user_identity').insert({
+      user_id: user.id,
+      workspace_id: workspaceId,
+      shared_values_md: params.sharedValues || null,
+      process_md: params.process || null,
+    });
   }
 
   const updated: string[] = [];

--- a/packages/api/src/mcp/tools/team-constitution-handlers.ts
+++ b/packages/api/src/mcp/tools/team-constitution-handlers.ts
@@ -1,0 +1,263 @@
+/**
+ * Team Constitution MCP Tool Handlers
+ *
+ * Tools for managing workspace-level shared documents (VALUES.md, PROCESS.md)
+ * that define the team's core principles and operational process.
+ *
+ * These are "constitution-level" documents — changes affect all SBs in the workspace.
+ * The canonical storage is `workspaces.shared_values` and `workspaces.process`.
+ *
+ * History is tracked via the `user_identity` table (which is also updated for
+ * backwards compatibility) and its `user_identity_history` trigger.
+ */
+
+import { z } from 'zod';
+import type { DataComposer } from '../../data/composer';
+import { logger } from '../../utils/logger';
+import { resolveUserOrThrow } from '../../services/user-resolver';
+
+const userIdentifierFields = {
+  userId: z
+    .string()
+    .uuid()
+    .optional()
+    .describe('User UUID — usually unnecessary, auto-resolved from OAuth token'),
+  email: z
+    .string()
+    .email()
+    .optional()
+    .describe('User email — usually unnecessary, auto-resolved from OAuth token'),
+  phone: z.string().optional().describe('Phone number in E.164 format (e.g., +14155551234)'),
+  platformId: z
+    .string()
+    .optional()
+    .describe('Platform-specific user ID — only needed for platform-based user lookup'),
+  platform: z
+    .enum(['telegram', 'whatsapp', 'discord'])
+    .optional()
+    .describe('Platform name — only needed for platform-based user lookup'),
+  workspaceId: z
+    .string()
+    .uuid()
+    .optional()
+    .describe('Workspace to update. Defaults to personal workspace if omitted.'),
+};
+
+// =====================================================
+// SCHEMAS
+// =====================================================
+
+export const saveTeamConstitutionSchema = z.object({
+  ...userIdentifierFields,
+  sharedValues: z
+    .string()
+    .optional()
+    .describe(
+      'VALUES.md — shared principles and core truths for all SBs. Changes affect the entire team.'
+    ),
+  process: z
+    .string()
+    .optional()
+    .describe(
+      'PROCESS.md — team operational process (sessions, memory, handoff, PR conventions). Changes affect the entire team.'
+    ),
+});
+
+export const getTeamConstitutionSchema = z.object({
+  ...userIdentifierFields,
+});
+
+// =====================================================
+// HELPERS
+// =====================================================
+
+async function resolveWorkspaceId(
+  supabase: ReturnType<DataComposer['getClient']>,
+  userId: string,
+  workspaceId?: string
+): Promise<string> {
+  if (workspaceId) return workspaceId;
+
+  // Fall back to personal workspace
+  const { data, error } = await supabase
+    .from('workspaces')
+    .select('id')
+    .eq('user_id', userId)
+    .eq('slug', 'personal')
+    .is('archived_at', null)
+    .single();
+
+  if (error || !data) {
+    throw new Error('No workspace specified and no personal workspace found');
+  }
+
+  return data.id;
+}
+
+// =====================================================
+// HANDLERS
+// =====================================================
+
+/**
+ * Save or update team constitution documents (VALUES.md, PROCESS.md).
+ * Writes to workspace-level storage (canonical) and syncs to user_identity for history.
+ */
+export async function handleSaveTeamConstitution(args: unknown, dataComposer: DataComposer) {
+  const params = saveTeamConstitutionSchema.parse(args);
+  const { user, resolvedBy } = await resolveUserOrThrow(params, dataComposer);
+
+  const supabase = dataComposer.getClient();
+  const workspaceId = await resolveWorkspaceId(supabase, user.id, params.workspaceId);
+
+  if (params.sharedValues === undefined && params.process === undefined) {
+    throw new Error('At least one of sharedValues or process must be provided');
+  }
+
+  // 1. Update workspace (canonical storage)
+  const workspaceUpdate: Record<string, unknown> = {};
+  if (params.sharedValues !== undefined) {
+    workspaceUpdate.shared_values = params.sharedValues;
+  }
+  if (params.process !== undefined) {
+    workspaceUpdate.process = params.process;
+  }
+
+  const { data: workspace, error: wsError } = await supabase
+    .from('workspaces')
+    .update(workspaceUpdate)
+    .eq('id', workspaceId)
+    .eq('user_id', user.id)
+    .select('id, shared_values, process, updated_at')
+    .single();
+
+  if (wsError) {
+    throw new Error(`Failed to update workspace constitution: ${wsError.message}`);
+  }
+
+  // 2. Sync to user_identity for history tracking
+  const identityUpdate: Record<string, unknown> = {};
+  if (params.sharedValues !== undefined) {
+    identityUpdate.shared_values_md = params.sharedValues;
+  }
+  if (params.process !== undefined) {
+    identityUpdate.process_md = params.process;
+  }
+
+  const { data: existing } = await supabase
+    .from('user_identity')
+    .select('id')
+    .eq('user_id', user.id)
+    .eq('workspace_id', workspaceId)
+    .single();
+
+  if (existing) {
+    await supabase.from('user_identity').update(identityUpdate).eq('id', existing.id);
+  } else {
+    // No workspace-scoped user_identity row yet — try global
+    const { data: global } = await supabase
+      .from('user_identity')
+      .select('id')
+      .eq('user_id', user.id)
+      .is('workspace_id', null)
+      .single();
+
+    if (global) {
+      await supabase.from('user_identity').update(identityUpdate).eq('id', global.id);
+    }
+    // If no user_identity exists at all, skip — workspace is canonical
+  }
+
+  const updated: string[] = [];
+  if (params.sharedValues !== undefined) updated.push('VALUES.md');
+  if (params.process !== undefined) updated.push('PROCESS.md');
+
+  logger.info(`Team constitution updated for workspace ${workspaceId}`, {
+    updated,
+    userId: user.id,
+  });
+
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: JSON.stringify(
+          {
+            success: true,
+            message: `Team constitution updated: ${updated.join(', ')}`,
+            user: { id: user.id, resolvedBy },
+            workspace: {
+              id: workspaceId,
+              hasSharedValues: !!workspace.shared_values,
+              hasProcess: !!workspace.process,
+              updatedAt: workspace.updated_at,
+            },
+          },
+          null,
+          2
+        ),
+      },
+    ],
+  };
+}
+
+/**
+ * Get team constitution documents (VALUES.md, PROCESS.md) from workspace storage.
+ */
+export async function handleGetTeamConstitution(args: unknown, dataComposer: DataComposer) {
+  const params = getTeamConstitutionSchema.parse(args);
+  const { user, resolvedBy } = await resolveUserOrThrow(params, dataComposer);
+
+  const supabase = dataComposer.getClient();
+  const workspaceId = await resolveWorkspaceId(supabase, user.id, params.workspaceId);
+
+  const { data: workspace, error } = await supabase
+    .from('workspaces')
+    .select('id, shared_values, process, updated_at')
+    .eq('id', workspaceId)
+    .eq('user_id', user.id)
+    .single();
+
+  if (error && error.code !== 'PGRST116') {
+    throw new Error(`Failed to get workspace constitution: ${error.message}`);
+  }
+
+  // Fall back to user_identity if workspace columns are empty
+  let sharedValues = workspace?.shared_values as string | null;
+  let process = workspace?.process as string | null;
+
+  if (!sharedValues || !process) {
+    const { data: identity } = await supabase
+      .from('user_identity')
+      .select('shared_values_md, process_md')
+      .eq('user_id', user.id)
+      .eq('workspace_id', workspaceId)
+      .single();
+
+    if (identity) {
+      if (!sharedValues) sharedValues = identity.shared_values_md;
+      if (!process) process = identity.process_md;
+    }
+  }
+
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: JSON.stringify(
+          {
+            success: true,
+            user: { id: user.id, resolvedBy },
+            workspace: { id: workspaceId },
+            constitution: {
+              sharedValues,
+              process,
+              updatedAt: workspace?.updated_at || null,
+            },
+          },
+          null,
+          2
+        ),
+      },
+    ],
+  };
+}

--- a/supabase/migrations/20260308051251_backfill_workspace_constitution.sql
+++ b/supabase/migrations/20260308051251_backfill_workspace_constitution.sql
@@ -1,0 +1,56 @@
+-- Backfill workspace constitution (shared_values, process) from user_identity
+--
+-- Copies data from user_identity to workspaces when:
+--   1. The workspace columns are NULL (never populated), OR
+--   2. The user_identity record is newer than the workspace record
+--
+-- This ensures that any edits made via the old save_user_identity path
+-- (which wrote to user_identity first) are promoted to the canonical
+-- workspace-level storage.
+
+-- Case 1: workspace fields are NULL but user_identity has content
+UPDATE public.workspaces w
+SET
+  shared_values = COALESCE(w.shared_values, ui.shared_values_md),
+  process = COALESCE(w.process, ui.process_md)
+FROM public.user_identity ui
+WHERE ui.workspace_id = w.id
+  AND (
+    (w.shared_values IS NULL AND ui.shared_values_md IS NOT NULL)
+    OR (w.process IS NULL AND ui.process_md IS NOT NULL)
+  );
+
+-- Case 2: user_identity was updated more recently than the workspace
+-- (someone used save_user_identity without workspaceId, or the sync
+-- to workspaces failed/wasn't wired up at the time)
+UPDATE public.workspaces w
+SET
+  shared_values = CASE
+    WHEN ui.shared_values_md IS NOT NULL AND ui.updated_at > w.updated_at
+    THEN ui.shared_values_md
+    ELSE w.shared_values
+  END,
+  process = CASE
+    WHEN ui.process_md IS NOT NULL AND ui.updated_at > w.updated_at
+    THEN ui.process_md
+    ELSE w.process
+  END
+FROM public.user_identity ui
+WHERE ui.workspace_id = w.id
+  AND ui.updated_at > w.updated_at
+  AND (ui.shared_values_md IS NOT NULL OR ui.process_md IS NOT NULL);
+
+-- Also handle user_identity records with NULL workspace_id:
+-- These are legacy global records. Match them to the user's personal workspace.
+UPDATE public.workspaces w
+SET
+  shared_values = COALESCE(w.shared_values, ui.shared_values_md),
+  process = COALESCE(w.process, ui.process_md)
+FROM public.user_identity ui
+WHERE ui.workspace_id IS NULL
+  AND ui.user_id = w.user_id
+  AND w.slug = 'personal'
+  AND (
+    (w.shared_values IS NULL AND ui.shared_values_md IS NOT NULL)
+    OR (w.process IS NULL AND ui.process_md IS NOT NULL)
+  );


### PR DESCRIPTION
## Summary

- **New MCP tools**: `save_team_constitution` and `get_team_constitution` for managing VALUES.md and PROCESS.md at the workspace level
- **Clearer separation**: constitution docs (shared values, process) are workspace-scoped team documents; `save_user_identity` is now clearly focused on USER.md (about the organic human)
- **Migration**: backfills workspace `shared_values`/`process` columns from `user_identity` when workspace fields are NULL or stale (handles legacy writes + NULL workspace_id records → personal workspace)
- **Updated tool descriptions**: `save_user_identity` and `get_user_identity` now note that values/process are legacy paths and point to the new tools

### Why

The old `save_user_identity` conflated two different concerns: "save things about Conor" (USER.md) and "save team constitution" (VALUES.md, PROCESS.md). The naming made it unclear which tool modifies which constitution file, and the workspace-level storage wasn't the primary write path. This caused SBs (including me) to edit local `~/.pcp/` files instead of the canonical DB records.

### Tool surface

| Tool | Purpose | Storage |
|------|---------|---------|
| `save_team_constitution` | Update VALUES.md, PROCESS.md | `workspaces.shared_values`, `workspaces.process` (canonical) |
| `get_team_constitution` | Read VALUES.md, PROCESS.md | Workspace with user_identity fallback |
| `save_user_identity` | Update USER.md (about the organic) | `user_identity.user_profile_md` |
| `get_user_identity` | Read USER.md | Same, still returns values/process for compat |

## Test plan

- [ ] Verify `save_team_constitution` writes to workspace and syncs to user_identity
- [ ] Verify `get_team_constitution` reads workspace-level docs, falls back to user_identity
- [ ] Verify migration backfills correctly (NULL workspace fields, stale timestamps, NULL workspace_id legacy rows)
- [ ] Verify `save_user_identity` still works for all three fields (backwards compat)
- [ ] Verify bootstrap serves the updated values from workspace-level storage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Wren