### PR TITLE
fix(api): complete media pipeline — counters, runner passthrough, cross-channel logging (by Wren)

### DIFF
--- a/packages/api/src/channels/gateway.ts
+++ b/packages/api/src/channels/gateway.ts
@@ -748,17 +748,35 @@ export class ChannelGateway extends EventEmitter {
         }
         // Log outgoing WhatsApp message to activity stream
         {
+          const logContent =
+            media && media.length > 0 && mediaResult
+              ? content
+                ? `${content} [+${media.length} media] sent=${mediaResult.sent} failed=${mediaResult.failed}`
+                : `[${media.length} media] sent=${mediaResult.sent} failed=${mediaResult.failed}`
+              : content;
           const userId = await this.resolveUserIdForConversation('whatsapp', conversationId);
           if (this.dataComposer && userId) {
             try {
+              const payload: Record<string, unknown> = {};
+              if (media && media.length > 0) {
+                payload.mediaCount = media.length;
+                payload.media = media.map((m) => ({
+                  type: m.type,
+                  path: m.path || null,
+                  url: m.url || null,
+                  filename: m.filename || null,
+                  contentType: m.contentType || null,
+                }));
+              }
               await this.dataComposer.repositories.activityStream.logMessage({
                 userId,
                 agentId: 'myra',
                 direction: 'out',
-                content,
+                content: logContent,
                 platform: 'whatsapp',
                 platformChatId: conversationId,
                 isDm: true,
+                payload: Object.keys(payload).length > 0 ? payload : undefined,
               });
             } catch (activityError) {
               logger.warn(
@@ -792,17 +810,35 @@ export class ChannelGateway extends EventEmitter {
         }
         // Log outgoing Discord message to activity stream
         {
+          const logContent =
+            media && media.length > 0 && mediaResult
+              ? content
+                ? `${content} [+${media.length} media] sent=${mediaResult.sent} failed=${mediaResult.failed}`
+                : `[${media.length} media] sent=${mediaResult.sent} failed=${mediaResult.failed}`
+              : content;
           const userId = await this.resolveUserIdForConversation('discord', conversationId);
           if (this.dataComposer && userId) {
             try {
+              const payload: Record<string, unknown> = {};
+              if (media && media.length > 0) {
+                payload.mediaCount = media.length;
+                payload.media = media.map((m) => ({
+                  type: m.type,
+                  path: m.path || null,
+                  url: m.url || null,
+                  filename: m.filename || null,
+                  contentType: m.contentType || null,
+                }));
+              }
               await this.dataComposer.repositories.activityStream.logMessage({
                 userId,
                 agentId: 'benson',
                 direction: 'out',
-                content,
+                content: logContent,
                 platform: 'discord',
                 platformChatId: conversationId,
                 isDm: true,
+                payload: Object.keys(payload).length > 0 ? payload : undefined,
               });
             } catch (activityError) {
               logger.warn(
@@ -818,20 +854,49 @@ export class ChannelGateway extends EventEmitter {
         if (!this.slackListener) {
           throw new Error('Slack listener not available');
         }
-        await this.slackListener.sendMessage(conversationId, content);
+        if (content) {
+          await this.slackListener.sendMessage(conversationId, content);
+        }
+        if (media && media.length > 0) {
+          // Slack file uploads not yet implemented — count as failures
+          mediaResult = {
+            sent: 0,
+            failed: media.length,
+            errors: ['Slack media sending not yet implemented'],
+          };
+          logger.warn('Slack media sending not yet implemented', { mediaCount: media.length });
+        }
         // Log outgoing Slack message to activity stream
         {
+          const logContent =
+            media && media.length > 0 && mediaResult
+              ? content
+                ? `${content} [+${media.length} media] sent=${mediaResult.sent} failed=${mediaResult.failed}`
+                : `[${media.length} media] sent=${mediaResult.sent} failed=${mediaResult.failed}`
+              : content;
           const userId = await this.resolveUserIdForConversation('slack', conversationId);
           if (this.dataComposer && userId) {
             try {
+              const payload: Record<string, unknown> = {};
+              if (media && media.length > 0) {
+                payload.mediaCount = media.length;
+                payload.media = media.map((m) => ({
+                  type: m.type,
+                  path: m.path || null,
+                  url: m.url || null,
+                  filename: m.filename || null,
+                  contentType: m.contentType || null,
+                }));
+              }
               await this.dataComposer.repositories.activityStream.logMessage({
                 userId,
-                agentId: 'slack', // Will be resolved by routing
+                agentId: 'slack',
                 direction: 'out',
-                content,
+                content: logContent,
                 platform: 'slack',
                 platformChatId: conversationId,
                 isDm: true,
+                payload: Object.keys(payload).length > 0 ? payload : undefined,
               });
             } catch (activityError) {
               logger.warn(

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -333,8 +333,9 @@ async function startServer(config: ServerConfig = {}): Promise<void> {
 
     // Register the response callback so send_response MCP calls route through ChannelGateway
     setResponseCallback(async (response) => {
-      await channelGateway!.sendResponse(response);
+      const result = await channelGateway!.sendResponse(response);
       logger.info(`Response routed via callback to ${response.channel}:${response.conversationId}`);
+      return result;
     });
     logger.info('Response callback registered for MCP send_response tool');
   } else {

--- a/packages/api/src/services/sessions/claude-runner.ts
+++ b/packages/api/src/services/sessions/claude-runner.ts
@@ -389,6 +389,7 @@ export class ClaudeRunner implements IClaudeRunner {
           format: input.format as 'text' | 'markdown' | 'code' | 'json' | undefined,
           replyToMessageId: input.replyToMessageId as string | undefined,
           metadata: input.metadata as Record<string, unknown> | undefined,
+          media: input.media as ChannelResponse['media'],
         };
         responses.push(response);
         logger.debug('Captured send_response call', { response });

--- a/packages/api/src/services/sessions/codex-runner.ts
+++ b/packages/api/src/services/sessions/codex-runner.ts
@@ -503,6 +503,7 @@ export class CodexRunner implements IClaudeRunner {
                 metadata: (input as Record<string, unknown>).metadata as
                   | Record<string, unknown>
                   | undefined,
+                media: (input as Record<string, unknown>).media as ChannelResponse['media'],
               });
             }
           }

--- a/packages/api/src/services/sessions/gemini-runner.ts
+++ b/packages/api/src/services/sessions/gemini-runner.ts
@@ -434,6 +434,7 @@ export class GeminiRunner implements IClaudeRunner {
                 format: typedInput.format as 'text' | 'markdown' | 'code' | 'json' | undefined,
                 replyToMessageId: typedInput.replyToMessageId as string | undefined,
                 metadata: typedInput.metadata as Record<string, unknown> | undefined,
+                media: typedInput.media as ChannelResponse['media'],
               });
               logger.debug('Captured send_response call from Gemini', { channel, conversationId });
             }


### PR DESCRIPTION
## Summary

Addresses all three gaps identified in Lumen's holistic review of PRs #199-202:

- **Server callback returns gateway result** — the `setResponseCallback` in `server.ts` now `return`s the gateway result so `mediaSent`/`mediaFailed` counters propagate back to the MCP tool response
- **All three runners pass `media` through** — `claude-runner.ts`, `codex-runner.ts`, and `gemini-runner.ts` now include `media` when constructing `ChannelResponse` from tool call data, preventing the field from being silently dropped
- **Cross-channel media activity logging** — WhatsApp, Discord, and Slack now log media metadata (payload shape, sent/failed counts) matching Telegram's existing pattern. Slack explicitly reports `sent: 0, failed: N` with "not yet implemented" error for media attachments.

Also updates PROCESS.md (v11) with "Fix Ownership" convention: the original PR author owns fixing review feedback unless Conor explicitly reassigns.

## Test plan

- [ ] Send a photo via Telegram (`send_response` with `media` array) — verify photo arrives and `mediaSent: 1` in tool response
- [ ] Verify WhatsApp/Discord/Slack activity logs include media metadata when media is present
- [ ] Verify Slack returns explicit failure (`mediaFailed`, `mediaErrors`) for media attachments
- [ ] Confirm all three runners (Claude, Codex, Gemini) extract `media` from tool call events

🤖 Generated with [Claude Code](https://claude.com/claude-code)