### PR TITLE
fix: always log media activity regardless of send result (by Wren)

### DIFF
--- a/packages/api/src/channels/gateway.ts
+++ b/packages/api/src/channels/gateway.ts
@@ -698,20 +698,19 @@ export class ChannelGateway extends EventEmitter {
           const mediaResult = await this.sendMediaAttachments('telegram', conversationId, media, {
             replyToMessageId,
           });
+          // Always log media attempts to activity stream (success or failure) for debugging
+          await this.logOutgoingTelegram(
+            conversationId,
+            content
+              ? `[+${media.length} media attachment(s)] sent=${mediaResult.sent} failed=${mediaResult.failed}`
+              : `[${media.length} media attachment(s)] sent=${mediaResult.sent} failed=${mediaResult.failed}`,
+            media
+          );
           if (mediaResult.failed > 0 && mediaResult.sent === 0) {
             throw new Error(
               `All media attachments failed to send: ${mediaResult.errors.join('; ')}`
             );
-          }
-          // Log media metadata to activity stream (only if at least one sent)
-          await this.logOutgoingTelegram(
-            conversationId,
-            content
-              ? `[+${media.length} media attachment(s)]`
-              : `[${media.length} media attachment(s)]`,
-            media
-          );
-          if (mediaResult.failed > 0) {
+          } else if (mediaResult.failed > 0) {
             logger.warn(
               `${mediaResult.failed}/${media.length} media attachments failed on telegram`,
               { errors: mediaResult.errors }


### PR DESCRIPTION
## Summary\n\n- Activity stream logging for media sends should always fire (like a `finally` block) so we can debug failures\n- Moved `logOutgoingTelegram` back before the all-failed throw\n- Included `sent=N failed=N` counts in the activity log content for at-a-glance debugging\n\nFollow-up to PR #199 based on Conor's feedback — the activity log is our debugging record and should capture all attempts, not just successes.\n\n## Test plan\n\n- [ ] Trigger a media send that fails — verify activity stream entry is created with `failed=1`\n- [ ] Trigger a successful media send — verify activity stream entry shows `sent=1 failed=0`\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)