### PR TITLE
fix: send_response media docs + activity logging (by Wren)

### DIFF
--- a/packages/api/src/channels/gateway.ts
+++ b/packages/api/src/channels/gateway.ts
@@ -696,6 +696,14 @@ export class ChannelGateway extends EventEmitter {
             await this.sendTelegramMessage(conversationId, content, { format, replyToMessageId });
           }
           await this.sendMediaAttachments('telegram', conversationId, media, { replyToMessageId });
+          // Log media metadata to activity stream
+          await this.logOutgoingTelegram(
+            conversationId,
+            content
+              ? `[+${media.length} media attachment(s)]`
+              : `[${media.length} media attachment(s)]`,
+            media
+          );
         }
         break;
 
@@ -920,11 +928,26 @@ export class ChannelGateway extends EventEmitter {
     await this.logOutgoingTelegram(conversationId, content);
   }
 
-  private async logOutgoingTelegram(conversationId: string, content: string): Promise<void> {
+  private async logOutgoingTelegram(
+    conversationId: string,
+    content: string,
+    media?: OutboundMedia[]
+  ): Promise<void> {
     // Log outgoing message to activity stream
     const userId = await this.resolveUserIdForConversation('telegram', conversationId);
     if (this.dataComposer && userId) {
       try {
+        const payload: Record<string, unknown> = {};
+        if (media && media.length > 0) {
+          payload.mediaCount = media.length;
+          payload.media = media.map((m) => ({
+            type: m.type,
+            path: m.path || null,
+            url: m.url || null,
+            filename: m.filename || null,
+            contentType: m.contentType || null,
+          }));
+        }
         await this.dataComposer.repositories.activityStream.logMessage({
           userId,
           agentId: 'myra',
@@ -933,6 +956,7 @@ export class ChannelGateway extends EventEmitter {
           platform: 'telegram',
           platformChatId: conversationId,
           isDm: true, // Will be corrected by context
+          payload: Object.keys(payload).length > 0 ? payload : undefined,
         });
       } catch (activityError) {
         logger.warn('Failed to log outgoing message to activity stream:', activityError);

--- a/packages/api/src/mcp/tools/index.ts
+++ b/packages/api/src/mcp/tools/index.ts
@@ -911,11 +911,22 @@ User can be identified by ONE of: userId, email, phone, or platform + platformId
   server.registerTool(
     'send_response',
     {
-      description: `Send a response to a specific channel. Use this tool to reply to messages from Telegram, terminal, or other channels.
+      description: `Send a response to a specific channel (Telegram, WhatsApp, Discord, etc.).
 
-This is the primary way to send responses back to users. Always use this tool instead of just outputting text.
+This is the PRIMARY way to send messages to users on external channels. You MUST call this tool — just outputting text does nothing.
 
-Supports media attachments (images, videos, documents) via the media parameter. Provide a local file path for each attachment.`,
+## Media Attachments
+
+To send photos, videos, or documents, use the \`media\` array parameter. Each attachment needs a \`type\` and either a \`path\` (local file) or \`url\` (remote).
+
+Example — send a photo with caption:
+  content: "Here's the screenshot"
+  media: [{ type: "image", path: "/absolute/path/to/photo.png", caption: "Routing page" }]
+
+Example — send a document:
+  media: [{ type: "document", path: "/path/to/report.pdf", filename: "report.pdf" }]
+
+Supported types: image, video, audio, document. The \`content\` field is sent as a separate text message before the media.`,
       inputSchema: {
         channel: z
           .enum(['telegram', 'terminal', 'discord', 'whatsapp', 'http', 'api', 'agent'])


### PR DESCRIPTION
## Summary

- **Rewrite `send_response` tool description** with concrete examples for sending photos and documents via the `media` parameter. The old description mentioned media in passing — agents (Myra) didn't use it when asked to send photos, sending text-only instead.
- **Log media metadata in outgoing Telegram activity entries** — captures `mediaCount`, file paths, types, and filenames in the `payload` field so we can audit what was sent without storing file contents.

## Test plan

- [ ] Deploy and trigger Myra to send a photo — verify she uses the `media` parameter
- [ ] Check activity stream for the `message_out` entry — verify `payload` contains media metadata
- [ ] Verify text-only messages still log correctly (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)