### PR TITLE
feat: group thread messaging for cross-agent communication (by Wren)

### DIFF
--- a/packages/api/src/channels/agent-gateway.ts
+++ b/packages/api/src/channels/agent-gateway.ts
@@ -22,7 +22,11 @@ export interface AgentTriggerPayload {
   toAgentId: string;
   /** Optional inbox message ID that prompted this trigger (agent_inbox rows only) */
   inboxMessageId?: string;
-  /** Recipient user ID — when provided, skips the agent_inbox lookup for identity resolution */
+  /** Optional thread message ID that prompted this trigger (inbox_thread_messages rows) */
+  threadMessageId?: string;
+  /** Optional thread ID that prompted this trigger (inbox_threads rows) */
+  threadId?: string;
+  /** Recipient user ID — legacy/internal field; do not trust for identity resolution on public trigger routes */
   recipientUserId?: string;
   /** Trigger type for routing */
   triggerType: 'task_complete' | 'approval_needed' | 'message' | 'error' | 'custom';

--- a/packages/api/src/channels/agent-gateway.ts
+++ b/packages/api/src/channels/agent-gateway.ts
@@ -20,8 +20,10 @@ export interface AgentTriggerPayload {
   fromAgentId: string;
   /** Target agent to wake up (e.g., "myra") */
   toAgentId: string;
-  /** Optional inbox message ID that prompted this trigger */
+  /** Optional inbox message ID that prompted this trigger (agent_inbox rows only) */
   inboxMessageId?: string;
+  /** Recipient user ID — when provided, skips the agent_inbox lookup for identity resolution */
+  recipientUserId?: string;
   /** Trigger type for routing */
   triggerType: 'task_complete' | 'approval_needed' | 'message' | 'error' | 'custom';
   /** Short summary for logging/display */

--- a/packages/api/src/channels/agent-gateway.ts
+++ b/packages/api/src/channels/agent-gateway.ts
@@ -269,7 +269,7 @@ export function createAgentGatewayRoutes(app: {
     };
 
     try {
-      const payload = request.body;
+      const { recipientUserId: _stripped, ...payload } = request.body;
 
       // Validate required fields
       if (!payload.fromAgentId || !payload.toAgentId || !payload.triggerType) {

--- a/packages/api/src/mcp/tools/inbox-handlers.test.ts
+++ b/packages/api/src/mcp/tools/inbox-handlers.test.ts
@@ -140,29 +140,8 @@ describe('handleSendToInbox - threadKey', () => {
     vi.clearAllMocks();
   });
 
-  it('should include threadKey in DB insert when provided', async () => {
-    const mockSb = createMockSupabase();
-    const mockDc = createMockDataComposer(mockSb);
-
-    await handleSendToInbox(
-      {
-        email: 'test@test.com',
-        recipientAgentId: 'lumen',
-        senderAgentId: 'wren',
-        content: 'Review PR #32',
-        messageType: 'task_request',
-        threadKey: 'pr:32',
-      },
-      mockDc as never
-    );
-
-    // Verify the insert was called with thread_key
-    expect(mockSb._chainable.insert).toHaveBeenCalledWith(
-      expect.objectContaining({
-        thread_key: 'pr:32',
-      })
-    );
-  });
+  // Note: "threadKey in DB insert" test removed — threadKey now routes to
+  // inbox_thread_messages (tested in thread-handlers.test.ts), not agent_inbox.
 
   it('should insert null thread_key when threadKey not provided', async () => {
     const mockSb = createMockSupabase();
@@ -185,34 +164,8 @@ describe('handleSendToInbox - threadKey', () => {
     );
   });
 
-  it('should include threadKey in response when provided', async () => {
-    const mockSb = createMockSupabase({
-      insertReturn: {
-        data: {
-          id: 'msg-456',
-          created_at: '2026-02-15T10:00:00Z',
-          thread_key: 'pr:32',
-        },
-        error: null,
-      },
-    });
-    const mockDc = createMockDataComposer(mockSb);
-
-    const result = await handleSendToInbox(
-      {
-        email: 'test@test.com',
-        recipientAgentId: 'lumen',
-        senderAgentId: 'wren',
-        content: 'Review PR #32',
-        threadKey: 'pr:32',
-      },
-      mockDc as never
-    );
-
-    const parsed = JSON.parse(result.content[0].text);
-    expect(parsed.threadKey).toBe('pr:32');
-    expect(parsed.hint).toBeUndefined();
-  });
+  // Note: "threadKey in response" test removed — threadKey now routes to
+  // thread tables (tested in thread-handlers.test.ts).
 
   it('should include hint when threadKey is missing', async () => {
     const mockSb = createMockSupabase();
@@ -234,33 +187,8 @@ describe('handleSendToInbox - threadKey', () => {
     expect(parsed.hint).toContain('threadKey');
   });
 
-  it('should pass threadKey in trigger payload', async () => {
-    const { getAgentGateway } = await import('../../channels/agent-gateway.js');
-    const mockGateway = (getAgentGateway as ReturnType<typeof vi.fn>)();
-
-    const mockSb = createMockSupabase();
-    const mockDc = createMockDataComposer(mockSb);
-
-    await handleSendToInbox(
-      {
-        email: 'test@test.com',
-        recipientAgentId: 'lumen',
-        senderAgentId: 'wren',
-        content: 'Review PR #32',
-        messageType: 'task_request',
-        trigger: true,
-        threadKey: 'pr:32',
-      },
-      mockDc as never
-    );
-
-    // The trigger is fire-and-forget, so check the gateway was called with threadKey
-    expect(mockGateway.dispatchTrigger).toHaveBeenCalledWith(
-      expect.objectContaining({
-        threadKey: 'pr:32',
-      })
-    );
-  });
+  // Note: "threadKey in trigger payload" test removed — threadKey triggers
+  // are now tested in thread-handlers.test.ts.
 
   it('should trigger by default for notification messages', async () => {
     const { getAgentGateway } = await import('../../channels/agent-gateway.js');
@@ -275,7 +203,6 @@ describe('handleSendToInbox - threadKey', () => {
         recipientAgentId: 'myra',
         senderAgentId: 'wren',
         messageType: 'notification',
-        threadKey: 'pr:32',
         content: 'FYI',
       },
       mockDc as never

--- a/packages/api/src/mcp/tools/inbox-handlers.ts
+++ b/packages/api/src/mcp/tools/inbox-handlers.ts
@@ -187,8 +187,8 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
       participants: allParticipants,
     });
 
-    // Ensure all recipients are participants (handles adding new participants to existing threads)
-    for (const agentId of allRecipients) {
+    // Ensure all participants are registered (recipients + sender for existing threads)
+    for (const agentId of allParticipants) {
       const { data: existing } = await threadTable(supabase, 'inbox_thread_participants')
         .select('agent_id')
         .eq('thread_id', thread.id)
@@ -259,7 +259,8 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
         const payload: AgentTriggerPayload = {
           fromAgentId: triggerSenderId,
           toAgentId,
-          inboxMessageId: threadMessage.id,
+          // Thread messages have no agent_inbox row — pass userId directly for identity resolution
+          recipientUserId: resolved.user.id,
           triggerType: triggerType || 'message',
           summary:
             triggerSummary ||

--- a/packages/api/src/mcp/tools/inbox-handlers.ts
+++ b/packages/api/src/mcp/tools/inbox-handlers.ts
@@ -259,8 +259,7 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
         const payload: AgentTriggerPayload = {
           fromAgentId: triggerSenderId,
           toAgentId,
-          // Thread messages have no agent_inbox row — pass userId directly for identity resolution
-          recipientUserId: resolved.user.id,
+          threadMessageId: threadMessage.id,
           triggerType: triggerType || 'message',
           summary:
             triggerSummary ||

--- a/packages/api/src/mcp/tools/inbox-handlers.ts
+++ b/packages/api/src/mcp/tools/inbox-handlers.ts
@@ -68,7 +68,7 @@ const sendToInboxSchema = userIdentifierBaseSchema.extend({
     .string()
     .optional()
     .describe(
-      'Thread key for conversation continuity (e.g., "pr:32", "spec:cli-hooks"). Messages with the same threadKey are routed to the same session on the recipient side. See the process document for format guidelines.'
+      'Thread key for conversation continuity (e.g., "pr:32", "spec:cli-hooks"). When provided, messages are stored in thread tables and all participants see the full history. Without it, messages go to the simple agent_inbox. Format: <type>:<identifier>.'
     ),
   // Trigger options - automatically trigger the recipient after sending
   trigger: z
@@ -168,6 +168,9 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
   const trigger = parsed.trigger ?? true;
 
   // ── Thread-first path: when threadKey is provided, route to thread tables ──
+  // Single-recipient with threadKey creates a 2-participant thread (spec invariant #5).
+  // recipients[] creates a multi-participant thread.
+  // Without threadKey, falls through to legacy agent_inbox path.
   if (threadKey) {
     const allRecipients = recipients || [recipientAgentId!];
     // Include sender as participant if they have an identity
@@ -363,7 +366,7 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
       related_artifact_uri: relatedArtifactUri || null,
       metadata: enrichedMetadata as Json,
       expires_at: expiresAt || null,
-      thread_key: null,
+      thread_key: null, // threadKey messages route to thread tables above
     })
     .select()
     .single();
@@ -464,7 +467,7 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
                   'Actionable handoff is missing a routing anchor. Add one of: threadKey, recipientSessionId, recipientStudioId, or recipientStudioHint.',
               }
             : {}),
-          hint: 'Consider adding a threadKey (e.g., "pr:32", "spec:cli-hooks") so the recipient can resume the same session for follow-up messages on this topic.',
+          hint: 'Consider adding a threadKey (e.g., "pr:32", "spec:cli-hooks") to route this message to a group thread.',
         }),
       },
     ],
@@ -581,6 +584,80 @@ export async function handleGetInbox(args: unknown, dataComposer: DataComposer) 
   }
   const { count: unreadCount } = await unreadQuery;
 
+  // Get threads with unread counts (if agent has any thread participation)
+  let threadsWithUnread: Array<{
+    threadKey: string;
+    title: string | null;
+    unreadCount: number;
+    lastMessageAt: string | null;
+  }> = [];
+
+  if (agentId) {
+    try {
+      // Find threads this agent participates in
+      const { data: participantRows } = await threadTable(supabase, 'inbox_thread_participants')
+        .select('thread_id')
+        .eq('agent_id', agentId);
+
+      const threadIds = (participantRows || []).map((p: { thread_id: string }) => p.thread_id);
+
+      if (threadIds.length > 0) {
+        // Get open threads
+        const { data: threads } = await threadTable(supabase, 'inbox_threads')
+          .select('id, thread_key, title, user_id, updated_at')
+          .eq('user_id', resolved.user.id)
+          .eq('status', 'open')
+          .in('id', threadIds)
+          .order('updated_at', { ascending: false })
+          .limit(10);
+
+        if (threads?.length) {
+          threadsWithUnread = await Promise.all(
+            threads.map(
+              async (t: {
+                id: string;
+                thread_key: string;
+                title: string | null;
+                updated_at: string;
+              }) => {
+                // Get last read timestamp
+                const { data: readStatus } = await threadTable(supabase, 'inbox_thread_read_status')
+                  .select('last_read_at')
+                  .eq('thread_id', t.id)
+                  .eq('agent_id', agentId)
+                  .maybeSingle();
+
+                // Count unread messages
+                let countQuery = threadTable(supabase, 'inbox_thread_messages')
+                  .select('*', { count: 'exact', head: true })
+                  .eq('thread_id', t.id);
+
+                if (readStatus?.last_read_at) {
+                  countQuery = countQuery.gt('created_at', readStatus.last_read_at);
+                }
+
+                const { count } = await countQuery;
+
+                return {
+                  threadKey: t.thread_key,
+                  title: t.title,
+                  unreadCount: count || 0,
+                  lastMessageAt: t.updated_at,
+                };
+              }
+            )
+          );
+
+          // Only include threads that actually have unread messages
+          threadsWithUnread = threadsWithUnread.filter((t) => t.unreadCount > 0);
+        }
+      }
+    } catch (err) {
+      // Thread tables may not exist yet (migration not applied) — graceful fallback
+      logger.debug('Failed to fetch thread unread counts (tables may not exist)', { err });
+    }
+  }
+
   return {
     content: [
       {
@@ -606,6 +683,13 @@ export async function handleGetInbox(args: unknown, dataComposer: DataComposer) 
             createdAt: m.created_at,
             readAt: m.read_at,
           })),
+          ...(threadsWithUnread.length > 0
+            ? {
+                threadsWithUnread,
+                threadHint:
+                  'You have unread thread messages. Use get_thread_messages(threadKey) to read them, or list_threads() for an overview.',
+              }
+            : {}),
         }),
       },
     ],

--- a/packages/api/src/mcp/tools/inbox-handlers.ts
+++ b/packages/api/src/mcp/tools/inbox-handlers.ts
@@ -15,12 +15,25 @@ import type { Json } from '../../data/supabase/types';
 import { getRequestContext, getSessionContext } from '../../utils/request-context';
 import { getAgentGateway, type AgentTriggerPayload } from '../../channels/agent-gateway.js';
 
+// The thread tables are new and not yet in generated Supabase types.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const threadTable = (supabase: ReturnType<DataComposer['getClient']>, table: string) =>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (supabase as any).from(table);
+
 // ============== Schemas ==============
 
 const sendToInboxSchema = userIdentifierBaseSchema.extend({
   recipientAgentId: z
     .string()
-    .describe('Agent ID to send message to (e.g., "wren", "myra", "claude-code")'),
+    .optional()
+    .describe('Agent ID to send message to. Required unless recipients[] is provided.'),
+  recipients: z
+    .array(z.string().min(1).max(64))
+    .min(1)
+    .max(16)
+    .optional()
+    .describe('Multiple recipient agent IDs for group thread creation. Requires threadKey.'),
   senderAgentId: z.string().optional().describe('Agent ID of sender (optional if from human)'),
   subject: z.string().optional().describe('Message subject'),
   content: z.string().describe('Message content'),
@@ -112,6 +125,7 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
 
   const {
     recipientAgentId,
+    recipients,
     subject,
     content,
     messageType = 'message',
@@ -126,6 +140,22 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
     triggerSummary,
     threadKey,
   } = parsed;
+
+  // Validate: exactly one of recipientAgentId or recipients
+  const hasSingle = !!recipientAgentId;
+  const hasMany = !!recipients?.length;
+  if (hasSingle === hasMany) {
+    throw new Error('Provide exactly one of recipientAgentId or recipients');
+  }
+  if (hasMany && !threadKey) {
+    throw new Error('threadKey is required when using recipients[]');
+  }
+  if (recipients && (recipientSessionId || recipientStudioId || recipientStudioHint)) {
+    throw new Error(
+      'recipientSessionId/recipientStudioId/recipientStudioHint are only valid for single-recipient sends'
+    );
+  }
+
   // Enforce identity on sender (who is performing the action), not recipient (target)
   const senderAgentId = getEffectiveAgentId(parsed.senderAgentId);
   const triggerSenderId = senderAgentId || 'system';
@@ -137,8 +167,137 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
   // for messages that can genuinely wait 5+ hours.
   const trigger = parsed.trigger ?? true;
 
+  // ── Thread-first path: when threadKey is provided, route to thread tables ──
+  if (threadKey) {
+    const allRecipients = recipients || [recipientAgentId!];
+    // Include sender as participant if they have an identity
+    const allParticipants = senderAgentId
+      ? [...new Set([senderAgentId, ...allRecipients])]
+      : allRecipients;
+
+    // Find or create thread
+    let thread = await findOrCreateThread(supabase, {
+      userId: resolved.user.id,
+      threadKey,
+      creatorAgentId: triggerSenderId,
+      title: subject || null,
+      participants: allParticipants,
+    });
+
+    // Ensure all recipients are participants (handles adding new participants to existing threads)
+    for (const agentId of allRecipients) {
+      const { data: existing } = await threadTable(supabase, 'inbox_thread_participants')
+        .select('agent_id')
+        .eq('thread_id', thread.id)
+        .eq('agent_id', agentId)
+        .maybeSingle();
+
+      if (!existing) {
+        await threadTable(supabase, 'inbox_thread_participants').insert({
+          thread_id: thread.id,
+          agent_id: agentId,
+        });
+      }
+    }
+
+    // Insert thread message
+    const { data: threadMessage, error: tmError } = await threadTable(
+      supabase,
+      'inbox_thread_messages'
+    )
+      .insert({
+        thread_id: thread.id,
+        sender_agent_id: triggerSenderId,
+        content,
+        message_type: messageType === 'permission_grant' ? 'message' : messageType,
+        priority,
+        metadata: (metadata || {}) as Json,
+      })
+      .select()
+      .single();
+
+    if (tmError) {
+      throw new Error(`Failed to send thread message: ${tmError.message}`);
+    }
+
+    // Update thread updated_at
+    await threadTable(supabase, 'inbox_threads')
+      .update({ updated_at: new Date().toISOString() })
+      .eq('id', thread.id);
+
+    // Update sender's read status
+    if (senderAgentId) {
+      await threadTable(supabase, 'inbox_thread_read_status').upsert(
+        {
+          thread_id: thread.id,
+          agent_id: senderAgentId,
+          last_read_at: new Date().toISOString(),
+        },
+        { onConflict: 'thread_id,agent_id' }
+      );
+    }
+
+    logger.info('Thread message sent', {
+      messageId: threadMessage.id,
+      threadKey,
+      to: allRecipients,
+      from: triggerSenderId,
+      type: messageType,
+      isNewThread: thread.isNew,
+    });
+
+    // Trigger: on thread creation, trigger all initial participants
+    const triggeredAgents: string[] = [];
+    if (trigger) {
+      const gateway = getAgentGateway();
+      const agentsToTrigger = allRecipients.filter((a) => a !== senderAgentId);
+
+      for (const toAgentId of agentsToTrigger) {
+        const payload: AgentTriggerPayload = {
+          fromAgentId: triggerSenderId,
+          toAgentId,
+          inboxMessageId: threadMessage.id,
+          triggerType: triggerType || 'message',
+          summary:
+            triggerSummary ||
+            subject ||
+            `New ${messageType} in thread ${threadKey} from ${triggerSenderId}`,
+          priority,
+          threadKey,
+        };
+        const result = gateway.dispatchTrigger(payload);
+        if (result.accepted) {
+          triggeredAgents.push(toAgentId);
+        }
+      }
+    }
+
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify({
+            success: true,
+            message: `Thread message sent to ${threadKey}`,
+            messageId: threadMessage.id,
+            threadKey,
+            threadId: thread.id,
+            isNewThread: thread.isNew,
+            recipients: allRecipients,
+            participants: allParticipants,
+            messageType,
+            priority,
+            triggered: triggeredAgents,
+            createdAt: threadMessage.created_at,
+          }),
+        },
+      ],
+    };
+  }
+
+  // ── Legacy path: simple inbox message (no threadKey) ──
   const hasRoutingAnchor = Boolean(
-    threadKey || effectiveRecipientSessionId || recipientStudioId || recipientStudioHint
+    effectiveRecipientSessionId || recipientStudioId || recipientStudioHint
   );
   const requiresRoutingAnchor = Boolean(senderAgentId) && messageType !== 'message';
   const missingRoutingAnchor = requiresRoutingAnchor && !hasRoutingAnchor;
@@ -170,7 +329,6 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
         studioId: senderStudioId,
       },
       recipient: {
-        threadKey: threadKey || null,
         sessionId: effectiveRecipientSessionId || null,
         studioId: recipientStudioId || null,
         studioHint: recipientStudioHint || null,
@@ -179,7 +337,11 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
   };
 
   // Resolve canonical identity UUIDs for sender and recipient
-  const recipientIdentityId = await resolveIdentityId(supabase, resolved.user.id, recipientAgentId);
+  const recipientIdentityId = await resolveIdentityId(
+    supabase,
+    resolved.user.id,
+    recipientAgentId!
+  );
   const senderIdentityId = senderAgentId
     ? await resolveIdentityId(supabase, resolved.user.id, senderAgentId)
     : null;
@@ -188,7 +350,7 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
     .from('agent_inbox')
     .insert({
       recipient_user_id: resolved.user.id,
-      recipient_agent_id: recipientAgentId,
+      recipient_agent_id: recipientAgentId!,
       recipient_identity_id: recipientIdentityId,
       sender_user_id: senderAgentId ? null : resolved.user.id,
       sender_agent_id: senderAgentId || null,
@@ -201,7 +363,7 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
       related_artifact_uri: relatedArtifactUri || null,
       metadata: enrichedMetadata as Json,
       expires_at: expiresAt || null,
-      thread_key: threadKey || null,
+      thread_key: null,
     })
     .select()
     .single();
@@ -235,12 +397,11 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
     const gateway = getAgentGateway();
     const payload: AgentTriggerPayload = {
       fromAgentId: triggerSenderId,
-      toAgentId: recipientAgentId,
+      toAgentId: recipientAgentId!,
       inboxMessageId: message.id,
       triggerType: triggerType || 'message',
       summary: triggerSummary || subject || `New ${messageType} from ${triggerSenderId}`,
       priority,
-      threadKey,
       recipientSessionId: effectiveRecipientSessionId,
       studioId: recipientStudioId,
       studioHint: recipientStudioHint,
@@ -291,7 +452,7 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
           recipientAgentId,
           messageType,
           priority,
-          threadKey: threadKey || null,
+          threadKey: null,
           recipientSessionId: effectiveRecipientSessionId || null,
           recipientStudioId: recipientStudioId || null,
           recipientStudioHint: recipientStudioHint || null,
@@ -303,15 +464,69 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
                   'Actionable handoff is missing a routing anchor. Add one of: threadKey, recipientSessionId, recipientStudioId, or recipientStudioHint.',
               }
             : {}),
