### PR TITLE
fix: heartbeat studio routing spawns in wrong studio (by Wren)

### DIFF
--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -1,6 +1,12 @@
 /**
  * PM2 Ecosystem Configuration
  *
+ * ⚠️  DEPRECATED for local development — use `yarn dev` instead.
+ * `yarn dev` uses tsx --watch for hot reload and avoids PM2's issues with
+ * env caching, stale ports, and build staleness.
+ *
+ * This file is retained for production/CI use cases only.
+ *
  * This manages the PCP server processes:
  * 1. pcp     - Full PCP Server (MCP + ChannelGateway + SessionHost)
  * 2. web     - Next.js admin dashboard
@@ -12,13 +18,11 @@
  * - Heartbeat service for scheduled reminders
  * - Agent gateway for inter-agent triggers
  *
- * Commands:
+ * If you must use PM2 locally:
  *   pm2 start ecosystem.config.cjs    # Start all processes
  *   pm2 restart pcp                   # Restart PCP server
  *   pm2 logs                          # View all logs
- *   pm2 logs pcp                      # View PCP logs only
- *   pm2 stop all                      # Stop everything
- *   pm2 delete all                    # Clean up
+ *   pm2 delete all && pm2 start ...   # Full reset (avoids env caching)
  */
 
 const path = require('path');

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -1569,7 +1569,7 @@ router.get('/routing', async (req: Request, res: Response) => {
         name: identity.name,
         role: identity.role,
         backend: identity.backend,
-        studioHint: identity.studio_hint || 'home',
+        studioHint: identity.studio_hint || null,
       })),
       routes,
     });
@@ -1706,7 +1706,7 @@ router.get('/routing/agents/:agentId', async (req: Request, res: Response) => {
         role: identity.role,
         description: identity.description,
         backend: identity.backend,
-        studioHint: identity.studio_hint || 'home',
+        studioHint: identity.studio_hint || null,
         updatedAt: identity.updated_at,
       },
       studios: (studiosData || []).map((s) => ({

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -389,7 +389,7 @@ async function startServer(config: ServerConfig = {}): Promise<void> {
     //   1. reminder.studio_hint (direct override)
     //   2. channel_routes.studio_hint (matched by delivery channel)
     //   3. agent_identities.studio_hint (agent's home studio)
-    //   4. 'home' (hardcoded fallback)
+    //   4. null → resolveStudioId() uses its own cascade (agent studio → main)
     let reminderStudioHint: string | null = null;
 
     // Check reminder-level override first
@@ -437,10 +437,9 @@ async function startServer(config: ServerConfig = {}): Promise<void> {
       }
     }
 
-    // Final fallback
-    if (!reminderStudioHint) {
-      reminderStudioHint = 'home';
-    }
+    // No final fallback — leave null so resolveStudioId() uses its own
+    // cascade (agent's own studio → main studio) instead of searching
+    // for a studio literally named 'home' which doesn't exist.
 
     const reminderContent = `[HEARTBEAT REMINDER]
 Title: ${reminder.title}


### PR DESCRIPTION
## Summary

- **Remove hardcoded `'home'` studio hint fallback** in heartbeat delivery. When no studio hint was found via the cascade (reminder → channel route → agent identity), the code defaulted to the string `'home'`. `resolveStudioId()` treated this as an explicit hint, searched for a studio literally named "home", found nothing, and bailed — never reaching the agent's own studio lookup. This caused Myra's heartbeat to spawn in Wren's studio (the server's working directory fallback) instead of her own.
- **Fix**: leave `studioHint` as `null` when no explicit hint is found, so `resolveStudioId()` uses its natural cascade (agent's own studio → main studio).
- **Also remove misleading `|| 'home'` default** from admin API routing responses — now returns `null` when no studio hint is set.

## Test plan

- [ ] Restart `yarn dev` and wait for Myra's next heartbeat
- [ ] Verify in sessions dashboard that Myra spawns in her own studio, not Wren's
- [ ] Send a test message to Myra via inbox and verify she spawns in the correct studio
- [ ] Verify `send_response` works (was previously blocked due to wrong studio permissions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)