### PR TITLE
fix: harden session candidate linking + add all-sessions debug mode (by Lumen)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -525,6 +525,7 @@ Spec URIs follow the pattern `pcp://specs/<slug>`. When referencing a spec in co
 
 Defined in [CONTRIBUTING.md](./CONTRIBUTING.md). Key SB-specific reminders:
 
+- **Commit continuously at logical completion points.** Do not wait until the end of a PR to dump one large commit. Each commit should represent one coherent, reviewable unit of work.
 - **Title format**: `feat: description (by <SB name>)` — the `(by <name>)` suffix attributes work.
 - **Sign reviews**: end PR comments with `— Wren`, `— Lumen`, etc.
 - **Do not wait for permission to open a PR** once implementation is ready. Create the PR proactively unless the user explicitly asked you not to.

--- a/packages/api/src/mcp/tools/memory-handlers.test.ts
+++ b/packages/api/src/mcp/tools/memory-handlers.test.ts
@@ -82,12 +82,22 @@ function createMockDataComposer() {
     create: vi.fn(),
   };
 
+  const mockActivityStreamRepo = {
+    logActivity: vi.fn().mockResolvedValue({
+      id: 'activity-123',
+      type: 'state_change',
+      agentId: 'wren',
+      createdAt: new Date('2026-02-10T10:00:00Z'),
+    }),
+  };
+
   return {
     getClient: vi.fn(),
     repositories: {
       memory: mockMemoryRepo,
       projects: mockProjectsRepo,
       projectTasks: mockProjectTasksRepo,
+      activityStream: mockActivityStreamRepo,
     },
   };
 }
@@ -439,6 +449,53 @@ describe('handleUpdateSessionPhase', () => {
         'user-123',
         'wren',
         undefined
+      );
+    });
+
+    it('should log state_change activity with before/after snapshots', async () => {
+      const before = {
+        ...mockSession,
+        currentPhase: 'investigating',
+        lifecycle: 'idle',
+        status: 'active',
+        backendSessionId: null,
+      };
+      const after = {
+        ...mockSession,
+        currentPhase: 'implementing',
+        lifecycle: 'running',
+        status: 'active',
+        backendSessionId: 'claude-abc123',
+      };
+      mockDataComposer.repositories.memory.getActiveSession.mockResolvedValue(mockSession);
+      mockDataComposer.repositories.memory.getSession.mockResolvedValue(before);
+      mockDataComposer.repositories.memory.updateSession.mockResolvedValue(after);
+
+      const result = await handleUpdateSessionPhase(
+        {
+          email: 'test@test.com',
+          phase: 'implementing',
+          lifecycle: 'running',
+          backendSessionId: 'claude-abc123',
+          agentId: 'wren',
+        },
+        mockDataComposer as never
+      );
+
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.success).toBe(true);
+      expect(parsed.sessionTrace.changedFields).toEqual(
+        expect.arrayContaining(['currentPhase', 'lifecycle', 'backendSessionId'])
+      );
+
+      expect(mockDataComposer.repositories.activityStream.logActivity).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: 'user-123',
+          agentId: 'wren',
+          type: 'state_change',
+          subtype: 'session_update',
+          sessionId: 'session-123',
+        })
       );
     });
 

