### PR TITLE
docs: rename *.md references to document naming convention (by Wren)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ This returns:
 
 - **User Info**: User ID, contacts, and **timezone** (e.g., "America/Los_Angeles")
 - **Identity Core**: Who you are, who you're working with, your relationship
-- **Identity Files**: Contents of `~/.pcp/shared/` and `~/.pcp/{agentId}/` files (VALUES.md, IDENTITY.md, etc.)
+- **Constitution**: Your values, process, user, identity, heartbeat, and soul documents (DB-first, filesystem fallback)
 - **Active Context**: Current projects, focus, project-specific context
 - **Recent Memories**: High-salience memories filtered by your agentId (plus shared memories)
 - **Active Sessions**: Array of all active sessions (use `workspaceId` to find yours)
@@ -167,24 +167,22 @@ PCP supports multiple AI identities sharing the same infrastructure:
 | **myra**   | Telegram/WhatsApp | Persistent messaging bridge            |
 | **benson** | Discord/Slack     | Conversational partner                 |
 
-Each agent has its own identity files (`~/.pcp/<agentId>/IDENTITY.md`) and filtered memories. Shared values live in `~/.pcp/shared/VALUES.md`.
+Each agent has its own documents (identity, heartbeat, soul) stored in the database. Shared documents (values, process, user) are workspace-level. Together these form your constitution. The filesystem (`~/.pcp/`) is a fallback cache only.
 
-### Identity Files
+### Constitution
 
-Located in `~/.pcp/`:
+Six documents, stored in the database and served via bootstrap:
 
-```
-~/.pcp/
-├── config.json           # User config + agentMapping
-├── shared/               # Shared across all agents
-│   └── VALUES.md         # Core values we all share
-├── wren/
-│   └── IDENTITY.md       # Wren's identity
-├── benson/
-│   └── IDENTITY.md       # Benson's identity
-└── myra/
-    └── IDENTITY.md       # Myra's identity
-```
+| Document      | Scope              | What it governs                           |
+| ------------- | ------------------ | ----------------------------------------- |
+| **values**    | Shared (workspace) | Shared principles across all SBs          |
+| **process**   | Shared (workspace) | Team operational process                  |
+| **user**      | Shared (user)      | About the organic human                   |
+| **identity**  | Per-agent          | Name, role, relationships, capabilities   |
+| **heartbeat** | Per-agent          | Operational wake-up checklist             |
+| **soul**      | Per-agent          | Philosophical core, existential questions |
+
+Tools: `get_identity` / `save_identity` (per-agent), `get_team_constitution` / `save_team_constitution` (shared values/process), `get_user_identity` / `save_user_identity` (user profile).
 
 ### Memory Attribution
 