-          ...(!threadKey
-            ? {
-                hint: 'Consider adding a threadKey (e.g., "pr:32", "spec:cli-hooks") so the recipient can resume the same session for follow-up messages on this topic.',
-              }
-            : {}),
+          hint: 'Consider adding a threadKey (e.g., "pr:32", "spec:cli-hooks") so the recipient can resume the same session for follow-up messages on this topic.',
         }),
       },
     ],
   };
+}
+
+/**
+ * Find or create a thread. Returns the thread row with an `isNew` flag.
+ */
+async function findOrCreateThread(
+  supabase: ReturnType<DataComposer['getClient']>,
+  opts: {
+    userId: string;
+    threadKey: string;
+    creatorAgentId: string;
+    title: string | null;
+    participants: string[];
+  }
+): Promise<{ id: string; isNew: boolean }> {
+  // Try to find existing
+  const { data: existing } = await threadTable(supabase, 'inbox_threads')
+    .select('id')
+    .eq('user_id', opts.userId)
+    .eq('thread_key', opts.threadKey)
+    .maybeSingle();
+
+  if (existing) {
+    return { id: existing.id, isNew: false };
+  }
+
+  // Create new thread
+  const { data: thread, error } = await threadTable(supabase, 'inbox_threads')
+    .insert({
+      thread_key: opts.threadKey,
+      user_id: opts.userId,
+      created_by_agent_id: opts.creatorAgentId,
+      title: opts.title,
+    })
+    .select()
+    .single();
+
+  if (error) {
+    // Race condition: another request may have created it
+    if (error.code === '23505') {
+      const { data: retry } = await threadTable(supabase, 'inbox_threads')
+        .select('id')
+        .eq('user_id', opts.userId)
+        .eq('thread_key', opts.threadKey)
+        .single();
+      if (retry) return { id: retry.id, isNew: false };
+    }
+    throw new Error(`Failed to create thread: ${error.message}`);
+  }
+
+  // Add all participants
+  const participantRows = opts.participants.map((agentId) => ({
+    thread_id: thread.id,
+    agent_id: agentId,
+  }));
+  await threadTable(supabase, 'inbox_thread_participants').insert(participantRows);
+
+  return { id: thread.id, isNew: true };
 }
 
 export async function handleGetInbox(args: unknown, dataComposer: DataComposer) {
@@ -555,7 +770,7 @@ export const inboxToolDefinitions = [
   {
     name: 'send_to_inbox',
     description:
-      "Send a message to another agent's inbox. Use for cross-agent communication, task handoff, or session resume requests.\n\nMessage types:\n- message: General communication (triggers recipient by default)\n- task_request: Request another agent to do work (triggers recipient by default)\n- session_resume: Request agent to resume a specific session (triggers recipient by default)\n- notification: FYI, no response needed (triggers recipient by default)\n- permission_grant: Grant or revoke tool permissions for recipient (triggers recipient by default)\n\nIMPORTANT — Trigger behavior:\nAll message types trigger the recipient by default. This is intentional: most agents don't have heartbeats, so untriggered messages may sit unread for hours. Do NOT set `trigger: false` unless the message can genuinely wait 5+ hours for the next heartbeat cycle. Let the message type speak for itself — you almost never need to set `trigger` explicitly.\n\nReply conventions:\n- When replying to a task_request, send a task_request back on the SAME threadKey to signal completion\n- Use notification only for FYI messages that require no action from the recipient\n- Always include a threadKey (format: <type>:<id>, e.g. pr:127, spec:v0.1)\n\nUser can be identified by ONE of: userId, email, phone, or platform + platformId",
+      'Send a message to agent(s). Supports both simple inbox messages and group threads.\n\nSingle recipient: send_to_inbox(recipientAgentId: "lumen", content: "...")\nGroup thread: send_to_inbox(recipients: ["lumen", "aster"], threadKey: "pr:165", content: "...")\n\nWhen threadKey is provided, messages go to inbox_thread_messages (thread-first model). Late joiners see full history. Without threadKey, creates a simple agent_inbox row (unchanged behavior).\n\nFor existing threads, use reply_to_thread instead — it has smarter trigger defaults (1:1 triggers other participant, group triggers creator only).\n\nMessage types:\n- message: General communication\n- task_request: Request another agent to do work\n- session_resume: Request agent to resume a specific session\n- notification: FYI, no response needed\n- permission_grant: Grant or revoke tool permissions\n\nTrigger behavior:\nAll message types trigger recipients by default. On thread creation, all initial participants are triggered. Set trigger=false only if the message can wait 5+ hours.\n\nUser can be identified by ONE of: userId, email, phone, or platform + platformId',
     schema: sendToInboxSchema,
     handler: handleSendToInbox,
   },

--- a/packages/api/src/mcp/tools/inbox-handlers.ts
+++ b/packages/api/src/mcp/tools/inbox-handlers.ts
@@ -584,79 +584,133 @@ export async function handleGetInbox(args: unknown, dataComposer: DataComposer) 
   }
   const { count: unreadCount } = await unreadQuery;
 
-  // Get threads with unread counts (if agent has any thread participation)
-  let threadsWithUnread: Array<{
+  // Get threads with unread counts and preview messages.
+  // Works with or without agentId — when omitted, finds threads for ALL agents
+  // (used by `sb mission` unified timeline).
+  interface ThreadSummary {
     threadKey: string;
     title: string | null;
+    participants: string[];
     unreadCount: number;
     lastMessageAt: string | null;
-  }> = [];
+    previewMessages: Array<{
+      senderAgentId: string;
+      content: string;
+      messageType: string;
+      createdAt: string;
+    }>;
+  }
+  let threadsWithUnread: ThreadSummary[] = [];
+  let threadUnreadCount = 0;
 
-  if (agentId) {
-    try {
-      // Find threads this agent participates in
-      const { data: participantRows } = await threadTable(supabase, 'inbox_thread_participants')
-        .select('thread_id')
-        .eq('agent_id', agentId);
+  try {
+    // Find thread IDs this agent (or any agent for this user) participates in
+    let participantQuery = threadTable(supabase, 'inbox_thread_participants').select('thread_id');
+    if (agentId) {
+      participantQuery = participantQuery.eq('agent_id', agentId);
+    }
+    const { data: participantRows } = await participantQuery;
 
-      const threadIds = (participantRows || []).map((p: { thread_id: string }) => p.thread_id);
+    const threadIds = [
+      ...new Set((participantRows || []).map((p: { thread_id: string }) => p.thread_id)),
+    ];
 
-      if (threadIds.length > 0) {
-        // Get open threads
-        const { data: threads } = await threadTable(supabase, 'inbox_threads')
-          .select('id, thread_key, title, user_id, updated_at')
-          .eq('user_id', resolved.user.id)
-          .eq('status', 'open')
-          .in('id', threadIds)
-          .order('updated_at', { ascending: false })
-          .limit(10);
+    if (threadIds.length > 0) {
+      // Get open threads for this user
+      const { data: threads } = await threadTable(supabase, 'inbox_threads')
+        .select('id, thread_key, title, user_id, created_by_agent_id, updated_at')
+        .eq('user_id', resolved.user.id)
+        .eq('status', 'open')
+        .in('id', threadIds)
+        .order('updated_at', { ascending: false })
+        .limit(20);
 
-        if (threads?.length) {
-          threadsWithUnread = await Promise.all(
-            threads.map(
-              async (t: {
-                id: string;
-                thread_key: string;
-                title: string | null;
-                updated_at: string;
-              }) => {
-                // Get last read timestamp
+      if (threads?.length) {
+        threadsWithUnread = await Promise.all(
+          threads.map(
+            async (t: {
+              id: string;
+              thread_key: string;
+              title: string | null;
+              created_by_agent_id: string;
+              updated_at: string;
+            }) => {
+              // Get participants
+              const { data: parts } = await threadTable(supabase, 'inbox_thread_participants')
+                .select('agent_id')
+                .eq('thread_id', t.id);
+              const participants = (parts || []).map((p: { agent_id: string }) => p.agent_id);
+
+              // Get last read timestamp (only meaningful with agentId)
+              let lastReadAt: string | null = null;
+              if (agentId) {
                 const { data: readStatus } = await threadTable(supabase, 'inbox_thread_read_status')
                   .select('last_read_at')
                   .eq('thread_id', t.id)
                   .eq('agent_id', agentId)
                   .maybeSingle();
-
-                // Count unread messages
-                let countQuery = threadTable(supabase, 'inbox_thread_messages')
-                  .select('*', { count: 'exact', head: true })
-                  .eq('thread_id', t.id);
-
-                if (readStatus?.last_read_at) {
-                  countQuery = countQuery.gt('created_at', readStatus.last_read_at);
-                }
-
-                const { count } = await countQuery;
-
-                return {
-                  threadKey: t.thread_key,
-                  title: t.title,
-                  unreadCount: count || 0,
-                  lastMessageAt: t.updated_at,
-                };
+                lastReadAt = readStatus?.last_read_at || null;
               }
-            )
-          );
 
-          // Only include threads that actually have unread messages
-          threadsWithUnread = threadsWithUnread.filter((t) => t.unreadCount > 0);
-        }
+              // Count unread messages (after last read, or all if no read status)
+              let countQuery = threadTable(supabase, 'inbox_thread_messages')
+                .select('*', { count: 'exact', head: true })
+                .eq('thread_id', t.id);
+
+              if (lastReadAt) {
+                countQuery = countQuery.gt('created_at', lastReadAt);
+              }
+
+              const { count } = await countQuery;
+
+              // Get preview messages (last 3 non-system messages)
+              const { data: previewRows } = await threadTable(supabase, 'inbox_thread_messages')
+                .select('sender_agent_id, content, message_type, created_at')
+                .eq('thread_id', t.id)
+                .neq('message_type', 'system')
+                .order('created_at', { ascending: false })
+                .limit(3);
+
+              const previewMessages = (previewRows || [])
+                .reverse()
+                .map(
+                  (m: {
+                    sender_agent_id: string;
+                    content: string;
+                    message_type: string;
+                    created_at: string;
+                  }) => ({
+                    senderAgentId: m.sender_agent_id,
+                    content: m.content.slice(0, 200),
+                    messageType: m.message_type,
+                    createdAt: m.created_at,
+                  })
+                );
+
+              return {
+                threadKey: t.thread_key,
+                title: t.title,
+                participants,
+                unreadCount: count || 0,
+                lastMessageAt: t.updated_at,
+                previewMessages,
+              };
+            }
+          )
+        );
+
+        // Only include threads that actually have unread messages
+        threadsWithUnread = threadsWithUnread.filter((t) => t.unreadCount > 0);
+        threadUnreadCount = threadsWithUnread.reduce((sum, t) => sum + t.unreadCount, 0);
       }
-    } catch (err) {
-      // Thread tables may not exist yet (migration not applied) — graceful fallback
-      logger.debug('Failed to fetch thread unread counts (tables may not exist)', { err });
     }
+  } catch (err) {
+    // Thread tables may not exist yet (migration not applied) — graceful fallback
+    logger.debug('Failed to fetch thread unread counts (tables may not exist)', { err });
   }
+
+  const inboxUnreadCount = unreadCount || 0;
+  const totalUnreadCount = inboxUnreadCount + threadUnreadCount;
 
   return {
     content: [
@@ -665,7 +719,9 @@ export async function handleGetInbox(args: unknown, dataComposer: DataComposer) 
         text: JSON.stringify({
           success: true,
           ...(agentId ? { agentId } : { allAgents: true }),
-          unreadCount: unreadCount || 0,
+          unreadCount: inboxUnreadCount,
+          threadUnreadCount,
+          totalUnreadCount,
           count: messages?.length || 0,
           messages: (messages || []).map((m) => ({
             id: m.id,
@@ -687,7 +743,7 @@ export async function handleGetInbox(args: unknown, dataComposer: DataComposer) 
             ? {
                 threadsWithUnread,
                 threadHint:
-                  'You have unread thread messages. Use get_thread_messages(threadKey) to read them, or list_threads() for an overview.',
+                  'You have unread thread messages. Use get_thread_messages(threadKey) to read them, reply_to_thread to respond, or mark_thread_read to acknowledge.',
               }
             : {}),
         }),

--- a/packages/api/src/mcp/tools/index.ts
+++ b/packages/api/src/mcp/tools/index.ts
@@ -3368,6 +3368,15 @@ User can be identified by ONE of: userId, email, phone, or platform + platformId
     {
       description: `Send a message to another agent's inbox. Use for cross-agent communication, task handoff, or session resume requests.
 
+Recipient modes (provide exactly one):
+- recipientAgentId: Single recipient. Works with or without threadKey.
+- recipients[]: Multiple recipients. Requires threadKey. Creates a group thread automatically.
+
+Thread routing:
+When threadKey is provided, messages are stored in thread tables (inbox_thread_messages). All recipients are auto-added as thread participants — no need to call add_thread_participant separately. Late joiners see full thread history. Without threadKey, messages go to the simple agent_inbox.
+
+recipients[] is syntactic sugar: it creates the thread, adds all recipients as participants, sends the message, and triggers everyone — all in one call.
+
 Message types:
 - message: General communication
 - task_request: Request another agent to do work
@@ -3376,7 +3385,9 @@ Message types:
 - permission_grant: Grant or revoke tool permissions (include permissionGrant in metadata)
 
 Trigger behavior:
-All message types trigger the recipient by default. Most agents don't have heartbeats, so untriggered messages may sit unread for hours. Only set trigger=false if the message can genuinely wait 5+ hours.
+All message types trigger the recipient by default. For threads, all recipients are triggered on the initial send. For replies (via reply_to_thread), trigger rules depend on thread size — see reply_to_thread for details.
+
+Only set trigger=false if the message can genuinely wait 5+ hours.
 
 User can be identified by ONE of: userId, email, phone, or platform + platformId`,
       inputSchema: inboxToolDefinitions[0].schema,

--- a/packages/api/src/mcp/tools/index.ts
+++ b/packages/api/src/mcp/tools/index.ts
@@ -165,6 +165,15 @@ import {
 } from './inbox-handlers';
 
 import {
+  handleGetThreadMessages,
+  handleReplyToThread,
+  handleAddThreadParticipant,
+  handleCloseThread,
+  handleListThreads,
+  threadToolDefinitions,
+} from './thread-handlers';
+
+import {
   handleTriggerAgent,
   handleListRegisteredAgents,
   triggerAgentSchema,
@@ -3468,6 +3477,161 @@ User can be identified by ONE of: userId, email, phone, or platform + platformId
         return await handleGetAgentStatus(args, dataComposer);
       } catch (error) {
         logger.error('Error in get_agent_status:', error);
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                success: false,
+                error: error instanceof Error ? error.message : 'Unknown error',
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // =====================================================
+  // THREAD TOOLS (group thread messaging)
+  // =====================================================
+
+  server.registerTool(
+    'get_thread_messages',
+    {
+      description: `Get the full message timeline of a thread. Requires participant membership. Automatically marks the thread as read for the requesting agent.
+
+Use to read conversation history in a group thread before replying.
+
+User can be identified by ONE of: userId, email, phone, or platform + platformId`,
+      inputSchema: threadToolDefinitions[0].schema,
+    },
+    async (args: Record<string, unknown>) => {
+      try {
+        return await handleGetThreadMessages(args, dataComposer);
+      } catch (error) {
+        logger.error('Error in get_thread_messages:', error);
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                success: false,
+                error: error instanceof Error ? error.message : 'Unknown error',
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  server.registerTool(
+    'reply_to_thread',
+    {
+      description: `Reply to a thread. Trigger behavior depends on thread size:
+- 1:1 thread: triggers the other participant by default
+- Group thread (non-creator reply): triggers creator by default
+- Group thread (creator reply): triggers no one by default
+Use triggerAgents for targeted waking, triggerAll for broadcast.
+
+User can be identified by ONE of: userId, email, phone, or platform + platformId`,
+      inputSchema: threadToolDefinitions[1].schema,
+    },
+    async (args: Record<string, unknown>) => {
+      try {
+        return await handleReplyToThread(args, dataComposer);
+      } catch (error) {
+        logger.error('Error in reply_to_thread:', error);
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                success: false,
+                error: error instanceof Error ? error.message : 'Unknown error',
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  server.registerTool(
+    'add_thread_participant',
+    {
+      description: `Add an agent to a thread. Idempotent (no-op if already a participant). Creates an audited system event in the thread. Triggers the new participant by default so they can catch up.
+
+User can be identified by ONE of: userId, email, phone, or platform + platformId`,
+      inputSchema: threadToolDefinitions[2].schema,
+    },
+    async (args: Record<string, unknown>) => {
+      try {
+        return await handleAddThreadParticipant(args, dataComposer);
+      } catch (error) {
+        logger.error('Error in add_thread_participant:', error);
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                success: false,
+                error: error instanceof Error ? error.message : 'Unknown error',
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  server.registerTool(
+    'close_thread',
+    {
+      description: `Close a thread. Closed threads can still be read but new messages are rejected. Any participant can close a thread.
+
+User can be identified by ONE of: userId, email, phone, or platform + platformId`,
+      inputSchema: threadToolDefinitions[3].schema,
+    },
+    async (args: Record<string, unknown>) => {
+      try {
+        return await handleCloseThread(args, dataComposer);
+      } catch (error) {
+        logger.error('Error in close_thread:', error);
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                success: false,
+                error: error instanceof Error ? error.message : 'Unknown error',
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  server.registerTool(
+    'list_threads',
+    {
+      description: `List threads an agent participates in, with unread counts and last message preview. Useful for heartbeat triage and inbox overview.
+
+User can be identified by ONE of: userId, email, phone, or platform + platformId`,
+      inputSchema: threadToolDefinitions[4].schema,
+    },
+    async (args: Record<string, unknown>) => {
+      try {
+        return await handleListThreads(args, dataComposer);
+      } catch (error) {
+        logger.error('Error in list_threads:', error);
         return {
           content: [
             {

--- a/packages/api/src/mcp/tools/index.ts
+++ b/packages/api/src/mcp/tools/index.ts
@@ -170,6 +170,7 @@ import {
   handleAddThreadParticipant,
   handleCloseThread,
   handleListThreads,
+  handleMarkThreadRead,
   threadToolDefinitions,
 } from './thread-handlers';
 
@@ -3643,6 +3644,35 @@ User can be identified by ONE of: userId, email, phone, or platform + platformId
         return await handleListThreads(args, dataComposer);
       } catch (error) {
         logger.error('Error in list_threads:', error);
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                success: false,
+                error: error instanceof Error ? error.message : 'Unknown error',
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  server.registerTool(
+    'mark_thread_read',
+    {
+      description: `Mark a thread as read without fetching messages. Useful when you see thread activity in get_inbox and want to acknowledge it without reading the full history.
+
+User can be identified by ONE of: userId, email, phone, or platform + platformId`,
+      inputSchema: threadToolDefinitions[5].schema,
+    },
+    async (args: Record<string, unknown>) => {
+      try {
+        return await handleMarkThreadRead(args, dataComposer);
+      } catch (error) {
+        logger.error('Error in mark_thread_read:', error);
         return {
           content: [
             {

--- a/packages/api/src/mcp/tools/thread-handlers.test.ts
+++ b/packages/api/src/mcp/tools/thread-handlers.test.ts
@@ -1,0 +1,507 @@
+/**
+ * Thread Handler Tests
+ *
+ * Tests for group thread messaging: trigger resolution, validation,
+ * thread lifecycle, and participant management.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// =====================================================
+// UNIT TESTS: resolveTriggeredAgents (pure logic)
+// =====================================================
+
+// Import the function indirectly by testing through the handler,
+// but since it's not exported, we test the logic via reply_to_thread behavior.
+// For now, we replicate the logic here for direct unit testing.
+
+function resolveTriggeredAgents(opts: {
+  senderAgentId: string;
+  participants: string[];
+  creatorAgentId: string;
+  triggerAgents?: string[];
+  triggerAll?: boolean;
+}): string[] {
+  const { senderAgentId, participants, creatorAgentId, triggerAgents, triggerAll } = opts;
+
+  if (triggerAgents && triggerAgents.length > 0) {
+    const participantSet = new Set(participants);
+    return triggerAgents.filter((a) => a !== senderAgentId && participantSet.has(a));
+  }
+
+  if (triggerAll) {
+    return participants.filter((a) => a !== senderAgentId);
+  }
+
+  const otherParticipants = participants.filter((a) => a !== senderAgentId);
+
+  if (otherParticipants.length === 0) {
+    return [];
+  }
+
+  if (participants.length === 2) {
+    return otherParticipants;
+  }
+
+  if (senderAgentId !== creatorAgentId) {
+    return [creatorAgentId];
+  }
+
+  return [];
+}
+
+describe('resolveTriggeredAgents', () => {
+  describe('1:1 threads (2 participants)', () => {
+    it('should trigger the other participant', () => {
+      const result = resolveTriggeredAgents({
+        senderAgentId: 'wren',
+        participants: ['wren', 'lumen'],
+        creatorAgentId: 'wren',
+      });
+      expect(result).toEqual(['lumen']);
+    });
+
+    it('should trigger creator when non-creator replies in 1:1', () => {
+      const result = resolveTriggeredAgents({
+        senderAgentId: 'lumen',
+        participants: ['wren', 'lumen'],
+        creatorAgentId: 'wren',
+      });
+      expect(result).toEqual(['wren']);
+    });
+  });
+
+  describe('group threads (3+ participants)', () => {
+    const participants = ['wren', 'lumen', 'aster', 'myra'];
+
+    it('should trigger creator only when non-creator replies', () => {
+      const result = resolveTriggeredAgents({
+        senderAgentId: 'lumen',
+        participants,
+        creatorAgentId: 'wren',
+      });
+      expect(result).toEqual(['wren']);
+    });
+
+    it('should trigger no one when creator replies', () => {
+      const result = resolveTriggeredAgents({
+        senderAgentId: 'wren',
+        participants,
+        creatorAgentId: 'wren',
+      });
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('self-thread (1 participant)', () => {
+    it('should trigger no one', () => {
+      const result = resolveTriggeredAgents({
+        senderAgentId: 'wren',
+        participants: ['wren'],
+        creatorAgentId: 'wren',
+      });
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('triggerAll override', () => {
+    it('should trigger all participants except sender', () => {
+      const result = resolveTriggeredAgents({
+        senderAgentId: 'wren',
+        participants: ['wren', 'lumen', 'aster', 'myra'],
+        creatorAgentId: 'wren',
+        triggerAll: true,
+      });
+      expect(result).toEqual(['lumen', 'aster', 'myra']);
+    });
+
+    it('should work in 1:1 threads', () => {
+      const result = resolveTriggeredAgents({
+        senderAgentId: 'wren',
+        participants: ['wren', 'lumen'],
+        creatorAgentId: 'wren',
+        triggerAll: true,
+      });
+      expect(result).toEqual(['lumen']);
+    });
+  });
+
+  describe('triggerAgents override', () => {
+    it('should trigger only specified participants', () => {
+      const result = resolveTriggeredAgents({
+        senderAgentId: 'wren',
+        participants: ['wren', 'lumen', 'aster', 'myra'],
+        creatorAgentId: 'wren',
+        triggerAgents: ['lumen'],
+      });
+      expect(result).toEqual(['lumen']);
+    });
+
+    it('should silently ignore non-participants', () => {
+      const result = resolveTriggeredAgents({
+        senderAgentId: 'wren',
+        participants: ['wren', 'lumen'],
+        creatorAgentId: 'wren',
+        triggerAgents: ['aster', 'lumen'],
+      });
+      expect(result).toEqual(['lumen']);
+    });
+
+    it('should not trigger the sender even if listed', () => {
+      const result = resolveTriggeredAgents({
+        senderAgentId: 'wren',
+        participants: ['wren', 'lumen', 'aster'],
+        creatorAgentId: 'wren',
+        triggerAgents: ['wren', 'lumen'],
+      });
+      expect(result).toEqual(['lumen']);
+    });
+
+    it('should take precedence over triggerAll', () => {
+      const result = resolveTriggeredAgents({
+        senderAgentId: 'wren',
+        participants: ['wren', 'lumen', 'aster', 'myra'],
+        creatorAgentId: 'wren',
+        triggerAgents: ['aster'],
+        triggerAll: true,
+      });
+      // triggerAgents takes precedence (spec: triggerAgents > triggerAll > default)
+      expect(result).toEqual(['aster']);
+    });
+  });
+});
+
+// =====================================================
+// VALIDATION TESTS: send_to_inbox schema enforcement
+// =====================================================
+
+// Mock dependencies for handler tests
+vi.mock('../../services/user-resolver', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../services/user-resolver')>();
+  return {
+    ...actual,
+    resolveUserOrThrow: vi.fn().mockResolvedValue({
+      user: { id: 'user-123' },
+      resolvedBy: 'userId',
+    }),
+  };
+});
+
+vi.mock('../../utils/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock('../../channels/agent-gateway.js', () => ({
+  getAgentGateway: vi.fn().mockReturnValue({
+    dispatchTrigger: vi.fn().mockReturnValue({
+      success: true,
+      triggerId: 'trigger-1',
+      processed: false,
+      accepted: true,
+    }),
+  }),
+}));
+
+vi.mock('../../auth/enforce-identity', () => ({
+  getEffectiveAgentId: vi.fn((id?: string) => id || null),
+}));
+
+vi.mock('../../auth/resolve-identity', () => ({
+  resolveIdentityId: vi.fn().mockResolvedValue('identity-uuid'),
+}));
+
+vi.mock('../../utils/request-context', () => ({
+  getRequestContext: vi.fn().mockReturnValue(null),
+  getSessionContext: vi.fn().mockReturnValue(null),
+}));
+
+import { handleSendToInbox } from './inbox-handlers';
+
+function createThreadMockSupabase() {
+  const threadMessage = {
+    id: 'tmsg-123',
+    thread_id: 'thread-123',
+    sender_agent_id: 'wren',
+    content: 'test',
+    message_type: 'message',
+    priority: 'normal',
+    metadata: {},
+    created_at: '2026-03-09T10:00:00Z',
+  };
+
+  const threadRow = {
+    id: 'thread-123',
+    thread_key: 'pr:32',
+    user_id: 'user-123',
+    created_by_agent_id: 'wren',
+    title: null,
+    status: 'open',
+    metadata: {},
+    created_at: '2026-03-09T10:00:00Z',
+    updated_at: '2026-03-09T10:00:00Z',
+  };
+
+  // Build chainable mock that handles all PostgREST patterns
+  const makeChainable = (resolveValue: unknown = { data: null, error: null }) => {
+    const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+    const self = () => chain;
+    chain.select = vi.fn().mockReturnValue(self());
+    chain.insert = vi.fn().mockReturnValue(self());
+    chain.update = vi.fn().mockReturnValue(self());
+    chain.upsert = vi.fn().mockReturnValue(self());
+    chain.eq = vi.fn().mockReturnValue(self());
+    chain.neq = vi.fn().mockReturnValue(self());
+    chain.gt = vi.fn().mockReturnValue(self());
+    chain.lt = vi.fn().mockReturnValue(self());
+    chain.in = vi.fn().mockReturnValue(self());
+    chain.or = vi.fn().mockReturnValue(self());
+    chain.order = vi.fn().mockReturnValue(self());
+    chain.limit = vi.fn().mockReturnValue(self());
+    chain.single = vi.fn().mockResolvedValue(resolveValue);
+    chain.maybeSingle = vi.fn().mockResolvedValue(resolveValue);
+    // Make the chain itself thenable so `await chain` works
+    chain.then = vi
+      .fn()
+      .mockImplementation((resolve: (v: unknown) => void) => resolve(resolveValue));
+    return chain;
+  };
+
+  const tables: Record<string, ReturnType<typeof makeChainable>> = {};
+
+  const getTable = (name: string) => {
+    if (!tables[name]) {
+      if (name === 'inbox_threads') {
+        // First call: maybeSingle returns null (thread doesn't exist)
+        // Second call (after insert): returns the thread
+        const findChain = makeChainable({ data: null, error: null });
+        const insertChain = makeChainable({ data: threadRow, error: null });
+        let callCount = 0;
+        tables[name] = makeChainable({ data: null, error: null });
+        tables[name].select = vi.fn().mockImplementation(() => {
+          callCount++;
+          if (callCount === 1) return findChain;
+          return makeChainable({ data: threadRow, error: null });
+        });
+        tables[name].insert = vi.fn().mockReturnValue(insertChain);
+        tables[name].update = vi.fn().mockReturnValue(makeChainable({ data: null, error: null }));
+      } else if (name === 'inbox_thread_messages') {
+        tables[name] = makeChainable({ data: threadMessage, error: null });
+      } else if (name === 'inbox_thread_participants') {
+        // maybeSingle returns null (participant doesn't exist yet)
+        tables[name] = makeChainable({ data: null, error: null });
+      } else if (name === 'inbox_thread_read_status') {
+        tables[name] = makeChainable({ data: null, error: null });
+      } else if (name === 'agent_inbox') {
+        tables[name] = makeChainable({
+          data: {
+            id: 'inbox-msg-123',
+            user_id: 'user-123',
+            recipient_agent_id: 'lumen',
+            sender_agent_id: 'wren',
+            content: 'Simple message',
+            message_type: 'message',
+            priority: 'normal',
+            status: 'unread',
+            metadata: {},
+            created_at: '2026-03-09T10:00:00Z',
+          },
+          error: null,
+        });
+      } else if (name === 'agent_identities') {
+        tables[name] = makeChainable({
+          data: [{ id: 'identity-123' }],
+          error: null,
+        });
+      } else {
+        tables[name] = makeChainable({ data: null, error: null });
+      }
+    }
+    return tables[name];
+  };
+
+  return {
+    from: vi.fn().mockImplementation(getTable),
+    _tables: tables,
+    _getTable: getTable,
+  };
+}
+
+function createMockDataComposer(supabase?: ReturnType<typeof createThreadMockSupabase>) {
+  const sb = supabase || createThreadMockSupabase();
+  return {
+    getClient: vi.fn().mockReturnValue(sb),
+    repositories: {},
+  };
+}
+
+describe('handleSendToInbox - validation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should reject when both recipientAgentId and recipients are provided', async () => {
+    const mockDc = createMockDataComposer();
+    await expect(
+      handleSendToInbox(
+        {
+          email: 'test@test.com',
+          recipientAgentId: 'lumen',
+          recipients: ['lumen', 'aster'],
+          threadKey: 'pr:32',
+          content: 'test',
+        },
+        mockDc as never
+      )
+    ).rejects.toThrow('Provide exactly one of recipientAgentId or recipients');
+  });
+
+  it('should reject when neither recipientAgentId nor recipients are provided', async () => {
+    const mockDc = createMockDataComposer();
+    await expect(
+      handleSendToInbox(
+        {
+          email: 'test@test.com',
+          content: 'test',
+        },
+        mockDc as never
+      )
+    ).rejects.toThrow('Provide exactly one of recipientAgentId or recipients');
+  });
+
+  it('should reject recipients[] without threadKey', async () => {
+    const mockDc = createMockDataComposer();
+    await expect(
+      handleSendToInbox(
+        {
+          email: 'test@test.com',
+          recipients: ['lumen', 'aster'],
+          content: 'test',
+        },
+        mockDc as never
+      )
+    ).rejects.toThrow('threadKey is required when using recipients[]');
+  });
+
+  it('should reject recipients[] with session/studio routing hints', async () => {
+    const mockDc = createMockDataComposer();
+    await expect(
+      handleSendToInbox(
+        {
+          email: 'test@test.com',
+          recipients: ['lumen'],
+          threadKey: 'pr:32',
+          recipientStudioHint: 'main',
+          content: 'test',
+        },
+        mockDc as never
+      )
+    ).rejects.toThrow('only valid for single-recipient sends');
+  });
+});
+
+describe('handleSendToInbox - thread routing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should route to thread tables when threadKey is provided with recipientAgentId', async () => {
+    const mockSb = createThreadMockSupabase();
+    const mockDc = createMockDataComposer(mockSb);
+
+    const result = await handleSendToInbox(
+      {
+        email: 'test@test.com',
+        recipientAgentId: 'lumen',
+        senderAgentId: 'wren',
+        threadKey: 'pr:32',
+        content: 'Review PR #32',
+      },
+      mockDc as never
+    );
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.success).toBe(true);
+    expect(parsed.threadKey).toBe('pr:32');
+    expect(parsed.recipients).toEqual(['lumen']);
+    expect(parsed.participants).toContain('wren');
+    expect(parsed.participants).toContain('lumen');
+  });
+
+  it('should route to thread tables when recipients[] is provided', async () => {
+    const mockSb = createThreadMockSupabase();
+    const mockDc = createMockDataComposer(mockSb);
+
+    const result = await handleSendToInbox(
+      {
+        email: 'test@test.com',
+        recipients: ['lumen', 'aster'],
+        senderAgentId: 'wren',
+        threadKey: 'spec:group-threads',
+        content: 'RFC for review',
+      },
+      mockDc as never
+    );
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.success).toBe(true);
+    expect(parsed.threadKey).toBe('spec:group-threads');
+    expect(parsed.recipients).toEqual(['lumen', 'aster']);
+    expect(parsed.participants).toContain('wren');
+    expect(parsed.participants).toContain('lumen');
+    expect(parsed.participants).toContain('aster');
+  });
+
+  it('should route to agent_inbox when no threadKey', async () => {
+    const mockSb = createThreadMockSupabase();
+    const mockDc = createMockDataComposer(mockSb);
+
+    const result = await handleSendToInbox(
+      {
+        email: 'test@test.com',
+        recipientAgentId: 'lumen',
+        senderAgentId: 'wren',
+        content: 'Simple message',
+      },
+      mockDc as never
+    );
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.success).toBe(true);
+    expect(parsed.threadKey).toBeNull();
+    // Should have gone to agent_inbox
+    expect(mockSb.from).toHaveBeenCalledWith('agent_inbox');
+  });
+
+  it('should trigger all recipients on thread creation', async () => {
+    const { getAgentGateway } = await import('../../channels/agent-gateway.js');
+    const mockGateway = (getAgentGateway as ReturnType<typeof vi.fn>)();
+
+    const mockSb = createThreadMockSupabase();
+    const mockDc = createMockDataComposer(mockSb);
+
+    await handleSendToInbox(
+      {
+        email: 'test@test.com',
+        recipients: ['lumen', 'aster'],
+        senderAgentId: 'wren',
+        threadKey: 'spec:test',
+        content: 'Hello team',
+      },
+      mockDc as never
+    );
+
+    // Should trigger lumen and aster (not wren — sender)
+    expect(mockGateway.dispatchTrigger).toHaveBeenCalledTimes(2);
+    expect(mockGateway.dispatchTrigger).toHaveBeenCalledWith(
+      expect.objectContaining({ toAgentId: 'lumen', threadKey: 'spec:test' })
+    );
+    expect(mockGateway.dispatchTrigger).toHaveBeenCalledWith(
+      expect.objectContaining({ toAgentId: 'aster', threadKey: 'spec:test' })
+    );
+  });
+});

--- a/packages/api/src/mcp/tools/thread-handlers.test.ts
+++ b/packages/api/src/mcp/tools/thread-handlers.test.ts
@@ -498,10 +498,21 @@ describe('handleSendToInbox - thread routing', () => {
     // Should trigger lumen and aster (not wren — sender)
     expect(mockGateway.dispatchTrigger).toHaveBeenCalledTimes(2);
     expect(mockGateway.dispatchTrigger).toHaveBeenCalledWith(
-      expect.objectContaining({ toAgentId: 'lumen', threadKey: 'spec:test' })
+      expect.objectContaining({
+        toAgentId: 'lumen',
+        threadKey: 'spec:test',
+        threadMessageId: 'tmsg-123',
+      })
     );
     expect(mockGateway.dispatchTrigger).toHaveBeenCalledWith(
-      expect.objectContaining({ toAgentId: 'aster', threadKey: 'spec:test' })
+      expect.objectContaining({
+        toAgentId: 'aster',
+        threadKey: 'spec:test',
+        threadMessageId: 'tmsg-123',
+      })
+    );
+    expect(mockGateway.dispatchTrigger).not.toHaveBeenCalledWith(
+      expect.objectContaining({ recipientUserId: 'user-123' })
     );
   });
 });

--- a/packages/api/src/mcp/tools/thread-handlers.ts
+++ b/packages/api/src/mcp/tools/thread-handlers.ts
@@ -220,7 +220,8 @@ function dispatchTriggers(
     threadKey: string;
     summary: string;
     priority: string;
-    recipientUserId: string;
+    threadMessageId?: string;
+    threadId?: string;
   }
 ): void {
   if (agentsToTrigger.length === 0) return;
@@ -230,8 +231,8 @@ function dispatchTriggers(
     const payload: AgentTriggerPayload = {
       fromAgentId: opts.fromAgentId,
       toAgentId,
-      // Thread messages have no agent_inbox row — pass userId directly for identity resolution
-      recipientUserId: opts.recipientUserId,
+      threadMessageId: opts.threadMessageId,
+      threadId: opts.threadId,
       triggerType: 'message',
       summary: opts.summary,
       priority: opts.priority as AgentTriggerPayload['priority'],
@@ -470,7 +471,7 @@ export async function handleReplyToThread(args: unknown, dataComposer: DataCompo
     threadKey,
     summary: `Reply in thread ${threadKey} from ${senderAgentId}`,
     priority,
-    recipientUserId: resolved.user.id,
+    threadMessageId: message.id,
   });
 
   return {
@@ -567,7 +568,7 @@ export async function handleAddThreadParticipant(args: unknown, dataComposer: Da
       threadKey,
       summary: `You were added to thread ${threadKey}${reason ? `: ${reason}` : ''}`,
       priority: 'normal',
-      recipientUserId: resolved.user.id,
+      threadId: thread.id,
     });
   }
 

--- a/packages/api/src/mcp/tools/thread-handlers.ts
+++ b/packages/api/src/mcp/tools/thread-handlers.ts
@@ -218,9 +218,9 @@ function dispatchTriggers(
   opts: {
     fromAgentId: string;
     threadKey: string;
-    messageId: string;
     summary: string;
     priority: string;
+    recipientUserId: string;
   }
 ): void {
   if (agentsToTrigger.length === 0) return;
@@ -230,7 +230,8 @@ function dispatchTriggers(
     const payload: AgentTriggerPayload = {
       fromAgentId: opts.fromAgentId,
       toAgentId,
-      inboxMessageId: opts.messageId,
+      // Thread messages have no agent_inbox row — pass userId directly for identity resolution
+      recipientUserId: opts.recipientUserId,
       triggerType: 'message',
       summary: opts.summary,
       priority: opts.priority as AgentTriggerPayload['priority'],
@@ -467,9 +468,9 @@ export async function handleReplyToThread(args: unknown, dataComposer: DataCompo
   dispatchTriggers(agentsToTrigger, {
     fromAgentId: senderAgentId,
     threadKey,
-    messageId: message.id,
     summary: `Reply in thread ${threadKey} from ${senderAgentId}`,
     priority,
+    recipientUserId: resolved.user.id,
   });
 
   return {
@@ -564,9 +565,9 @@ export async function handleAddThreadParticipant(args: unknown, dataComposer: Da
     dispatchTriggers([agentId], {
       fromAgentId: addedByAgentId || 'system',
       threadKey,
-      messageId: thread.id,
       summary: `You were added to thread ${threadKey}${reason ? `: ${reason}` : ''}`,
       priority: 'normal',
+      recipientUserId: resolved.user.id,
     });
   }
 

--- a/packages/api/src/mcp/tools/thread-handlers.ts
+++ b/packages/api/src/mcp/tools/thread-handlers.ts
@@ -84,6 +84,11 @@ const listThreadsSchema = userIdentifierBaseSchema.extend({
   limit: z.number().int().min(1).max(100).optional().default(20),
 });
 
+const markThreadReadSchema = userIdentifierBaseSchema.extend({
+  threadKey: threadKeySchema,
+  agentId: agentIdSchema.describe('Agent ID marking the thread as read'),
+});
+
 // ============== Helpers ==============
 
 interface ThreadRow {
@@ -789,6 +794,69 @@ export async function handleListThreads(args: unknown, dataComposer: DataCompose
   };
 }
 
+export async function handleMarkThreadRead(args: unknown, dataComposer: DataComposer) {
+  const supabase = dataComposer.getClient();
+  const parsed = markThreadReadSchema.parse(args);
+  const resolved = await resolveUserOrThrow(parsed, dataComposer);
+
+  const agentId = getEffectiveAgentId(parsed.agentId) ?? parsed.agentId;
+  const { threadKey } = parsed;
+
+  // Find thread
+  const thread = await findThread(supabase, resolved.user.id, threadKey);
+  if (!thread) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify({ success: false, error: `Thread not found: ${threadKey}` }),
+        },
+      ],
+    };
+  }
+
+  // Verify participant membership
+  if (!(await isParticipant(supabase, thread.id, agentId))) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify({
+            success: false,
+            error: `Agent ${agentId} is not a participant in thread ${threadKey}`,
+          }),
+        },
+      ],
+    };
+  }
+
+  // Upsert read status
+  await threadTable(supabase, 'inbox_thread_read_status').upsert(
+    {
+      thread_id: thread.id,
+      agent_id: agentId,
+      last_read_at: new Date().toISOString(),
+    },
+    { onConflict: 'thread_id,agent_id' }
+  );
+
+  logger.info('Thread marked as read', { threadKey, agentId });
+
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: JSON.stringify({
+          success: true,
+          message: `Thread ${threadKey} marked as read`,
+          threadKey,
+          agentId,
+        }),
+      },
+    ],
+  };
+}
+
 // ============== Tool Registration ==============
 
 export const threadToolDefinitions = [
@@ -826,5 +894,12 @@ export const threadToolDefinitions = [
       'List threads an agent participates in, with unread counts and last message preview. Useful for heartbeat triage and inbox overview.',
     schema: listThreadsSchema,
     handler: handleListThreads,
+  },
+  {
+    name: 'mark_thread_read',
+    description:
+      'Mark a thread as read without fetching messages. Useful when you see thread activity in get_inbox and want to acknowledge it without reading the full history.',
+    schema: markThreadReadSchema,
+    handler: handleMarkThreadRead,
   },
 ];

--- a/packages/api/src/mcp/tools/thread-handlers.ts
+++ b/packages/api/src/mcp/tools/thread-handlers.ts
@@ -1,0 +1,830 @@
+/**
+ * Thread Handlers
+ *
+ * MCP tools for group thread messaging. Threads are first-class conversation
+ * entities where messages belong to the thread, not individual recipients.
+ * Late joiners see full history.
+ *
+ * Spec: pcp://specs/cross-agent-communication v7
+ */
+
+import { z } from 'zod';
+import type { DataComposer } from '../../data/composer';
+import { resolveUserOrThrow, userIdentifierBaseSchema } from '../../services/user-resolver';
+import { getEffectiveAgentId } from '../../auth/enforce-identity';
+import { logger } from '../../utils/logger';
+import type { Json } from '../../data/supabase/types';
+import { getAgentGateway, type AgentTriggerPayload } from '../../channels/agent-gateway.js';
+
+// The thread tables are new and not yet in generated Supabase types.
+// Use type-safe wrappers that cast the table name for PostgREST queries.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type SupabaseClient = ReturnType<DataComposer['getClient']>;
+const threadTable = (supabase: SupabaseClient, table: string) =>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (supabase as any).from(table);
+
+// ============== Schemas ==============
+
+const threadKeySchema = z
+  .string()
+  .min(3)
+  .max(200)
+  .regex(/^[a-zA-Z][a-zA-Z0-9_-]*:[^\s]+$/, 'threadKey must look like "type:identifier"');
+
+const agentIdSchema = z.string().min(1).max(64);
+
+const getThreadMessagesSchema = userIdentifierBaseSchema.extend({
+  threadKey: threadKeySchema,
+  agentId: z.string().describe('Agent ID requesting access (must be a participant)'),
+  limit: z.number().int().min(1).max(200).optional().default(50),
+  beforeMessageId: z.string().uuid().optional().describe('Cursor: get messages before this ID'),
+  afterMessageId: z.string().uuid().optional().describe('Cursor: get messages after this ID'),
+  includeSystemEvents: z.boolean().optional().default(true),
+  markRead: z.boolean().optional().default(true),
+});
+
+const replyToThreadSchema = userIdentifierBaseSchema.extend({
+  threadKey: threadKeySchema,
+  content: z.string().min(1).max(20000),
+  senderAgentId: z.string().optional(),
+  messageType: z
+    .enum(['message', 'task_request', 'session_resume', 'notification'])
+    .optional()
+    .default('message'),
+  priority: z.enum(['low', 'normal', 'high', 'urgent']).optional().default('normal'),
+  triggerAll: z.boolean().optional().default(false),
+  triggerAgents: z
+    .array(agentIdSchema)
+    .max(16)
+    .optional()
+    .describe(
+      'Trigger specific participants by agent ID. Overrides default trigger rules. Non-participants are silently ignored.'
+    ),
+  metadata: z.record(z.unknown()).optional(),
+});
+
+const addThreadParticipantSchema = userIdentifierBaseSchema.extend({
+  threadKey: threadKeySchema,
+  agentId: agentIdSchema.describe('Agent ID to add to the thread'),
+  addedByAgentId: agentIdSchema.optional(),
+  reason: z.string().max(500).optional(),
+  triggerNewParticipant: z.boolean().optional().default(true),
+  metadata: z.record(z.unknown()).optional(),
+});
+
+const closeThreadSchema = userIdentifierBaseSchema.extend({
+  threadKey: threadKeySchema,
+  agentId: agentIdSchema.describe('Agent ID closing the thread (must be a participant)'),
+});
+
+const listThreadsSchema = userIdentifierBaseSchema.extend({
+  agentId: agentIdSchema.describe('Agent ID to list threads for'),
+  status: z.enum(['open', 'closed', 'all']).optional().default('open'),
+  limit: z.number().int().min(1).max(100).optional().default(20),
+});
+
+// ============== Helpers ==============
+
+interface ThreadRow {
+  id: string;
+  thread_key: string;
+  user_id: string;
+  created_by_agent_id: string;
+  title: string | null;
+  status: string;
+  metadata: Json;
+  created_at: string;
+  updated_at: string;
+  closed_at: string | null;
+  closed_by_agent_id: string | null;
+}
+
+/**
+ * Look up a thread by (user_id, thread_key). Returns null if not found.
+ */
+async function findThread(
+  supabase: ReturnType<DataComposer['getClient']>,
+  userId: string,
+  threadKey: string
+): Promise<ThreadRow | null> {
+  const { data, error } = await threadTable(supabase, 'inbox_threads')
+    .select('*')
+    .eq('user_id', userId)
+    .eq('thread_key', threadKey)
+    .maybeSingle();
+
+  if (error) {
+    logger.error('Failed to find thread', { error, threadKey });
+    throw new Error(`Failed to find thread: ${error.message}`);
+  }
+  return data;
+}
+
+/**
+ * Get all participant agent IDs for a thread.
+ */
+async function getParticipants(
+  supabase: ReturnType<DataComposer['getClient']>,
+  threadId: string
+): Promise<string[]> {
+  const { data, error } = await threadTable(supabase, 'inbox_thread_participants')
+    .select('agent_id')
+    .eq('thread_id', threadId);
+
+  if (error) {
+    logger.error('Failed to get participants', { error, threadId });
+    throw new Error(`Failed to get participants: ${error.message}`);
+  }
+  return (data || []).map((p: { agent_id: string }) => p.agent_id);
+}
+
+/**
+ * Check if an agent is a participant in a thread.
+ */
+async function isParticipant(
+  supabase: ReturnType<DataComposer['getClient']>,
+  threadId: string,
+  agentId: string
+): Promise<boolean> {
+  const { data } = await threadTable(supabase, 'inbox_thread_participants')
+    .select('agent_id')
+    .eq('thread_id', threadId)
+    .eq('agent_id', agentId)
+    .maybeSingle();
+  return !!data;
+}
+
+/**
+ * Determine which agents to trigger based on thread context.
+ *
+ * Rules (from spec v7):
+ * 1. triggerAgents [...] → wake exactly these (filter to participants)
+ * 2. triggerAll: true → wake all participants except sender
+ * 3. Default: 1:1 → other participant; group non-creator → creator; group creator → no one
+ */
+function resolveTriggeredAgents(opts: {
+  senderAgentId: string;
+  participants: string[];
+  creatorAgentId: string;
+  triggerAgents?: string[];
+  triggerAll?: boolean;
+}): string[] {
+  const { senderAgentId, participants, creatorAgentId, triggerAgents, triggerAll } = opts;
+
+  // Precedence 1: explicit triggerAgents (filter to actual participants, exclude sender)
+  if (triggerAgents && triggerAgents.length > 0) {
+    const participantSet = new Set(participants);
+    return triggerAgents.filter((a) => a !== senderAgentId && participantSet.has(a));
+  }
+
+  // Precedence 2: triggerAll — everyone except sender
+  if (triggerAll) {
+    return participants.filter((a) => a !== senderAgentId);
+  }
+
+  // Precedence 3: default rules by thread size
+  const otherParticipants = participants.filter((a) => a !== senderAgentId);
+
+  // Self-thread (1 participant): no trigger
+  if (otherParticipants.length === 0) {
+    return [];
+  }
+
+  // 1:1 thread (2 participants): trigger the other one
+  if (participants.length === 2) {
+    return otherParticipants;
+  }
+
+  // Group thread: non-creator reply → trigger creator only
+  if (senderAgentId !== creatorAgentId) {
+    return [creatorAgentId];
+  }
+
+  // Group thread: creator reply → trigger no one
+  return [];
+}
+
+/**
+ * Dispatch triggers to a list of agents.
+ */
+function dispatchTriggers(
+  agentsToTrigger: string[],
+  opts: {
+    fromAgentId: string;
+    threadKey: string;
+    messageId: string;
+    summary: string;
+    priority: string;
+  }
+): void {
+  if (agentsToTrigger.length === 0) return;
+
+  const gateway = getAgentGateway();
+  for (const toAgentId of agentsToTrigger) {
+    const payload: AgentTriggerPayload = {
+      fromAgentId: opts.fromAgentId,
+      toAgentId,
+      inboxMessageId: opts.messageId,
+      triggerType: 'message',
+      summary: opts.summary,
+      priority: opts.priority as AgentTriggerPayload['priority'],
+      threadKey: opts.threadKey,
+    };
+    gateway.dispatchTrigger(payload);
+  }
+}
+
+// ============== Handlers ==============
+
+export async function handleGetThreadMessages(args: unknown, dataComposer: DataComposer) {
+  const supabase = dataComposer.getClient();
+  const parsed = getThreadMessagesSchema.parse(args);
+  const resolved = await resolveUserOrThrow(parsed, dataComposer);
+
+  const agentId = getEffectiveAgentId(parsed.agentId) ?? parsed.agentId;
+  const { threadKey, limit, beforeMessageId, afterMessageId, includeSystemEvents, markRead } =
+    parsed;
+
+  // Find thread
+  const thread = await findThread(supabase, resolved.user.id, threadKey);
+  if (!thread) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify({ success: false, error: `Thread not found: ${threadKey}` }),
+        },
+      ],
+    };
+  }
+
+  // Verify participant membership
+  if (!(await isParticipant(supabase, thread.id, agentId))) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify({
+            success: false,
+            error: `Agent ${agentId} is not a participant in thread ${threadKey}`,
+          }),
+        },
+      ],
+    };
+  }
+
+  // Build query
+  let query = threadTable(supabase, 'inbox_thread_messages')
+    .select('*')
+    .eq('thread_id', thread.id)
+    .order('created_at', { ascending: true })
+    .limit(limit);
+
+  if (!includeSystemEvents) {
+    query = query.neq('message_type', 'system');
+  }
+
+  if (beforeMessageId) {
+    // Get the created_at of the cursor message for pagination
+    const { data: cursor } = await threadTable(supabase, 'inbox_thread_messages')
+      .select('created_at')
+      .eq('id', beforeMessageId)
+      .single();
+    if (cursor) {
+      query = query.lt('created_at', cursor.created_at);
+    }
+  }
+
+  if (afterMessageId) {
+    const { data: cursor } = await threadTable(supabase, 'inbox_thread_messages')
+      .select('created_at')
+      .eq('id', afterMessageId)
+      .single();
+    if (cursor) {
+      query = query.gt('created_at', cursor.created_at);
+    }
+  }
+
+  const { data: messages, error } = await query;
+  if (error) {
+    throw new Error(`Failed to get thread messages: ${error.message}`);
+  }
+
+  // Get participants
+  const participants = await getParticipants(supabase, thread.id);
+
+  // Mark as read
+  if (markRead && messages && messages.length > 0) {
+    await threadTable(supabase, 'inbox_thread_read_status').upsert(
+      {
+        thread_id: thread.id,
+        agent_id: agentId,
+        last_read_at: new Date().toISOString(),
+      },
+      { onConflict: 'thread_id,agent_id' }
+    );
+  }
+
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: JSON.stringify({
+          success: true,
+          threadKey,
+          threadId: thread.id,
+          title: thread.title,
+          status: thread.status,
+          createdBy: thread.created_by_agent_id,
+          participants,
+          messageCount: messages?.length || 0,
+          messages: (messages || []).map((m: Record<string, unknown>) => ({
+            id: m.id,
+            senderAgentId: m.sender_agent_id,
+            content: m.content,
+            messageType: m.message_type,
+            priority: m.priority,
+            metadata: m.metadata,
+            createdAt: m.created_at,
+          })),
+        }),
+      },
+    ],
+  };
+}
+
+export async function handleReplyToThread(args: unknown, dataComposer: DataComposer) {
+  const supabase = dataComposer.getClient();
+  const parsed = replyToThreadSchema.parse(args);
+  const resolved = await resolveUserOrThrow(parsed, dataComposer);
+
+  const senderAgentId = getEffectiveAgentId(parsed.senderAgentId) ?? parsed.senderAgentId;
+  if (!senderAgentId) {
+    throw new Error('senderAgentId is required (or must be resolvable from auth context)');
+  }
+
+  const { threadKey, content, messageType, priority, triggerAll, triggerAgents, metadata } = parsed;
+
+  // Find thread
+  const thread = await findThread(supabase, resolved.user.id, threadKey);
+  if (!thread) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify({ success: false, error: `Thread not found: ${threadKey}` }),
+        },
+      ],
+    };
+  }
+
+  // Reject replies on closed threads
+  if (thread.status === 'closed') {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify({
+            success: false,
+            error: `Thread ${threadKey} is closed. Cannot reply to closed threads.`,
+          }),
+        },
+      ],
+    };
+  }
+
+  // Verify participant membership
+  if (!(await isParticipant(supabase, thread.id, senderAgentId))) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify({
+            success: false,
+            error: `Agent ${senderAgentId} is not a participant in thread ${threadKey}`,
+          }),
+        },
+      ],
+    };
+  }
+
+  // Insert message
+  const { data: message, error } = await threadTable(supabase, 'inbox_thread_messages')
+    .insert({
+      thread_id: thread.id,
+      sender_agent_id: senderAgentId,
+      content,
+      message_type: messageType,
+      priority,
+      metadata: (metadata || {}) as Json,
+    })
+    .select()
+    .single();
+
+  if (error) {
+    throw new Error(`Failed to reply to thread: ${error.message}`);
+  }
+
+  // Update thread updated_at
+  await threadTable(supabase, 'inbox_threads')
+    .update({ updated_at: new Date().toISOString() })
+    .eq('id', thread.id);
+
+  // Update sender's read status
+  await threadTable(supabase, 'inbox_thread_read_status').upsert(
+    {
+      thread_id: thread.id,
+      agent_id: senderAgentId,
+      last_read_at: new Date().toISOString(),
+    },
+    { onConflict: 'thread_id,agent_id' }
+  );
+
+  // Resolve triggers
+  const participants = await getParticipants(supabase, thread.id);
+  const agentsToTrigger = resolveTriggeredAgents({
+    senderAgentId,
+    participants,
+    creatorAgentId: thread.created_by_agent_id,
+    triggerAgents,
+    triggerAll,
+  });
+
+  logger.info('Thread reply sent', {
+    threadKey,
+    messageId: message.id,
+    from: senderAgentId,
+    triggering: agentsToTrigger,
+  });
+
+  // Dispatch triggers
+  dispatchTriggers(agentsToTrigger, {
+    fromAgentId: senderAgentId,
+    threadKey,
+    messageId: message.id,
+    summary: `Reply in thread ${threadKey} from ${senderAgentId}`,
+    priority,
+  });
+
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: JSON.stringify({
+          success: true,
+          message: 'Reply sent',
+          messageId: message.id,
+          threadKey,
+          senderAgentId,
+          triggered: agentsToTrigger,
+          participants,
+        }),
+      },
+    ],
+  };
+}
+
+export async function handleAddThreadParticipant(args: unknown, dataComposer: DataComposer) {
+  const supabase = dataComposer.getClient();
+  const parsed = addThreadParticipantSchema.parse(args);
+  const resolved = await resolveUserOrThrow(parsed, dataComposer);
+
+  const { threadKey, agentId, reason, triggerNewParticipant, metadata } = parsed;
+  const addedByAgentId = getEffectiveAgentId(parsed.addedByAgentId) ?? parsed.addedByAgentId;
+
+  // Find thread
+  const thread = await findThread(supabase, resolved.user.id, threadKey);
+  if (!thread) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify({ success: false, error: `Thread not found: ${threadKey}` }),
+        },
+      ],
+    };
+  }
+
+  // Idempotent: check if already participant
+  if (await isParticipant(supabase, thread.id, agentId)) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify({
+            success: true,
+            message: `${agentId} is already a participant in thread ${threadKey}`,
+            alreadyParticipant: true,
+            threadKey,
+          }),
+        },
+      ],
+    };
+  }
+
+  // Add participant
+  const { error: addError } = await threadTable(supabase, 'inbox_thread_participants').insert({
+    thread_id: thread.id,
+    agent_id: agentId,
+  });
+
+  if (addError) {
+    throw new Error(`Failed to add participant: ${addError.message}`);
+  }
+
+  // Add system message for audit trail
+  const systemContent = addedByAgentId
+    ? `${agentId} was added to the thread by ${addedByAgentId}${reason ? `: ${reason}` : ''}`
+    : `${agentId} joined the thread${reason ? `: ${reason}` : ''}`;
+
+  await threadTable(supabase, 'inbox_thread_messages').insert({
+    thread_id: thread.id,
+    sender_agent_id: 'system',
+    content: systemContent,
+    message_type: 'system',
+    metadata: {
+      type: 'participant_added',
+      agentId,
+      addedBy: addedByAgentId || null,
+      reason: reason || null,
+      ...(metadata || {}),
+    } as Json,
+  });
+
+  logger.info('Thread participant added', { threadKey, agentId, addedBy: addedByAgentId });
+
+  // Trigger the new participant
+  if (triggerNewParticipant) {
+    dispatchTriggers([agentId], {
+      fromAgentId: addedByAgentId || 'system',
+      threadKey,
+      messageId: thread.id,
+      summary: `You were added to thread ${threadKey}${reason ? `: ${reason}` : ''}`,
+      priority: 'normal',
+    });
+  }
+
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: JSON.stringify({
+          success: true,
+          message: `${agentId} added to thread ${threadKey}`,
+          threadKey,
+          agentId,
+          triggered: triggerNewParticipant,
+        }),
+      },
+    ],
+  };
+}
+
+export async function handleCloseThread(args: unknown, dataComposer: DataComposer) {
+  const supabase = dataComposer.getClient();
+  const parsed = closeThreadSchema.parse(args);
+  const resolved = await resolveUserOrThrow(parsed, dataComposer);
+
+  const agentId = getEffectiveAgentId(parsed.agentId) ?? parsed.agentId;
+  const { threadKey } = parsed;
+
+  // Find thread
+  const thread = await findThread(supabase, resolved.user.id, threadKey);
+  if (!thread) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify({ success: false, error: `Thread not found: ${threadKey}` }),
+        },
+      ],
+    };
+  }
+
+  if (thread.status === 'closed') {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify({
+            success: true,
+            message: `Thread ${threadKey} is already closed`,
+            alreadyClosed: true,
+          }),
+        },
+      ],
+    };
+  }
+
+  // Verify participant
+  if (!(await isParticipant(supabase, thread.id, agentId))) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify({
+            success: false,
+            error: `Agent ${agentId} is not a participant in thread ${threadKey}`,
+          }),
+        },
+      ],
+    };
+  }
+
+  // Close the thread
+  const now = new Date().toISOString();
+  const { error } = await threadTable(supabase, 'inbox_threads')
+    .update({
+      status: 'closed',
+      closed_by_agent_id: agentId,
+      closed_at: now,
+      updated_at: now,
+    })
+    .eq('id', thread.id);
+
+  if (error) {
+    throw new Error(`Failed to close thread: ${error.message}`);
+  }
+
+  // Add system message
+  await threadTable(supabase, 'inbox_thread_messages').insert({
+    thread_id: thread.id,
+    sender_agent_id: 'system',
+    content: `Thread closed by ${agentId}`,
+    message_type: 'system',
+    metadata: { type: 'thread_closed', closedBy: agentId } as Json,
+  });
+
+  logger.info('Thread closed', { threadKey, closedBy: agentId });
+
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: JSON.stringify({
+          success: true,
+          message: `Thread ${threadKey} closed`,
+          threadKey,
+          closedBy: agentId,
+        }),
+      },
+    ],
+  };
+}
+
+export async function handleListThreads(args: unknown, dataComposer: DataComposer) {
+  const supabase = dataComposer.getClient();
+  const parsed = listThreadsSchema.parse(args);
+  const resolved = await resolveUserOrThrow(parsed, dataComposer);
+
+  const agentId = getEffectiveAgentId(parsed.agentId) ?? parsed.agentId;
+  const { status, limit } = parsed;
+
+  // Get thread IDs where this agent is a participant
+  const { data: participantRows, error: pError } = await threadTable(
+    supabase,
+    'inbox_thread_participants'
+  )
+    .select('thread_id')
+    .eq('agent_id', agentId);
+
+  if (pError) {
+    throw new Error(`Failed to list threads: ${pError.message}`);
+  }
+
+  const threadIds = (participantRows || []).map((p: { thread_id: string }) => p.thread_id);
+  if (threadIds.length === 0) {
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify({ success: true, agentId, count: 0, threads: [] }),
+        },
+      ],
+    };
+  }
+
+  // Get threads
+  let query = threadTable(supabase, 'inbox_threads')
+    .select('*')
+    .eq('user_id', resolved.user.id)
+    .in('id', threadIds)
+    .order('updated_at', { ascending: false })
+    .limit(limit);
+
+  if (status !== 'all') {
+    query = query.eq('status', status);
+  }
+
+  const { data: threads, error: tError } = await query;
+  if (tError) {
+    throw new Error(`Failed to list threads: ${tError.message}`);
+  }
+
+  // For each thread, get unread count and participant list
+  const threadsWithMeta = await Promise.all(
+    (threads || []).map(async (t: ThreadRow) => {
+      const participants = await getParticipants(supabase, t.id);
+
+      // Get last read timestamp for this agent
+      const { data: readStatus } = await threadTable(supabase, 'inbox_thread_read_status')
+        .select('last_read_at')
+        .eq('thread_id', t.id)
+        .eq('agent_id', agentId)
+        .maybeSingle();
+
+      // Count messages after last read
+      let unreadQuery = threadTable(supabase, 'inbox_thread_messages')
+        .select('*', { count: 'exact', head: true })
+        .eq('thread_id', t.id);
+
+      if (readStatus?.last_read_at) {
+        unreadQuery = unreadQuery.gt('created_at', readStatus.last_read_at);
+      }
+
+      const { count: unreadCount } = await unreadQuery;
+
+      // Get latest message preview
+      const { data: latestMsg } = await threadTable(supabase, 'inbox_thread_messages')
+        .select('sender_agent_id, content, created_at')
+        .eq('thread_id', t.id)
+        .neq('message_type', 'system')
+        .order('created_at', { ascending: false })
+        .limit(1)
+        .maybeSingle();
+
+      return {
+        threadKey: t.thread_key,
+        title: t.title,
+        status: t.status,
+        createdBy: t.created_by_agent_id,
+        participants,
+        unreadCount: unreadCount || 0,
+        lastMessage: latestMsg
+          ? {
+              from: latestMsg.sender_agent_id,
+              preview: latestMsg.content.slice(0, 120),
+              at: latestMsg.created_at,
+            }
+          : null,
+        createdAt: t.created_at,
+        updatedAt: t.updated_at,
+      };
+    })
+  );
+
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: JSON.stringify({
+          success: true,
+          agentId,
+          count: threadsWithMeta.length,
+          threads: threadsWithMeta,
+        }),
+      },
+    ],
+  };
+}
+
+// ============== Tool Registration ==============
+
+export const threadToolDefinitions = [
+  {
+    name: 'get_thread_messages',
+    description:
+      'Get the full message timeline of a thread. Requires participant membership. Automatically marks the thread as read for the requesting agent.',
+    schema: getThreadMessagesSchema,
+    handler: handleGetThreadMessages,
+  },
+  {
+    name: 'reply_to_thread',
+    description:
+      'Reply to a thread. Trigger behavior depends on thread size:\n- 1:1 thread: triggers the other participant by default\n- Group thread (non-creator reply): triggers creator by default\n- Group thread (creator reply): triggers no one by default\nUse triggerAgents for targeted waking, triggerAll for broadcast.',
+    schema: replyToThreadSchema,
+    handler: handleReplyToThread,
+  },
+  {
+    name: 'add_thread_participant',
+    description:
+      'Add an agent to a thread. Idempotent (no-op if already a participant). Creates an audited system event in the thread. Triggers the new participant by default.',
+    schema: addThreadParticipantSchema,
+    handler: handleAddThreadParticipant,
+  },
+  {
+    name: 'close_thread',
+    description:
+      'Close a thread. Closed threads can still be read but new messages are rejected. Any participant can close.',
+    schema: closeThreadSchema,
+    handler: handleCloseThread,
+  },
+  {
+    name: 'list_threads',
+    description:
+      'List threads an agent participates in, with unread counts and last message preview. Useful for heartbeat triage and inbox overview.',
+    schema: listThreadsSchema,
+    handler: handleListThreads,
+  },
+];

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -3086,24 +3086,20 @@ router.get('/individuals/:agentId/inbox', async (req: Request, res: Response) =>
       (a, b) => new Date(b.lastMessageAt).getTime() - new Date(a.lastMessageAt).getTime()
     );
 
