### PR TITLE
fix: send_response callback drops media field — root cause of photo failures (by Wren)

### DIFF
--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -333,14 +333,7 @@ async function startServer(config: ServerConfig = {}): Promise<void> {
 
     // Register the response callback so send_response MCP calls route through ChannelGateway
     setResponseCallback(async (response) => {
-      const channelResponse: ChannelResponse = {
-        channel: response.channel as ChannelType,
-        conversationId: response.conversationId,
-        content: response.content,
-        format: response.format,
-        replyToMessageId: response.replyToMessageId,
-      };
-      await channelGateway!.sendResponse(channelResponse);
+      await channelGateway!.sendResponse(response);
       logger.info(`Response routed via callback to ${response.channel}:${response.conversationId}`);
     });
     logger.info('Response callback registered for MCP send_response tool');

--- a/packages/api/src/services/sessions/types.ts
+++ b/packages/api/src/services/sessions/types.ts
@@ -138,6 +138,8 @@ export interface ChannelResponse {
   format?: 'text' | 'markdown' | 'code' | 'json';
   replyToMessageId?: string;
   metadata?: Record<string, unknown>;
+  /** Media attachments (images, videos, documents) to send alongside text */
+  media?: import('../../agent/types').OutboundMedia[];
 }
 
 export interface SessionResult {


### PR DESCRIPTION
## Summary\n\n**Root cause found**: `server.ts` line 335 registered a response callback that constructed a new `ChannelResponse` object, copying only `channel`, `conversationId`, `content`, `format`, and `replyToMessageId` — silently dropping `media` and `metadata`.\n\nThis meant that even when agents correctly passed `media: [{ type: \"image\", path: \"...\" }]` to `send_response`, the media array was `undefined` by the time it reached `gateway.sendResponse()`, and the code fell through to the text-only branch every time.\n\n**Fix**: Pass the full `AgentResponse` object directly to `channelGateway.sendResponse()` instead of constructing a reduced copy. One line replaces eight.\n\n## Diagnosis trail\n\n1. Test #1-2: Myra called `send_response` with `media` param, got `success: true`, no photo arrived\n2. Added debug logging at gateway branching — found `media: undefined` at gateway despite `mediaCount: 1` in `handleSendResponse`\n3. Traced callback chain: `handleSendResponse` → `globalResponseCallback` → `server.ts` callback → `channelGateway.sendResponse()`\n4. Found `server.ts` callback constructing `ChannelResponse` without `media` field\n5. Test #4 after fix: photo arrived on Telegram, Conor confirmed \"IT WORKED\"\n\n## Test plan\n\n- [x] Test #4: Photo arrived on Telegram (confirmed by Conor)\n- [x] Activity stream shows `sent=1 failed=0` with media metadata\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)