### PR TITLE
fix: graceful shutdown — stop heartbeat + agent gateway on SIGTERM (by Wren)

### DIFF
--- a/packages/api/src/channels/telegram-listener.ts
+++ b/packages/api/src/channels/telegram-listener.ts
@@ -174,6 +174,7 @@ export class TelegramListener extends EventEmitter {
   private isRunning = false;
   private lastUpdateId = 0;
   private pollTimeout: NodeJS.Timeout | null = null;
+  private pollAbortController: AbortController | null = null;
   private messageCallback?: MessageCallback;
   private mediaGroupBuffer: MediaGroupBuffer | null = null;
   private authService: AuthorizationService;
@@ -254,6 +255,12 @@ export class TelegramListener extends EventEmitter {
       this.pollTimeout = null;
     }
 
+    // Abort any in-flight long-poll request to Telegram API
+    if (this.pollAbortController) {
+      this.pollAbortController.abort();
+      this.pollAbortController = null;
+    }
+
     this.mediaGroupBuffer?.destroy();
 
     this.emit('disconnected');
@@ -298,7 +305,17 @@ export class TelegramListener extends EventEmitter {
       allowed_updates: ['message', 'edited_message', 'my_chat_member', 'chat_member'],
     };
 
-    return this.apiCall<TelegramUpdate[]>('getUpdates', params);
+    // Use an AbortController so stop() can cancel the long-poll request
+    this.pollAbortController = new AbortController();
+    try {
+      return await this.apiCall<TelegramUpdate[]>(
+        'getUpdates',
+        params,
+        this.pollAbortController.signal
+      );
+    } finally {
+      this.pollAbortController = null;
+    }
   }
 
   /**
@@ -885,13 +902,18 @@ export class TelegramListener extends EventEmitter {
   /**
    * Make a Telegram API call
    */
-  private async apiCall<T>(method: string, params?: Record<string, unknown>): Promise<T> {
+  private async apiCall<T>(
+    method: string,
+    params?: Record<string, unknown>,
+    signal?: AbortSignal
+  ): Promise<T> {
     const url = `${TELEGRAM_API}/bot${this.token}/${method}`;
 
     const response = await fetch(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: params ? JSON.stringify(params) : undefined,
+      signal,
     });
 
     const data = (await response.json()) as TelegramApiResponse<T>;

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -33,7 +33,12 @@ import {
   type ChannelGateway,
 } from './mcp/server';
 import type { GatewayChannel } from './channels/gateway';
-import { initHeartbeatService, processHeartbeat, type DueReminder } from './services/heartbeat';
+import {
+  initHeartbeatService,
+  stopHeartbeatService,
+  processHeartbeat,
+  type DueReminder,
+} from './services/heartbeat';
 import { setResponseCallback, hasExplicitResponse } from './mcp/tools/response-handlers';
 import { getAgentGateway, type AgentTriggerPayload } from './channels/agent-gateway';
 import { resolveRouteAgentId } from './services/routing/resolve-route';
@@ -954,6 +959,14 @@ async function shutdown(): Promise<void> {
   isShuttingDown = true;
 
   logger.info('\nShutting down PCP Server...');
+
+  // Stop heartbeat cron job
+  stopHeartbeatService();
+  logger.info('Heartbeat service stopped');
+
+  // Remove agent gateway listeners to release event loop references
+  getAgentGateway().removeAllListeners();
+  logger.info('Agent gateway listeners removed');
 
   // Shutdown MCP server (includes ChannelGateway shutdown)
   if (mcpServer) {


### PR DESCRIPTION
## Summary

- Stop heartbeat cron job (`stopHeartbeatService()`) during shutdown — was keeping the event loop alive
- Remove agent gateway event listeners (`removeAllListeners()`) during shutdown — `trigger:error` listener held references preventing exit
- Import `stopHeartbeatService` (already exported, never used)

**Root cause:** `tsx watch` couldn't restart the server because the old process never exited. The heartbeat cron (node-cron) and agent gateway listener kept Node's event loop alive indefinitely after SIGTERM. This caused the cascading "Previous process hasn't exited yet. Force killing..." messages and MaxListenersExceededWarning.

**Before:** Server hangs on SIGTERM, requires SIGKILL, tsx accumulates zombie processes
**After:** Clean exit in <1s — heartbeat stopped, listeners removed, MCP server shut down

## Test plan

- [x] `MCP_HTTP_PORT=3099 npx tsx src/server.ts` → SIGTERM → exits cleanly in <1s
- [x] Shutdown logs show: heartbeat stopped → gateway listeners removed → MCP server stopped → shutdown complete
- [x] Type-check passes (only pre-existing ESM errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)