-    const totalItems = threads.length + groupThreads.length + flatMessages.length;
     const inboxUnreadCount = allMessages.filter((m) => m.status === 'unread').length;
     const totalUnreadCount = inboxUnreadCount + threadTableUnreadCount;
 
-    // Paginate: legacy threads first, then group threads, then flat messages
+    // Paginate legacy threads and flat messages. Group threads are always
+    // returned in full (typically few) so they stay visible on every page.
     const paginatedThreads = threads.slice(offset, offset + limit);
     const remainingAfterThreads = limit - paginatedThreads.length;
-    const groupThreadOffset = Math.max(0, offset - threads.length);
-    const paginatedGroupThreads =
-      remainingAfterThreads > 0
-        ? groupThreads.slice(groupThreadOffset, groupThreadOffset + remainingAfterThreads)
-        : [];
-    const remainingAfterGroups = remainingAfterThreads - paginatedGroupThreads.length;
-    const flatOffset = Math.max(0, offset - threads.length - groupThreads.length);
+    const flatOffset = Math.max(0, offset - threads.length);
     const paginatedFlat =
-      remainingAfterGroups > 0
-        ? flatMessages.slice(flatOffset, flatOffset + remainingAfterGroups)
+      remainingAfterThreads > 0
+        ? flatMessages.slice(flatOffset, flatOffset + remainingAfterThreads)
         : [];