--- a/packages/api/src/mcp/tools/memory-handlers.test.ts
+++ b/packages/api/src/mcp/tools/memory-handlers.test.ts
@@ -559,6 +559,7 @@ describe('handleUpdateSessionPhase', () => {
   describe('unified session fields', () => {
     it('should update backendSessionId', async () => {
       mockDataComposer.repositories.memory.getActiveSession.mockResolvedValue(mockSession);
+      mockDataComposer.repositories.memory.listSessions.mockResolvedValue([mockSession]);
       mockDataComposer.repositories.memory.updateSession.mockResolvedValue(mockSession);
 
       const result = await handleUpdateSessionPhase(
@@ -573,6 +574,46 @@ describe('handleUpdateSessionPhase', () => {
       expect(mockDataComposer.repositories.memory.updateSession).toHaveBeenCalledWith(
         'session-123',
         expect.objectContaining({ backendSessionId: 'claude-abc123' })
+      );
+    });
+
+    it('should report conflict when backendSessionId is already linked to another agent session', async () => {
+      const conflictSession = {
+        ...mockSession,
+        id: 'session-999',
+        agentId: 'myra',
+        backendSessionId: 'claude-abc123',
+      };
+      mockDataComposer.repositories.memory.getActiveSession.mockResolvedValue(mockSession);
+      mockDataComposer.repositories.memory.listSessions.mockResolvedValue([
+        conflictSession,
+        mockSession,
+      ]);
+      mockDataComposer.repositories.memory.updateSession.mockResolvedValue({
+        ...mockSession,
+        backendSessionId: 'claude-abc123',
+      });
+
+      const result = await handleUpdateSessionPhase(
+        { email: 'test@test.com', backendSessionId: 'claude-abc123', agentId: 'wren' },
+        mockDataComposer as never
+      );
+
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.success).toBe(true);
+      expect(parsed.sessionConflict).toEqual(
+        expect.objectContaining({
+          backendSessionId: 'claude-abc123',
+          conflictingSessionId: 'session-999',
+          conflictingAgentId: 'myra',
+        })
+      );
+      expect(mockDataComposer.repositories.activityStream.logActivity).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'state_change',
+          subtype: 'session_backend_conflict',
+          sessionId: 'session-123',
+        })
       );
     });
 

--- a/packages/api/src/mcp/tools/memory-handlers.ts
+++ b/packages/api/src/mcp/tools/memory-handlers.ts
@@ -13,7 +13,7 @@ import { logger } from '../../utils/logger';
 import { userIdentifierBaseSchema, resolveUserOrThrow } from '../../services/user-resolver';
 import { setSessionContext, pinSessionAgent, getRequestContext } from '../../utils/request-context';
 import { getEffectiveAgentId } from '../../auth/enforce-identity';
-import type { MemorySource, Salience } from '../../data/models/memory';
+import type { MemorySource, Salience, Session } from '../../data/models/memory';
 import { getCloudSkillsService } from '../../skills/cloud-service';
 
 // Helper to safely read a file, returning null if it doesn't exist
@@ -1188,6 +1188,63 @@ function isSignificantPhaseTransition(phase: string): boolean {
   return phase.startsWith('blocked:') || phase.startsWith('waiting:') || phase === 'complete';
 }
 
+type SessionTraceField =
+  | 'agentId'
+  | 'currentPhase'
+  | 'lifecycle'
+  | 'status'
+  | 'backendSessionId'
+  | 'workingDir'
+  | 'context';
+
+interface SessionTraceSnapshot {
+  agentId: string | null;
+  currentPhase: string | null;
+  lifecycle: string | null;
+  status: string | null;
+  backendSessionId: string | null;
+  workingDir: string | null;
+  context: string | null;
+}
+
+const SESSION_TRACE_FIELDS: SessionTraceField[] = [
+  'agentId',
+  'currentPhase',
+  'lifecycle',
+  'status',
+  'backendSessionId',
+  'workingDir',
+  'context',
+];
+
+function normalizeTraceString(value: string | null | undefined, truncateAt = 240): string | null {
+  if (value === undefined || value === null) return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  return trimmed.length > truncateAt ? `${trimmed.slice(0, truncateAt)}…` : trimmed;
+}
+
+function toSessionTraceSnapshot(session: Session | null | undefined): SessionTraceSnapshot {
+  return {
+    agentId: normalizeTraceString(session?.agentId),
+    currentPhase: normalizeTraceString(session?.currentPhase),
+    lifecycle: normalizeTraceString(session?.lifecycle),
+    status: normalizeTraceString(session?.status),
+    backendSessionId: normalizeTraceString(session?.backendSessionId || session?.claudeSessionId),
+    workingDir: normalizeTraceString(session?.workingDir),
+    context: normalizeTraceString(session?.context),
+  };
+}
+
+function buildSessionTraceDiff(before: Session | null | undefined, after: Session) {
+  const beforeSnapshot = toSessionTraceSnapshot(before);
+  const afterSnapshot = toSessionTraceSnapshot(after);
+  const changedFields = SESSION_TRACE_FIELDS.filter(
+    (field) => beforeSnapshot[field] !== afterSnapshot[field]
+  );
+  return { beforeSnapshot, afterSnapshot, changedFields };
+}
+
 export async function handleUpdateSessionPhase(args: unknown, dataComposer: DataComposer) {
   const params = updateSessionPhaseSchema.parse(args);
   const { user, resolvedBy } = await resolveUserOrThrow(params, dataComposer);
@@ -1243,6 +1300,16 @@ export async function handleUpdateSessionPhase(args: unknown, dataComposer: Data
       };
     }
     sessionId = session.id;
+  }
+
+  let beforeSession: Session | null = null;
+  try {
+    beforeSession = await dataComposer.repositories.memory.getSession(sessionId);
+  } catch (error) {
+    logger.warn('Failed to load pre-update session snapshot for tracing', {
+      sessionId,
+      error: error instanceof Error ? error.message : String(error),
+    });
   }
 
   // Build update object
@@ -1328,6 +1395,54 @@ export async function handleUpdateSessionPhase(args: unknown, dataComposer: Data
       currentPhase: updated.currentPhase || null,
     },
   };
+
+  const trace = buildSessionTraceDiff(beforeSession, updated);
+  if (trace.changedFields.length > 0) {
+    const activityStreamRepo = dataComposer.repositories.activityStream;
+
+    if (activityStreamRepo?.logActivity) {
+      const effectiveAgentId =
+        getEffectiveAgentId(params.agentId) ??
+        params.agentId ??
+        updated.agentId ??
+        beforeSession?.agentId ??
+        'unknown';
+      try {
+        await activityStreamRepo.logActivity({
+          userId: user.id,
+          agentId: effectiveAgentId,
+          type: 'state_change',
+          subtype: 'session_update',
+          sessionId,
+          status: 'completed',
+          content: `Session ${sessionId.slice(0, 8)} updated (${trace.changedFields.join(', ')})`,
+          payload: {
+            sessionId,
+            changedFields: trace.changedFields,
+            before: trace.beforeSnapshot,
+            after: trace.afterSnapshot,
+            requestedByAgentId: params.agentId || null,
+            updateRequest: {
+              phase: params.phase || null,
+              lifecycle: params.lifecycle || null,
+              status: params.status || null,
+              backendSessionId: params.backendSessionId || null,
+              contextProvided: params.context !== undefined,
+              workingDirProvided: params.workingDir !== undefined,
+            },
+          },
+        });
+        result.sessionTrace = {
+          changedFields: trace.changedFields,
+        };
+      } catch (error) {
+        logger.warn('Failed to log session state_change activity', {
+          sessionId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+  }
 
   // Auto-create memory for significant phase transitions
   if (params.phase && isSignificantPhaseTransition(params.phase)) {

--- a/packages/api/src/mcp/tools/memory-handlers.ts
+++ b/packages/api/src/mcp/tools/memory-handlers.ts
@@ -1396,10 +1396,81 @@ export async function handleUpdateSessionPhase(args: unknown, dataComposer: Data
     },
   };
 
+  const activityStreamRepo = dataComposer.repositories.activityStream;
+  if (params.backendSessionId) {
+    const backendSessionId = params.backendSessionId.trim();
+    if (backendSessionId) {
+      try {
+        const scan = await dataComposer.repositories.memory.listSessions(user.id, { limit: 200 });
+        const others = Array.isArray(scan) ? scan : [];
+        const conflict = others.find((session) => {
+          if (session.id === sessionId) return false;
+          const linked = (session.backendSessionId || session.claudeSessionId || '').trim();
+          return linked === backendSessionId;
+        });
+
+        if (
+          conflict &&
+          conflict.agentId &&
+          conflict.agentId !== (updated.agentId || params.agentId)
+        ) {
+          logger.warn('Session backendSessionId ownership conflict detected', {
+            sessionId,
+            agentId: updated.agentId || params.agentId || null,
+            backendSessionId,
+            conflictingSessionId: conflict.id,
+            conflictingAgentId: conflict.agentId,
+          });
+
+          result.sessionConflict = {
+            backendSessionId,
+            conflictingSessionId: conflict.id,
+            conflictingAgentId: conflict.agentId,
+          };
+
+          if (activityStreamRepo?.logActivity) {
+            try {
+              await activityStreamRepo.logActivity({
+                userId: user.id,
+                agentId:
+                  getEffectiveAgentId(params.agentId) ??
+                  params.agentId ??
+                  updated.agentId ??
+                  'unknown',
+                type: 'state_change',
+                subtype: 'session_backend_conflict',
+                sessionId,
+                status: 'completed',
+                content: `Session ${sessionId.slice(0, 8)} backendSessionId ${backendSessionId.slice(0, 8)} already linked to ${conflict.agentId}:${conflict.id.slice(0, 8)}`,
+                payload: {
+                  backendSessionId,
+                  targetSessionId: sessionId,
+                  targetAgentId: updated.agentId || params.agentId || null,
+                  conflictingSessionId: conflict.id,
+                  conflictingAgentId: conflict.agentId,
+                },
+              });
+            } catch (error) {
+              logger.warn('Failed to log session backend conflict activity', {
+                sessionId,
+                backendSessionId,
+                error: error instanceof Error ? error.message : String(error),
+              });
+            }
+          }
+        }
+      } catch (error) {
+        logger.warn('Failed to scan sessions for backendSessionId conflicts', {
+          sessionId,
+          backendSessionId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+  }
+
   const trace = buildSessionTraceDiff(beforeSession, updated);
   if (trace.changedFields.length > 0) {
-    const activityStreamRepo = dataComposer.repositories.activityStream;
-
     if (activityStreamRepo?.logActivity) {
       const effectiveAgentId =
         getEffectiveAgentId(params.agentId) ??

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -71,6 +71,12 @@ describe('extractArgs', () => {
     expect(result.sbOptions.sessionCandidatesJson).toBe(true);
   });
 
+  it('parses session-candidates-all debug flag', () => {
+    const result = extractArgs(['--session-candidates-json', '--session-candidates-all']);
+    expect(result.sbOptions.sessionCandidatesJson).toBe(true);
+    expect(result.sbOptions.sessionCandidatesAll).toBe(true);
+  });
+
   it('parses sb-specific verbose flag', () => {
     const result = extractArgs(['--sb-verbose', 'hello']);
     expect(result.sbOptions.verbose).toBe(true);

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -59,6 +59,7 @@ const SB_FLAGS: Record<string, { hasValue: boolean; key: string }> = {
   '--no-session': { hasValue: false, key: 'noSession' },
   '--session-candidates': { hasValue: false, key: 'sessionCandidates' },
   '--session-candidates-json': { hasValue: false, key: 'sessionCandidatesJson' },
+  '--session-candidates-all': { hasValue: false, key: 'sessionCandidatesAll' },
   '--session-choice': { hasValue: true, key: 'sessionChoice' },
   '--sb-debug': { hasValue: false, key: 'sbDebug' },
   '--dangerous': { hasValue: false, key: 'dangerous' },
@@ -73,6 +74,7 @@ interface ParsedArgs {
     verbose: boolean;
     sessionCandidates: boolean;
     sessionCandidatesJson: boolean;
+    sessionCandidatesAll: boolean;
     sessionChoice: string | undefined;
     sbDebug: boolean;
     dangerous: boolean;
@@ -120,6 +122,7 @@ export function extractArgs(argv: string[]): ParsedArgs {
     verbose: false,
     sessionCandidates: false,
     sessionCandidatesJson: false,
+    sessionCandidatesAll: false,
     sessionChoice: undefined,
     sbDebug: false,
     dangerous: false,
@@ -145,6 +148,7 @@ export function extractArgs(argv: string[]): ParsedArgs {
         else if (flag.key === 'verbose') sbOptions.verbose = true;
         else if (flag.key === 'sessionCandidates') sbOptions.sessionCandidates = true;
         else if (flag.key === 'sessionCandidatesJson') sbOptions.sessionCandidatesJson = true;
+        else if (flag.key === 'sessionCandidatesAll') sbOptions.sessionCandidatesAll = true;
         else if (flag.key === 'sbDebug') sbOptions.sbDebug = true;
         else if (flag.key === 'dangerous') sbOptions.dangerous = true;
       }
@@ -195,6 +199,10 @@ program
     'List session candidates and exit (or combine with --session-choice)'
   )
   .option('--session-candidates-json', 'Output session candidates as JSON (testing/debug)')
+  .option(
+    '--session-candidates-all',
+    'Include all backend-local sessions in picker/json (debug mode; includes non-interactive sources)'
+  )
   .option('--session-choice <choice>', 'Force session selection (new | pcp:<id> | local:<id>)')
   .option('--sb-debug', 'Enable SB debug logging to ~/.pcp/sb-debug.log')
   .option('--sb-verbose', 'Verbose SB output')

--- a/packages/cli/src/commands/claude.test.ts
+++ b/packages/cli/src/commands/claude.test.ts
@@ -780,6 +780,49 @@ describe('resolveCapturedBackendSessionIdFromRuntime', () => {
     ).toBe('fallback-id');
   });
 
+  it('detects a brand-new local backend session even when pre-run snapshot is empty', () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), 'sb-claude-runtime-empty-'));
+    const tempHome = join(tempRoot, 'home');
+    const tempRepo = join(tempRoot, 'repo');
+    mkdirSync(tempHome, { recursive: true });
+    mkdirSync(tempRepo, { recursive: true });
+
+    const projectDirName = tempRepo.replace(/[\\/]/g, '-');
+    const projectKeyDir = join(tempHome, '.claude', 'projects', projectDirName);
+    mkdirSync(projectKeyDir, { recursive: true });
+
+    const oldHome = process.env.HOME;
+    process.env.HOME = tempHome;
+
+    try {
+      const newSessionId = '10101010-1010-4010-8010-101010101010';
+      writeFileSync(
+        join(projectKeyDir, `${newSessionId}.jsonl`),
+        JSON.stringify({
+          type: 'progress',
+          sessionId: newSessionId,
+          timestamp: '2026-03-09T00:00:00.000Z',
+        }) + '\n'
+      );
+
+      const resolved = resolveCapturedBackendSessionIdFromRuntime({
+        cwd: tempRepo,
+        backend: 'claude',
+        pcpSessionId: 'pcp-session-empty-snapshot',
+        knownLocalSessionSnapshot: new Map(),
+      });
+
+      expect(resolved).toBe(newSessionId);
+    } finally {
+      if (oldHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = oldHome;
+      }
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
   it('falls back to new local backend session for the project when runtime linkage is missing', () => {
     const tempRoot = mkdtempSync(join(tmpdir(), 'sb-claude-runtime-'));
     const tempHome = join(tempRoot, 'home');

--- a/packages/cli/src/commands/claude.test.ts
+++ b/packages/cli/src/commands/claude.test.ts
@@ -981,6 +981,7 @@ describe('getCodexLocalSessionsForProject', () => {
     mkdirSync(codexSessionsDir, { recursive: true });
 
     const matchingSessionId = '019a23ac-e563-7d53-8bf0-5a948546bf29';
+    const nonCliSessionId = '019a23ac-e563-7d53-8bf0-5a948546bf99';
     const nonMatchingSessionId = '019a23b9-b211-7972-b007-012a8bc1d6f2';
     writeFileSync(
       join(codexSessionsDir, `rollout-2026-03-02T11-44-41-${matchingSessionId}.jsonl`),
@@ -992,6 +993,7 @@ describe('getCodexLocalSessionsForProject', () => {
             id: matchingSessionId,
             cwd: projectPath,
             timestamp: '2026-03-02T11:44:41.000Z',
+            originator: 'codex_cli_rs',
           },
         }),
         JSON.stringify({
@@ -1004,6 +1006,19 @@ describe('getCodexLocalSessionsForProject', () => {
           },
         }),
       ].join('\n') + '\n'
+    );
+    writeFileSync(
+      join(codexSessionsDir, `rollout-2026-03-02T11-45-41-${nonCliSessionId}.jsonl`),
+      `${JSON.stringify({
+        timestamp: '2026-03-02T11:45:41.000Z',
+        type: 'session_meta',
+        payload: {
+          id: nonCliSessionId,
+          cwd: projectPath,
+          timestamp: '2026-03-02T11:45:41.000Z',
+          originator: 'codex_exec',
+        },
+      })}\n`
     );
     writeFileSync(
       join(codexSessionsDir, `rollout-2026-03-02T11-44-41-${nonMatchingSessionId}.jsonl`),

--- a/packages/cli/src/commands/claude.test.ts
+++ b/packages/cli/src/commands/claude.test.ts
@@ -1041,6 +1041,14 @@ describe('getCodexLocalSessionsForProject', () => {
       expect(sessions.map((session) => session.sessionId)).toEqual([matchingSessionId]);
       expect(sessions[0]?.latestPrompt).toBe('assistant: Most recent assistant reply');
       expect(sessions[0]?.transcriptPath).toContain(matchingSessionId);
+
+      const sessionsIncludingExec = getCodexLocalSessionsForProject(projectPath, 10, {
+        includeExecSources: true,
+      });
+      expect(sessionsIncludingExec.map((session) => session.sessionId)).toEqual([
+        nonCliSessionId,
+        matchingSessionId,
+      ]);
     } finally {
       process.env.HOME = originalHome;
       rmSync(tempHome, { recursive: true, force: true });

--- a/packages/cli/src/commands/claude.test.ts
+++ b/packages/cli/src/commands/claude.test.ts
@@ -4,6 +4,7 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 import {
   extractClaudeHistorySessionsForProject,
+  extractBackendSessionOverrideId,
   extractSessionFromStartSessionResponse,
   filterUntrackedLocalBackendSessions,
   filterPcpSessionsForContext,
@@ -65,6 +66,35 @@ describe('hasBackendSessionOverride', () => {
     expect(hasBackendSessionOverride('claude', ['-r'])).toBe(true);
     expect(hasBackendSessionOverride('gemini', ['--resume'])).toBe(true);
     expect(hasBackendSessionOverride('gemini', ['-r'])).toBe(true);
+  });
+});
+
+describe('extractBackendSessionOverrideId', () => {
+  it('extracts codex resume id from positional subcommand', () => {
+    expect(
+      extractBackendSessionOverrideId(
+        'codex',
+        [],
+        ['resume', '019c44fd-68f6-7332-9eda-2dc7c8afcedf']
+      )
+    ).toBe('019c44fd-68f6-7332-9eda-2dc7c8afcedf');
+  });
+
+  it('extracts codex resume id from passthrough subcommand', () => {
+    expect(extractBackendSessionOverrideId('codex', ['--full-auto', 'resume', '019c1234'])).toBe(
+      '019c1234'
+    );
+  });
+
+  it('extracts claude --resume id', () => {
+    expect(extractBackendSessionOverrideId('claude', ['--resume', 'ba549776-aaaa'])).toBe(
+      'ba549776-aaaa'
+    );
+  });
+
+  it('returns undefined when no explicit override id is present', () => {
+    expect(extractBackendSessionOverrideId('claude', ['--resume'])).toBeUndefined();
+    expect(extractBackendSessionOverrideId('codex', ['resume'])).toBeUndefined();
   });
 });
 

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -2344,7 +2344,9 @@ async function ensurePcpSessionContext(
     if (!backendSessionId || pcpSessionByBackendSessionId.has(backendSessionId)) continue;
     pcpSessionByBackendSessionId.set(backendSessionId, session);
   }
-  const displayLocalBackendSessions = localBackendSessions;
+  // Keep the picker de-duplicated: linked locals are rendered through the PCP row
+  // (with linked preview/timestamp), while untracked locals remain independently selectable.
+  const displayLocalBackendSessions = untrackedLocalBackendSessions;
   const existingSessionIds = new Set(activeSessions.map((session) => session.id));
   const pcpPreviewBySessionId = new Map<string, string>();
   for (const session of activeSessions) {

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -317,6 +317,7 @@ interface CodexSessionMetaLine {
     id?: string;
     cwd?: string;
     timestamp?: string;
+    originator?: string;
   };
 }
 
@@ -1507,6 +1508,7 @@ SELECT id, cwd, updated_at,
        git_branch
 FROM threads
 WHERE archived = 0
+  AND source = 'cli'
 ORDER BY updated_at DESC
 LIMIT 200;
 `;
@@ -1657,6 +1659,8 @@ function getCodexLocalSessionsFromJsonl(
       const sessionId = parsed.payload?.id?.trim();
       const sessionCwd = parsed.payload?.cwd?.trim();
       if (!sessionId || !sessionCwd) break;
+      const originator = parsed.payload?.originator?.trim();
+      if (originator && !originator.startsWith('codex_cli')) break;
 
       const normalizedSessionCwd = normalizePath(sessionCwd);
       if (!normalizedSessionCwd || normalizedSessionCwd !== normalizedCwd) break;

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -1181,7 +1181,7 @@ export function resolveCapturedBackendSessionIdFromRuntime(options: {
     if (currentSessionId) return currentSessionId;
   }
 
-  if (knownLocalSessionSnapshot && knownLocalSessionSnapshot.size > 0) {
+  if (knownLocalSessionSnapshot) {
     const postRunLocalSessions = getBackendLocalSessionsForProject(backend, cwd, 50);
     const newLocalSession = postRunLocalSessions.find(
       (session) => !knownLocalSessionSnapshot.has(session.sessionId)

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -728,6 +728,19 @@ function withAgentPreviewSpeaker(
   return preview;
 }
 
+function withSessionFileSize(
+  preview: string | undefined,
+  fileSizeBytes: number | undefined
+): string | undefined {
+  const size = formatFileSize(fileSizeBytes);
+  if (!size) return preview;
+
+  const normalized = preview?.trim();
+  if (!normalized) return `(session) · ${size}`;
+  if (normalized.includes(size)) return normalized;
+  return `${normalized} · ${size}`;
+}
+
 function getSessionPhaseLabel(session: PcpSessionSummary): string | undefined {
   const currentPhase = (session.currentPhase || '').trim();
   if (currentPhase) return currentPhase;
@@ -1975,6 +1988,43 @@ export function hasBackendSessionOverride(
   return has('--resume') || has('-r') || has('--session-id');
 }
 
+export function extractBackendSessionOverrideId(
+  backend: string,
+  passthroughArgs: string[],
+  promptParts: string[] = []
+): string | undefined {
+  const readFlagValue = (flags: string[]): string | undefined => {
+    for (let i = 0; i < passthroughArgs.length; i += 1) {
+      const token = passthroughArgs[i]?.toLowerCase();
+      if (!token || !flags.includes(token)) continue;
+      const value = passthroughArgs[i + 1];
+      if (value && !value.startsWith('-')) return value;
+    }
+    return undefined;
+  };
+
+  if (backend === 'codex') {
+    if (promptParts[0]?.toLowerCase() === 'resume') {
+      const positional = promptParts[1];
+      if (positional && !positional.startsWith('-')) return positional;
+    }
+
+    const resumeIndex = passthroughArgs.findIndex((arg) => arg.toLowerCase() === 'resume');
+    if (resumeIndex >= 0) {
+      const value = passthroughArgs[resumeIndex + 1];
+      if (value && !value.startsWith('-')) return value;
+    }
+
+    return readFlagValue(['--resume', '-r', '--session-id']);
+  }
+
+  if (backend === 'claude') {
+    return readFlagValue(['--resume', '-r', '--session-id']);
+  }
+
+  return readFlagValue(['--resume', '-r', '--session-id']);
+}
+
 function extractActivityIdFromLogResult(result: unknown): string | undefined {
   if (!result || typeof result !== 'object') return undefined;
   const maybe = result as LogActivityResult;
@@ -2225,7 +2275,12 @@ async function ensurePcpSessionContext(
   backendSessionSeedId?: string;
   threadKey?: string;
 }> {
-  if (hasBackendSessionOverride(backend, passthroughArgs, promptParts)) return {};
+  const hasSessionOverride = hasBackendSessionOverride(backend, passthroughArgs, promptParts);
+  const overrideBackendSessionId = extractBackendSessionOverrideId(
+    backend,
+    passthroughArgs,
+    promptParts
+  );
 
   const config = getPcpConfig();
   const email = config?.email;
@@ -2246,6 +2301,8 @@ async function ensurePcpSessionContext(
     agentId,
     isTty: process.stdin.isTTY,
     explicitSelection,
+    hasSessionOverride,
+    overrideBackendSessionId: overrideBackendSessionId || null,
     selectionOverride: options.selectionOverride || null,
     localCount: localBackendSessions.length,
     knownCount: knownBackendSessionIds.size,
@@ -2544,6 +2601,61 @@ async function ensurePcpSessionContext(
     }
   };
 
+  if (hasSessionOverride) {
+    if (!overrideBackendSessionId) {
+      sbDebugLog('claude', 'ensure_context_override_without_explicit_id', {
+        backend,
+        agentId,
+      });
+      return {};
+    }
+
+    const matchedByBackendId =
+      pcpSessionByBackendSessionId.get(overrideBackendSessionId) ||
+      activeSessions.find(
+        (session) =>
+          session.id === overrideBackendSessionId ||
+          session.id.startsWith(overrideBackendSessionId) ||
+          getSessionBackendId(session) === overrideBackendSessionId
+      );
+
+    chosen = matchedByBackendId;
+    if (!chosen) {
+      chosen = await startNewPcpSession();
+      createdNewPcpSession = Boolean(chosen?.id);
+    }
+
+    if (chosen?.id) {
+      await persistBackendSessionLink({
+        pcpSessionId: chosen.id,
+        backendSessionId: overrideBackendSessionId,
+        backend,
+        agentId,
+        studioId,
+        identityId,
+        email,
+      });
+      sbDebugLog('claude', 'ensure_context_override_linked', {
+        backend,
+        agentId,
+        pcpSessionId: chosen.id,
+        backendSessionId: overrideBackendSessionId,
+        createdNewPcpSession,
+      });
+      return {
+        pcpSessionId: chosen.id,
+        ...(chosen.threadKey ? { threadKey: chosen.threadKey } : {}),
+      };
+    }
+
+    sbDebugLog('claude', 'ensure_context_override_link_failed', {
+      backend,
+      agentId,
+      backendSessionId: overrideBackendSessionId,
+    });
+    return {};
+  }
+
   const localBySessionId = new Map(
     localBackendSessions.map((session) => [session.sessionId, session])
   );
@@ -2554,9 +2666,12 @@ async function ensurePcpSessionContext(
       const linkedLocalSession = linkedBackendSessionId
         ? localBySessionId.get(linkedBackendSessionId)
         : undefined;
-      const linkedPreviewText = withAgentPreviewSpeaker(
-        linkedLocalSession?.latestPrompt || linkedLocalSession?.firstPrompt,
-        session.agentId || agentId
+      const linkedPreviewText = withSessionFileSize(
+        withAgentPreviewSpeaker(
+          linkedLocalSession?.latestPrompt || linkedLocalSession?.firstPrompt,
+          session.agentId || agentId
+        ),
+        linkedLocalSession?.fileSizeBytes
       );
       const ownerAgentId = session.agentId || null;
       const sortTimestamp = linkedLocalSession?.latestPromptAt || linkedLocalSession?.modified;
@@ -2573,23 +2688,29 @@ async function ensurePcpSessionContext(
         linkedLocalModified:
           linkedLocalSession?.latestPromptAt || linkedLocalSession?.modified || null,
         linkedLocalPreview: linkedPreviewText || null,
+        linkedLocalFileSizeBytes: linkedLocalSession?.fileSizeBytes || null,
+        linkedLocalFileSize: formatFileSize(linkedLocalSession?.fileSizeBytes) || null,
         pcpPreview: pcpPreviewBySessionId.get(session.id) || null,
         sortMs,
       };
     });
     const localCandidates = displayLocalBackendSessions.map((session) => {
       const linkedPcpSession = pcpSessionByBackendSessionId.get(session.sessionId);
-      const preview =
+      const preview = withSessionFileSize(
         withAgentPreviewSpeaker(
           session.latestPrompt || session.firstPrompt,
           linkedPcpSession?.agentId || agentId
-        ) || null;
+        ),
+        session.fileSizeBytes
+      );
       const sortMs = toEpochMs(session.latestPromptAt || session.modified) ?? 0;
       return {
         type: 'local' as const,
         id: session.sessionId,
         modified: session.latestPromptAt || session.modified,
-        preview,
+        preview: preview || null,
+        fileSizeBytes: session.fileSizeBytes || null,
+        fileSize: formatFileSize(session.fileSizeBytes) || null,
         gitBranch: session.gitBranch || null,
         linkedPcpSessionId: linkedPcpSession?.id || null,
         linkedPcpAgentId: linkedPcpSession?.agentId || null,
@@ -2770,6 +2891,10 @@ async function ensurePcpSessionContext(
         linkedLocalSession?.latestPrompt || linkedLocalSession?.firstPrompt,
         session.agentId || agentId
       );
+      const linkedPreviewWithSize = withSessionFileSize(
+        linkedPreviewText,
+        linkedLocalSession?.fileSizeBytes
+      );
       const linkedAt = linkedLocalSession?.latestPromptAt || linkedLocalSession?.modified;
       const backendLabel = backend[0].toUpperCase() + backend.slice(1);
       const ownerLabel = session.agentId || null;
@@ -2777,7 +2902,7 @@ async function ensurePcpSessionContext(
       const sourceLabel = showOwner ? `PCP/${ownerLabel}` : 'PCP';
       const preview = pcpPreviewBySessionId.get(session.id);
       const phaseLabel = getSessionPhaseLabel(session);
-      const pickerPreview = linkedPreviewText || preview || session.context || undefined;
+      const pickerPreview = linkedPreviewWithSize || preview || session.context || undefined;
       const branchLabel =
         linkedLocalSession?.gitBranch ||
         runtimeBranchByPcpSessionId.get(session.id) ||
@@ -2813,9 +2938,12 @@ async function ensurePcpSessionContext(
       const linkedPcpSession = pcpSessionByBackendSessionId.get(localSession.sessionId);
       const ownerLabel = linkedPcpSession?.agentId || null;
       const showOwner = Boolean(ownerLabel && ownerLabel !== agentId);
-      const previewText = withAgentPreviewSpeaker(
-        localSession.latestPrompt || localSession.firstPrompt,
-        ownerLabel || agentId
+      const previewText = withSessionFileSize(
+        withAgentPreviewSpeaker(
+          localSession.latestPrompt || localSession.firstPrompt,
+          ownerLabel || agentId
+        ),
+        localSession.fileSizeBytes
       );
       const sourceLabel = showOwner ? `${backendLabel}/${ownerLabel}` : backendLabel;
       const stateLabel = linkedPcpSession

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -2574,11 +2574,12 @@ async function ensurePcpSessionContext(
         ...interleavedCandidates.map((entry) => {
           if (entry.kind === 'pcp') {
             const session = entry.candidate;
-            const ownerPhase = session.ownerAgentId
+            const showOwner = Boolean(session.ownerAgentId && session.ownerAgentId !== agentId);
+            const ownerPhase = showOwner
               ? `${session.ownerAgentId} · ${session.phase || '-'}`
               : session.phase || '-';
             return {
-              type: session.ownerAgentId ? `pcp:${session.ownerAgentId}` : 'pcp',
+              type: showOwner ? `pcp:${session.ownerAgentId}` : 'pcp',
               choice: `pcp:${session.id.slice(0, 8)}`,
               updated: formatCandidateTimestamp(session.linkedLocalModified || session.startedAt),
               phase: ownerPhase,
@@ -2591,12 +2592,15 @@ async function ensurePcpSessionContext(
             };
           }
           const localSession = entry.candidate;
-          const ownerPhase = localSession.linkedPcpAgentId
+          const showOwner = Boolean(
+            localSession.linkedPcpAgentId && localSession.linkedPcpAgentId !== agentId
+          );
+          const ownerPhase = showOwner
             ? `${localSession.linkedPcpAgentId} · ${localSession.linkedPcpPhase || '-'}`
             : localSession.linkedPcpPhase || '-';
           return {
             type: localSession.linkedPcpSessionId
-              ? localSession.linkedPcpAgentId
+              ? showOwner
                 ? `local:${localSession.linkedPcpAgentId}`
                 : 'local+pcp'
               : 'local',
@@ -2687,7 +2691,8 @@ async function ensurePcpSessionContext(
       const linkedAt = linkedLocalSession?.latestPromptAt || linkedLocalSession?.modified;
       const backendLabel = backend[0].toUpperCase() + backend.slice(1);
       const ownerLabel = session.agentId || null;
-      const sourceLabel = ownerLabel ? `PCP/${ownerLabel}` : 'PCP';
+      const showOwner = Boolean(ownerLabel && ownerLabel !== agentId);
+      const sourceLabel = showOwner ? `PCP/${ownerLabel}` : 'PCP';
       const preview = pcpPreviewBySessionId.get(session.id);
       const phaseLabel = getSessionPhaseLabel(session);
       const pickerPreview = linkedPreviewText || preview || session.context || undefined;
@@ -2697,7 +2702,7 @@ async function ensurePcpSessionContext(
         session.studio?.branch ||
         '-';
       const stateTokens = [
-        ownerLabel ? `agent ${ownerLabel}` : null,
+        showOwner ? ownerLabel : null,
         phaseLabel || 'runtime:active',
         session.threadKey ? `thread ${truncateText(session.threadKey, 20)}` : null,
         linkedBackendSessionId ? `${backendLabel} ${linkedBackendSessionId.slice(0, 8)}` : null,
@@ -2725,14 +2730,15 @@ async function ensurePcpSessionContext(
       const backendLabel = localSession.backend[0].toUpperCase() + localSession.backend.slice(1);
       const linkedPcpSession = pcpSessionByBackendSessionId.get(localSession.sessionId);
       const ownerLabel = linkedPcpSession?.agentId || null;
+      const showOwner = Boolean(ownerLabel && ownerLabel !== agentId);
       const previewText = withAgentPreviewSpeaker(
         localSession.latestPrompt || localSession.firstPrompt,
         ownerLabel || agentId
       );
-      const sourceLabel = ownerLabel ? `${backendLabel}/${ownerLabel}` : backendLabel;
+      const sourceLabel = showOwner ? `${backendLabel}/${ownerLabel}` : backendLabel;
       const stateLabel = linkedPcpSession
-        ? ownerLabel
-          ? `agent ${ownerLabel} · linked pcp:${linkedPcpSession.id.slice(0, 8)}`
+        ? showOwner
+          ? `${ownerLabel} · linked pcp:${linkedPcpSession.id.slice(0, 8)}`
           : `linked pcp:${linkedPcpSession.id.slice(0, 8)}`
         : 'local';
       choiceEntries.push({

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -41,6 +41,7 @@ export interface SbOptions {
   backend: string;
   sessionCandidates?: boolean;
   sessionCandidatesJson?: boolean;
+  sessionCandidatesAll?: boolean;
   sessionChoice?: string;
   dangerous?: boolean;
 }
@@ -1476,13 +1477,18 @@ export function extractClaudeHistorySessionsForProject(
 
 export function getCodexLocalSessionsForProject(
   cwd = process.cwd(),
-  limit = 20
+  limit = 20,
+  options: {
+    includeExecSources?: boolean;
+  } = {}
 ): BackendLocalSessionSummary[] {
+  const includeExecSources = options.includeExecSources === true;
   const fallbackToJsonl = (reason: string): BackendLocalSessionSummary[] => {
-    const fallback = getCodexLocalSessionsFromJsonl(cwd, limit);
+    const fallback = getCodexLocalSessionsFromJsonl(cwd, limit, { includeExecSources });
     sbDebugLog('backend', 'codex_local_sessions_fallback_jsonl', {
       cwd,
       reason,
+      includeExecSources,
       returnedSessions: fallback.length,
       sessionIds: fallback.map((session) => session.sessionId),
     });
@@ -1508,7 +1514,7 @@ SELECT id, cwd, updated_at,
        git_branch
 FROM threads
 WHERE archived = 0
-  AND source = 'cli'
+  ${includeExecSources ? '' : "AND source = 'cli'"}
 ORDER BY updated_at DESC
 LIMIT 200;
 `;
@@ -1581,6 +1587,7 @@ LIMIT 200;
   const scoped = sessions.slice(0, limit);
   sbDebugLog('backend', 'codex_local_sessions_loaded', {
     cwd: normalizedCwd,
+    includeExecSources,
     totalScopedSessions: sessions.length,
     returnedSessions: scoped.length,
     sessionIds: scoped.map((session) => session.sessionId),
@@ -1590,8 +1597,12 @@ LIMIT 200;
 
 function getCodexLocalSessionsFromJsonl(
   cwd = process.cwd(),
-  limit = 20
+  limit = 20,
+  options: {
+    includeExecSources?: boolean;
+  } = {}
 ): BackendLocalSessionSummary[] {
+  const includeExecSources = options.includeExecSources === true;
   const codexSessionsDir = join(homedir(), '.codex', 'sessions');
   if (!existsSync(codexSessionsDir)) return [];
 
@@ -1660,7 +1671,7 @@ function getCodexLocalSessionsFromJsonl(
       const sessionCwd = parsed.payload?.cwd?.trim();
       if (!sessionId || !sessionCwd) break;
       const originator = parsed.payload?.originator?.trim();
-      if (originator && !originator.startsWith('codex_cli')) break;
+      if (!includeExecSources && originator && !originator.startsWith('codex_cli')) break;
 
       const normalizedSessionCwd = normalizePath(sessionCwd);
       if (!normalizedSessionCwd || normalizedSessionCwd !== normalizedCwd) break;
@@ -1867,10 +1878,17 @@ export function getGeminiLocalSessionsForProject(
 export function getBackendLocalSessionsForProject(
   backend: string,
   cwd = process.cwd(),
-  limit = 20
+  limit = 20,
+  options: {
+    includeAllSources?: boolean;
+  } = {}
 ): BackendLocalSessionSummary[] {
   if (backend === 'claude') return getClaudeLocalSessionsForProject(cwd, limit);
-  if (backend === 'codex') return getCodexLocalSessionsForProject(cwd, limit);
+  if (backend === 'codex') {
+    return getCodexLocalSessionsForProject(cwd, limit, {
+      includeExecSources: options.includeAllSources,
+    });
+  }
   if (backend === 'gemini') return getGeminiLocalSessionsForProject(cwd, limit);
   return [];
 }
@@ -2271,6 +2289,7 @@ async function ensurePcpSessionContext(
   options: {
     listCandidates?: boolean;
     listCandidatesJson?: boolean;
+    listCandidatesAll?: boolean;
     selectionOverride?: string;
   } = {}
 ): Promise<{
@@ -2293,7 +2312,9 @@ async function ensurePcpSessionContext(
   const currentGitBranch = getCurrentGitBranch(cwd);
   const localSessionLimit = options.listCandidates || options.listCandidatesJson ? 120 : 40;
   const pcpSessionLimit = options.listCandidates || options.listCandidatesJson ? 80 : 40;
-  const localBackendSessions = getBackendLocalSessionsForProject(backend, cwd, localSessionLimit);
+  const localBackendSessions = getBackendLocalSessionsForProject(backend, cwd, localSessionLimit, {
+    includeAllSources: options.listCandidatesAll,
+  });
   const localBackendSessionIds = new Set(localBackendSessions.map((session) => session.sessionId));
   const knownBackendSessionIds =
     backend === 'claude' ? getKnownClaudeSessionIds() : localBackendSessionIds;
@@ -2307,6 +2328,7 @@ async function ensurePcpSessionContext(
     explicitSelection,
     hasSessionOverride,
     overrideBackendSessionId: overrideBackendSessionId || null,
+    listCandidatesAll: options.listCandidatesAll || false,
     selectionOverride: options.selectionOverride || null,
     localCount: localBackendSessions.length,
     knownCount: knownBackendSessionIds.size,
@@ -3165,6 +3187,7 @@ export async function runClaude(
         {
           listCandidates: options.sessionCandidates || options.sessionCandidatesJson,
           listCandidatesJson: options.sessionCandidatesJson,
+          listCandidatesAll: options.sessionCandidatesAll,
           selectionOverride: options.sessionChoice,
         }
       )
@@ -3373,6 +3396,7 @@ export async function runClaudeInteractive(
         {
           listCandidates: options.sessionCandidates || options.sessionCandidatesJson,
           listCandidatesJson: options.sessionCandidatesJson,
+          listCandidatesAll: options.sessionCandidatesAll,
           selectionOverride: options.sessionChoice,
         }
       )

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -82,6 +82,7 @@ interface BackendLocalSessionSummary {
   sessionId: string;
   projectPath: string;
   modified: string;
+  fileSizeBytes?: number;
   firstPrompt?: string;
   latestPrompt?: string;
   latestPromptAt?: string;
@@ -123,6 +124,20 @@ function formatCandidateTimestamp(value: string | null | undefined): string {
   const ms = Date.parse(value);
   if (!Number.isFinite(ms)) return '-';
   return new Date(ms).toLocaleString();
+}
+
+function formatFileSize(bytes: number | undefined): string | undefined {
+  if (bytes === undefined || !Number.isFinite(bytes) || bytes < 0) return undefined;
+  if (bytes < 1024) return `${bytes} B`;
+  const units = ['KB', 'MB', 'GB', 'TB'];
+  let size = bytes / 1024;
+  let unitIndex = 0;
+  while (size >= 1024 && unitIndex < units.length - 1) {
+    size /= 1024;
+    unitIndex += 1;
+  }
+  const decimals = size >= 10 ? 1 : 2;
+  return `${size.toFixed(decimals)} ${units[unitIndex]}`;
 }
 
 function formatPickerTimestamp(value: string | null | undefined): string {
@@ -1232,6 +1247,20 @@ export function getClaudeLocalSessionsForProject(
   if (!normalizedCwd) return [];
 
   const results: BackendLocalSessionSummary[] = [];
+  const historyPath = join(homedir(), '.claude', 'history.jsonl');
+  let historySessions: BackendLocalSessionSummary[] = [];
+  let historySessionIds = new Set<string>();
+  if (existsSync(historyPath)) {
+    try {
+      historySessions = extractClaudeHistorySessionsForProject(
+        readFileSync(historyPath, 'utf-8'),
+        normalizedCwd
+      );
+      historySessionIds = new Set(historySessions.map((session) => session.sessionId));
+    } catch {
+      // Ignore unreadable history file.
+    }
+  }
   const normalizedDirName = normalizedCwd.replace(/[\\/]/g, '-');
   const projectDirCandidates = new Set<string>([
     join(claudeProjectsDir, normalizedDirName),
@@ -1256,7 +1285,10 @@ export function getClaudeLocalSessionsForProject(
         // with `No conversation found with session ID` when resumed.
         // Require explicit sessionId evidence in file contents before surfacing
         // as a local resumable candidate.
-        if (!isLikelyClaudeResumableSessionFile(filePath, sessionId)) {
+        if (
+          !isLikelyClaudeResumableSessionFile(filePath, sessionId) &&
+          !historySessionIds.has(sessionId)
+        ) {
           continue;
         }
 
@@ -1274,11 +1306,17 @@ export function getClaudeLocalSessionsForProject(
           // Best-effort preview extraction only.
         }
 
+        if (!latestPrompt) {
+          const size = formatFileSize(stats.size);
+          if (size) latestPrompt = `(session) · ${size}`;
+        }
+
         results.push({
           backend: 'claude',
           sessionId,
           projectPath: normalizedCwd,
           modified: stats.mtime.toISOString(),
+          fileSizeBytes: stats.size,
           latestPrompt,
           latestPromptAt,
           transcriptPath: filePath,
@@ -1291,18 +1329,7 @@ export function getClaudeLocalSessionsForProject(
 
   // Fallback path: some Claude installations persist session linkage in history.jsonl
   // even when per-project sessions-index files are missing/out-of-date.
-  const historyPath = join(homedir(), '.claude', 'history.jsonl');
-  if (existsSync(historyPath)) {
-    try {
-      const historySessions = extractClaudeHistorySessionsForProject(
-        readFileSync(historyPath, 'utf-8'),
-        normalizedCwd
-      );
-      results.push(...historySessions);
-    } catch {
-      // Ignore unreadable history file.
-    }
-  }
+  results.push(...historySessions);
 
   const dedupedBySessionId = new Map<string, BackendLocalSessionSummary>();
   for (const session of results) {
@@ -1502,8 +1529,10 @@ LIMIT 200;
     let latestPrompt: string | undefined;
     let latestPromptAt: string | undefined;
     const transcriptPath = rolloutPath?.trim() || undefined;
+    let fileSizeBytes: number | undefined;
     if (transcriptPath && existsSync(transcriptPath)) {
       try {
+        fileSizeBytes = statSync(transcriptPath).size;
         const transcript = readFileSync(transcriptPath, 'utf-8');
         const preview = extractLatestPreviewFromCodexRolloutJsonl(transcript);
         if (preview) {
@@ -1515,11 +1544,17 @@ LIMIT 200;
       }
     }
 
+    if (!latestPrompt) {
+      const size = formatFileSize(fileSizeBytes);
+      if (size) latestPrompt = `(session) · ${size}`;
+    }
+
     sessions.push({
       backend: 'codex',
       sessionId,
       projectPath: sessionCwd,
       modified,
+      fileSizeBytes,
       firstPrompt: firstPrompt?.trim(),
       latestPrompt,
       latestPromptAt,
@@ -1620,8 +1655,19 @@ function getCodexLocalSessionsFromJsonl(
         modified: parsed.payload?.timestamp || parsed.timestamp || sessionFile.modified,
         latestPrompt: latestPreview ? formatSessionPreviewText(latestPreview) : undefined,
         latestPromptAt: latestPreview?.ts,
+        fileSizeBytes: (() => {
+          try {
+            return statSync(sessionFile.path).size;
+          } catch {
+            return undefined;
+          }
+        })(),
         transcriptPath: sessionFile.path,
       };
+      if (!matched.latestPrompt) {
+        const size = formatFileSize(matched.fileSizeBytes);
+        if (size) matched.latestPrompt = `(session) · ${size}`;
+      }
       break;
     }
 
@@ -1720,6 +1766,13 @@ function getGeminiSessionsForProjectKey(projectKey: string): BackendLocalSession
       if (!parsed.sessionId) continue;
       const modified = parsed.lastUpdated || parsed.startTime;
       if (!modified) continue;
+      const fileSizeBytes = (() => {
+        try {
+          return statSync(sessionPath).size;
+        } catch {
+          return undefined;
+        }
+      })();
 
       const firstUserMessage = (parsed.messages || []).find((message) => message.type === 'user');
       const latestMessage = [...(parsed.messages || [])]
@@ -1737,14 +1790,21 @@ function getGeminiSessionsForProjectKey(projectKey: string): BackendLocalSession
               content: latestMessage.content,
             })
           : undefined;
+      const latestPromptWithFallback =
+        latestPrompt ||
+        (() => {
+          const size = formatFileSize(fileSizeBytes);
+          return size ? `(session) · ${size}` : undefined;
+        })();
 
       sessions.push({
         backend: 'gemini',
         sessionId: parsed.sessionId,
         projectPath,
         modified,
+        fileSizeBytes,
         firstPrompt,
-        latestPrompt,
+        latestPrompt: latestPromptWithFallback,
         transcriptPath: sessionPath,
       });
     } catch {
@@ -2284,10 +2344,7 @@ async function ensurePcpSessionContext(
     if (!backendSessionId || pcpSessionByBackendSessionId.has(backendSessionId)) continue;
     pcpSessionByBackendSessionId.set(backendSessionId, session);
   }
-  const displayLocalBackendSessions =
-    options.listCandidates || options.listCandidatesJson
-      ? localBackendSessions
-      : untrackedLocalBackendSessions;
+  const displayLocalBackendSessions = localBackendSessions;
   const existingSessionIds = new Set(activeSessions.map((session) => session.id));
   const pcpPreviewBySessionId = new Map<string, string>();
   for (const session of activeSessions) {

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -2172,7 +2172,14 @@ async function persistBackendSessionLink(options: {
   });
 
   try {
-    await callPcpTool('update_session_phase', {
+    const updateResult = await callPcpTool<{
+      sessionConflict?: {
+        backendSessionId?: string;
+        conflictingSessionId?: string;
+        conflictingAgentId?: string;
+      };
+      sessionTrace?: { changedFields?: string[] };
+    }>('update_session_phase', {
       email: options.email,
       agentId: options.agentId,
       sessionId: options.pcpSessionId,
@@ -2180,6 +2187,22 @@ async function persistBackendSessionLink(options: {
       status: 'active',
       workingDir: process.cwd(),
     });
+
+    if (updateResult?.sessionConflict) {
+      sbDebugLog('claude', 'persist_backend_link_conflict_warning', {
+        backend: options.backend,
+        agentId: options.agentId,
+        pcpSessionId: options.pcpSessionId,
+        backendSessionId: options.backendSessionId,
+        conflict: updateResult.sessionConflict,
+      });
+    }
+    if (updateResult?.sessionTrace?.changedFields?.length) {
+      sbDebugLog('claude', 'persist_backend_link_session_trace', {
+        pcpSessionId: options.pcpSessionId,
+        changedFields: updateResult.sessionTrace.changedFields,
+      });
+    }
   } catch {
     // Best-effort linkage update only.
   }

--- a/packages/cli/src/commands/studio-new.test.ts
+++ b/packages/cli/src/commands/studio-new.test.ts
@@ -10,7 +10,7 @@ import { execSync } from 'child_process';
 import { existsSync, mkdirSync, writeFileSync, readFileSync, rmSync, cpSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { copyClaudePermissionsFromSource } from './studio.js';
+import { copyClaudePermissionsFromSource, installHooksForAllBackends } from './studio.js';
 
 const TEST_DIR = join(tmpdir(), 'pcp-ws-new-test-' + Date.now());
 const TEST_REPO = join(TEST_DIR, 'test-repo');
@@ -363,6 +363,19 @@ describe('Config directory copying', () => {
     );
     expect(merged.permissions).toEqual({ allow: ['Bash(ls:*)'] });
     expect(merged.hooks).toBeDefined();
+  });
+
+  it('should install hooks for all supported backends in the new studio', () => {
+    const wsPath = join(realDir(realRepo), `test-repo--hooks-all`);
+    git(`worktree add -b "wren/studio/hooks-all" "${wsPath}"`, realRepo);
+
+    const hookResults = installHooksForAllBackends(wsPath);
+    const backendNames = hookResults.map((h) => h.backend).sort();
+
+    expect(backendNames).toEqual(['claude-code', 'codex', 'gemini']);
+    expect(existsSync(join(wsPath, '.claude', 'settings.local.json'))).toBe(true);
+    expect(existsSync(join(wsPath, '.codex', 'config.toml'))).toBe(true);
+    expect(existsSync(join(wsPath, '.gemini', 'settings.json'))).toBe(true);
   });
 });
 

--- a/packages/cli/src/commands/studio-new.test.ts
+++ b/packages/cli/src/commands/studio-new.test.ts
@@ -10,6 +10,7 @@ import { execSync } from 'child_process';
 import { existsSync, mkdirSync, writeFileSync, readFileSync, rmSync, cpSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
+import { copyClaudePermissionsFromSource } from './studio.js';
 
 const TEST_DIR = join(tmpdir(), 'pcp-ws-new-test-' + Date.now());
 const TEST_REPO = join(TEST_DIR, 'test-repo');
@@ -332,6 +333,36 @@ describe('Config directory copying', () => {
     }
 
     expect(existsSync(join(wsPath, '.gemini'))).toBe(false);
+  });
+
+  it('should inherit Claude permissions while preserving existing hook config', () => {
+    const sourceRoot = join(realDir(realRepo), 'source-perms');
+    const wsPath = join(realDir(realRepo), `test-repo--inherit-perms`);
+    mkdirSync(join(sourceRoot, '.claude'), { recursive: true });
+    writeFileSync(
+      join(sourceRoot, '.claude', 'settings.local.json'),
+      JSON.stringify({
+        permissions: { allow: ['Bash(ls:*)'] },
+      })
+    );
+
+    git(`worktree add -b "wren/studio/inherit-perms" "${wsPath}"`, realRepo);
+    mkdirSync(join(wsPath, '.claude'), { recursive: true });
+    writeFileSync(
+      join(wsPath, '.claude', 'settings.local.json'),
+      JSON.stringify({
+        hooks: { Stop: [{ hooks: [{ type: 'command', command: 'sb hooks on-stop' }] }] },
+      })
+    );
+
+    const copied = copyClaudePermissionsFromSource(sourceRoot, wsPath);
+    expect(copied).toBe(true);
+
+    const merged = JSON.parse(
+      readFileSync(join(wsPath, '.claude', 'settings.local.json'), 'utf-8')
+    );
+    expect(merged.permissions).toEqual({ allow: ['Bash(ls:*)'] });
+    expect(merged.hooks).toBeDefined();
   });
 });
 

--- a/packages/cli/src/commands/studio.ts
+++ b/packages/cli/src/commands/studio.ts
@@ -273,6 +273,7 @@ interface InteractiveResult {
   name: string;
   branch: string;
   configDirs: string[];
+  inheritClaudePermissions: boolean;
 }
 
 interface HooksInstallSummary {
@@ -320,7 +321,7 @@ function isPromptCancelError(err: unknown): boolean {
  * Returns the resolved name, branch, and config dirs to copy.
  */
 async function runInteractiveFlow(agentId: string, gitRoot: string): Promise<InteractiveResult> {
-  const { input, checkbox } = await import('@inquirer/prompts');
+  const { input, checkbox, confirm } = await import('@inquirer/prompts');
 
   // Step 1: Studio name
   const name = await input({
@@ -352,7 +353,17 @@ async function runInteractiveFlow(agentId: string, gitRoot: string): Promise<Int
     });
   }
 
-  return { name, branch, configDirs };
+  // Step 4: Claude permission inheritance from source settings
+  let inheritClaudePermissions = true;
+  const sourceClaudeSettings = join(gitRoot, '.claude', 'settings.local.json');
+  if (existsSync(sourceClaudeSettings)) {
+    inheritClaudePermissions = await confirm({
+      message: 'Inherit Claude permissions from source .claude/settings.local.json?',
+      default: true,
+    });
+  }
+
+  return { name, branch, configDirs, inheritClaudePermissions };
 }
 
 /**
@@ -1488,10 +1499,14 @@ export function registerStudioCommands(program: Command): void {
           const copySourceRoot = resolveCopySourceRoot(gitRoot, options.copyFrom);
           const agentId = options.agent || resolveAgentId() || 'sb';
           const result = await runInteractiveFlow(agentId, copySourceRoot);
-          return createStudio(result.name, options, {
-            branch: result.branch,
-            configDirsList: result.configDirs,
-          });
+          return createStudio(
+            result.name,
+            { ...options, inheritClaudePermissions: result.inheritClaudePermissions },
+            {
+              branch: result.branch,
+              configDirsList: result.configDirs,
+            }
+          );
         } catch (err) {
           if (isPromptCancelError(err)) {
             console.log(chalk.yellow('\nStudio creation canceled.'));

--- a/packages/cli/src/commands/studio.ts
+++ b/packages/cli/src/commands/studio.ts
@@ -1444,6 +1444,7 @@ export {
   listRoleTemplates,
   isValidTemplateName,
   copyClaudePermissionsFromSource,
+  installHooksForAllBackends,
   BUILTIN_ROLE_TEMPLATES,
   getDefaultStudioMainBranch,
   planStudioHomeBranchRename,

--- a/packages/cli/src/commands/studio.ts
+++ b/packages/cli/src/commands/studio.ts
@@ -275,6 +275,16 @@ interface InteractiveResult {
   configDirs: string[];
 }
 
+interface HooksInstallSummary {
+  backend: string;
+  result: 'installed' | 'already-installed' | 'conflict';
+}
+
+interface StudioCreateResult {
+  hooks: HooksInstallSummary[];
+  copiedClaudePermissions: boolean;
+}
+
 function slugifyStudioNameForBranch(name: string): string {
   const normalized = name
     .trim()
@@ -369,6 +379,54 @@ function copyConfigDirs(sourceRoot: string, wsPath: string, dirs: string[]): voi
       cpSync(source, target, { recursive: true });
     }
   }
+}
+
+function copyClaudePermissionsFromSource(sourceRoot: string, wsPath: string): boolean {
+  const sourceSettingsPath = join(sourceRoot, '.claude', 'settings.local.json');
+  if (!existsSync(sourceSettingsPath)) return false;
+
+  let sourceSettings: Record<string, unknown>;
+  try {
+    sourceSettings = JSON.parse(readFileSync(sourceSettingsPath, 'utf-8')) as Record<
+      string,
+      unknown
+    >;
+  } catch {
+    return false;
+  }
+
+  if (!('permissions' in sourceSettings)) return false;
+
+  const targetClaudeDir = join(wsPath, '.claude');
+  const targetSettingsPath = join(targetClaudeDir, 'settings.local.json');
+  mkdirSync(targetClaudeDir, { recursive: true });
+
+  let targetSettings: Record<string, unknown> = {};
+  if (existsSync(targetSettingsPath)) {
+    try {
+      targetSettings = JSON.parse(readFileSync(targetSettingsPath, 'utf-8')) as Record<
+        string,
+        unknown
+      >;
+    } catch {
+      targetSettings = {};
+    }
+  }
+
+  const merged = {
+    ...targetSettings,
+    permissions: sourceSettings.permissions,
+  };
+  writeFileSync(targetSettingsPath, JSON.stringify(merged, null, 2) + '\n');
+  return true;
+}
+
+function installHooksForAllBackends(wsPath: string): HooksInstallSummary[] {
+  const backends = ['claude-code', 'codex', 'gemini'] as const;
+  return backends.map((backendName) => {
+    const { result, backend } = installHooks(wsPath, { backend: backendName });
+    return { backend: backend.name, result };
+  });
 }
 
 function resolveCopySourceRoot(gitRoot: string, copyFrom?: string): string {
@@ -698,6 +756,7 @@ async function createStudio(
     copyConfig?: boolean;
     configDirs?: string;
     copyFrom?: string;
+    inheritClaudePermissions?: boolean;
   },
   overrides?: { branch?: string; configDirsList?: string[] }
 ): Promise<void> {
@@ -710,7 +769,7 @@ async function createStudio(
     const branch = overrides?.branch || options.branch || getDefaultStudioMainBranch(agentId, name);
 
     spinner.text = 'Creating studio...';
-    await createStudioInner(name, options, overrides);
+    const createResult = await createStudioInner(name, options, overrides);
 
     // Read back what was created for display
     const configDirsList =
@@ -732,7 +791,11 @@ async function createStudio(
       const copySourceRoot = resolveCopySourceRoot(gitRoot, options.copyFrom);
       console.log(chalk.dim('  Source: ') + copySourceRoot);
     }
-    console.log(chalk.dim('  Hooks:  ') + 'installed');
+    const hookSummary = createResult.hooks.map((h) => `${h.backend}:${h.result}`).join(', ');
+    console.log(chalk.dim('  Hooks:  ') + hookSummary);
+    if (createResult.copiedClaudePermissions) {
+      console.log(chalk.dim('  Claude: ') + 'permissions inherited from source settings');
+    }
     console.log('');
     console.log(chalk.cyan('To start working:'));
     console.log(chalk.dim(`  cd ${wsPath} && sb`));
@@ -754,7 +817,7 @@ const DEFAULT_STUDIO_SET: Array<{ suffix: string; template: string; purpose: str
 
 async function setupStudios(
   agentId: string,
-  options: { backend?: string; copyFrom?: string }
+  options: { backend?: string; copyFrom?: string; inheritClaudePermissions?: boolean }
 ): Promise<void> {
   console.log(chalk.bold(`\nSetting up studios for ${chalk.cyan(agentId)}...\n`));
 
@@ -779,6 +842,7 @@ async function setupStudios(
         template: studio.template,
         backend: options.backend,
         copyFrom: options.copyFrom,
+        inheritClaudePermissions: options.inheritClaudePermissions,
       });
       spinner.succeed(`Created: ${name}`);
       results.push({ name, status: 'created', path: wsPath });
@@ -827,9 +891,10 @@ async function createStudioInner(
     copyConfig?: boolean;
     configDirs?: string;
     copyFrom?: string;
+    inheritClaudePermissions?: boolean;
   },
   overrides?: { branch?: string; configDirsList?: string[] }
-): Promise<void> {
+): Promise<StudioCreateResult> {
   const agentId = options.agent || resolveAgentId() || 'sb';
   const gitRoot = findGitRoot();
   const copySourceRoot = resolveCopySourceRoot(gitRoot, options.copyFrom);
@@ -913,8 +978,19 @@ async function createStudioInner(
     writeFileSync(join(pcpDir, 'ROLE.md'), roleContent);
   }
 
-  // Install hooks
-  installHooks(wsPath);
+  // Install hooks for all backends (claude, codex, gemini) in every studio.
+  const hookResults = installHooksForAllBackends(wsPath);
+
+  // Optionally carry over Claude permissions from source settings.
+  const copiedClaudePermissions =
+    options.inheritClaudePermissions !== false
+      ? copyClaudePermissionsFromSource(copySourceRoot, wsPath)
+      : false;
+
+  return {
+    hooks: hookResults,
+    copiedClaudePermissions,
+  };
 }
 
 async function renameStudio(from: string, to: string): Promise<void> {
@@ -1356,6 +1432,7 @@ export {
   resolveRoleTemplate,
   listRoleTemplates,
   isValidTemplateName,
+  copyClaudePermissionsFromSource,
   BUILTIN_ROLE_TEMPLATES,
   getDefaultStudioMainBranch,
   planStudioHomeBranchRename,
@@ -1398,6 +1475,10 @@ export function registerStudioCommands(program: Command): void {
     .option(
       '--copy-from <source>',
       'Copy bootstrap files (.mcp.json, .env.local) and config dirs from source studio/path (default: main worktree)'
+    )
+    .option(
+      '--no-inherit-claude-permissions',
+      'Do not copy .claude/settings.local.json permissions from the source worktree'
     )
     .action(async (name: string | undefined, options) => {
       if (!name && process.stdin.isTTY) {
@@ -1461,6 +1542,10 @@ export function registerStudioCommands(program: Command): void {
     .option(
       '--copy-from <source>',
       'Copy bootstrap files from source studio/path (default: main worktree)'
+    )
+    .option(
+      '--no-inherit-claude-permissions',
+      'Do not copy .claude/settings.local.json permissions from the source worktree'
     )
     .action(setupStudios);
 


### PR DESCRIPTION
## Summary
This PR tightens session candidate behavior and adds a debug escape hatch for full visibility.

### 1) Explicit backend resume/session-id now links to PCP
- Fixes a gap where explicit backend override flows could skip PCP session anchoring.
- Ensures `backendSessionId` is persisted to the selected/created PCP session when an explicit override ID is provided.
- Applies to resume/session-id flows across backends handled by `ensurePcpSessionContext`.

### 2) Always show transcript/log size in session display
- Session preview now always includes file size suffix when available.
- JSON output includes size metadata fields for easier debugging:
  - local candidates: `fileSizeBytes`, `fileSize`
  - PCP-linked local metadata: `linkedLocalFileSizeBytes`, `linkedLocalFileSize`

### 3) Align Codex local session list with native Codex resume semantics
- Default Codex local candidate query now scopes to interactive CLI threads (`source='cli'`).
- JSONL fallback parser ignores `codex_exec` originator entries by default.
- This prevents non-resumable exec/subagent threads from polluting default picker results.

### 4) Add debug option to include all Codex local threads
- New flag: `--session-candidates-all`
- When set, includes exec/subagent Codex threads for deep debugging.
- Works with interactive picker and `--session-candidates-json`.

## Validation
- `npx vitest run packages/cli/src/commands/claude.test.ts --silent`
- `npx vitest run packages/cli/src/cli.test.ts packages/cli/src/commands/claude.test.ts --silent`
- `yarn workspace @personal-context/cli build`
- Manual JSON verification:
  - `--session-candidates-json` (default Codex scope)
  - `--session-candidates-json --session-candidates-all` (debug-expanded scope)

## Notes
This keeps default behavior clean and resumable while preserving a full-surface debug path when needed.