### PR TITLE
fix(api): cap bootstrap activeSessions and fix get_identity docs (by Wren)

### DIFF
--- a/packages/api/src/data/repositories/memory-repository.ts
+++ b/packages/api/src/data/repositories/memory-repository.ts
@@ -572,17 +572,19 @@ export class MemoryRepository {
   }
 
   /**
-   * Get all active sessions for a user (without ended_at), ordered most recent first.
-   * Used by bootstrap to return all active sessions so the client can pick the right one.
+   * Get recent active sessions for a user (without ended_at), ordered most recent first.
+   * Used by bootstrap to return active sessions so the client can pick the right one.
+   * Capped to avoid bloating bootstrap response with zombie sessions.
    */
-  async getActiveSessions(userId: string, agentId?: string): Promise<Session[]> {
+  async getActiveSessions(userId: string, agentId?: string, limit = 10): Promise<Session[]> {
     let query = this.supabase
       .from('sessions')
       .select('*')
       .eq('user_id', userId)
       .is('ended_at', null)
       .neq('lifecycle', 'failed')
-      .order('started_at', { ascending: false });
+      .order('started_at', { ascending: false })
+      .limit(limit);
 
     if (agentId) {
       query = query.eq('agent_id', agentId);

--- a/packages/api/src/mcp/tools/index.ts
+++ b/packages/api/src/mcp/tools/index.ts
@@ -2488,7 +2488,7 @@ User can be identified by ONE of: userId, email, phone, or platform + platformId
     {
       description: `Get an AI being's identity by agent ID. Returns structured identity data including name, role, values, relationships, and capabilities.
 
-Use the optional 'file' parameter to fetch a single document (heartbeat, soul, values, identity) for minimal token usage. Omit to get everything.
+Use the optional 'file' parameter to fetch a single document (heartbeat, soul, identity) for minimal token usage. Omit to get everything. For VALUES.md and PROCESS.md, use get_team_constitution instead.
 
 User can be identified by ONE of: userId, email, phone, or platform + platformId`,
       inputSchema: getIdentitySchema,

--- a/packages/api/src/mcp/tools/memory-handlers.ts
+++ b/packages/api/src/mcp/tools/memory-handlers.ts
@@ -1900,8 +1900,8 @@ export async function handleBootstrap(args: unknown, dataComposer: DataComposer)
                 : null,
             },
 
-            // All active sessions — use studioId to pick the right one
-            // Match against .pcp/identity.json studioId/workspaceId in your local environment
+            // Recent active sessions (most recent 10) — use workspaceId to pick yours
+            // Match against .pcp/identity.json workspaceId in your local environment
             activeSessions: activeSessions.map((s) => ({
               id: s.id,
               agentId: s.agentId,


### PR DESCRIPTION
## Summary

- **Cap `getActiveSessions` to 10 results** — bootstrap was returning all 138 zombie sessions (39% of the response payload, ~38K chars). Now returns the 10 most recent, ordered by `started_at DESC`. Clients match by `workspaceId` so the limit doesn't affect session routing.
- **Fix `get_identity` tool description** — removed `values` from the file parameter options since VALUES.md and PROCESS.md are now served via `get_team_constitution`, not `get_identity`.
- **Updated PROCESS.md in the database** (via `save_team_constitution`) — the "Read tools" section now correctly lists `get_identity(file: "soul"|"heartbeat"|"identity")` without `"values"`, and reorders `get_team_constitution` before `get_user_identity`.

## Test plan

- [ ] `yarn workspace @personal-context/api build` compiles
- [ ] Bootstrap response is significantly smaller (activeSessions capped at 10)
- [ ] `get_identity` tool description no longer mentions `values` as a file option
- [ ] Existing session matching by `workspaceId` still works with the limited set

🤖 Generated with [Claude Code](https://claude.com/claude-code)