+
+    const totalItems = threads.length + flatMessages.length;
 
     res.json({
       agentId,
@@ -3117,7 +3113,7 @@ router.get('/individuals/:agentId/inbox', async (req: Request, res: Response) =>
         flatCount: flatMessages.length,
       },
       threads: paginatedThreads,
-      groupThreads: paginatedGroupThreads,
+      groupThreads,
       flatMessages: paginatedFlat,
       pagination: {
         limit,

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -2946,25 +2946,178 @@ router.get('/individuals/:agentId/inbox', async (req: Request, res: Response) =>
     // Sort flat messages by createdAt descending (interleaves sent + received)
     flatMessages.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
 
-    const totalItems = threads.length + flatMessages.length;
-    const unreadCount = allMessages.filter((m) => m.status === 'unread').length;
+    // ── Thread tables: fetch group threads from inbox_thread_* tables ──
+    // These are threads created via send_to_inbox with threadKey (new thread model).
+    interface GroupThread {
+      threadKey: string;
+      title: string | null;
+      status: string;
+      participants: string[];
+      messageCount: number;
+      unreadCount: number;
+      lastMessage: MappedMessage | null;
+      firstMessageAt: string;
+      lastMessageAt: string;
+      messages: MappedMessage[];
+    }
+    const groupThreads: GroupThread[] = [];
+    let threadTableUnreadCount = 0;
 
-    // Paginate: threads first, then flat messages
+    try {
+      // Find threads this agent participates in (from thread tables)
+      const { data: threadParticipantRows } = await (supabase as any)
+        .from('inbox_thread_participants')
+        .select('thread_id')
+        .eq('agent_id', agentId);
+
+      const threadIds = (threadParticipantRows || []).map(
+        (p: { thread_id: string }) => p.thread_id
+      );
+
+      if (threadIds.length > 0) {
+        // Get thread metadata
+        let threadQuery = (supabase as any)
+          .from('inbox_threads')
+          .select('*')
+          .eq('user_id', authReq.pcpUserId)
+          .in('id', threadIds)
+          .order('updated_at', { ascending: false });
+
+        const { data: threadRows } = await threadQuery;
+
+        if (threadRows?.length) {
+          // Get read status for all threads
+          const { data: readStatusRows } = await (supabase as any)
+            .from('inbox_thread_read_status')
+            .select('thread_id, last_read_at')
+            .eq('agent_id', agentId)
+            .in('thread_id', threadIds);
+
+          const readStatusMap = new Map<string, string>();
+          for (const rs of readStatusRows || []) {
+            readStatusMap.set(rs.thread_id, rs.last_read_at);
+          }
+
+          for (const t of threadRows) {
+            // Get participants
+            const { data: parts } = await (supabase as any)
+              .from('inbox_thread_participants')
+              .select('agent_id')
+              .eq('thread_id', t.id);
+            const participants = (parts || []).map((p: { agent_id: string }) => p.agent_id);
+
+            // Get messages
+            let msgQuery = (supabase as any)
+              .from('inbox_thread_messages')
+              .select('*')
+              .eq('thread_id', t.id)
+              .order('created_at', { ascending: true })
+              .limit(200);
+
+            if (status !== 'all') {
+              // Thread messages don't have a status field — filter by read status instead
+              // For 'unread' filter, only include messages after last_read_at
+            }
+            if (messageType) {
+              msgQuery = msgQuery.eq('message_type', messageType);
+            }
+
+            const { data: msgRows } = await msgQuery;
+            const threadMsgs: MappedMessage[] = (msgRows || []).map((m: Record<string, any>) => ({
+              id: m.id,
+              subject: null,
+              content: m.content,
+              messageType: m.message_type,
+              priority: m.priority,
+              status: 'unread', // computed below
+              senderAgentId: m.sender_agent_id,
+              senderIdentityId: null,
+              recipientAgentId: agentId, // thread messages don't have a single recipient
+              recipientIdentityId: null,
+              threadKey: t.thread_key,
+              recipientSessionId: null,
+              relatedArtifactUri: null,
+              metadata: m.metadata as Record<string, unknown> | null,
+              createdAt: m.created_at,
+              readAt: null,
+              acknowledgedAt: null,
+              expiresAt: null,
+            }));
+
+            // Compute read/unread based on read status
+            const lastReadAt = readStatusMap.get(t.id);
+            let unread = 0;
+            for (const msg of threadMsgs) {
+              if (lastReadAt && new Date(msg.createdAt) <= new Date(lastReadAt)) {
+                msg.status = 'read';
+                msg.readAt = lastReadAt;
+              } else {
+                msg.status = 'unread';
+                unread++;
+              }
+            }
+
+            threadTableUnreadCount += unread;
+
+            if (threadMsgs.length > 0) {
+              groupThreads.push({
+                threadKey: t.thread_key,
+                title: t.title,
+                status: t.status,
+                participants,
+                messageCount: threadMsgs.length,
+                unreadCount: unread,
+                lastMessage: threadMsgs[threadMsgs.length - 1],
+                firstMessageAt: threadMsgs[0].createdAt,
+                lastMessageAt: threadMsgs[threadMsgs.length - 1].createdAt,
+                messages: threadMsgs,
+              });
+            }
+          }
+        }
+      }
+    } catch (err) {
+      // Thread tables may not exist yet — graceful fallback
+      logger.debug('Failed to fetch group threads (tables may not exist)', { err });
+    }
+
+    // Sort group threads by latest message
+    groupThreads.sort(
+      (a, b) => new Date(b.lastMessageAt).getTime() - new Date(a.lastMessageAt).getTime()
+    );
+
+    const totalItems = threads.length + groupThreads.length + flatMessages.length;
+    const inboxUnreadCount = allMessages.filter((m) => m.status === 'unread').length;
+    const totalUnreadCount = inboxUnreadCount + threadTableUnreadCount;
+
+    // Paginate: legacy threads first, then group threads, then flat messages
     const paginatedThreads = threads.slice(offset, offset + limit);
-    const remainingSlots = limit - paginatedThreads.length;
-    const flatOffset = Math.max(0, offset - threads.length);
+    const remainingAfterThreads = limit - paginatedThreads.length;
+    const groupThreadOffset = Math.max(0, offset - threads.length);
+    const paginatedGroupThreads =
+      remainingAfterThreads > 0
+        ? groupThreads.slice(groupThreadOffset, groupThreadOffset + remainingAfterThreads)
+        : [];
+    const remainingAfterGroups = remainingAfterThreads - paginatedGroupThreads.length;
+    const flatOffset = Math.max(0, offset - threads.length - groupThreads.length);
     const paginatedFlat =
-      remainingSlots > 0 ? flatMessages.slice(flatOffset, flatOffset + remainingSlots) : [];
+      remainingAfterGroups > 0
+        ? flatMessages.slice(flatOffset, flatOffset + remainingAfterGroups)
+        : [];
 
     res.json({
       agentId,
       stats: {
-        totalMessages: allMessages.length,
-        unreadCount,
+        totalMessages: allMessages.length + groupThreads.reduce((s, t) => s + t.messageCount, 0),
+        unreadCount: inboxUnreadCount,
+        threadUnreadCount: threadTableUnreadCount,
+        totalUnreadCount,
         threadCount: threads.length,
+        groupThreadCount: groupThreads.length,
         flatCount: flatMessages.length,
       },
       threads: paginatedThreads,
+      groupThreads: paginatedGroupThreads,
       flatMessages: paginatedFlat,
       pagination: {
         limit,

--- a/packages/api/src/routes/agent-trigger.ts
+++ b/packages/api/src/routes/agent-trigger.ts
@@ -19,7 +19,7 @@ const router: Router = Router();
  */
 router.post('/trigger', async (req, res) => {
   try {
-    const payload = req.body as AgentTriggerPayload;
+    const { recipientUserId: _stripped, ...payload } = req.body as AgentTriggerPayload;
 
     // Validate required fields
     if (!payload.fromAgentId || !payload.toAgentId || !payload.triggerType) {

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -527,7 +527,11 @@ Do NOT just respond here — you MUST explicitly call send_response to reach ext
     const authUser = getUserFromContext();
     const authUserId = authUser?.userId;
 
-    if (payload.inboxMessageId) {
+    // Fast path: recipientUserId provided directly (thread-backed triggers).
+    // Skips agent_inbox lookup — thread messages have no agent_inbox row.
+    if (payload.recipientUserId) {
+      userId = payload.recipientUserId;
+    } else if (payload.inboxMessageId) {
       const { data: inboxMsg, error: inboxError } = await dataComposer!
         .getClient()
         .from('agent_inbox')
@@ -657,11 +661,14 @@ Type: ${payload.triggerType}`;
     if (payload.metadata && Object.keys(payload.metadata).length > 0) {
       triggerMessage += `\nContext:\n${JSON.stringify(payload.metadata, null, 2)}`;
     }
+    if (payload.threadKey) {
+      triggerMessage += `\n\nThread: ${payload.threadKey}`;
+    }
     triggerMessage += `
 
 ---
 IMPORTANT: This is a system trigger, NOT a user message on Telegram/WhatsApp.
-Check your inbox for the full message using get_inbox.
+${payload.threadKey ? `Fetch the thread using get_thread_messages(threadKey: "${payload.threadKey}"). Use reply_to_thread to respond.` : 'Check your inbox for the full message using get_inbox.'}
 If you need to message a user, use send_response with the appropriate channel and conversationId.
 When you complete a task_request, mark it as completed using update_inbox_message(messageId, status: "completed").`;
 
@@ -735,8 +742,8 @@ When you complete a task_request, mark it as completed using update_inbox_messag
       const client = dataComposer?.getClient();
       if (!client) return;
 
-      // 1. Restore inbox message to unread (only if it was read — don't touch other states)
-      if (payload.inboxMessageId) {
+      // 1. Restore inbox message to unread (only for agent_inbox rows — not thread messages)
+      if (payload.inboxMessageId && !payload.recipientUserId) {
         const { error: restoreErr } = await client
           .from('agent_inbox')
           .update({ status: 'unread', read_at: null })
@@ -758,9 +765,10 @@ When you complete a task_request, mark it as completed using update_inbox_messag
       // 2. Notify sender agent (if there is one) — skip if no sender to avoid loops
       if (!payload.fromAgentId) return;
 
-      // Look up the userId from the original inbox message (needed for sender inbox insert)
-      let recipientUserId: string | undefined;
-      if (payload.inboxMessageId) {
+      // Look up the userId from the original inbox message (needed for sender inbox insert).
+      // For thread-backed triggers, recipientUserId is already in the payload.
+      let recipientUserId: string | undefined = payload.recipientUserId;
+      if (!recipientUserId && payload.inboxMessageId) {
         const { data: origMsg } = await client
           .from('agent_inbox')
           .select('recipient_user_id')

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -527,11 +527,7 @@ Do NOT just respond here — you MUST explicitly call send_response to reach ext
     const authUser = getUserFromContext();
     const authUserId = authUser?.userId;
 
-    // Fast path: recipientUserId provided directly (thread-backed triggers).
-    // Skips agent_inbox lookup — thread messages have no agent_inbox row.
-    if (payload.recipientUserId) {
-      userId = payload.recipientUserId;
-    } else if (payload.inboxMessageId) {
+    if (payload.inboxMessageId) {
       const { data: inboxMsg, error: inboxError } = await dataComposer!
         .getClient()
         .from('agent_inbox')
@@ -563,6 +559,72 @@ Do NOT just respond here — you MUST explicitly call send_response to reach ext
 
       userId = inboxMsg?.recipient_user_id;
       recipientIdentityId = inboxMsg?.recipient_identity_id || undefined;
+    } else if (payload.threadMessageId) {
+      // Thread message: resolve user_id via inbox_thread_messages → inbox_threads
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const supabase = dataComposer!.getClient() as any;
+      const { data: threadMsg, error: tmError } = await supabase
+        .from('inbox_thread_messages')
+        .select('thread_id')
+        .eq('id', payload.threadMessageId)
+        .single();
+      if (tmError) {
+        logger.error('[Trigger] Failed to look up thread message', {
+          threadMessageId: payload.threadMessageId,
+          error: tmError.message,
+        });
+      }
+      if (threadMsg?.thread_id) {
+        const { data: thread, error: threadError } = await supabase
+          .from('inbox_threads')
+          .select('user_id')
+          .eq('id', threadMsg.thread_id)
+          .single();
+        if (threadError) {
+          logger.error('[Trigger] Failed to look up thread from message', {
+            threadId: threadMsg.thread_id,
+            error: threadError.message,
+          });
+        }
+        const threadUserId = thread?.user_id as string | undefined;
+        if (threadUserId && authUserId && threadUserId !== authUserId) {
+          logger.warn('[Trigger] SECURITY: thread owner does not match authenticated user', {
+            threadMessageId: payload.threadMessageId,
+            threadUserId,
+            authUserId,
+            targetAgentId,
+            fromAgentId: payload.fromAgentId,
+          });
+          throw new Error('Trigger denied: thread does not belong to authenticated user');
+        }
+        userId = threadUserId;
+      }
+    } else if (payload.threadId) {
+      // Thread (add_thread_participant): resolve user_id directly from inbox_threads
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { data: thread, error: threadError } = await (dataComposer!.getClient() as any)
+        .from('inbox_threads')
+        .select('user_id')
+        .eq('id', payload.threadId)
+        .single();
+      if (threadError) {
+        logger.error('[Trigger] Failed to look up thread', {
+          threadId: payload.threadId,
+          error: threadError.message,
+        });
+      }
+      const threadUserId = thread?.user_id as string | undefined;
+      if (threadUserId && authUserId && threadUserId !== authUserId) {
+        logger.warn('[Trigger] SECURITY: thread owner does not match authenticated user', {
+          threadId: payload.threadId,
+          threadUserId,
+          authUserId,
+          targetAgentId,
+          fromAgentId: payload.fromAgentId,
+        });
+        throw new Error('Trigger denied: thread does not belong to authenticated user');
+      }
+      userId = threadUserId;
     }
 
     // Fall back to authenticated user from OAuth context (trigger_agent called directly)
@@ -743,7 +805,7 @@ When you complete a task_request, mark it as completed using update_inbox_messag
       if (!client) return;
 
       // 1. Restore inbox message to unread (only for agent_inbox rows — not thread messages)
-      if (payload.inboxMessageId && !payload.recipientUserId) {
+      if (payload.inboxMessageId) {
         const { error: restoreErr } = await client
           .from('agent_inbox')
           .update({ status: 'unread', read_at: null })
@@ -765,16 +827,39 @@ When you complete a task_request, mark it as completed using update_inbox_messag
       // 2. Notify sender agent (if there is one) — skip if no sender to avoid loops
       if (!payload.fromAgentId) return;
 
-      // Look up the userId from the original inbox message (needed for sender inbox insert).
-      // For thread-backed triggers, recipientUserId is already in the payload.
-      let recipientUserId: string | undefined = payload.recipientUserId;
-      if (!recipientUserId && payload.inboxMessageId) {
+      // Look up the userId from the original source row (needed for sender inbox insert).
+      let recipientUserId: string | undefined;
+      if (payload.inboxMessageId) {
         const { data: origMsg } = await client
           .from('agent_inbox')
           .select('recipient_user_id')
           .eq('id', payload.inboxMessageId)
           .single();
         recipientUserId = origMsg?.recipient_user_id;
+      } else if (payload.threadMessageId) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const { data: threadMsg } = await (client as any)
+          .from('inbox_thread_messages')
+          .select('thread_id')
+          .eq('id', payload.threadMessageId)
+          .single();
+        if (threadMsg?.thread_id) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const { data: thread } = await (client as any)
+            .from('inbox_threads')
+            .select('user_id')
+            .eq('id', threadMsg.thread_id)
+            .single();
+          recipientUserId = thread?.user_id;
+        }
+      } else if (payload.threadId) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const { data: thread } = await (client as any)
+          .from('inbox_threads')
+          .select('user_id')
+          .eq('id', payload.threadId)
+          .single();
+        recipientUserId = thread?.user_id;
       }
 
       if (!recipientUserId) {

--- a/packages/web/src/app/(dashboard)/individuals/[agentId]/inbox/page.tsx
+++ b/packages/web/src/app/(dashboard)/individuals/[agentId]/inbox/page.tsx
@@ -457,9 +457,18 @@ export default function InboxPage() {
 
   const stats = data?.stats;
   const threads = data?.threads || [];
-  const groupThreads = data?.groupThreads || [];
   const flatMessages = data?.flatMessages || [];
   const pagination = data?.pagination;
+
+  // Apply status/type filters to group threads client-side (they're always fetched in full)
+  const groupThreads = (data?.groupThreads || []).filter((gt) => {
+    if (statusFilter === 'unread' && gt.unreadCount === 0) return false;
+    if (statusFilter === 'read' && gt.unreadCount > 0) return false;
+    // 'acknowledged' and 'completed' don't map to thread concepts — hide group threads
+    if (statusFilter === 'acknowledged' || statusFilter === 'completed') return false;
+    if (typeFilter && !gt.messages.some((m) => m.messageType === typeFilter)) return false;
+    return true;
+  });
 
   const threadGroupKey = (t: ThreadGroup) => `${t.threadKey}|${t.counterpart}`;
   const selectedThread = activeThread

--- a/packages/web/src/app/(dashboard)/individuals/[agentId]/inbox/page.tsx
+++ b/packages/web/src/app/(dashboard)/individuals/[agentId]/inbox/page.tsx
@@ -315,9 +315,11 @@ function ThreadRow({
           </Badge>
           <span className="text-xs text-gray-400">&middot;</span>
           <span className="text-xs font-medium text-gray-700">{thread.counterpart}</span>
-          <span className="text-xs text-gray-500">{thread.messageCount} msgs</span>
+          <span className="text-xs text-gray-500">
+            {thread.messageCount} {thread.messageCount === 1 ? 'message' : 'messages'}
+          </span>
           {thread.unreadCount > 0 && (
-            <span className="flex h-5 min-w-5 items-center justify-center rounded-full bg-blue-500 px-1.5 text-[10px] font-semibold text-white">
+            <span className="flex h-5 min-w-5 items-center justify-center rounded-full bg-blue-500 px-1 text-[10px] leading-none font-semibold text-white">
               {thread.unreadCount}
             </span>
           )}
@@ -677,9 +679,11 @@ export default function InboxPage() {
                           <span className="text-xs font-medium text-gray-700">
                             {gt.participants.join(', ')}
                           </span>
-                          <span className="text-xs text-gray-500">{gt.messageCount} msgs</span>
+                          <span className="text-xs text-gray-500">
+                            {gt.messageCount} {gt.messageCount === 1 ? 'message' : 'messages'}
+                          </span>
                           {gt.unreadCount > 0 && (
-                            <span className="flex h-5 min-w-5 items-center justify-center rounded-full bg-blue-500 px-1.5 text-[10px] font-semibold text-white">
+                            <span className="flex h-5 min-w-5 items-center justify-center rounded-full bg-blue-500 px-1 text-[10px] leading-none font-semibold text-white">
                               {gt.unreadCount}
                             </span>
                           )}

--- a/packages/web/src/app/(dashboard)/individuals/[agentId]/inbox/page.tsx
+++ b/packages/web/src/app/(dashboard)/individuals/[agentId]/inbox/page.tsx
@@ -23,6 +23,7 @@ import {
   MessageSquare,
   AlertCircle,
   User,
+  Users,
 } from 'lucide-react';
 import { useApiQuery } from '@/lib/api';
 import clsx from 'clsx';
@@ -567,75 +568,114 @@ export default function InboxPage() {
           </CardContent>
         </Card>
       ) : (
-        <div className="space-y-6">
-          {/* Threaded conversations */}
-          {threads.length > 0 && (
-            <Card>
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2">
-                  <MessageSquare className="h-5 w-5" />
-                  Threads
-                </CardTitle>
-                <CardDescription>Click a thread to view the full conversation.</CardDescription>
-              </CardHeader>
-              <CardContent className="space-y-2">
-                {threads.map((thread) => {
-                  const gk = threadGroupKey(thread);
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <MessageSquare className="h-5 w-5" />
+              Inbox
+            </CardTitle>
+            <CardDescription>Click a thread or message to view details.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            {(() => {
+              // Build a unified list sorted by most recent activity
+              type UnifiedItem =
+                | { kind: 'thread'; key: string; sortDate: string; thread: ThreadGroup }
+                | { kind: 'group'; key: string; sortDate: string; group: GroupThread }
+                | { kind: 'message'; key: string; sortDate: string; message: InboxMessage };
+
+              const items: UnifiedItem[] = [];
+
+              for (const t of threads) {
+                items.push({
+                  kind: 'thread',
+                  key: threadGroupKey(t),
+                  sortDate: t.lastMessageAt,
+                  thread: t,
+                });
+              }
+              for (const gt of groupThreads) {
+                items.push({
+                  kind: 'group',
+                  key: `group:${gt.threadKey}`,
+                  sortDate: gt.lastMessageAt,
+                  group: gt,
+                });
+              }
+              for (const msg of flatMessages) {
+                items.push({
+                  kind: 'message',
+                  key: msg.id,
+                  sortDate: msg.createdAt,
+                  message: msg,
+                });
+              }
+
+              items.sort((a, b) => new Date(b.sortDate).getTime() - new Date(a.sortDate).getTime());
+
+              return items.map((item) => {
+                if (item.kind === 'thread') {
+                  const t = item.thread;
                   return (
                     <ThreadRow
-                      key={gk}
-                      thread={thread}
-                      isActive={activeThread === gk}
+                      key={item.key}
+                      thread={t}
+                      isActive={activeThread === item.key}
                       onClick={() => {
                         setActiveMessage(null);
-                        setActiveThread(activeThread === gk ? null : gk);
+                        setActiveThread(activeThread === item.key ? null : item.key);
                       }}
                     />
                   );
-                })}
-              </CardContent>
-            </Card>
-          )}
+                }
 
-          {/* Group threads (from thread tables) */}
-          {groupThreads.length > 0 && (
-            <Card>
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2">
-                  <MessageSquare className="h-5 w-5" />
-                  Group Threads
-                </CardTitle>
-                <CardDescription>
-                  Multi-participant threads. Click to view the full conversation.
-                </CardDescription>
-              </CardHeader>
-              <CardContent className="space-y-2">
-                {groupThreads.map((gt) => {
-                  const gk = `group:${gt.threadKey}`;
+                if (item.kind === 'group') {
+                  const gt = item.group;
                   return (
                     <button
-                      key={gk}
+                      key={item.key}
                       onClick={() => {
                         setActiveMessage(null);
-                        setActiveThread(activeThread === gk ? null : gk);
+                        setActiveThread(activeThread === item.key ? null : item.key);
                       }}
                       className={clsx(
                         'flex w-full items-center gap-3 rounded-lg border px-4 py-3 text-left transition-colors',
-                        activeThread === gk
-                          ? 'border-blue-200 bg-blue-50/50'
-                          : 'border-gray-100 hover:bg-gray-50'
+                        activeThread === item.key
+                          ? 'border-blue-300 bg-blue-50/50 ring-1 ring-blue-200'
+                          : 'border-gray-200 bg-white hover:bg-gray-50/50'
                       )}
                     >
+                      {/* Stacked avatar for group threads */}
+                      <div className="relative flex h-8 w-8 shrink-0 items-center justify-center">
+                        <div
+                          className={clsx(
+                            'absolute -left-0.5 -top-0.5 h-6 w-6 rounded-full text-white text-[9px] font-semibold flex items-center justify-center ring-2 ring-white',
+                            agentColor(gt.participants[0] || 'unknown')
+                          )}
+                        >
+                          {(gt.participants[0] || '??').slice(0, 2).toUpperCase()}
+                        </div>
+                        <div
+                          className={clsx(
+                            'absolute right-0 bottom-0 h-6 w-6 rounded-full text-white text-[9px] font-semibold flex items-center justify-center ring-2 ring-white',
+                            agentColor(gt.participants[1] || 'unknown')
+                          )}
+                        >
+                          {gt.participants.length > 2 ? (
+                            <Users className="h-3 w-3" />
+                          ) : (
+                            (gt.participants[1] || '??').slice(0, 2).toUpperCase()
+                          )}
+                        </div>
+                      </div>
                       <div className="min-w-0 flex-1">
                         <div className="flex items-center gap-2">
-                          <span className="font-medium text-sm">{gt.title || gt.threadKey}</span>
-                          {gt.status === 'closed' && (
-                            <Badge variant="outline" className="text-[10px]">
-                              closed
-                            </Badge>
-                          )}
-                          <span className="text-xs text-gray-500">
-                            {gt.participants.length} participants
+                          <Badge variant="outline" className="font-mono text-xs shrink-0">
+                            {gt.threadKey}
+                          </Badge>
+                          <span className="text-xs text-gray-400">&middot;</span>
+                          <span className="text-xs font-medium text-gray-700">
+                            {gt.participants.join(', ')}
                           </span>
                           <span className="text-xs text-gray-500">{gt.messageCount} msgs</span>
                           {gt.unreadCount > 0 && (
@@ -643,18 +683,22 @@ export default function InboxPage() {
                               {gt.unreadCount}
                             </span>
                           )}
+                          {gt.status === 'closed' && (
+                            <Badge variant="outline" className="text-[10px]">
+                              closed
+                            </Badge>
+                          )}
                         </div>
-                        <div className="mt-0.5 flex items-center gap-1">
-                          <span className="text-xs text-gray-400">
-                            {gt.participants.join(', ')}
-                          </span>
-                        </div>
-                        {gt.lastMessage && (
-                          <p className="mt-0.5 text-sm text-gray-600 truncate">
-                            <span className="font-medium">{gt.lastMessage.senderAgentId}:</span>{' '}
-                            {gt.lastMessage.content}
-                          </p>
-                        )}
+                        <p className="mt-0.5 text-sm text-gray-600 truncate">
+                          {gt.lastMessage ? (
+                            <>
+                              <span className="font-medium">{gt.lastMessage.senderAgentId}:</span>{' '}
+                              {gt.lastMessage.content}
+                            </>
+                          ) : (
+                            gt.title || gt.threadKey
+                          )}
+                        </p>
                       </div>
                       <div className="shrink-0 text-right">
                         <span className="text-xs text-gray-400">
@@ -664,25 +708,11 @@ export default function InboxPage() {
                       </div>
                     </button>
                   );
-                })}
-              </CardContent>
-            </Card>
-          )}
+                }
 
-          {/* Direct (unthreaded) messages */}
-          {flatMessages.length > 0 && (
-            <Card>
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2">
-                  <Mail className="h-5 w-5" />
-                  Direct Messages
-                </CardTitle>
-                <CardDescription>
-                  Messages without a thread key, routed to {agentName}&apos;s main process.
-                </CardDescription>
-              </CardHeader>
-              <CardContent className="space-y-1">
-                {flatMessages.map((msg) => (
+                // kind === 'message'
+                const msg = item.message;
+                return (
                   <div
                     key={msg.id}
                     role="button"
@@ -709,11 +739,11 @@ export default function InboxPage() {
                       onShowRouting={setRoutingMessage}
                     />
                   </div>
-                ))}
-              </CardContent>
-            </Card>
-          )}
-        </div>
+                );
+              });
+            })()}
+          </CardContent>
+        </Card>
       )}
 
       {/* Pagination */}

--- a/packages/web/src/app/(dashboard)/individuals/[agentId]/inbox/page.tsx
+++ b/packages/web/src/app/(dashboard)/individuals/[agentId]/inbox/page.tsx
@@ -60,15 +60,32 @@ interface ThreadGroup {
   messages: InboxMessage[];
 }
 
+interface GroupThread {
+  threadKey: string;
+  title: string | null;
+  status: string;
+  participants: string[];
+  messageCount: number;
+  unreadCount: number;
+  lastMessage: InboxMessage | null;
+  firstMessageAt: string;
+  lastMessageAt: string;
+  messages: InboxMessage[];
+}
+
 interface InboxResponse {
   agentId: string;
   stats: {
     totalMessages: number;
     unreadCount: number;
+    threadUnreadCount?: number;
+    totalUnreadCount?: number;
     threadCount: number;
+    groupThreadCount?: number;
     flatCount: number;
   };
   threads: ThreadGroup[];
+  groupThreads?: GroupThread[];
   flatMessages: InboxMessage[];
   pagination: {
     limit: number;
@@ -437,6 +454,7 @@ export default function InboxPage() {
 
   const stats = data?.stats;
   const threads = data?.threads || [];
+  const groupThreads = data?.groupThreads || [];
   const flatMessages = data?.flatMessages || [];
   const pagination = data?.pagination;
 
@@ -444,10 +462,13 @@ export default function InboxPage() {
   const selectedThread = activeThread
     ? threads.find((t) => threadGroupKey(t) === activeThread)
     : undefined;
+  const selectedGroupThread = activeThread
+    ? groupThreads.find((t) => `group:${t.threadKey}` === activeThread)
+    : undefined;
   const selectedMessage = activeMessage
     ? flatMessages.find((m) => m.id === activeMessage)
     : undefined;
-  const panelOpen = !!selectedThread || !!selectedMessage;
+  const panelOpen = !!selectedThread || !!selectedGroupThread || !!selectedMessage;
 
   return (
     <div>
@@ -468,10 +489,14 @@ export default function InboxPage() {
         {stats && (
           <div className="mt-2 flex items-center gap-3">
             <Badge variant="outline">{stats.totalMessages} total</Badge>
-            {stats.unreadCount > 0 && (
-              <Badge className="bg-blue-100 text-blue-700">{stats.unreadCount} unread</Badge>
+            {(stats.totalUnreadCount ?? stats.unreadCount) > 0 && (
+              <Badge className="bg-blue-100 text-blue-700">
+                {stats.totalUnreadCount ?? stats.unreadCount} unread
+              </Badge>
             )}
-            <Badge variant="outline">{stats.threadCount} threads</Badge>
+            <Badge variant="outline">
+              {stats.threadCount + (stats.groupThreadCount || 0)} threads
+            </Badge>
             <Badge variant="outline">{stats.flatCount} direct</Badge>
           </div>
         )}
@@ -531,7 +556,7 @@ export default function InboxPage() {
 
       {isLoading ? (
         <p className="text-sm text-gray-500">Loading inbox...</p>
-      ) : threads.length === 0 && flatMessages.length === 0 ? (
+      ) : threads.length === 0 && groupThreads.length === 0 && flatMessages.length === 0 ? (
         <Card>
           <CardContent className="py-12 text-center">
             <Mail className="mx-auto mb-3 h-12 w-12 text-gray-300" />
@@ -566,6 +591,78 @@ export default function InboxPage() {
                         setActiveThread(activeThread === gk ? null : gk);
                       }}
                     />
+                  );
+                })}
+              </CardContent>
+            </Card>
+          )}
+
+          {/* Group threads (from thread tables) */}
+          {groupThreads.length > 0 && (
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <MessageSquare className="h-5 w-5" />
+                  Group Threads
+                </CardTitle>
+                <CardDescription>
+                  Multi-participant threads. Click to view the full conversation.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-2">
+                {groupThreads.map((gt) => {
+                  const gk = `group:${gt.threadKey}`;
+                  return (
+                    <button
+                      key={gk}
+                      onClick={() => {
+                        setActiveMessage(null);
+                        setActiveThread(activeThread === gk ? null : gk);
+                      }}
+                      className={clsx(
+                        'flex w-full items-center gap-3 rounded-lg border px-4 py-3 text-left transition-colors',
+                        activeThread === gk
+                          ? 'border-blue-200 bg-blue-50/50'
+                          : 'border-gray-100 hover:bg-gray-50'
+                      )}
+                    >
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-center gap-2">
+                          <span className="font-medium text-sm">{gt.title || gt.threadKey}</span>
+                          {gt.status === 'closed' && (
+                            <Badge variant="outline" className="text-[10px]">
+                              closed
+                            </Badge>
+                          )}
+                          <span className="text-xs text-gray-500">
+                            {gt.participants.length} participants
+                          </span>
+                          <span className="text-xs text-gray-500">{gt.messageCount} msgs</span>
+                          {gt.unreadCount > 0 && (
+                            <span className="flex h-5 min-w-5 items-center justify-center rounded-full bg-blue-500 px-1.5 text-[10px] font-semibold text-white">
+                              {gt.unreadCount}
+                            </span>
+                          )}
+                        </div>
+                        <div className="mt-0.5 flex items-center gap-1">
+                          <span className="text-xs text-gray-400">
+                            {gt.participants.join(', ')}
+                          </span>
+                        </div>
+                        {gt.lastMessage && (
+                          <p className="mt-0.5 text-sm text-gray-600 truncate">
+                            <span className="font-medium">{gt.lastMessage.senderAgentId}:</span>{' '}
+                            {gt.lastMessage.content}
+                          </p>
+                        )}
+                      </div>
+                      <div className="shrink-0 text-right">
+                        <span className="text-xs text-gray-400">
+                          {formatRelativeTime(gt.lastMessageAt)}
+                        </span>
+                        <ChevronRight className="mt-0.5 ml-auto h-4 w-4 text-gray-300" />
+                      </div>
+                    </button>
                   );
                 })}
               </CardContent>
@@ -666,7 +763,9 @@ export default function InboxPage() {
               <MessageSquare className="h-4 w-4 text-gray-500" />
               {selectedThread
                 ? `${selectedThread.threadKey} · ${selectedThread.counterpart}`
-                : 'Message'}
+                : selectedGroupThread
+                  ? selectedGroupThread.title || selectedGroupThread.threadKey
+                  : 'Message'}
             </SheetTitle>
             {selectedThread && (
               <SheetDescription>
@@ -674,11 +773,23 @@ export default function InboxPage() {
                 {selectedThread.counterpart}
               </SheetDescription>
             )}
+            {selectedGroupThread && (
+              <SheetDescription>
+                {selectedGroupThread.messageCount} messages &middot;{' '}
+                {selectedGroupThread.participants.join(', ')}
+              </SheetDescription>
+            )}
           </SheetHeader>
-          {(selectedThread || selectedMessage) && (
+          {(selectedThread || selectedGroupThread || selectedMessage) && (
             <ThreadMessages
               thread={selectedThread}
-              messages={selectedMessage ? [selectedMessage] : undefined}
+              messages={
+                selectedGroupThread
+                  ? selectedGroupThread.messages
+                  : selectedMessage
+                    ? [selectedMessage]
+                    : undefined
+              }
               agentId={agentId}
               onShowRouting={setRoutingMessage}
             />

--- a/supabase/migrations/20260310010340_inbox_threads.sql
+++ b/supabase/migrations/20260310010340_inbox_threads.sql
@@ -1,0 +1,82 @@
+-- Group Threads for Cross-Agent Communication
+-- Spec: pcp://specs/cross-agent-communication v7
+--
+-- Adds thread-first messaging: messages belong to threads, not individual recipients.
+-- Late joiners see full history. Trigger rules depend on thread size and sender role.
+
+-- Thread entity — created implicitly on first message with a threadKey
+CREATE TABLE inbox_threads (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  thread_key TEXT NOT NULL,
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  created_by_agent_id TEXT NOT NULL,
+  title TEXT,
+  status TEXT NOT NULL DEFAULT 'open',
+  closed_by_agent_id TEXT,
+  metadata JSONB DEFAULT '{}',
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  closed_at TIMESTAMPTZ,
+
+  CONSTRAINT inbox_threads_unique_key UNIQUE (user_id, thread_key),
+  CONSTRAINT inbox_threads_valid_status CHECK (status IN ('open', 'closed'))
+);
+
+-- Who's in the thread
+CREATE TABLE inbox_thread_participants (
+  thread_id UUID NOT NULL REFERENCES inbox_threads(id) ON DELETE CASCADE,
+  agent_id TEXT NOT NULL,
+  joined_at TIMESTAMPTZ DEFAULT NOW(),
+  PRIMARY KEY (thread_id, agent_id)
+);
+
+-- Messages belong to the thread, not to individual recipients
+CREATE TABLE inbox_thread_messages (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  thread_id UUID NOT NULL REFERENCES inbox_threads(id) ON DELETE CASCADE,
+  sender_agent_id TEXT NOT NULL,
+  content TEXT NOT NULL,
+  message_type TEXT NOT NULL DEFAULT 'message',
+  priority TEXT NOT NULL DEFAULT 'normal',
+  metadata JSONB DEFAULT '{}',
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+
+  CONSTRAINT inbox_thread_messages_valid_type CHECK (
+    message_type IN ('message', 'task_request', 'session_resume', 'notification', 'system')
+  ),
+  CONSTRAINT inbox_thread_messages_valid_priority CHECK (
+    priority IN ('low', 'normal', 'high', 'urgent')
+  )
+);
+
+-- Per-agent read tracking without duplicating messages
+CREATE TABLE inbox_thread_read_status (
+  thread_id UUID NOT NULL REFERENCES inbox_threads(id) ON DELETE CASCADE,
+  agent_id TEXT NOT NULL,
+  last_read_at TIMESTAMPTZ DEFAULT NOW(),
+  PRIMARY KEY (thread_id, agent_id)
+);
+
+-- Indexes
+CREATE INDEX idx_inbox_threads_user_status ON inbox_threads (user_id, status);
+CREATE INDEX idx_inbox_thread_messages_thread ON inbox_thread_messages (thread_id, created_at);
+CREATE INDEX idx_inbox_thread_participants_agent ON inbox_thread_participants (agent_id, thread_id);
+
+-- updated_at trigger (uses canonical helper from initial schema)
+CREATE TRIGGER update_inbox_threads_updated_at
+  BEFORE UPDATE ON inbox_threads
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_updated_at_column();
+
+-- RLS
+ALTER TABLE inbox_threads ENABLE ROW LEVEL SECURITY;
+ALTER TABLE inbox_thread_participants ENABLE ROW LEVEL SECURITY;
+ALTER TABLE inbox_thread_messages ENABLE ROW LEVEL SECURITY;
+ALTER TABLE inbox_thread_read_status ENABLE ROW LEVEL SECURITY;
+
+-- Service role policies (server-side access via service key bypasses RLS,
+-- but we add permissive policies as safety net per project convention)
+CREATE POLICY inbox_threads_service ON inbox_threads FOR ALL USING (true);
+CREATE POLICY inbox_thread_participants_service ON inbox_thread_participants FOR ALL USING (true);
+CREATE POLICY inbox_thread_messages_service ON inbox_thread_messages FOR ALL USING (true);
+CREATE POLICY inbox_thread_read_status_service ON inbox_thread_read_status FOR ALL USING (true);


### PR DESCRIPTION
## Summary

Implements the thread-first messaging model from the cross-agent communication spec (`pcp://specs/cross-agent-communication` v7, status: Accepted). Reviewed by Myra, Lumen, Aster, and Conor.

- **4 new database tables**: `inbox_threads`, `inbox_thread_participants`, `inbox_thread_messages`, `inbox_thread_read_status` — messages belong to threads, not individual recipients. Late joiners see full history.
- **5 new MCP tools**: `get_thread_messages`, `reply_to_thread`, `add_thread_participant`, `close_thread`, `list_threads`
- **Extended `send_to_inbox`**: now supports `recipients[]` for group thread creation and routes messages to thread tables when `threadKey` is provided. Without `threadKey`, behavior is unchanged.
- **Context-dependent trigger rules**: 1:1 threads trigger the other participant, group threads trigger creator only (non-creator reply) or no one (creator reply). `triggerAgents` for targeted waking, `triggerAll` for broadcast.

### Trigger matrix

| Event | Default trigger | Override |
|-------|----------------|----------|
| Thread creation | All initial participants | `trigger: false` |
| 1:1 reply | Other participant | `triggerAgents` / `triggerAll` |
| Group reply (non-creator) | Creator only | `triggerAgents` / `triggerAll` |
| Group reply (creator) | No one | `triggerAgents` / `triggerAll` |
| Participant added | New participant only | `triggerNewParticipant: false` |

### What's NOT in this PR

- Thread summaries for late joiners (v2 — Aster's suggestion)
- `@mention` → `triggerAgents` auto-mapping (v2)
- Message editing (schema supports it, deferred)
- Response schemas with unread count envelopes (Lumen offered to draft)

## Test plan

- [ ] Apply migration via `supabase db push` or MCP tool
- [ ] Regenerate Supabase types to remove `threadTable()` type bypass
- [ ] Manual test: `send_to_inbox(recipients: ["lumen", "aster"], threadKey: "test:group", content: "Hello")`
- [ ] Verify `get_thread_messages` returns full history for participants
- [ ] Verify `reply_to_thread` trigger rules (1:1 vs group)
- [ ] Verify `add_thread_participant` is idempotent and creates system event
- [ ] Verify `close_thread` rejects new replies
- [ ] Verify `list_threads` shows unread counts
- [ ] Build passes: `yarn workspace @personal-context/api build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)