### PR TITLE
feat: per-document artifact permissions editor UX (by lumen)

### DIFF
--- a/packages/api/src/data/supabase/types.ts
+++ b/packages/api/src/data/supabase/types.ts
@@ -618,6 +618,7 @@ export type Database = {
           content_type: string | null;
           created_at: string | null;
           created_by_identity_id: string | null;
+          edit_mode: string;
           id: string;
           metadata: Json | null;
           tags: string[] | null;
@@ -636,6 +637,7 @@ export type Database = {
           content_type?: string | null;
           created_at?: string | null;
           created_by_identity_id?: string | null;
+          edit_mode?: string;
           id?: string;
           metadata?: Json | null;
           tags?: string[] | null;
@@ -654,6 +656,7 @@ export type Database = {
           content_type?: string | null;
           created_at?: string | null;
           created_by_identity_id?: string | null;
+          edit_mode?: string;
           id?: string;
           metadata?: Json | null;
           tags?: string[] | null;

--- a/packages/api/src/mcp/tools/artifact-handlers.test.ts
+++ b/packages/api/src/mcp/tools/artifact-handlers.test.ts
@@ -396,6 +396,101 @@ describe('handleUpdateArtifact', () => {
   });
 
   describe('non-content updates', () => {
+    it('allows workspace-scoped edits even when agent is not in explicit editors list', async () => {
+      const { supabase } = createMockSupabase({
+        artifact: {
+          id: 'artifact-1',
+          uri: 'pcp://test/doc',
+          title: 'Test Doc',
+          content: 'Original content',
+          version: 3,
+          metadata: {},
+          edit_mode: 'workspace',
+          collaborators: ['wren'],
+          created_by_identity_id: null,
+          created_at: '2026-01-01',
+          updated_at: '2026-01-01',
+        },
+      });
+      const dataComposer = createMockDataComposer(supabase);
+
+      const result = await handleUpdateArtifact(
+        {
+          userId: '00000000-0000-0000-0000-000000000001',
+          uri: 'pcp://test/doc',
+          content: 'Updated by another workspace agent',
+          agentId: 'myra',
+        },
+        dataComposer
+      );
+
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.success).toBe(true);
+    });
+
+    it('rejects edits when editMode is editors and agent is not listed', async () => {
+      const { supabase } = createMockSupabase({
+        artifact: {
+          id: 'artifact-1',
+          uri: 'pcp://test/doc',
+          title: 'Test Doc',
+          content: 'Original content',
+          version: 3,
+          metadata: {},
+          edit_mode: 'editors',
+          collaborators: ['wren'],
+          created_by_identity_id: null,
+          created_at: '2026-01-01',
+          updated_at: '2026-01-01',
+        },
+      });
+      const dataComposer = createMockDataComposer(supabase);
+
+      await expect(
+        handleUpdateArtifact(
+          {
+            userId: '00000000-0000-0000-0000-000000000001',
+            uri: 'pcp://test/doc',
+            content: 'Unauthorized edit',
+            agentId: 'myra',
+          },
+          dataComposer
+        )
+      ).rejects.toThrow('Agent myra does not have permission to edit this artifact');
+    });
+
+    it('rejects editMode=editors updates without at least one editor', async () => {
+      const { supabase } = createMockSupabase({
+        artifact: {
+          id: 'artifact-1',
+          uri: 'pcp://test/doc',
+          title: 'Test Doc',
+          content: 'Original content',
+          version: 3,
+          metadata: {},
+          edit_mode: 'workspace',
+          collaborators: [],
+          created_by_identity_id: null,
+          created_at: '2026-01-01',
+          updated_at: '2026-01-01',
+        },
+      });
+      const dataComposer = createMockDataComposer(supabase);
+
+      await expect(
+        handleUpdateArtifact(
+          {
+            userId: '00000000-0000-0000-0000-000000000001',
+            uri: 'pcp://test/doc',
+            editMode: 'editors',
+            editors: [],
+            agentId: 'wren',
+          },
+          dataComposer
+        )
+      ).rejects.toThrow('editMode "editors" requires at least one editor agent ID');
+    });
+
     it('should not trigger merge for metadata-only updates even with baseVersion', async () => {
       const { supabase } = createMockSupabase({
         artifact: {
@@ -668,6 +763,35 @@ describe('artifact comment + identity UUID flows', () => {
     ).toMatchObject({
       changed_by_identity_id: 'identity-1',
     });
+  });
+
+  it('handleCreateArtifact rejects editMode=editors when no editors are provided', async () => {
+    const supabase = createTableAwareSupabaseMock({
+      agent_identities: [
+        {
+          then: {
+            data: [{ workspace_id: '11111111-1111-1111-1111-111111111111' }],
+            error: null,
+          },
+        },
+      ],
+    });
+
+    await expect(
+      handleCreateArtifact(
+        {
+          userId: '00000000-0000-0000-0000-000000000001',
+          uri: 'pcp://specs/no-editors',
+          title: 'No editors',
+          content: '# Hello',
+          artifactType: 'spec',
+          agentId: 'lumen',
+          editMode: 'editors',
+          editors: [],
+        },
+        createMockDataComposer(supabase)
+      )
+    ).rejects.toThrow('editMode "editors" requires at least one editor agent ID');
   });
 
   it('handleCreateArtifact keeps slug behavior when identity row is missing', async () => {

--- a/packages/api/src/mcp/tools/artifact-handlers.test.ts
+++ b/packages/api/src/mcp/tools/artifact-handlers.test.ts
@@ -488,7 +488,40 @@ describe('handleUpdateArtifact', () => {
           },
           dataComposer
         )
-      ).rejects.toThrow('editMode "editors" requires at least one editor agent ID');
+      ).rejects.toThrow('editMode "editors" requires at least one editor');
+    });
+
+    it('preserves existing editor list when switching to workspace mode', async () => {
+      const { supabase, updatedArtifact } = createMockSupabase({
+        artifact: {
+          id: 'artifact-1',
+          uri: 'pcp://test/doc',
+          title: 'Test Doc',
+          content: 'Original content',
+          version: 3,
+          metadata: {},
+          edit_mode: 'editors',
+          collaborators: ['identity-wren', 'identity-lumen'],
+          created_by_identity_id: null,
+          created_at: '2026-01-01',
+          updated_at: '2026-01-01',
+        },
+      });
+      const dataComposer = createMockDataComposer(supabase);
+
+      const result = await handleUpdateArtifact(
+        {
+          userId: '00000000-0000-0000-0000-000000000001',
+          uri: 'pcp://test/doc',
+          editMode: 'workspace',
+          agentId: 'identity-wren',
+        },
+        dataComposer
+      );
+
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.success).toBe(true);
+      expect(updatedArtifact.collaborators).toEqual(['identity-wren', 'identity-lumen']);
     });
 
     it('should not trigger merge for metadata-only updates even with baseVersion', async () => {
@@ -791,7 +824,7 @@ describe('artifact comment + identity UUID flows', () => {
         },
         createMockDataComposer(supabase)
       )
-    ).rejects.toThrow('editMode "editors" requires at least one editor agent ID');
+    ).rejects.toThrow('editMode "editors" requires at least one editor');
   });
 
   it('handleCreateArtifact keeps slug behavior when identity row is missing', async () => {

--- a/packages/api/src/mcp/tools/artifact-handlers.ts
+++ b/packages/api/src/mcp/tools/artifact-handlers.ts
@@ -36,6 +36,12 @@ const createArtifactSchema = workspaceScopedUserIdentifierSchema.extend({
     .default('document')
     .describe('Type of artifact'),
   agentId: z.string().optional().describe('Agent creating this artifact'),
+  editMode: z
+    .enum(['workspace', 'editors'])
+    .optional()
+    .default('workspace')
+    .describe('Edit permission mode: workspace (all workspace agents) or editors list only'),
+  editors: z.array(z.string()).optional().describe('Editor agent IDs when editMode is editors'),
   collaborators: z.array(z.string()).optional().describe('Agent IDs who can edit'),
   visibility: z
     .enum(['private', 'shared', 'public'])
@@ -76,6 +82,8 @@ const updateArtifactSchema = workspaceScopedUserIdentifierSchema.extend({
       'Version this edit is based on. When provided, enables three-way merge: if the artifact has been modified since this version, the server will attempt to merge changes automatically. Omit for legacy last-write-wins behavior.'
     ),
   agentId: z.string().optional().describe('Agent making the update'),
+  editMode: z.enum(['workspace', 'editors']).optional().describe('Updated edit permission mode'),
+  editors: z.array(z.string()).optional().describe('Updated editor agent IDs'),
   collaborators: z.array(z.string()).optional().describe('Updated collaborator list'),
   tags: z.array(z.string()).optional().describe('Updated tags'),
   changeSummary: z.string().optional().describe('Summary of changes'),
@@ -131,6 +139,19 @@ function parseWithContext<T extends z.ZodTypeAny>(schema: T, args: unknown): z.i
 function toArgsRecord(args: unknown): Record<string, unknown> {
   if (!args || typeof args !== 'object') return {};
   return args as Record<string, unknown>;
+}
+
+type ArtifactEditMode = 'workspace' | 'editors';
+
+function normalizeEditMode(value: string | null | undefined): ArtifactEditMode {
+  return value === 'editors' ? 'editors' : 'workspace';
+}
+
+function normalizeEditorAgentIds(values: string[] | undefined): string[] {
+  if (!values) return [];
+  return Array.from(
+    new Set(values.map((value) => value.trim()).filter((value) => value.length > 0))
+  );
 }
 
 async function deriveWorkspaceIdFromAgent(
@@ -267,12 +288,19 @@ export async function handleCreateArtifact(args: unknown, dataComposer: DataComp
     title,
     content,
     artifactType = 'document',
-    collaborators = [],
+    editMode = 'workspace',
+    editors,
+    collaborators,
     visibility = 'private',
     tags = [],
     metadata = {},
     workspaceId,
   } = parsed;
+  const normalizedEditors = normalizeEditorAgentIds(editors ?? collaborators);
+  if (editMode === 'editors' && normalizedEditors.length === 0) {
+    throw new Error('editMode "editors" requires at least one editor agent ID');
+  }
+  const effectiveEditors = editMode === 'editors' ? normalizedEditors : [];
   const agentId = getEffectiveAgentId(parsed.agentId);
   const workspaceResolution = await resolveWorkspaceScopeForWrite({
     rawArgs,
@@ -317,7 +345,8 @@ export async function handleCreateArtifact(args: unknown, dataComposer: DataComp
       title,
       content,
       artifact_type: artifactType,
-      collaborators,
+      collaborators: effectiveEditors,
+      edit_mode: editMode,
       visibility,
       tags,
       metadata: metadata as Json,
@@ -358,6 +387,8 @@ export async function handleCreateArtifact(args: unknown, dataComposer: DataComp
             uri: artifact.uri,
             title: artifact.title,
             artifactType: artifact.artifact_type,
+            editMode: normalizeEditMode(artifact.edit_mode),
+            editors: artifact.collaborators || [],
             version: artifact.version,
             createdAt: artifact.created_at,
           },
@@ -533,6 +564,8 @@ export async function handleGetArtifact(args: unknown, dataComposer: DataCompose
             artifactType: artifact.artifact_type,
             createdByIdentityId: artifact.created_by_identity_id,
             collaborators: artifact.collaborators,
+            editMode: normalizeEditMode(artifact.edit_mode),
+            editors: artifact.collaborators || [],
             visibility: artifact.visibility,
             version: artifact.version,
             tags: artifact.tags,
@@ -559,6 +592,8 @@ export async function handleUpdateArtifact(args: unknown, dataComposer: DataComp
     title,
     content,
     baseVersion,
+    editMode,
+    editors,
     collaborators,
     tags,
     changeSummary,
@@ -598,10 +633,13 @@ export async function handleUpdateArtifact(args: unknown, dataComposer: DataComp
   }
 
   // Check if agent has permission to edit
-  if (agentId && current.collaborators && !current.collaborators.includes(agentId)) {
-    // Compare via identity UUID when available, fall back to collaborators list
+  if (agentId) {
+    const currentEditMode = normalizeEditMode(current.edit_mode);
+    const currentEditors = current.collaborators || [];
     const isCreator = editorIdentity && current.created_by_identity_id === editorIdentity.id;
-    if (!isCreator) {
+    const hasEditorAccess = currentEditMode === 'workspace' || currentEditors.includes(agentId);
+
+    if (!isCreator && !hasEditorAccess) {
       throw new Error(`Agent ${agentId} does not have permission to edit this artifact`);
     }
   }
@@ -714,9 +752,28 @@ export async function handleUpdateArtifact(args: unknown, dataComposer: DataComp
     },
   };
 
+  const currentEditMode = normalizeEditMode(current.edit_mode);
+  const requestedEditors = normalizeEditorAgentIds(editors ?? collaborators);
+  const nextEditMode: ArtifactEditMode = editMode ?? currentEditMode;
+  let nextEditors =
+    editors !== undefined || collaborators !== undefined
+      ? requestedEditors
+      : current.collaborators || [];
+
+  if (nextEditMode === 'workspace') {
+    nextEditors = [];
+  }
+
+  if (nextEditMode === 'editors' && nextEditors.length === 0) {
+    throw new Error('editMode "editors" requires at least one editor agent ID');
+  }
+
   if (title !== undefined) updates.title = title;
   if (finalContent !== undefined) updates.content = finalContent;
-  if (collaborators !== undefined) updates.collaborators = collaborators;
+  if (editMode !== undefined || editors !== undefined || collaborators !== undefined) {
+    updates.edit_mode = nextEditMode;
+    updates.collaborators = nextEditors;
+  }
   if (tags !== undefined) updates.tags = tags;
 
   // CAS (compare-and-swap) guard: only write if version hasn't changed since we read it.
@@ -796,6 +853,8 @@ export async function handleUpdateArtifact(args: unknown, dataComposer: DataComp
             id: updated.id,
             uri: updated.uri,
             title: updated.title,
+            editMode: normalizeEditMode(updated.edit_mode),
+            editors: updated.collaborators || [],
             version: updated.version,
             updatedAt: updated.updated_at,
           },
@@ -817,7 +876,9 @@ export async function handleListArtifacts(args: unknown, dataComposer: DataCompo
 
   let query = supabase
     .from('artifacts')
-    .select('id, uri, title, artifact_type, visibility, version, tags, created_at, updated_at')
+    .select(
+      'id, uri, title, artifact_type, visibility, edit_mode, collaborators, version, tags, created_at, updated_at'
+    )
     .eq('user_id', resolved.user.id);
   query = withWorkspaceFilter(query, workspaceId);
   query = query.order('updated_at', { ascending: false }).limit(limit);
@@ -854,6 +915,8 @@ export async function handleListArtifacts(args: unknown, dataComposer: DataCompo
             title: a.title,
             artifactType: a.artifact_type,
             visibility: a.visibility,
+            editMode: normalizeEditMode(a.edit_mode),
+            editors: a.collaborators || [],
             version: a.version,
             tags: a.tags,
             createdAt: a.created_at,

--- a/packages/api/src/mcp/tools/artifact-handlers.ts
+++ b/packages/api/src/mcp/tools/artifact-handlers.ts
@@ -41,8 +41,8 @@ const createArtifactSchema = workspaceScopedUserIdentifierSchema.extend({
     .optional()
     .default('workspace')
     .describe('Edit permission mode: workspace (all workspace agents) or editors list only'),
-  editors: z.array(z.string()).optional().describe('Editor agent IDs when editMode is editors'),
-  collaborators: z.array(z.string()).optional().describe('Agent IDs who can edit'),
+  editors: z.array(z.string()).optional().describe('Editor IDs when editMode is editors'),
+  collaborators: z.array(z.string()).optional().describe('Backward-compatible alias for editors'),
   visibility: z
     .enum(['private', 'shared', 'public'])
     .optional()
@@ -83,8 +83,8 @@ const updateArtifactSchema = workspaceScopedUserIdentifierSchema.extend({
     ),
   agentId: z.string().optional().describe('Agent making the update'),
   editMode: z.enum(['workspace', 'editors']).optional().describe('Updated edit permission mode'),
-  editors: z.array(z.string()).optional().describe('Updated editor agent IDs'),
-  collaborators: z.array(z.string()).optional().describe('Updated collaborator list'),
+  editors: z.array(z.string()).optional().describe('Updated editor IDs'),
+  collaborators: z.array(z.string()).optional().describe('Backward-compatible alias for editors'),
   tags: z.array(z.string()).optional().describe('Updated tags'),
   changeSummary: z.string().optional().describe('Summary of changes'),
 });
@@ -298,9 +298,9 @@ export async function handleCreateArtifact(args: unknown, dataComposer: DataComp
   } = parsed;
   const normalizedEditors = normalizeEditorAgentIds(editors ?? collaborators);
   if (editMode === 'editors' && normalizedEditors.length === 0) {
-    throw new Error('editMode "editors" requires at least one editor agent ID');
+    throw new Error('editMode "editors" requires at least one editor');
   }
-  const effectiveEditors = editMode === 'editors' ? normalizedEditors : [];
+  const effectiveEditors = normalizedEditors;
   const agentId = getEffectiveAgentId(parsed.agentId);
   const workspaceResolution = await resolveWorkspaceScopeForWrite({
     rawArgs,
@@ -636,8 +636,12 @@ export async function handleUpdateArtifact(args: unknown, dataComposer: DataComp
   if (agentId) {
     const currentEditMode = normalizeEditMode(current.edit_mode);
     const currentEditors = current.collaborators || [];
+    const editorIdentityId = editorIdentity?.id || null;
     const isCreator = editorIdentity && current.created_by_identity_id === editorIdentity.id;
-    const hasEditorAccess = currentEditMode === 'workspace' || currentEditors.includes(agentId);
+    const hasEditorAccess =
+      currentEditMode === 'workspace' ||
+      (!!editorIdentityId && currentEditors.includes(editorIdentityId)) ||
+      currentEditors.includes(agentId);
 
     if (!isCreator && !hasEditorAccess) {
       throw new Error(`Agent ${agentId} does not have permission to edit this artifact`);
@@ -760,12 +764,8 @@ export async function handleUpdateArtifact(args: unknown, dataComposer: DataComp
       ? requestedEditors
       : current.collaborators || [];
 
-  if (nextEditMode === 'workspace') {
-    nextEditors = [];
-  }
-
   if (nextEditMode === 'editors' && nextEditors.length === 0) {
-    throw new Error('editMode "editors" requires at least one editor agent ID');
+    throw new Error('editMode "editors" requires at least one editor');
   }
 
   if (title !== undefined) updates.title = title;

--- a/packages/api/src/routes/admin-endpoints.test.ts
+++ b/packages/api/src/routes/admin-endpoints.test.ts
@@ -761,6 +761,36 @@ describe('admin endpoint handlers (no-500 regression)', () => {
       expect((res._json as any).success).toBe(true);
       expect((res._json as any).artifact.editMode).toBe('workspace');
     });
+
+    it('preserves stored editor identities when switching to workspace mode', async () => {
+      const artifactsChain = createQueryChain([
+        {
+          id: 'artifact-1',
+          edit_mode: 'editors',
+          collaborators: ['identity-wren', 'identity-lumen'],
+          updated_at: '2026-03-07T05:00:00.000Z',
+        },
+      ]);
+
+      mockSupabaseFrom.mockImplementation((table: string) => {
+        if (table === 'artifacts') return artifactsChain;
+        return createQueryChain([]);
+      });
+
+      const handler = findRouteHandler('patch', '/artifacts/:id/permissions');
+      const req = createAuthenticatedReq({
+        params: { id: 'artifact-1' },
+        body: { editMode: 'workspace' },
+      });
+      const res = createMockRes();
+      await handler!(req, res);
+
+      expect(res._status).toBe(200);
+      expect((artifactsChain.update as ReturnType<typeof vi.fn>).mock.calls[0][0]).toMatchObject({
+        edit_mode: 'workspace',
+        collaborators: ['identity-wren', 'identity-lumen'],
+      });
+    });
   });
 
   describe('PATCH /artifacts/permissions', () => {
@@ -784,6 +814,24 @@ describe('admin endpoint handlers (no-500 regression)', () => {
       expect(res._status).toBe(200);
       expect((res._json as any).success).toBe(true);
       expect((res._json as any).updatedCount).toBe(2);
+    });
+
+    it('does not clear collaborator lists when applying workspace mode in bulk', async () => {
+      const artifactsChain = createQueryChain([{ id: 'artifact-1' }, { id: 'artifact-2' }]);
+      mockSupabaseFrom.mockImplementation((table: string) => {
+        if (table === 'artifacts') return artifactsChain;
+        return createQueryChain([]);
+      });
+
+      const handler = findRouteHandler('patch', '/artifacts/permissions');
+      const req = createAuthenticatedReq({ body: { editMode: 'workspace' } });
+      const res = createMockRes();
+      await handler!(req, res);
+
+      expect(res._status).toBe(200);
+      const updatePayload = (artifactsChain.update as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(updatePayload).toMatchObject({ edit_mode: 'workspace' });
+      expect(updatePayload).not.toHaveProperty('collaborators');
     });
   });
 

--- a/packages/api/src/routes/admin-endpoints.test.ts
+++ b/packages/api/src/routes/admin-endpoints.test.ts
@@ -731,6 +731,62 @@ describe('admin endpoint handlers (no-500 regression)', () => {
     });
   });
 
+  describe('PATCH /artifacts/:id/permissions', () => {
+    it('should update permissions for a single artifact', async () => {
+      mockSupabaseFrom.mockImplementation((table: string) => {
+        if (table === 'artifacts') {
+          return createQueryChain([
+            {
+              id: 'artifact-1',
+              edit_mode: 'workspace',
+              collaborators: [],
+              updated_at: '2026-03-07T05:00:00.000Z',
+            },
+          ]);
+        }
+        return createQueryChain([]);
+      });
+
+      const handler = findRouteHandler('patch', '/artifacts/:id/permissions');
+      expect(handler).not.toBeNull();
+
+      const req = createAuthenticatedReq({
+        params: { id: 'artifact-1' },
+        body: { editMode: 'workspace' },
+      });
+      const res = createMockRes();
+      await handler!(req, res);
+
+      expect(res._status).toBe(200);
+      expect((res._json as any).success).toBe(true);
+      expect((res._json as any).artifact.editMode).toBe('workspace');
+    });
+  });
+
+  describe('PATCH /artifacts/permissions', () => {
+    it('should bulk update permissions in the active workspace', async () => {
+      mockSupabaseFrom.mockImplementation((table: string) => {
+        if (table === 'artifacts') {
+          return createQueryChain([{ id: 'artifact-1' }, { id: 'artifact-2' }]);
+        }
+        return createQueryChain([]);
+      });
+
+      const handler = findRouteHandler('patch', '/artifacts/permissions');
+      expect(handler).not.toBeNull();
+
+      const req = createAuthenticatedReq({
+        body: { editMode: 'workspace' },
+      });
+      const res = createMockRes();
+      await handler!(req, res);
+
+      expect(res._status).toBe(200);
+      expect((res._json as any).success).toBe(true);
+      expect((res._json as any).updatedCount).toBe(2);
+    });
+  });
+
   // =========================================================================
   // GET /connected-accounts — loaded by connected accounts page
   // =========================================================================

--- a/packages/api/src/routes/admin-endpoints.test.ts
+++ b/packages/api/src/routes/admin-endpoints.test.ts
@@ -166,6 +166,12 @@ function findRouteHandler(
   return handler?.handle ?? null;
 }
 
+function findRouteIndex(method: 'get' | 'post' | 'put' | 'delete' | 'patch', path: string): number {
+  return (router as any).stack.findIndex(
+    (entry: any) => entry.route?.path === path && entry.route?.methods?.[method]
+  );
+}
+
 /** Create a mock request with auth context already set (as if middleware passed) */
 function createAuthenticatedReq(overrides: Record<string, unknown> = {}): Request {
   return {
@@ -794,6 +800,15 @@ describe('admin endpoint handlers (no-500 regression)', () => {
   });
 
   describe('PATCH /artifacts/permissions', () => {
+    it('registers bulk route before per-artifact route to avoid path shadowing', () => {
+      const bulkRouteIndex = findRouteIndex('patch', '/artifacts/permissions');
+      const singleRouteIndex = findRouteIndex('patch', '/artifacts/:id/permissions');
+
+      expect(bulkRouteIndex).toBeGreaterThanOrEqual(0);
+      expect(singleRouteIndex).toBeGreaterThanOrEqual(0);
+      expect(bulkRouteIndex).toBeLessThan(singleRouteIndex);
+    });
+
     it('should bulk update permissions in the active workspace', async () => {
       mockSupabaseFrom.mockImplementation((table: string) => {
         if (table === 'artifacts') {

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -130,6 +130,24 @@ function normalizeNullableText(input: unknown): string | null {
   return normalized.length > 0 ? normalized : null;
 }
 
+type ArtifactEditMode = 'workspace' | 'editors';
+
+function normalizeArtifactEditMode(input: unknown): ArtifactEditMode {
+  return input === 'editors' ? 'editors' : 'workspace';
+}
+
+function normalizeArtifactEditors(input: unknown): string[] {
+  if (!Array.isArray(input)) return [];
+  return Array.from(
+    new Set(
+      input
+        .filter((value): value is string => typeof value === 'string')
+        .map((value) => value.trim())
+        .filter((value) => value.length > 0)
+    )
+  );
+}
+
 function parseRouteMetadata(input: unknown): Record<string, unknown> {
   if (!input || typeof input !== 'object' || Array.isArray(input)) {
     return {};
@@ -3281,7 +3299,9 @@ router.get('/artifacts', async (req: Request, res: Response) => {
 
     const { data, error } = await supabase
       .from('artifacts')
-      .select('id, uri, title, artifact_type, visibility, version, tags, created_at, updated_at')
+      .select(
+        'id, uri, title, artifact_type, visibility, edit_mode, collaborators, version, tags, created_at, updated_at'
+      )
       .eq('user_id', authReq.pcpUserId)
       .eq('workspace_id', authReq.pcpWorkspaceId)
       .order('updated_at', { ascending: false });
@@ -3299,6 +3319,8 @@ router.get('/artifacts', async (req: Request, res: Response) => {
         title: a.title,
         artifactType: a.artifact_type,
         visibility: a.visibility,
+        editMode: normalizeArtifactEditMode(a.edit_mode),
+        editors: a.collaborators || [],
         version: a.version,
         tags: a.tags,
         createdAt: a.created_at,
@@ -3344,6 +3366,8 @@ router.get('/artifacts/:id', async (req: Request, res: Response) => {
         artifactType: artifact.artifact_type,
         createdByIdentityId: artifact.created_by_identity_id,
         collaborators: artifact.collaborators,
+        editMode: normalizeArtifactEditMode(artifact.edit_mode),
+        editors: artifact.collaborators || [],
         visibility: artifact.visibility,
         version: artifact.version,
         tags: artifact.tags,
@@ -3355,6 +3379,159 @@ router.get('/artifacts/:id', async (req: Request, res: Response) => {
   } catch (error) {
     logger.error('Failed to get artifact:', error);
     res.status(500).json(errorJson('Failed to get artifact', error));
+  }
+});
+
+/**
+ * PATCH /api/admin/artifacts/:id/permissions
+ * Update edit permissions for one artifact
+ */
+router.patch('/artifacts/:id/permissions', async (req: Request, res: Response) => {
+  try {
+    const { id } = req.params;
+    const { editMode } = req.body as {
+      editMode?: 'workspace' | 'editors';
+      editors?: string[];
+      collaborators?: string[];
+    };
+
+    if (editMode !== undefined && !['workspace', 'editors'].includes(editMode)) {
+      res.status(400).json({ error: 'editMode must be "workspace" or "editors"' });
+      return;
+    }
+
+    const supabase = createClient(env.SUPABASE_URL, env.SUPABASE_SECRET_KEY);
+    const authReq = req as AdminAuthRequest;
+    const pcpUserId = authReq.pcpUserId;
+    const workspaceId = authReq.pcpWorkspaceId;
+
+    const { data: current, error: fetchError } = await supabase
+      .from('artifacts')
+      .select('id, edit_mode, collaborators')
+      .eq('id', id)
+      .eq('user_id', pcpUserId)
+      .eq('workspace_id', workspaceId)
+      .single();
+
+    if (fetchError || !current) {
+      res.status(404).json({ error: 'Artifact not found' });
+      return;
+    }
+
+    const normalizedMode = editMode ?? normalizeArtifactEditMode(current.edit_mode);
+    const body = req.body as { editors?: unknown; collaborators?: unknown };
+    const requestedEditorsRaw =
+      body.editors !== undefined
+        ? body.editors
+        : body.collaborators !== undefined
+          ? body.collaborators
+          : undefined;
+    const normalizedEditors =
+      requestedEditorsRaw !== undefined
+        ? normalizeArtifactEditors(requestedEditorsRaw)
+        : current.collaborators || [];
+
+    const nextEditors = normalizedMode === 'workspace' ? [] : normalizedEditors;
+    if (normalizedMode === 'editors' && nextEditors.length === 0) {
+      res.status(400).json({ error: 'editMode "editors" requires at least one editor' });
+      return;
+    }
+
+    const { data: updated, error: updateError } = await supabase
+      .from('artifacts')
+      .update({
+        edit_mode: normalizedMode,
+        collaborators: nextEditors,
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', id)
+      .eq('user_id', pcpUserId)
+      .eq('workspace_id', workspaceId)
+      .select('id, edit_mode, collaborators, updated_at')
+      .single();
+
+    if (updateError || !updated) {
+      logger.error('Failed to update artifact permissions:', updateError);
+      res.status(500).json(errorJson('Failed to update artifact permissions', updateError));
+      return;
+    }
+
+    res.json({
+      success: true,
+      artifact: {
+        id: updated.id,
+        editMode: normalizeArtifactEditMode(updated.edit_mode),
+        editors: updated.collaborators || [],
+        updatedAt: updated.updated_at,
+      },
+    });
+  } catch (error) {
+    logger.error('Failed to update artifact permissions:', error);
+    res.status(500).json(errorJson('Failed to update artifact permissions', error));
+  }
+});
+
+/**
+ * PATCH /api/admin/artifacts/permissions
+ * Bulk update edit permissions for all artifacts in active workspace
+ */
+router.patch('/artifacts/permissions', async (req: Request, res: Response) => {
+  try {
+    const { editMode } = req.body as {
+      editMode?: 'workspace' | 'editors';
+      editors?: string[];
+      collaborators?: string[];
+    };
+
+    if (!editMode || !['workspace', 'editors'].includes(editMode)) {
+      res.status(400).json({ error: 'editMode is required and must be "workspace" or "editors"' });
+      return;
+    }
+
+    const body = req.body as { editors?: unknown; collaborators?: unknown };
+    const requestedEditorsRaw =
+      body.editors !== undefined
+        ? body.editors
+        : body.collaborators !== undefined
+          ? body.collaborators
+          : undefined;
+    const normalizedEditors = normalizeArtifactEditors(requestedEditorsRaw);
+    const nextEditors = editMode === 'workspace' ? [] : normalizedEditors;
+
+    if (editMode === 'editors' && nextEditors.length === 0) {
+      res.status(400).json({ error: 'editMode "editors" requires at least one editor' });
+      return;
+    }
+
+    const supabase = createClient(env.SUPABASE_URL, env.SUPABASE_SECRET_KEY);
+    const authReq = req as AdminAuthRequest;
+
+    const { data: updatedRows, error } = await supabase
+      .from('artifacts')
+      .update({
+        edit_mode: editMode,
+        collaborators: nextEditors,
+        updated_at: new Date().toISOString(),
+      })
+      .eq('user_id', authReq.pcpUserId)
+      .eq('workspace_id', authReq.pcpWorkspaceId)
+      .select('id');
+
+    if (error) {
+      logger.error('Failed to bulk update artifact permissions:', error);
+      res.status(500).json(errorJson('Failed to bulk update artifact permissions', error));
+      return;
+    }
+
+    res.json({
+      success: true,
+      updatedCount: updatedRows?.length || 0,
+      editMode,
+      editors: nextEditors,
+    });
+  } catch (error) {
+    logger.error('Failed to bulk update artifact permissions:', error);
+    res.status(500).json(errorJson('Failed to bulk update artifact permissions', error));
   }
 });
 

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -3431,7 +3431,7 @@ router.patch('/artifacts/:id/permissions', async (req: Request, res: Response) =
         ? normalizeArtifactEditors(requestedEditorsRaw)
         : current.collaborators || [];
 
-    const nextEditors = normalizedMode === 'workspace' ? [] : normalizedEditors;
+    const nextEditors = normalizedEditors;
     if (normalizedMode === 'editors' && nextEditors.length === 0) {
       res.status(400).json({ error: 'editMode "editors" requires at least one editor' });
       return;
@@ -3496,23 +3496,26 @@ router.patch('/artifacts/permissions', async (req: Request, res: Response) => {
           ? body.collaborators
           : undefined;
     const normalizedEditors = normalizeArtifactEditors(requestedEditorsRaw);
-    const nextEditors = editMode === 'workspace' ? [] : normalizedEditors;
-
-    if (editMode === 'editors' && nextEditors.length === 0) {
-      res.status(400).json({ error: 'editMode "editors" requires at least one editor' });
-      return;
-    }
 
     const supabase = createClient(env.SUPABASE_URL, env.SUPABASE_SECRET_KEY);
     const authReq = req as AdminAuthRequest;
 
+    const updates: { edit_mode: ArtifactEditMode; collaborators?: string[]; updated_at: string } = {
+      edit_mode: editMode,
+      updated_at: new Date().toISOString(),
+    };
+
+    if (editMode === 'editors') {
+      if (normalizedEditors.length === 0) {
+        res.status(400).json({ error: 'editMode "editors" requires at least one editor' });
+        return;
+      }
+      updates.collaborators = normalizedEditors;
+    }
+
     const { data: updatedRows, error } = await supabase
       .from('artifacts')
-      .update({
-        edit_mode: editMode,
-        collaborators: nextEditors,
-        updated_at: new Date().toISOString(),
-      })
+      .update(updates)
       .eq('user_id', authReq.pcpUserId)
       .eq('workspace_id', authReq.pcpWorkspaceId)
       .select('id');
@@ -3527,7 +3530,7 @@ router.patch('/artifacts/permissions', async (req: Request, res: Response) => {
       success: true,
       updatedCount: updatedRows?.length || 0,
       editMode,
-      editors: nextEditors,
+      editors: editMode === 'editors' ? normalizedEditors : undefined,
     });
   } catch (error) {
     logger.error('Failed to bulk update artifact permissions:', error);

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -148,6 +148,24 @@ function normalizeArtifactEditors(input: unknown): string[] {
   );
 }
 
+function resolveArtifactEditorsFromBody(
+  body: { editors?: unknown; collaborators?: unknown },
+  fallbackEditors: string[] = []
+): string[] {
+  const requestedEditorsRaw =
+    body.editors !== undefined
+      ? body.editors
+      : body.collaborators !== undefined
+        ? body.collaborators
+        : undefined;
+
+  if (requestedEditorsRaw === undefined) {
+    return fallbackEditors;
+  }
+
+  return normalizeArtifactEditors(requestedEditorsRaw);
+}
+
 function parseRouteMetadata(input: unknown): Record<string, unknown> {
   if (!input || typeof input !== 'object' || Array.isArray(input)) {
     return {};
@@ -3294,7 +3312,9 @@ router.post('/oauth/:provider/upgrade-scopes', async (req: Request, res: Respons
  */
 router.get('/artifacts', async (req: Request, res: Response) => {
   try {
-    const supabase = createClient(env.SUPABASE_URL, env.SUPABASE_SECRET_KEY);
+    const supabase = createClient(env.SUPABASE_URL, env.SUPABASE_SECRET_KEY, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
     const authReq = req as AdminAuthRequest;
 
     const { data, error } = await supabase
@@ -3340,7 +3360,9 @@ router.get('/artifacts', async (req: Request, res: Response) => {
 router.get('/artifacts/:id', async (req: Request, res: Response) => {
   try {
     const { id } = req.params;
-    const supabase = createClient(env.SUPABASE_URL, env.SUPABASE_SECRET_KEY);
+    const supabase = createClient(env.SUPABASE_URL, env.SUPABASE_SECRET_KEY, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
     const authReq = req as AdminAuthRequest;
 
     const { data: artifact, error } = await supabase
@@ -3383,95 +3405,6 @@ router.get('/artifacts/:id', async (req: Request, res: Response) => {
 });
 
 /**
- * PATCH /api/admin/artifacts/:id/permissions
- * Update edit permissions for one artifact
- */
-router.patch('/artifacts/:id/permissions', async (req: Request, res: Response) => {
-  try {
-    const { id } = req.params;
-    const { editMode } = req.body as {
-      editMode?: 'workspace' | 'editors';
-      editors?: string[];
-      collaborators?: string[];
-    };
-
-    if (editMode !== undefined && !['workspace', 'editors'].includes(editMode)) {
-      res.status(400).json({ error: 'editMode must be "workspace" or "editors"' });
-      return;
-    }
-
-    const supabase = createClient(env.SUPABASE_URL, env.SUPABASE_SECRET_KEY);
-    const authReq = req as AdminAuthRequest;
-    const pcpUserId = authReq.pcpUserId;
-    const workspaceId = authReq.pcpWorkspaceId;
-
-    const { data: current, error: fetchError } = await supabase
-      .from('artifacts')
-      .select('id, edit_mode, collaborators')
-      .eq('id', id)
-      .eq('user_id', pcpUserId)
-      .eq('workspace_id', workspaceId)
-      .single();
-
-    if (fetchError || !current) {
-      res.status(404).json({ error: 'Artifact not found' });
-      return;
-    }
-
-    const normalizedMode = editMode ?? normalizeArtifactEditMode(current.edit_mode);
-    const body = req.body as { editors?: unknown; collaborators?: unknown };
-    const requestedEditorsRaw =
-      body.editors !== undefined
-        ? body.editors
-        : body.collaborators !== undefined
-          ? body.collaborators
-          : undefined;
-    const normalizedEditors =
-      requestedEditorsRaw !== undefined
-        ? normalizeArtifactEditors(requestedEditorsRaw)
-        : current.collaborators || [];
-
-    const nextEditors = normalizedEditors;
-    if (normalizedMode === 'editors' && nextEditors.length === 0) {
-      res.status(400).json({ error: 'editMode "editors" requires at least one editor' });
-      return;
-    }
-
-    const { data: updated, error: updateError } = await supabase
-      .from('artifacts')
-      .update({
-        edit_mode: normalizedMode,
-        collaborators: nextEditors,
-        updated_at: new Date().toISOString(),
-      })
-      .eq('id', id)
-      .eq('user_id', pcpUserId)
-      .eq('workspace_id', workspaceId)
-      .select('id, edit_mode, collaborators, updated_at')
-      .single();
-
-    if (updateError || !updated) {
-      logger.error('Failed to update artifact permissions:', updateError);
-      res.status(500).json(errorJson('Failed to update artifact permissions', updateError));
-      return;
-    }
-
-    res.json({
-      success: true,
-      artifact: {
-        id: updated.id,
-        editMode: normalizeArtifactEditMode(updated.edit_mode),
-        editors: updated.collaborators || [],
-        updatedAt: updated.updated_at,
-      },
-    });
-  } catch (error) {
-    logger.error('Failed to update artifact permissions:', error);
-    res.status(500).json(errorJson('Failed to update artifact permissions', error));
-  }
-});
-
-/**
  * PATCH /api/admin/artifacts/permissions
  * Bulk update edit permissions for all artifacts in active workspace
  */
@@ -3489,15 +3422,11 @@ router.patch('/artifacts/permissions', async (req: Request, res: Response) => {
     }
 
     const body = req.body as { editors?: unknown; collaborators?: unknown };
-    const requestedEditorsRaw =
-      body.editors !== undefined
-        ? body.editors
-        : body.collaborators !== undefined
-          ? body.collaborators
-          : undefined;
-    const normalizedEditors = normalizeArtifactEditors(requestedEditorsRaw);
+    const normalizedEditors = resolveArtifactEditorsFromBody(body);
 
-    const supabase = createClient(env.SUPABASE_URL, env.SUPABASE_SECRET_KEY);
+    const supabase = createClient(env.SUPABASE_URL, env.SUPABASE_SECRET_KEY, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
     const authReq = req as AdminAuthRequest;
 
     const updates: { edit_mode: ArtifactEditMode; collaborators?: string[]; updated_at: string } = {
@@ -3535,6 +3464,87 @@ router.patch('/artifacts/permissions', async (req: Request, res: Response) => {
   } catch (error) {
     logger.error('Failed to bulk update artifact permissions:', error);
     res.status(500).json(errorJson('Failed to bulk update artifact permissions', error));
+  }
+});
+
+/**
+ * PATCH /api/admin/artifacts/:id/permissions
+ * Update edit permissions for one artifact
+ */
+router.patch('/artifacts/:id/permissions', async (req: Request, res: Response) => {
+  try {
+    const { id } = req.params;
+    const { editMode } = req.body as {
+      editMode?: 'workspace' | 'editors';
+      editors?: string[];
+      collaborators?: string[];
+    };
+
+    if (editMode !== undefined && !['workspace', 'editors'].includes(editMode)) {
+      res.status(400).json({ error: 'editMode must be "workspace" or "editors"' });
+      return;
+    }
+
+    const supabase = createClient(env.SUPABASE_URL, env.SUPABASE_SECRET_KEY, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+    const authReq = req as AdminAuthRequest;
+    const pcpUserId = authReq.pcpUserId;
+    const workspaceId = authReq.pcpWorkspaceId;
+
+    const { data: current, error: fetchError } = await supabase
+      .from('artifacts')
+      .select('id, edit_mode, collaborators')
+      .eq('id', id)
+      .eq('user_id', pcpUserId)
+      .eq('workspace_id', workspaceId)
+      .single();
+
+    if (fetchError || !current) {
+      res.status(404).json({ error: 'Artifact not found' });
+      return;
+    }
+
+    const normalizedMode = editMode ?? normalizeArtifactEditMode(current.edit_mode);
+    const body = req.body as { editors?: unknown; collaborators?: unknown };
+    const nextEditors = resolveArtifactEditorsFromBody(body, current.collaborators || []);
+
+    if (normalizedMode === 'editors' && nextEditors.length === 0) {
+      res.status(400).json({ error: 'editMode "editors" requires at least one editor' });
+      return;
+    }
+
+    const { data: updated, error: updateError } = await supabase
+      .from('artifacts')
+      .update({
+        edit_mode: normalizedMode,
+        collaborators: nextEditors,
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', id)
+      .eq('user_id', pcpUserId)
+      .eq('workspace_id', workspaceId)
+      .select('id, edit_mode, collaborators, updated_at')
+      .single();
+
+    if (updateError || !updated) {
+      logger.error('Failed to update artifact permissions:', updateError);
+      res.status(500).json(errorJson('Failed to update artifact permissions', updateError));
+      return;
+    }
+
+    res.json({
+      success: true,
+      artifact: {
+        id: updated.id,
+        editMode: normalizeArtifactEditMode(updated.edit_mode),
+        editors: updated.collaborators || [],
+        updatedAt: updated.updated_at,
+      },
+    });
+  } catch (error) {
+    logger.error('Failed to update artifact permissions:', error);
+    res.status(500).json(errorJson('Failed to update artifact permissions', error));
   }
 });
 

--- a/packages/web/src/app/(dashboard)/artifacts/[artifactId]/page.tsx
+++ b/packages/web/src/app/(dashboard)/artifacts/[artifactId]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useParams } from 'next/navigation';
 import Link from 'next/link';
 import { Card, CardContent } from '@/components/ui/card';
@@ -19,7 +19,7 @@ import {
   History,
   Loader2,
 } from 'lucide-react';
-import { useApiPost, useApiQuery, useQueryClient } from '@/lib/api';
+import { apiPatch, useApiPost, useApiQuery, useQueryClient } from '@/lib/api';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import clsx from 'clsx';
@@ -32,6 +32,8 @@ interface Artifact {
   contentType: string;
   artifactType: 'spec' | 'design' | 'decision' | 'document' | 'note';
   createdByAgentId?: string;
+  editMode: 'workspace' | 'editors';
+  editors: string[];
   collaborators?: string[];
   visibility: 'private' | 'shared' | 'public';
   version: number;
@@ -133,6 +135,13 @@ export default function ArtifactDetailPage() {
   const queryClient = useQueryClient();
   const [commentDraft, setCommentDraft] = useState('');
   const [commentAgentId, setCommentAgentId] = useState('');
+  const [permissionEditMode, setPermissionEditMode] = useState<'workspace' | 'editors'>(
+    'workspace'
+  );
+  const [permissionEditorsInput, setPermissionEditorsInput] = useState('');
+  const [isSavingPermissions, setIsSavingPermissions] = useState(false);
+  const [permissionError, setPermissionError] = useState<string | null>(null);
+  const [permissionSuccess, setPermissionSuccess] = useState<string | null>(null);
 
   const {
     data: artifactData,
@@ -166,6 +175,12 @@ export default function ArtifactDetailPage() {
 
   const artifact = artifactData?.artifact ?? null;
   const comments = commentsData?.comments ?? [];
+
+  useEffect(() => {
+    if (!artifact) return;
+    setPermissionEditMode(artifact.editMode || 'workspace');
+    setPermissionEditorsInput((artifact.editors || []).join(', '));
+  }, [artifact]);
 
   if (isLoading) {
     return (
@@ -212,6 +227,42 @@ export default function ArtifactDetailPage() {
       content: commentDraft.trim(),
       ...(commentAgentId.trim() ? { agentId: commentAgentId.trim() } : {}),
     });
+  };
+
+  const parseEditors = (raw: string): string[] =>
+    Array.from(
+      new Set(
+        raw
+          .split(',')
+          .map((item) => item.trim())
+          .filter((item) => item.length > 0)
+      )
+    );
+
+  const handleSavePermissions = async () => {
+    setPermissionError(null);
+    setPermissionSuccess(null);
+    setIsSavingPermissions(true);
+
+    try {
+      const editors = parseEditors(permissionEditorsInput);
+      const payload =
+        permissionEditMode === 'editors'
+          ? { editMode: permissionEditMode, editors }
+          : { editMode: permissionEditMode };
+
+      await apiPatch(`/api/admin/artifacts/${artifactId}/permissions`, payload);
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['artifacts', artifactId] }),
+        queryClient.invalidateQueries({ queryKey: ['artifacts'] }),
+      ]);
+      setPermissionSuccess('Permissions updated.');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to update permissions';
+      setPermissionError(message);
+    } finally {
+      setIsSavingPermissions(false);
+    }
   };
 
   return (
@@ -266,6 +317,53 @@ export default function ArtifactDetailPage() {
           <div className="prose prose-sm max-w-none prose-headings:font-semibold prose-headings:mt-4 prose-headings:mb-2 prose-p:my-2 prose-ul:my-2 prose-ol:my-2 prose-li:my-0">
             <ReactMarkdown remarkPlugins={[remarkGfm]}>{artifact.content}</ReactMarkdown>
           </div>
+        </CardContent>
+      </Card>
+
+      <Card className="mt-6">
+        <CardContent className="p-6 space-y-4">
+          <div>
+            <h2 className="text-lg font-semibold text-gray-900">Edit permissions</h2>
+            <p className="text-sm text-gray-500">
+              Control who can update this document via MCP or dashboard actions.
+            </p>
+          </div>
+
+          <div className="grid gap-3 md:grid-cols-[220px_1fr_auto] md:items-end">
+            <div>
+              <label className="mb-1 block text-sm font-medium text-gray-700">Edit mode</label>
+              <select
+                value={permissionEditMode}
+                onChange={(event) =>
+                  setPermissionEditMode(event.target.value as 'workspace' | 'editors')
+                }
+                className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+              >
+                <option value="workspace">Workspace editors</option>
+                <option value="editors">Specific editor list</option>
+              </select>
+            </div>
+
+            <div>
+              <label className="mb-1 block text-sm font-medium text-gray-700">
+                Editors (comma-separated)
+              </label>
+              <input
+                value={permissionEditorsInput}
+                onChange={(event) => setPermissionEditorsInput(event.target.value)}
+                disabled={permissionEditMode !== 'editors'}
+                placeholder="wren, lumen, myra"
+                className="h-10 w-full rounded-md border border-gray-300 px-3 text-sm focus:border-gray-400 focus:outline-none disabled:bg-gray-100 disabled:text-gray-400"
+              />
+            </div>
+
+            <Button onClick={handleSavePermissions} disabled={isSavingPermissions}>
+              {isSavingPermissions ? 'Saving…' : 'Save'}
+            </Button>
+          </div>
+
+          {permissionError && <p className="text-sm text-red-700">{permissionError}</p>}
+          {permissionSuccess && <p className="text-sm text-green-700">{permissionSuccess}</p>}
         </CardContent>
       </Card>
 
@@ -349,8 +447,12 @@ export default function ArtifactDetailPage() {
       <div className="mt-6 flex items-center justify-between text-sm text-gray-500">
         <div className="flex items-center gap-4">
           {artifact.createdByAgentId && <span>Created by: {artifact.createdByAgentId}</span>}
-          {artifact.collaborators && artifact.collaborators.length > 0 && (
-            <span>Collaborators: {artifact.collaborators.join(', ')}</span>
+          <span>
+            Edit mode:{' '}
+            {artifact.editMode === 'workspace' ? 'workspace editors' : 'specific editor list'}
+          </span>
+          {artifact.editMode === 'editors' && artifact.editors && artifact.editors.length > 0 && (
+            <span>Editors: {artifact.editors.join(', ')}</span>
           )}
         </div>
         <div className="flex items-center gap-4">

--- a/packages/web/src/app/(dashboard)/artifacts/[artifactId]/page.tsx
+++ b/packages/web/src/app/(dashboard)/artifacts/[artifactId]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useParams } from 'next/navigation';
 import Link from 'next/link';
 import { Card, CardContent } from '@/components/ui/card';
@@ -23,6 +23,10 @@ import { apiPatch, useApiPost, useApiQuery, useQueryClient } from '@/lib/api';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import clsx from 'clsx';
+import {
+  ObjectPermissionsEditor,
+  type PermissionIdentityOption,
+} from '@/components/permissions/object-permissions-editor';
 
 interface Artifact {
   id: string;
@@ -79,6 +83,16 @@ interface ArtifactComment {
 interface ArtifactCommentsResponse {
   artifactId: string;
   comments: ArtifactComment[];
+}
+
+interface IndividualIdentity {
+  id: string;
+  agentId: string;
+  name: string;
+}
+
+interface IndividualsResponse {
+  individuals: IndividualIdentity[];
 }
 
 const typeConfig = {
@@ -138,7 +152,7 @@ export default function ArtifactDetailPage() {
   const [permissionEditMode, setPermissionEditMode] = useState<'workspace' | 'editors'>(
     'workspace'
   );
-  const [permissionEditorsInput, setPermissionEditorsInput] = useState('');
+  const [permissionEditorIdentityIds, setPermissionEditorIdentityIds] = useState<string[]>([]);
   const [isSavingPermissions, setIsSavingPermissions] = useState(false);
   const [permissionError, setPermissionError] = useState<string | null>(null);
   const [permissionSuccess, setPermissionSuccess] = useState<string | null>(null);
@@ -159,6 +173,10 @@ export default function ArtifactDetailPage() {
     ['artifact-comments', artifactId],
     `/api/admin/artifacts/${artifactId}/comments`
   );
+  const { data: identitiesData } = useApiQuery<IndividualsResponse>(
+    ['individual-identities'],
+    '/api/admin/individuals'
+  );
 
   const addCommentMutation = useApiPost<
     { comment: ArtifactComment },
@@ -175,12 +193,43 @@ export default function ArtifactDetailPage() {
 
   const artifact = artifactData?.artifact ?? null;
   const comments = commentsData?.comments ?? [];
+  const identityOptions: PermissionIdentityOption[] = useMemo(
+    () =>
+      identitiesData?.individuals.map((identity) => ({
+        id: identity.id,
+        name: identity.name,
+      })) ?? [],
+    [identitiesData?.individuals]
+  );
+  const identityNameById = useMemo(
+    () => new Map(identityOptions.map((identity) => [identity.id, identity.name] as const)),
+    [identityOptions]
+  );
+  const identityIdByAgentId = useMemo(
+    () =>
+      new Map(
+        (identitiesData?.individuals ?? []).map(
+          (identity) => [identity.agentId, identity.id] as const
+        )
+      ),
+    [identitiesData?.individuals]
+  );
 
   useEffect(() => {
     if (!artifact) return;
+    const normalizedEditorIds = Array.from(
+      new Set(
+        (artifact.editors || [])
+          .map((value) => value.trim())
+          .filter((value) => value.length > 0)
+          .map((value) =>
+            identityNameById.get(value) ? value : identityIdByAgentId.get(value) || value
+          )
+      )
+    );
     setPermissionEditMode(artifact.editMode || 'workspace');
-    setPermissionEditorsInput((artifact.editors || []).join(', '));
-  }, [artifact]);
+    setPermissionEditorIdentityIds(normalizedEditorIds);
+  }, [artifact, identityNameById, identityIdByAgentId]);
 
   if (isLoading) {
     return (
@@ -229,29 +278,16 @@ export default function ArtifactDetailPage() {
     });
   };
 
-  const parseEditors = (raw: string): string[] =>
-    Array.from(
-      new Set(
-        raw
-          .split(',')
-          .map((item) => item.trim())
-          .filter((item) => item.length > 0)
-      )
-    );
-
   const handleSavePermissions = async () => {
     setPermissionError(null);
     setPermissionSuccess(null);
     setIsSavingPermissions(true);
 
     try {
-      const editors = parseEditors(permissionEditorsInput);
-      const payload =
-        permissionEditMode === 'editors'
-          ? { editMode: permissionEditMode, editors }
-          : { editMode: permissionEditMode };
-
-      await apiPatch(`/api/admin/artifacts/${artifactId}/permissions`, payload);
+      await apiPatch(`/api/admin/artifacts/${artifactId}/permissions`, {
+        editMode: permissionEditMode,
+        editors: permissionEditorIdentityIds,
+      });
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: ['artifacts', artifactId] }),
         queryClient.invalidateQueries({ queryKey: ['artifacts'] }),
@@ -322,48 +358,21 @@ export default function ArtifactDetailPage() {
 
       <Card className="mt-6">
         <CardContent className="p-6 space-y-4">
-          <div>
-            <h2 className="text-lg font-semibold text-gray-900">Edit permissions</h2>
-            <p className="text-sm text-gray-500">
-              Control who can update this document via MCP or dashboard actions.
-            </p>
-          </div>
-
-          <div className="grid gap-3 md:grid-cols-[220px_1fr_auto] md:items-end">
-            <div>
-              <label className="mb-1 block text-sm font-medium text-gray-700">Edit mode</label>
-              <select
-                value={permissionEditMode}
-                onChange={(event) =>
-                  setPermissionEditMode(event.target.value as 'workspace' | 'editors')
-                }
-                className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
-              >
-                <option value="workspace">Workspace editors</option>
-                <option value="editors">Specific editor list</option>
-              </select>
-            </div>
-
-            <div>
-              <label className="mb-1 block text-sm font-medium text-gray-700">
-                Editors (comma-separated)
-              </label>
-              <input
-                value={permissionEditorsInput}
-                onChange={(event) => setPermissionEditorsInput(event.target.value)}
-                disabled={permissionEditMode !== 'editors'}
-                placeholder="wren, lumen, myra"
-                className="h-10 w-full rounded-md border border-gray-300 px-3 text-sm focus:border-gray-400 focus:outline-none disabled:bg-gray-100 disabled:text-gray-400"
-              />
-            </div>
-
-            <Button onClick={handleSavePermissions} disabled={isSavingPermissions}>
-              {isSavingPermissions ? 'Saving…' : 'Save'}
-            </Button>
-          </div>
-
-          {permissionError && <p className="text-sm text-red-700">{permissionError}</p>}
-          {permissionSuccess && <p className="text-sm text-green-700">{permissionSuccess}</p>}
+          <ObjectPermissionsEditor
+            title="Edit permissions"
+            description="Control who can update this document. “Anyone” mode keeps stored editor selections so you can switch back safely."
+            mode={permissionEditMode}
+            onModeChange={setPermissionEditMode}
+            editorIdentityIds={permissionEditorIdentityIds}
+            onEditorIdentityIdsChange={setPermissionEditorIdentityIds}
+            identities={identityOptions}
+            actionLabel="Save"
+            pendingActionLabel="Saving…"
+            onAction={handleSavePermissions}
+            isActionPending={isSavingPermissions}
+            error={permissionError}
+            success={permissionSuccess}
+          />
         </CardContent>
       </Card>
 
@@ -452,7 +461,18 @@ export default function ArtifactDetailPage() {
             {artifact.editMode === 'workspace' ? 'workspace editors' : 'specific editor list'}
           </span>
           {artifact.editMode === 'editors' && artifact.editors && artifact.editors.length > 0 && (
-            <span>Editors: {artifact.editors.join(', ')}</span>
+            <span>
+              Editors:{' '}
+              {artifact.editors
+                .map((identityId) => {
+                  const identityName = identityNameById.get(identityId);
+                  if (identityName) return identityName;
+                  const remappedId = identityIdByAgentId.get(identityId);
+                  const remappedIdentityName = remappedId ? identityNameById.get(remappedId) : null;
+                  return remappedIdentityName || identityId;
+                })
+                .join(', ')}
+            </span>
           )}
         </div>
         <div className="flex items-center gap-4">

--- a/packages/web/src/app/(dashboard)/artifacts/[artifactId]/page.tsx
+++ b/packages/web/src/app/(dashboard)/artifacts/[artifactId]/page.tsx
@@ -231,6 +231,12 @@ export default function ArtifactDetailPage() {
     setPermissionEditorIdentityIds(normalizedEditorIds);
   }, [artifact, identityNameById, identityIdByAgentId]);
 
+  useEffect(() => {
+    if (!permissionSuccess) return;
+    const timeout = window.setTimeout(() => setPermissionSuccess(null), 3000);
+    return () => window.clearTimeout(timeout);
+  }, [permissionSuccess]);
+
   if (isLoading) {
     return (
       <div className="flex items-center justify-center py-12">

--- a/packages/web/src/app/(dashboard)/artifacts/page.tsx
+++ b/packages/web/src/app/(dashboard)/artifacts/page.tsx
@@ -1,10 +1,8 @@
 'use client';
 
 import Link from 'next/link';
-import { useState } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
 import {
   FileText,
   BookOpen,
@@ -16,7 +14,7 @@ import {
   Lock,
   History,
 } from 'lucide-react';
-import { apiPatch, useApiQuery, useQueryClient } from '@/lib/api';
+import { useApiQuery } from '@/lib/api';
 import clsx from 'clsx';
 
 interface Artifact {
@@ -100,55 +98,12 @@ function formatRelativeTime(date: string): string {
 }
 
 export default function ArtifactsPage() {
-  const queryClient = useQueryClient();
-  const [bulkEditMode, setBulkEditMode] = useState<'workspace' | 'editors'>('workspace');
-  const [bulkEditorsInput, setBulkEditorsInput] = useState('');
-  const [isBulkUpdating, setIsBulkUpdating] = useState(false);
-  const [bulkError, setBulkError] = useState<string | null>(null);
-  const [bulkSuccess, setBulkSuccess] = useState<string | null>(null);
-
   const { data, isLoading, error } = useApiQuery<ArtifactsResponse>(
     ['artifacts'],
     '/api/admin/artifacts'
   );
 
   const artifacts = data?.artifacts ?? [];
-
-  const parseEditorInput = (raw: string): string[] =>
-    Array.from(
-      new Set(
-        raw
-          .split(',')
-          .map((item) => item.trim())
-          .filter((item) => item.length > 0)
-      )
-    );
-
-  const handleBulkPermissionUpdate = async () => {
-    setBulkError(null);
-    setBulkSuccess(null);
-    setIsBulkUpdating(true);
-
-    try {
-      const editors = parseEditorInput(bulkEditorsInput);
-      const payload =
-        bulkEditMode === 'editors'
-          ? { editMode: bulkEditMode, editors }
-          : { editMode: bulkEditMode };
-
-      const response = await apiPatch<{ updatedCount: number }>(
-        '/api/admin/artifacts/permissions',
-        payload
-      );
-      setBulkSuccess(`Updated ${response.updatedCount} document permissions.`);
-      await queryClient.invalidateQueries({ queryKey: ['artifacts'] });
-    } catch (err) {
-      const message = err instanceof Error ? err.message : 'Failed to update permissions';
-      setBulkError(message);
-    } finally {
-      setIsBulkUpdating(false);
-    }
-  };
 
   // Stats by type
   const stats = {
@@ -172,50 +127,6 @@ export default function ArtifactsPage() {
       </div>
 
       {error && <div className="mt-4 rounded-md bg-red-50 p-4 text-red-800">{error.message}</div>}
-
-      <Card className="mt-6">
-        <CardHeader>
-          <CardTitle>Document edit permissions</CardTitle>
-          <CardDescription>
-            Apply a workspace-wide edit policy to all current documents.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-3">
-          <div className="grid gap-3 md:grid-cols-[220px_1fr_auto] md:items-end">
-            <div>
-              <label className="mb-1 block text-sm font-medium text-gray-700">Edit mode</label>
-              <select
-                value={bulkEditMode}
-                onChange={(event) => setBulkEditMode(event.target.value as 'workspace' | 'editors')}
-                className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
-              >
-                <option value="workspace">Workspace editors (recommended)</option>
-                <option value="editors">Specific editor list</option>
-              </select>
-            </div>
-
-            <div>
-              <label className="mb-1 block text-sm font-medium text-gray-700">
-                Editors (comma-separated)
-              </label>
-              <input
-                value={bulkEditorsInput}
-                onChange={(event) => setBulkEditorsInput(event.target.value)}
-                disabled={bulkEditMode !== 'editors'}
-                placeholder="wren, lumen, myra"
-                className="h-10 w-full rounded-md border border-gray-300 px-3 text-sm focus:border-gray-400 focus:outline-none disabled:bg-gray-100 disabled:text-gray-400"
-              />
-            </div>
-
-            <Button onClick={handleBulkPermissionUpdate} disabled={isBulkUpdating}>
-              {isBulkUpdating ? 'Applying…' : 'Apply to all'}
-            </Button>
-          </div>
-
-          {bulkError && <p className="text-sm text-red-700">{bulkError}</p>}
-          {bulkSuccess && <p className="text-sm text-green-700">{bulkSuccess}</p>}
-        </CardContent>
-      </Card>
 
       {/* Stats */}
       <div className="grid grid-cols-6 gap-4 mt-6">

--- a/packages/web/src/app/(dashboard)/artifacts/page.tsx
+++ b/packages/web/src/app/(dashboard)/artifacts/page.tsx
@@ -1,8 +1,10 @@
 'use client';
 
 import Link from 'next/link';
+import { useState } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
 import {
   FileText,
   BookOpen,
@@ -14,7 +16,7 @@ import {
   Lock,
   History,
 } from 'lucide-react';
-import { useApiQuery } from '@/lib/api';
+import { apiPatch, useApiQuery, useQueryClient } from '@/lib/api';
 import clsx from 'clsx';
 
 interface Artifact {
@@ -23,6 +25,8 @@ interface Artifact {
   title: string;
   artifactType: 'spec' | 'design' | 'decision' | 'document' | 'note';
   visibility: 'private' | 'shared' | 'public';
+  editMode: 'workspace' | 'editors';
+  editors: string[];
   version: number;
   tags: string[] | null;
   createdAt: string;
@@ -96,12 +100,55 @@ function formatRelativeTime(date: string): string {
 }
 
 export default function ArtifactsPage() {
+  const queryClient = useQueryClient();
+  const [bulkEditMode, setBulkEditMode] = useState<'workspace' | 'editors'>('workspace');
+  const [bulkEditorsInput, setBulkEditorsInput] = useState('');
+  const [isBulkUpdating, setIsBulkUpdating] = useState(false);
+  const [bulkError, setBulkError] = useState<string | null>(null);
+  const [bulkSuccess, setBulkSuccess] = useState<string | null>(null);
+
   const { data, isLoading, error } = useApiQuery<ArtifactsResponse>(
     ['artifacts'],
     '/api/admin/artifacts'
   );
 
   const artifacts = data?.artifacts ?? [];
+
+  const parseEditorInput = (raw: string): string[] =>
+    Array.from(
+      new Set(
+        raw
+          .split(',')
+          .map((item) => item.trim())
+          .filter((item) => item.length > 0)
+      )
+    );
+
+  const handleBulkPermissionUpdate = async () => {
+    setBulkError(null);
+    setBulkSuccess(null);
+    setIsBulkUpdating(true);
+
+    try {
+      const editors = parseEditorInput(bulkEditorsInput);
+      const payload =
+        bulkEditMode === 'editors'
+          ? { editMode: bulkEditMode, editors }
+          : { editMode: bulkEditMode };
+
+      const response = await apiPatch<{ updatedCount: number }>(
+        '/api/admin/artifacts/permissions',
+        payload
+      );
+      setBulkSuccess(`Updated ${response.updatedCount} document permissions.`);
+      await queryClient.invalidateQueries({ queryKey: ['artifacts'] });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to update permissions';
+      setBulkError(message);
+    } finally {
+      setIsBulkUpdating(false);
+    }
+  };
 
   // Stats by type
   const stats = {
@@ -125,6 +172,50 @@ export default function ArtifactsPage() {
       </div>
 
       {error && <div className="mt-4 rounded-md bg-red-50 p-4 text-red-800">{error.message}</div>}
+
+      <Card className="mt-6">
+        <CardHeader>
+          <CardTitle>Document edit permissions</CardTitle>
+          <CardDescription>
+            Apply a workspace-wide edit policy to all current documents.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="grid gap-3 md:grid-cols-[220px_1fr_auto] md:items-end">
+            <div>
+              <label className="mb-1 block text-sm font-medium text-gray-700">Edit mode</label>
+              <select
+                value={bulkEditMode}
+                onChange={(event) => setBulkEditMode(event.target.value as 'workspace' | 'editors')}
+                className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+              >
+                <option value="workspace">Workspace editors (recommended)</option>
+                <option value="editors">Specific editor list</option>
+              </select>
+            </div>
+
+            <div>
+              <label className="mb-1 block text-sm font-medium text-gray-700">
+                Editors (comma-separated)
+              </label>
+              <input
+                value={bulkEditorsInput}
+                onChange={(event) => setBulkEditorsInput(event.target.value)}
+                disabled={bulkEditMode !== 'editors'}
+                placeholder="wren, lumen, myra"
+                className="h-10 w-full rounded-md border border-gray-300 px-3 text-sm focus:border-gray-400 focus:outline-none disabled:bg-gray-100 disabled:text-gray-400"
+              />
+            </div>
+
+            <Button onClick={handleBulkPermissionUpdate} disabled={isBulkUpdating}>
+              {isBulkUpdating ? 'Applying…' : 'Apply to all'}
+            </Button>
+          </div>
+
+          {bulkError && <p className="text-sm text-red-700">{bulkError}</p>}
+          {bulkSuccess && <p className="text-sm text-green-700">{bulkSuccess}</p>}
+        </CardContent>
+      </Card>
 
       {/* Stats */}
       <div className="grid grid-cols-6 gap-4 mt-6">
@@ -193,6 +284,9 @@ export default function ArtifactsPage() {
                           <Badge variant="outline" className="text-xs">
                             <VisIcon className="h-3 w-3 mr-1" />
                             {visConfig.label}
+                          </Badge>
+                          <Badge variant="outline" className="text-xs">
+                            {artifact.editMode === 'workspace' ? 'Workspace edit' : 'Editors only'}
                           </Badge>
                           <span className="text-xs text-gray-400">v{artifact.version}</span>
                           {artifact.version > 1 && (

--- a/packages/web/src/components/permissions/object-permissions-editor.tsx
+++ b/packages/web/src/components/permissions/object-permissions-editor.tsx
@@ -1,0 +1,167 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+export type PermissionEditMode = 'workspace' | 'editors';
+
+export interface PermissionIdentityOption {
+  id: string;
+  name: string;
+}
+
+interface ObjectPermissionsEditorProps {
+  title?: string;
+  description?: string;
+  mode: PermissionEditMode;
+  onModeChange: (mode: PermissionEditMode) => void;
+  editorIdentityIds: string[];
+  onEditorIdentityIdsChange: (next: string[]) => void;
+  identities: PermissionIdentityOption[];
+  actionLabel: string;
+  pendingActionLabel?: string;
+  onAction: () => void;
+  isActionPending?: boolean;
+  error?: string | null;
+  success?: string | null;
+}
+
+export function ObjectPermissionsEditor({
+  title = 'Edit permissions',
+  description = 'Choose whether anyone in this workspace can edit, or only selected editors.',
+  mode,
+  onModeChange,
+  editorIdentityIds,
+  onEditorIdentityIdsChange,
+  identities,
+  actionLabel,
+  pendingActionLabel,
+  onAction,
+  isActionPending = false,
+  error,
+  success,
+}: ObjectPermissionsEditorProps) {
+  const [nextEditorId, setNextEditorId] = useState('');
+
+  const identitiesById = useMemo(
+    () => new Map(identities.map((identity) => [identity.id, identity])),
+    [identities]
+  );
+
+  const availableIdentities = useMemo(
+    () => identities.filter((identity) => !editorIdentityIds.includes(identity.id)),
+    [editorIdentityIds, identities]
+  );
+
+  const addEditor = () => {
+    if (!nextEditorId) return;
+    if (editorIdentityIds.includes(nextEditorId)) {
+      setNextEditorId('');
+      return;
+    }
+    onEditorIdentityIdsChange([...editorIdentityIds, nextEditorId]);
+    setNextEditorId('');
+  };
+
+  const removeEditor = (identityId: string) => {
+    onEditorIdentityIdsChange(editorIdentityIds.filter((current) => current !== identityId));
+  };
+
+  const submitDisabled = isActionPending || (mode === 'editors' && editorIdentityIds.length === 0);
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h2 className="text-lg font-semibold text-gray-900">{title}</h2>
+        <p className="text-sm text-gray-500">{description}</p>
+      </div>
+
+      <div>
+        <label className="mb-1 block text-sm font-medium text-gray-700">Access mode</label>
+        <select
+          value={mode}
+          onChange={(event) => onModeChange(event.target.value as PermissionEditMode)}
+          className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm md:max-w-sm"
+        >
+          <option value="workspace">Anyone in workspace can edit</option>
+          <option value="editors">Only selected editors can edit</option>
+        </select>
+      </div>
+
+      {mode === 'editors' ? (
+        <div className="space-y-3 rounded-md border border-gray-200 bg-gray-50 p-3">
+          <div className="flex flex-col gap-2 md:flex-row md:items-end">
+            <div className="flex-1">
+              <label className="mb-1 block text-sm font-medium text-gray-700">Add editor</label>
+              <select
+                value={nextEditorId}
+                onChange={(event) => setNextEditorId(event.target.value)}
+                className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+              >
+                <option value="">Select a person…</option>
+                {availableIdentities.map((identity) => (
+                  <option key={identity.id} value={identity.id}>
+                    {identity.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <Button type="button" variant="outline" onClick={addEditor} disabled={!nextEditorId}>
+              Add editor
+            </Button>
+          </div>
+
+          <div className="space-y-2">
+            <p className="text-xs font-medium uppercase tracking-wide text-gray-500">
+              Selected editors
+            </p>
+            {editorIdentityIds.length === 0 ? (
+              <p className="text-sm text-red-700">Select at least one editor.</p>
+            ) : (
+              <div className="space-y-2">
+                {editorIdentityIds.map((identityId) => {
+                  const identity = identitiesById.get(identityId);
+                  return (
+                    <div
+                      key={identityId}
+                      className="flex items-center justify-between rounded-md border border-gray-200 bg-white px-3 py-2 text-sm text-gray-800"
+                    >
+                      <span>{identity?.name || 'Unknown identity'}</span>
+                      <button
+                        type="button"
+                        onClick={() => removeEditor(identityId)}
+                        className="rounded p-1 text-gray-500 hover:bg-gray-100 hover:text-gray-700"
+                        aria-label={`Remove ${identity ? identity.name : identityId}`}
+                      >
+                        <X className="h-3 w-3" />
+                      </button>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        </div>
+      ) : (
+        <div className="rounded-md border border-blue-200 bg-blue-50 p-3 text-sm text-blue-900">
+          <p>Anyone in this workspace can edit.</p>
+          {editorIdentityIds.length > 0 ? (
+            <p className="mt-1 text-blue-800">
+              Saved editor list ({editorIdentityIds.length}) is preserved if you switch back.
+            </p>
+          ) : null}
+        </div>
+      )}
+
+      <div className="flex items-center gap-3">
+        <Button type="button" onClick={onAction} disabled={submitDisabled}>
+          {isActionPending ? pendingActionLabel || `${actionLabel}…` : actionLabel}
+        </Button>
+      </div>
+
+      {error ? <p className="text-sm text-red-700">{error}</p> : null}
+      {success ? <p className="text-sm text-green-700">{success}</p> : null}
+    </div>
+  );
+}

--- a/supabase/migrations/20260307050219_artifact_edit_modes.sql
+++ b/supabase/migrations/20260307050219_artifact_edit_modes.sql
@@ -1,0 +1,33 @@
+-- Artifact edit permissions
+-- Adds explicit edit mode support so artifacts can be editable by:
+-- 1) everyone in the workspace, or
+-- 2) a specific list of editor agent IDs.
+--
+-- Requirement: default all existing artifacts to workspace-level edit access.
+
+ALTER TABLE public.artifacts
+  ADD COLUMN IF NOT EXISTS edit_mode text;
+
+UPDATE public.artifacts
+SET edit_mode = 'workspace'
+WHERE edit_mode IS NULL;
+
+ALTER TABLE public.artifacts
+  ALTER COLUMN edit_mode SET DEFAULT 'workspace',
+  ALTER COLUMN edit_mode SET NOT NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'artifacts_edit_mode_check'
+  ) THEN
+    ALTER TABLE public.artifacts
+      ADD CONSTRAINT artifacts_edit_mode_check
+      CHECK (edit_mode IN ('workspace', 'editors'));
+  END IF;
+END $$;
+
+COMMENT ON COLUMN public.artifacts.edit_mode IS
+  'Artifact edit permission mode: workspace (all workspace agents can edit) or editors (only listed collaborators).';


### PR DESCRIPTION
## Summary

Implements default artifact edit permissions with a polished per-document permissions flow.

### Backend / MCP
- Supports artifact `edit_mode` (`workspace` or `editors`) and editor lists.
- Preserves stored editor list when switching mode to `workspace` (so switching back restores previous editors).
- Keeps owner/editor authorization checks compatible while supporting current identity resolution.
- Adds migration for artifact edit mode fields and corresponding API/test updates.

### Dashboard UX
- Removes bulk "apply to all documents" permissions controls from `/artifacts` list.
- Adds document-scoped permissions editing in artifact detail view.
- Adds reusable `ObjectPermissionsEditor` component with:
  - `Anyone in workspace can edit` vs `Only selected editors can edit`
  - row-based selected editors list (one person per row)
  - remove action per row
  - names-only display (no agent IDs in the permissions list)
  - preserved selected editor list when toggling mode

## Validation

- `yarn workspace @personal-context/web type-check`
- `npx vitest run packages/api/src/mcp/tools/artifact-handlers.test.ts packages/api/src/routes/admin-endpoints.test.ts`

All passing.

## Notes

Screenshots were captured and reviewed at 1440px width for the permissions flow and list page.