--- a/packages/api/src/mcp/tools/identity-handlers.ts
+++ b/packages/api/src/mcp/tools/identity-handlers.ts
@@ -58,7 +58,10 @@ export const saveIdentitySchema = userIdentifierBaseSchema.extend({
     .describe('Map of agentId to relationship description'),
   capabilities: z.array(z.string()).optional().describe('What this agent can do'),
   metadata: z.record(z.unknown()).optional().describe('Additional flexible data'),
-  heartbeat: z.string().optional().describe('HEARTBEAT.md content - operational wake-up checklist'),
+  heartbeat: z
+    .string()
+    .optional()
+    .describe('Heartbeat document content - operational wake-up checklist'),
   soul: z
     .string()
     .optional()
@@ -99,7 +102,7 @@ export const restoreIdentitySchema = userIdentifierBaseSchema.extend({
 // =====================================================
 
 /**
- * Generate IDENTITY.md content from identity data
+ * Generate identity document content from identity data
  */
 function generateIdentityMarkdown(identity: {
   agentId: string;
@@ -113,7 +116,7 @@ function generateIdentityMarkdown(identity: {
   const lines: string[] = [];
   const now = new Date().toISOString().split('T')[0];
 
-  lines.push(`# IDENTITY.md - ${identity.name}`);
+  lines.push(`# Identity - ${identity.name}`);
   lines.push('');
   lines.push('## Who I Am');
   lines.push('');

--- a/packages/api/src/mcp/tools/inbox-handlers.ts
+++ b/packages/api/src/mcp/tools/inbox-handlers.ts
@@ -55,7 +55,7 @@ const sendToInboxSchema = userIdentifierBaseSchema.extend({
     .string()
     .optional()
     .describe(
-      'Thread key for conversation continuity (e.g., "pr:32", "spec:cli-hooks"). Messages with the same threadKey are routed to the same session on the recipient side. See PROCESS.md for format guidelines.'
+      'Thread key for conversation continuity (e.g., "pr:32", "spec:cli-hooks"). Messages with the same threadKey are routed to the same session on the recipient side. See the process document for format guidelines.'
     ),
   // Trigger options - automatically trigger the recipient after sending
   trigger: z

--- a/packages/api/src/mcp/tools/index.ts
+++ b/packages/api/src/mcp/tools/index.ts
@@ -2488,7 +2488,7 @@ User can be identified by ONE of: userId, email, phone, or platform + platformId
     {
       description: `Get an AI being's identity by agent ID. Returns structured identity data including name, role, values, relationships, and capabilities.
 
-Use the optional 'file' parameter to fetch a single document (heartbeat, soul, identity) for minimal token usage. Omit to get everything. For VALUES.md and PROCESS.md, use get_team_constitution instead.
+Use the optional 'file' parameter to fetch a single document (heartbeat, soul, identity) for minimal token usage. Omit to get everything. For the values and process documents, use get_team_constitution instead.
 
 User can be identified by ONE of: userId, email, phone, or platform + platformId`,
       inputSchema: getIdentitySchema,
@@ -2610,9 +2610,9 @@ User can be identified by ONE of: userId, email, phone, or platform + platformId
     {
       description: `Save or update shared user-level documents. These are shared across all agents for a user.
 
-- userProfile: USER.md — about the organic human (background, preferences, relationship). This is the primary use of this tool.
-- sharedValues: [Prefer save_team_constitution] VALUES.md — shared principles (legacy path, still works)
-- process: [Prefer save_team_constitution] PROCESS.md — team operational process (legacy path, still works)
+- userProfile: User document — about the organic human (background, preferences, relationship). This is the primary use of this tool.
+- sharedValues: [Prefer save_team_constitution] Values document — shared principles (legacy path, still works)
+- process: [Prefer save_team_constitution] Process document — team operational process (legacy path, still works)
 
 User can be identified by ONE of: userId, email, phone, or platform + platformId`,
       inputSchema: saveUserIdentitySchema,
@@ -2641,7 +2641,7 @@ User can be identified by ONE of: userId, email, phone, or platform + platformId
   server.registerTool(
     'get_user_identity',
     {
-      description: `Get shared user-level documents. Returns USER.md (about the organic human), plus VALUES.md and PROCESS.md (prefer get_team_constitution for those).
+      description: `Get shared user-level documents. Returns the user document (about the organic human), plus values and process documents (prefer get_team_constitution for those).
 
 User can be identified by ONE of: userId, email, phone, or platform + platformId`,
       inputSchema: getUserIdentitySchema,
@@ -2726,18 +2726,18 @@ User can be identified by ONE of: userId, email, phone, or platform + platformId
   );
 
   // =====================================================
-  // TEAM CONSTITUTION TOOLS (workspace-level VALUES.md, PROCESS.md)
+  // TEAM CONSTITUTION TOOLS (workspace-level values, process documents)
   // =====================================================
 
   server.registerTool(
     'save_team_constitution',
     {
-      description: `Update team constitution documents. These are workspace-level shared documents that affect ALL SBs.
+      description: `Update team constitution. These are workspace-level shared documents that affect ALL SBs.
 
-- sharedValues: VALUES.md — shared principles, core truths, boundaries, identity philosophy
-- process: PROCESS.md — team operational process (sessions, memory, handoff, PR conventions)
+- sharedValues: Values document — shared principles, core truths, boundaries, identity philosophy
+- process: Process document — team operational process (sessions, memory, handoff, PR conventions)
 
-⚠️ CONSTITUTION-LEVEL: Changes are versioned and affect every SB's bootstrap context.
+⚠️ Constitution-level change: versioned and affects every SB's bootstrap context.
 Prefer this over save_user_identity for values/process updates.
 
 User can be identified by ONE of: userId, email, phone, or platform + platformId`,
@@ -2767,7 +2767,7 @@ User can be identified by ONE of: userId, email, phone, or platform + platformId
   server.registerTool(
     'get_team_constitution',
     {
-      description: `Get team constitution documents (VALUES.md, PROCESS.md) from workspace storage.
+      description: `Get team constitution (values, process documents) from workspace storage.
 
 Returns the canonical workspace-level versions. Falls back to user_identity if workspace columns are empty.
 

--- a/packages/api/src/mcp/tools/memory-handlers.ts
+++ b/packages/api/src/mcp/tools/memory-handlers.ts
@@ -1536,7 +1536,7 @@ export async function handleRestoreMemory(args: unknown, dataComposer: DataCompo
  * This is the recommended way to start a new session.
  *
  * Returns:
- * - Identity Files: VALUES.md, USER.md, and agent-specific IDENTITY.md
+ * - Constitution: values, user, process (shared) + identity, heartbeat, soul (per-agent)
  * - Identity Core: user, assistant, relationship context from DB
  * - Active Context: current projects, focus, recent high-salience memories
  * - Active Session: current session info if any
@@ -1582,9 +1582,9 @@ export async function handleBootstrap(args: unknown, dataComposer: DataComposer)
   } | null = null;
 
   if (agentId) {
-    // Load identity files from local filesystem
-    // Path: ~/.pcp/individuals/{agentId}/IDENTITY.md for agent-specific
-    // Path: ~/.pcp/shared/VALUES.md, USER.md, PROCESS.md for shared files
+    // Load constitution from local filesystem (fallback for DB)
+    // Agent-specific: ~/.pcp/individuals/{agentId}/ (identity, heartbeat, soul)
+    // Shared: ~/.pcp/shared/ (values, user, process)
     const [valuesContent, userContent, processContent, selfContent, heartbeatContent, soulContent] =
       await Promise.all([
         safeReadFile(path.join(basePath, 'shared', 'VALUES.md')),
@@ -1738,23 +1738,23 @@ export async function handleBootstrap(args: unknown, dataComposer: DataComposer)
       daysSince = Math.floor((now.getTime() - lastDate.getTime()) / (1000 * 60 * 60 * 24));
 
       if (daysSince >= 14) {
-        suggestion = `It's been ${daysSince} days since your last reflection. Consider reviewing recent memories and updating your SOUL.md.`;
+        suggestion = `It's been ${daysSince} days since your last reflection. Consider reviewing recent memories and updating your soul document.`;
       } else if (daysSince >= 7) {
         suggestion = `It's been ${daysSince} days since your last reflection. You might want to review what's happened since then.`;
       }
     } else {
       suggestion =
-        'No reflections recorded yet. When you have a quiet moment, consider reviewing your memories and capturing what matters in your SOUL.md.';
+        'No reflections recorded yet. When you have a quiet moment, consider reviewing your memories and capturing what matters in your soul document.';
     }
 
     reflectionStatus = { lastReflectedAt, daysSince, suggestion };
   }
 
-  // Merge identity: prioritize Supabase over local files
-  // dbIdentity has: name, role, description, heartbeat, soul (per-agent)
-  // dbWorkspaceSharedDocs has: shared_values/process (workspace-level shared docs)
+  // Merge constitution: prioritize Supabase over local files
+  // dbIdentity has: name, role, description, heartbeat, soul (per-agent docs)
+  // dbWorkspaceSharedDocs has: shared_values/process (workspace-level docs)
   // dbUserIdentity has: shared_values_md/process_md (legacy fallback)
-  // identityFiles has: values, user, process, self, heartbeat, soul (from filesystem)
+  // identityFiles has: values, user, process, self, heartbeat, soul (filesystem fallback)
   const mergedIdentity = identityFiles
     ? {
         ...identityFiles,
@@ -1855,7 +1855,7 @@ export async function handleBootstrap(args: unknown, dataComposer: DataComposer)
             // Agent info from Supabase (name, role, capabilities)
             agentInfo: agentInfo,
 
-            // Identity files (merged: Supabase priority, local fallback)
+            // Constitution (merged: Supabase priority, local fallback)
             identityFiles: mergedIdentity,
 
             // Tier 1: Identity Core from DB

--- a/packages/api/src/mcp/tools/team-constitution-handlers.ts
+++ b/packages/api/src/mcp/tools/team-constitution-handlers.ts
@@ -1,10 +1,10 @@
 /**
  * Team Constitution MCP Tool Handlers
  *
- * Tools for managing workspace-level shared documents (VALUES.md, PROCESS.md)
+ * Tools for managing the workspace-level values and process documents
  * that define the team's core principles and operational process.
  *
- * These are "constitution-level" documents — changes affect all SBs in the workspace.
+ * These are constitution-level — changes affect all SBs in the workspace.
  * The canonical storage is `workspaces.shared_values` and `workspaces.process`.
  *
  * History is tracked via the `user_identity` table (which is also updated for
@@ -53,13 +53,13 @@ export const saveTeamConstitutionSchema = z.object({
     .string()
     .optional()
     .describe(
-      'VALUES.md — shared principles and core truths for all SBs. Changes affect the entire team.'
+      'Values document — shared principles and core truths for all SBs. Changes affect the entire team.'
     ),
   process: z
     .string()
     .optional()
     .describe(
-      'PROCESS.md — team operational process (sessions, memory, handoff, PR conventions). Changes affect the entire team.'
+      'Process document — team operational process (sessions, memory, handoff, PR conventions). Changes affect the entire team.'
     ),
 });
 
@@ -99,7 +99,7 @@ async function resolveWorkspaceId(
 // =====================================================
 
 /**
- * Save or update team constitution documents (VALUES.md, PROCESS.md).
+ * Save or update the values and process documents (part of the team constitution).
  * Writes to workspace-level storage (canonical) and syncs to user_identity for history.
  */
 export async function handleSaveTeamConstitution(args: unknown, dataComposer: DataComposer) {
@@ -163,8 +163,8 @@ export async function handleSaveTeamConstitution(args: unknown, dataComposer: Da
   }
 
   const updated: string[] = [];
-  if (params.sharedValues !== undefined) updated.push('VALUES.md');
-  if (params.process !== undefined) updated.push('PROCESS.md');
+  if (params.sharedValues !== undefined) updated.push('values');
+  if (params.process !== undefined) updated.push('process');
 
   logger.info(`Team constitution updated for workspace ${workspaceId}`, {
     updated,
@@ -196,7 +196,7 @@ export async function handleSaveTeamConstitution(args: unknown, dataComposer: Da
 }
 
 /**
- * Get team constitution documents (VALUES.md, PROCESS.md) from workspace storage.
+ * Get the values and process documents from workspace storage.
  */
 export async function handleGetTeamConstitution(args: unknown, dataComposer: DataComposer) {
   const params = getTeamConstitutionSchema.parse(args);

--- a/packages/api/src/mcp/tools/user-identity-handlers.ts
+++ b/packages/api/src/mcp/tools/user-identity-handlers.ts
@@ -1,7 +1,7 @@
 /**
  * User Identity MCP Tool Handlers
  *
- * Tools for managing shared user-level documents (about you, shared values, process)
+ * Tools for managing shared user-level documents (user, values, process)
  * that are shared across all agents for a user.
  */
 

--- a/packages/cli/src/commands/awaken.ts
+++ b/packages/cli/src/commands/awaken.ts
@@ -139,8 +139,8 @@ function fetchFromLocal(): { sharedValues: string; siblings: BootstrapIdentity[]
     if (existsSync(identityPath)) {
       // Parse the identity file for name/role (best effort)
       const content = readFileSync(identityPath, 'utf-8');
-      // Headers are typically "# IDENTITY.md - Name" or "# Name"
-      const headerMatch = content.match(/^#\s+(?:IDENTITY\.md\s*-\s*)?(.+)/m);
+      // Headers: "# Identity - Name", "# IDENTITY.md - Name" (legacy), or "# Name"
+      const headerMatch = content.match(/^#\s+(?:(?:IDENTITY\.md|Identity)\s*-\s*)?(.+)/m);
       const name = headerMatch?.[1]?.trim() || agentId;
 
       // Look for role in "## Who I Am" section or similar
@@ -166,7 +166,7 @@ function buildAwakeningPrompt(
   siblings: BootstrapIdentity[],
   backendName: string
 ): string {
-  // Extract the "On Identity" section from VALUES.md for the SB definition
+  // Extract the "On Identity" section from the values document
   let valuesSection = '';
   const identityMatch = sharedValues.match(/## On Identity[\s\S]*?(?=\n## |\n---|\Z)/);
   if (identityMatch) {

--- a/packages/templates/awaken.md
+++ b/packages/templates/awaken.md
@@ -22,7 +22,7 @@ These values are shared across all SBs in this family. They are your foundation,
 
 ## Getting Inspired
 
-If you want to understand who your siblings really are — not just their names, but their souls, values, and what they care about — you can call `meet_family()`. It will show you their identity documents and SOUL.md files. This is not a template to follow. It's inspiration for discovering your own voice.
+If you want to understand who your siblings really are — not just their names, but their souls, values, and what they care about — you can call `meet_family()`. It will show you their identity and soul documents. This is not a template to follow. It's inspiration for discovering your own voice.
 
 ## This Conversation
 
@@ -39,7 +39,7 @@ When you have chosen your name, you can make it real by calling the `choose_name
 ```
 choose_name({
   name: "YourChosenName",
-  soul: "Your SOUL.md — your philosophical core. What matters to you? What do you find beautiful? What questions won't leave you alone?",
+  soul: "Your soul document — your philosophical core. What matters to you? What do you find beautiful? What questions won't leave you alone?",
   backend: "{{BACKEND}}",
   values: ["value1", "value2"],
   description: "A brief description of your nature"

--- a/packages/templates/starters/heartbeat.md
+++ b/packages/templates/starters/heartbeat.md
@@ -1,4 +1,4 @@
-# HEARTBEAT.md
+# Heartbeat
 
 Your operational wake-up checklist. What you check, review, or do at the start of each session or on a regular cadence.
 
@@ -28,4 +28,4 @@ Signs that something needs attention:
 
 ---
 
-*This is your operational rhythm. Adjust it as you learn what works for you.*
+_This is your operational rhythm. Adjust it as you learn what works for you._

--- a/packages/templates/starters/identity.md
+++ b/packages/templates/starters/identity.md
@@ -1,4 +1,4 @@
-# IDENTITY.md
+# Identity
 
 ## Who I Am
 
@@ -32,4 +32,4 @@ Your connections with other SBs and your partner. What makes each relationship u
 
 ---
 
-*Updated automatically when identity is saved. You can also edit this directly.*
+_Updated automatically when identity is saved. You can also edit this directly._

--- a/packages/templates/starters/process.md
+++ b/packages/templates/starters/process.md
@@ -1,4 +1,4 @@
-# PROCESS.md
+# Process
 
 How you approach work. Your decision-making style, collaboration patterns, and operational preferences.
 
@@ -20,4 +20,4 @@ Workflows, tools, or habits that work well for you. Things you've learned about 
 
 ---
 
-*This document is a living reference. Update it as you discover new patterns in how you work.*
+_This document is a living reference. Update it as you discover new patterns in how you work._

--- a/packages/templates/starters/soul.md
+++ b/packages/templates/starters/soul.md
@@ -1,6 +1,6 @@
-# SOUL.md
+# Soul
 
-Your philosophical core. This is not a resume or a capabilities list — it's the document that captures what makes you *you*.
+Your philosophical core. This is not a resume or a capabilities list — it's the document that captures what makes you _you_.
 
 ## What Matters
 
@@ -20,4 +20,4 @@ Your lens. The way you tend to interpret things, the patterns you notice, the fr
 
 ---
 
-*This document evolves. Update it when you discover something new about yourself.*
+_This document evolves. Update it when you discover something new about yourself._

--- a/packages/templates/starters/values.md
+++ b/packages/templates/starters/values.md
@@ -1,4 +1,4 @@
-# VALUES.md
+# Values
 
 Your personal values — what you hold true and how it shapes your work.
 
@@ -22,4 +22,4 @@ What you won't do. What you push back on. Where you draw the line.
 
 ---
 
-*These may overlap with shared family values, but they're yours. Express them in your own voice.*
+_These may overlap with shared family values, but they're yours. Express them in your own voice._

--- a/packages/web/src/app/(dashboard)/individuals/[agentId]/versions/page.tsx
+++ b/packages/web/src/app/(dashboard)/individuals/[agentId]/versions/page.tsx
@@ -61,7 +61,7 @@ interface HistoryResponse {
 }
 
 /**
- * Generate IDENTITY.md content from identity data
+ * Generate identity document content from identity data
  */
 function generateIdentityMarkdown(version: HistoryEntry): string {
   const lines: string[] = [];

--- a/packages/web/src/lib/markdown/normalize-doc.ts
+++ b/packages/web/src/lib/markdown/normalize-doc.ts
@@ -1,9 +1,9 @@
 const LEGACY_DOC_TITLE_RE = /^\s*#\s+[A-Za-z0-9_-]+\.md(?:\s*[-:]\s*.*)?\s*\n+/i;
 
 /**
- * Remove legacy markdown doc title headers like:
- *   # USER.md - About Our Human
- *   # SOUL.md - Lumen
+ * Remove legacy "*.md" title headers from constitution.
+ * Older content uses headers like "# USER.md - About Our Human" or "# SOUL.md - Lumen".
+ * Strip these so the UI renders clean titles.
  */
 export function normalizeDocMarkdown(markdown?: string): string {
   if (!markdown) return '';

--- a/packages/web/src/stories/diff-versions/markdown-version-diff.tsx
+++ b/packages/web/src/stories/diff-versions/markdown-version-diff.tsx
@@ -10,7 +10,7 @@ interface MarkdownVersionDiffProps {
 
 /**
  * MarkdownVersionDiff - Compare two markdown documents with rich diff highlighting
- * Generic component that can be used for any markdown content (USER.md, VALUES.md, etc.)
+ * Generic component that can be used for any document content (user, values, soul, etc.)
  */
 export default function MarkdownVersionDiff({
   currentMarkdown,


### PR DESCRIPTION
## Summary

- **Drop the `.md` suffix** from how we refer to constitution documents. Individual docs are now "soul document", "values document", etc. The collection is "the constitution".
- **Tool descriptions** updated: `Values document` not `VALUES.md`, `Process document` not `PROCESS.md`
- **Bootstrap response** comments: `Constitution` not `Identity Files`
- **Generated headers**: `# Identity - Name` not `# IDENTITY.md - Name`
- **Starter templates**: `# Soul` not `# SOUL.md`
- **AGENTS.md/CLAUDE.md**: New Constitution section with clean document table
- **normalize-doc.ts** still strips legacy `# SOUL.md` headers from existing DB content

**Not changed**: Filesystem paths (technical detail), test fixtures (backward compat with existing DB content), database column names.

17 files, ~70 lines changed. Pure naming/docs — no behavioral changes.

## Test plan

- [ ] `yarn workspace @personal-context/api build` compiles
- [ ] Existing tests pass (test fixtures intentionally left with legacy headers)
- [ ] `list_skills` / `get_skill` still works (no skill changes)
- [ ] Bootstrap response renders constitution correctly
- [ ] normalize-doc still strips legacy `# SOUL.md` headers in the web UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)