### PR TITLE
feat: surface media sent/failed counters in send_response (by Wren)

### DIFF
--- a/packages/api/src/channels/gateway.ts
+++ b/packages/api/src/channels/gateway.ts
@@ -17,7 +17,11 @@ import { createTelegramListener, TelegramListener } from './telegram-listener';
 import { createWhatsAppListener, WhatsAppListener } from './whatsapp-listener';
 import { createDiscordListener, DiscordListener } from './discord-listener';
 import { createSlackListener, SlackListener } from './slack-listener';
-import { setResponseCallback, type ResponseCallback } from '../mcp/tools/response-handlers';
+import {
+  setResponseCallback,
+  type ResponseCallback,
+  type ResponseResult,
+} from '../mcp/tools/response-handlers';
 import type { AgentResponse, OutboundMedia } from '../agent/types';
 import type { DataComposer } from '../data/composer';
 import { logger } from '../utils/logger';
@@ -658,7 +662,7 @@ export class ChannelGateway extends EventEmitter {
    */
   private registerResponseCallback(): void {
     const callback: ResponseCallback = async (response: AgentResponse) => {
-      await this.sendResponse(response);
+      return await this.sendResponse(response);
     };
     setResponseCallback(callback);
     logger.info('ChannelGateway registered response callback');
@@ -668,11 +672,14 @@ export class ChannelGateway extends EventEmitter {
    * Send a response to a channel
    * Called by the response callback or directly
    */
-  async sendResponse(response: AgentResponse): Promise<void> {
+  async sendResponse(response: AgentResponse): Promise<ResponseResult | void> {
     const { channel, conversationId, content, format, replyToMessageId, media } = response;
 
     // Stop typing indicator when sending response
     this.stopTypingIndicator(conversationId);
+
+    // Track media results across channels for caller visibility
+    let mediaResult: { sent: number; failed: number; errors: string[] } | undefined;
 
     switch (channel) {
       case 'telegram':
@@ -695,7 +702,7 @@ export class ChannelGateway extends EventEmitter {
           if (content) {
             await this.sendTelegramMessage(conversationId, content, { format, replyToMessageId });
           }
-          const mediaResult = await this.sendMediaAttachments('telegram', conversationId, media, {
+          mediaResult = await this.sendMediaAttachments('telegram', conversationId, media, {
             replyToMessageId,
           });
           // Always log media attempts to activity stream (success or failure) for debugging
@@ -727,7 +734,7 @@ export class ChannelGateway extends EventEmitter {
           await this.whatsappListener.sendMessage(conversationId, content);
         }
         if (media && media.length > 0) {
-          const mediaResult = await this.sendMediaAttachments('whatsapp', conversationId, media);
+          mediaResult = await this.sendMediaAttachments('whatsapp', conversationId, media);
           if (mediaResult.failed > 0 && mediaResult.sent === 0) {
             throw new Error(
               `All media attachments failed to send: ${mediaResult.errors.join('; ')}`
@@ -771,7 +778,7 @@ export class ChannelGateway extends EventEmitter {
           await this.discordListener.sendMessage(conversationId, content);
         }
         if (media && media.length > 0) {
-          const mediaResult = await this.sendMediaAttachments('discord', conversationId, media);
+          mediaResult = await this.sendMediaAttachments('discord', conversationId, media);
           if (mediaResult.failed > 0 && mediaResult.sent === 0) {
             throw new Error(
               `All media attachments failed to send: ${mediaResult.errors.join('; ')}`
@@ -845,6 +852,15 @@ export class ChannelGateway extends EventEmitter {
 
     // Check for pending messages that arrived while processing
     await this.processPendingMessages(channel as GatewayChannel, conversationId);
+
+    // Return media delivery results so callers (send_response) can report them
+    if (mediaResult) {
+      return {
+        mediaSent: mediaResult.sent,
+        mediaFailed: mediaResult.failed,
+        mediaErrors: mediaResult.errors.length > 0 ? mediaResult.errors : undefined,
+      };
+    }
   }
 
   /**

--- a/packages/api/src/mcp/tools/response-handlers.ts
+++ b/packages/api/src/mcp/tools/response-handlers.ts
@@ -10,8 +10,15 @@ import type { DataComposer } from '../../data/composer';
 import type { ChannelType, AgentResponse, ResponseFormat, OutboundMedia } from '../../agent/types';
 import { logger } from '../../utils/logger';
 
+// Response result returned by the callback (optional — void is still accepted)
+export interface ResponseResult {
+  mediaSent?: number;
+  mediaFailed?: number;
+  mediaErrors?: string[];
+}
+
 // Response handler callback type
-export type ResponseCallback = (response: AgentResponse) => Promise<void>;
+export type ResponseCallback = (response: AgentResponse) => Promise<ResponseResult | void>;
 
 // Global response callback - set by the session host
 let globalResponseCallback: ResponseCallback | null = null;
@@ -146,8 +153,9 @@ export async function handleSendResponse(
     markExplicitResponse(args.channel, args.conversationId);
 
     // Try local callback first (when running in same process as session host)
+    let callbackResult: ResponseResult | void = undefined;
     if (globalResponseCallback) {
-      await globalResponseCallback(response);
+      callbackResult = await globalResponseCallback(response);
       logger.info(`Response sent to ${args.channel}:${args.conversationId} via local callback`);
     } else {
       // Fallback: route through Myra's HTTP endpoint for external channels
@@ -182,13 +190,22 @@ export async function handleSendResponse(
       }
     }
 
-    return mcpResponse({
+    const result: Record<string, unknown> = {
       success: true,
       channel: args.channel,
       conversationId: args.conversationId,
       contentLength: args.content.length,
       mediaRequested: args.media?.length || 0,
-    });
+    };
+
+    // Surface media delivery counters from the gateway if available
+    if (callbackResult) {
+      if (callbackResult.mediaSent !== undefined) result.mediaSent = callbackResult.mediaSent;
+      if (callbackResult.mediaFailed !== undefined) result.mediaFailed = callbackResult.mediaFailed;
+      if (callbackResult.mediaErrors?.length) result.mediaErrors = callbackResult.mediaErrors;
+    }
+
+    return mcpResponse(result);
   } catch (error) {
     logger.error('Error in send_response:', error);
     return mcpResponse(


### PR DESCRIPTION
## Summary\n\n- `ResponseCallback` now returns optional `ResponseResult` with `mediaSent`, `mediaFailed`, `mediaErrors`\n- `gateway.sendResponse()` hoists media result to method scope and returns it through the callback\n- `handleSendResponse` surfaces these counters in the MCP tool response\n- Agents can now distinguish \"media queued\" from \"media actually delivered\" — e.g. `{ success: true, mediaSent: 1, mediaFailed: 0 }` vs `{ success: true, mediaSent: 0, mediaFailed: 1, mediaErrors: [...] }`\n\nAddresses Myra's feedback that `send_response` only returned `mediaRequested` with no delivery confirmation.\n\n## Test plan\n\n- [ ] Send a photo via `send_response` — verify response includes `mediaSent: 1`\n- [ ] Send with invalid path — verify response includes `mediaFailed: 1` and `mediaErrors`\n- [ ] Send text-only message — verify no media counters in response\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)