### PR TITLE
fix: retry Claude session capture after close (by Lumen)

### DIFF
--- a/packages/cli/src/commands/claude.integration.test.ts
+++ b/packages/cli/src/commands/claude.integration.test.ts
@@ -10,7 +10,7 @@ import {
 } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { runClaude, type SbOptions } from './claude.js';
+import { getBackendLocalSessionsForProject, runClaude, type SbOptions } from './claude.js';
 
 const cleanupPaths: string[] = [];
 
@@ -211,6 +211,191 @@ console.log(JSON.stringify({ session_id: process.env.FAKE_CLAUDE_SESSION_ID || '
 
       if (oldFakeSessionId === undefined) delete process.env.FAKE_CLAUDE_SESSION_ID;
       else process.env.FAKE_CLAUDE_SESSION_ID = oldFakeSessionId;
+    }
+  });
+
+  it('reconciles delayed local transcript backend session id after close', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'sb-claude-int-delayed-'));
+    cleanupPaths.push(root);
+
+    const homeDir = join(root, 'home');
+    const repoDir = join(root, 'repo');
+    const binDir = join(root, 'bin');
+    mkdirSync(homeDir, { recursive: true });
+    mkdirSync(repoDir, { recursive: true });
+    mkdirSync(binDir, { recursive: true });
+    mkdirSync(join(homeDir, '.pcp'), { recursive: true });
+    mkdirSync(join(repoDir, '.pcp'), { recursive: true });
+
+    writeFileSync(
+      join(homeDir, '.pcp', 'config.json'),
+      JSON.stringify({ email: 'integration@example.com' }, null, 2)
+    );
+    writeFileSync(
+      join(repoDir, '.pcp', 'identity.json'),
+      JSON.stringify({ studioId: 'studio-test' }, null, 2)
+    );
+
+    const fakeClaudeArgsPath = join(root, 'fake-claude-args-delayed.json');
+    const fakeClaudePath = join(binDir, 'claude');
+    const delayedSessionId = '30303030-3030-4030-8030-303030303030';
+    writeFileSync(
+      fakeClaudePath,
+      `#!/usr/bin/env node
+const { writeFileSync } = require('fs');
+const { spawn } = require('child_process');
+writeFileSync(process.env.FAKE_CLAUDE_ARGS_PATH, JSON.stringify(process.argv.slice(2)));
+const writer = spawn(
+  process.execPath,
+  [
+    '-e',
+    "const fs=require('fs');const path=require('path');const out=process.env.DELAYED_TRANSCRIPT_PATH;const sessionId=process.env.DELAYED_SESSION_ID;const delayMs=Number(process.env.DELAYED_TRANSCRIPT_DELAY_MS||'120');setTimeout(()=>{fs.mkdirSync(path.dirname(out),{recursive:true});fs.writeFileSync(out,JSON.stringify({type:'progress',sessionId,timestamp:new Date().toISOString()})+'\\\\n');}, delayMs);"
+  ],
+  { detached: true, stdio: 'ignore', env: process.env }
+);
+writer.unref();
+console.log('fake-claude-run-complete');
+`
+    );
+    chmodSync(fakeClaudePath, 0o755);
+
+    const pcpToolCalls: Array<{
+      name: string;
+      args: Record<string, unknown>;
+      headers: Record<string, string>;
+    }> = [];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (_input: unknown, init?: { body?: unknown; headers?: unknown }) => {
+        const body = JSON.parse(String(init?.body || '{}')) as {
+          id?: number;
+          params?: { name?: string; arguments?: Record<string, unknown> };
+        };
+        const toolName = body.params?.name || '';
+        const toolArgs = body.params?.arguments || {};
+        const rawHeaders = (init?.headers || {}) as Record<string, unknown>;
+        const normalizedHeaders = Object.fromEntries(
+          Object.entries(rawHeaders).map(([key, value]) => [key.toLowerCase(), String(value)])
+        );
+        pcpToolCalls.push({ name: toolName, args: toolArgs, headers: normalizedHeaders });
+
+        let payload: Record<string, unknown> = { success: true };
+        if (toolName === 'list_sessions') {
+          payload = { sessions: [] };
+        } else if (toolName === 'start_session') {
+          payload = {
+            session: {
+              id: String(toolArgs.sessionId || 'generated-session-id'),
+              startedAt: new Date().toISOString(),
+              backend: 'claude',
+            },
+          };
+        }
+
+        return new Response(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            id: body.id ?? 1,
+            result: {
+              content: [{ type: 'text', text: JSON.stringify(payload) }],
+            },
+          }),
+          {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }
+        );
+      })
+    );
+
+    const oldHome = process.env.HOME;
+    const oldPath = process.env.PATH;
+    const oldPcpUrl = process.env.PCP_SERVER_URL;
+    const oldArgsPath = process.env.FAKE_CLAUDE_ARGS_PATH;
+    const oldDelayedTranscriptPath = process.env.DELAYED_TRANSCRIPT_PATH;
+    const oldDelayedSessionId = process.env.DELAYED_SESSION_ID;
+    const oldDelayedTranscriptDelayMs = process.env.DELAYED_TRANSCRIPT_DELAY_MS;
+    const oldCwd = process.cwd();
+
+    process.env.HOME = homeDir;
+    process.env.PATH = `${binDir}:${oldPath || ''}`;
+    process.env.PCP_SERVER_URL = 'http://pcp.test.local';
+    process.env.FAKE_CLAUDE_ARGS_PATH = fakeClaudeArgsPath;
+    process.env.DELAYED_SESSION_ID = delayedSessionId;
+    process.env.DELAYED_TRANSCRIPT_DELAY_MS = '120';
+    process.chdir(repoDir);
+    const runtimeRepoDir = process.cwd();
+    const claudeProjectDir = join(
+      homeDir,
+      '.claude',
+      'projects',
+      runtimeRepoDir.replace(/[\\/]/g, '-')
+    );
+    mkdirSync(claudeProjectDir, { recursive: true });
+    const delayedTranscriptPath = join(claudeProjectDir, `${delayedSessionId}.jsonl`);
+    process.env.DELAYED_TRANSCRIPT_PATH = delayedTranscriptPath;
+
+    try {
+      const options: SbOptions = {
+        agent: 'wren',
+        model: undefined,
+        session: true,
+        verbose: false,
+        backend: 'claude',
+      };
+
+      await runClaude(
+        'hello delayed integration',
+        ['hello', 'delayed', 'integration'],
+        options,
+        []
+      );
+      await waitForFile(fakeClaudeArgsPath);
+      await waitForFile(delayedTranscriptPath);
+      const observedLocalSessions = getBackendLocalSessionsForProject('claude', repoDir, 20).map(
+        (session) => session.sessionId
+      );
+      expect(observedLocalSessions).toContain(delayedSessionId);
+
+      const runtimePath = join(repoDir, '.pcp', 'runtime', 'sessions.json');
+      await waitForFile(runtimePath);
+      const runtimeState = JSON.parse(readFileSync(runtimePath, 'utf-8')) as {
+        sessions?: Array<{ pcpSessionId?: string; backendSessionId?: string }>;
+      };
+      expect(runtimeState.sessions?.[0]?.pcpSessionId).toBeTruthy();
+      const persistedBackendSessionId = await waitForRuntimeBackendSessionId(runtimePath, 5_000);
+      expect(persistedBackendSessionId).toBe(delayedSessionId);
+
+      const phaseUpdatesWithBackendId = pcpToolCalls
+        .filter((call) => call.name === 'update_session_phase')
+        .some((call) => call.args.backendSessionId === delayedSessionId);
+      expect(phaseUpdatesWithBackendId).toBe(true);
+    } finally {
+      process.chdir(oldCwd);
+
+      if (oldHome === undefined) delete process.env.HOME;
+      else process.env.HOME = oldHome;
+
+      if (oldPath === undefined) delete process.env.PATH;
+      else process.env.PATH = oldPath;
+
+      if (oldPcpUrl === undefined) delete process.env.PCP_SERVER_URL;
+      else process.env.PCP_SERVER_URL = oldPcpUrl;
+
+      if (oldArgsPath === undefined) delete process.env.FAKE_CLAUDE_ARGS_PATH;
+      else process.env.FAKE_CLAUDE_ARGS_PATH = oldArgsPath;
+
+      if (oldDelayedTranscriptPath === undefined) delete process.env.DELAYED_TRANSCRIPT_PATH;
+      else process.env.DELAYED_TRANSCRIPT_PATH = oldDelayedTranscriptPath;
+
+      if (oldDelayedSessionId === undefined) delete process.env.DELAYED_SESSION_ID;
+      else process.env.DELAYED_SESSION_ID = oldDelayedSessionId;
+
+      if (oldDelayedTranscriptDelayMs === undefined) {
+        delete process.env.DELAYED_TRANSCRIPT_DELAY_MS;
+      } else {
+        process.env.DELAYED_TRANSCRIPT_DELAY_MS = oldDelayedTranscriptDelayMs;
+      }
     }
   });
 

--- a/packages/cli/src/commands/claude.test.ts
+++ b/packages/cli/src/commands/claude.test.ts
@@ -26,6 +26,7 @@ import {
   shouldRetryWithFreshBackendSession,
   shouldAutoResumeRuntimeSession,
 } from './claude.js';
+import { setCurrentRuntimeSession, upsertRuntimeSession } from '../session/runtime.js';
 
 describe('hasBackendSessionOverride', () => {
   it('detects explicit Codex resume subcommand in positional prompt parts', () => {
@@ -968,6 +969,94 @@ describe('resolveCapturedBackendSessionIdFromRuntime', () => {
       });
 
       expect(resolved).toBe(existingSessionId);
+    } finally {
+      if (oldHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = oldHome;
+      }
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('ignores stale runtime-linked backend ids and waits for a newly created local session id', async () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), 'sb-claude-runtime-stale-'));
+    const tempHome = join(tempRoot, 'home');
+    const tempRepo = join(tempRoot, 'repo');
+    mkdirSync(tempHome, { recursive: true });
+    mkdirSync(tempRepo, { recursive: true });
+
+    const projectDirName = tempRepo.replace(/[\\/]/g, '-');
+    const projectKeyDir = join(tempHome, '.claude', 'projects', projectDirName);
+    mkdirSync(projectKeyDir, { recursive: true });
+
+    const oldHome = process.env.HOME;
+    process.env.HOME = tempHome;
+
+    try {
+      const pcpSessionId = 'pcp-session-stale-1';
+      const staleSessionId = '44444444-4444-4444-8444-444444444444';
+      const newSessionId = '55555555-5555-4555-8555-555555555555';
+      const stalePath = join(projectKeyDir, `${staleSessionId}.jsonl`);
+      writeFileSync(
+        stalePath,
+        JSON.stringify({
+          type: 'progress',
+          sessionId: staleSessionId,
+          timestamp: '2026-03-10T00:00:00.000Z',
+        }) + '\n'
+      );
+
+      const staleModified = '2000-01-01T00:00:00.000Z';
+      const snapshot = new Map([[staleSessionId, staleModified]]);
+
+      // Runtime cache still points at a stale backend id from a failed resume attempt.
+      upsertRuntimeSession(tempRepo, {
+        pcpSessionId,
+        backend: 'claude',
+        agentId: 'wren',
+        backendSessionId: staleSessionId,
+      });
+      setCurrentRuntimeSession(tempRepo, pcpSessionId, 'claude', { agentId: 'wren' });
+
+      const timer = setTimeout(() => {
+        // Old stale session gets touched first (e.g., resume error side-effect).
+        writeFileSync(
+          stalePath,
+          JSON.stringify({
+            type: 'progress',
+            sessionId: staleSessionId,
+            timestamp: '2026-03-10T00:00:01.000Z',
+          }) + '\n'
+        );
+      }, 30);
+      const timer2 = setTimeout(() => {
+        // Fresh fallback session appears slightly later.
+        writeFileSync(
+          join(projectKeyDir, `${newSessionId}.jsonl`),
+          JSON.stringify({
+            type: 'progress',
+            sessionId: newSessionId,
+            timestamp: '2026-03-10T00:00:02.000Z',
+          }) + '\n'
+        );
+      }, 120);
+
+      const resolved = await resolveCapturedBackendSessionIdWithRetry({
+        cwd: tempRepo,
+        backend: 'claude',
+        pcpSessionId,
+        agentId: 'wren',
+        knownLocalSessionSnapshot: snapshot,
+        fallbackBackendSessionId: staleSessionId,
+        ignoredBackendSessionIds: [staleSessionId],
+        attempts: 12,
+        intervalMs: 40,
+      });
+
+      clearTimeout(timer);
+      clearTimeout(timer2);
+      expect(resolved).toBe(newSessionId);
     } finally {
       if (oldHome === undefined) {
         delete process.env.HOME;

--- a/packages/cli/src/commands/claude.test.ts
+++ b/packages/cli/src/commands/claude.test.ts
@@ -6,6 +6,7 @@ import {
   extractClaudeHistorySessionsForProject,
   extractBackendSessionOverrideId,
   extractLatestPreviewFromClaudeSessionJsonl,
+  extractLatestPreviewFromPcpTranscriptJsonl,
   extractSessionFromStartSessionResponse,
   filterUntrackedLocalBackendSessions,
   filterPcpSessionsForContext,
@@ -14,6 +15,7 @@ import {
   getClaudeLocalSessionsForProject,
   getKnownClaudeSessionIds,
   getCodexLocalSessionsForProject,
+  getGeminiLocalSessionsForProject,
   hasBackendSessionOverride,
   renderSessionCandidatesTable,
   resolveCapturedBackendSessionIdFromRuntime,
@@ -1158,6 +1160,32 @@ describe('extractLatestPreviewFromClaudeSessionJsonl', () => {
   });
 });
 
+describe('extractLatestPreviewFromPcpTranscriptJsonl', () => {
+  it('ignores local-command wrapper chatter and keeps last meaningful conversational text', () => {
+    const preview = extractLatestPreviewFromPcpTranscriptJsonl(
+      [
+        JSON.stringify({
+          type: 'assistant',
+          ts: '2026-03-10T08:10:00.000Z',
+          content: 'Real assistant reply',
+        }),
+        JSON.stringify({
+          type: 'user',
+          ts: '2026-03-10T08:10:01.000Z',
+          content:
+            '<local-command-stdout>Authentication successful. Connected to supabase.</local-command-stdout>',
+        }),
+      ].join('\n')
+    );
+
+    expect(preview).toEqual({
+      role: 'assistant',
+      content: 'Real assistant reply',
+      ts: '2026-03-10T08:10:00.000Z',
+    });
+  });
+});
+
 describe('getCodexLocalSessionsForProject', () => {
   it('falls back to codex session jsonl files when sqlite db is unavailable', () => {
     const tempHome = mkdtempSync(join(tmpdir(), 'codex-jsonl-fallback-'));
@@ -1181,6 +1209,20 @@ describe('getCodexLocalSessionsForProject', () => {
             cwd: projectPath,
             timestamp: '2026-03-02T11:44:41.000Z',
             originator: 'codex_cli_rs',
+          },
+        }),
+        JSON.stringify({
+          timestamp: '2026-03-02T11:44:46.000Z',
+          type: 'response_item',
+          payload: {
+            type: 'message',
+            role: 'user',
+            content: [
+              {
+                type: 'output_text',
+                text: '<local-command-stdout>Authentication successful. Connected to supabase.</local-command-stdout>',
+              },
+            ],
           },
         }),
         JSON.stringify({
@@ -1238,6 +1280,55 @@ describe('getCodexLocalSessionsForProject', () => {
       ]);
     } finally {
       process.env.HOME = originalHome;
+      rmSync(tempHome, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('getGeminiLocalSessionsForProject', () => {
+  it('skips noisy auth/tool chatter and falls back to latest meaningful message', () => {
+    const tempHome = mkdtempSync(join(tmpdir(), 'gemini-preview-filter-'));
+    const projectPath = join(tempHome, 'repo');
+    mkdirSync(projectPath, { recursive: true });
+
+    const projectKey = projectPath.replace(/[\\/]/g, '-');
+    const chatsDir = join(tempHome, '.gemini', 'tmp', projectKey, 'chats');
+    const historyDir = join(tempHome, '.gemini', 'history', projectKey);
+    mkdirSync(chatsDir, { recursive: true });
+    mkdirSync(historyDir, { recursive: true });
+    writeFileSync(join(historyDir, '.project_root'), projectPath);
+
+    writeFileSync(
+      join(chatsDir, 'session-1.json'),
+      JSON.stringify({
+        sessionId: 'gemini-session-1',
+        startTime: '2026-03-10T08:15:00.000Z',
+        lastUpdated: '2026-03-10T08:15:03.000Z',
+        messages: [
+          { type: 'user', content: 'Hello Gemini' },
+          { type: 'assistant', content: 'Here is the real reply' },
+          {
+            type: 'assistant',
+            content:
+              '<local-command-stdout>Authentication successful. Connected to supabase.</local-command-stdout>',
+          },
+        ],
+      })
+    );
+
+    const originalHome = process.env.HOME;
+    process.env.HOME = tempHome;
+
+    try {
+      const sessions = getGeminiLocalSessionsForProject(projectPath, 10);
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0]?.latestPrompt).toBe('assistant: Here is the real reply');
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
       rmSync(tempHome, { recursive: true, force: true });
     }
   });

--- a/packages/cli/src/commands/claude.test.ts
+++ b/packages/cli/src/commands/claude.test.ts
@@ -1077,6 +1077,45 @@ describe('getClaudeLocalSessionsForProject previews', () => {
       rmSync(tempRoot, { recursive: true, force: true });
     }
   });
+
+  it('uses size-first fallback labels when no conversational preview is available', () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), 'sb-claude-preview-fallback-'));
+    const tempHome = join(tempRoot, 'home');
+    const projectPath = join(tempRoot, 'repo');
+    mkdirSync(tempHome, { recursive: true });
+    mkdirSync(projectPath, { recursive: true });
+
+    const projectDirName = projectPath.replace(/[\\/]/g, '-');
+    const projectDir = join(tempHome, '.claude', 'projects', projectDirName);
+    mkdirSync(projectDir, { recursive: true });
+
+    const sessionId = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+    writeFileSync(
+      join(projectDir, `${sessionId}.jsonl`),
+      `${JSON.stringify({
+        type: 'progress',
+        sessionId,
+        timestamp: '2026-03-10T08:00:00.000Z',
+      })}\n`
+    );
+
+    const originalHome = process.env.HOME;
+    process.env.HOME = tempHome;
+
+    try {
+      const sessions = getClaudeLocalSessionsForProject(projectPath, 10);
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0]?.latestPrompt).toMatch(/ · \(session\)$/);
+      expect(sessions[0]?.latestPrompt).not.toContain('(session) ·');
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('extractLatestPreviewFromClaudeSessionJsonl', () => {
@@ -1296,6 +1335,47 @@ describe('getCodexLocalSessionsForProject', () => {
       rmSync(tempHome, { recursive: true, force: true });
     }
   });
+
+  it('uses size-first fallback labels when rollout transcripts have no previewable messages', () => {
+    const tempHome = mkdtempSync(join(tmpdir(), 'codex-jsonl-fallback-label-'));
+    const projectPath = join(tempHome, 'repo');
+    mkdirSync(projectPath, { recursive: true });
+
+    const codexSessionsDir = join(tempHome, '.codex', 'sessions', '2026', '03', '02');
+    mkdirSync(codexSessionsDir, { recursive: true });
+
+    const sessionId = '019a23ac-e563-7d53-8bf0-5a948546bf88';
+    writeFileSync(
+      join(codexSessionsDir, `rollout-2026-03-02T11-44-41-${sessionId}.jsonl`),
+      `${JSON.stringify({
+        timestamp: '2026-03-02T11:44:41.000Z',
+        type: 'session_meta',
+        payload: {
+          id: sessionId,
+          cwd: projectPath,
+          timestamp: '2026-03-02T11:44:41.000Z',
+          originator: 'codex_cli_rs',
+        },
+      })}\n`
+    );
+
+    const originalHome = process.env.HOME;
+    process.env.HOME = tempHome;
+
+    try {
+      const sessions = getCodexLocalSessionsForProject(projectPath, 10);
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0]?.latestPrompt).toMatch(/ · \(session\)$/);
+      expect(sessions[0]?.latestPrompt).not.toContain('(session) ·');
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+      rmSync(tempHome, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('getGeminiLocalSessionsForProject', () => {
@@ -1336,6 +1416,46 @@ describe('getGeminiLocalSessionsForProject', () => {
       const sessions = getGeminiLocalSessionsForProject(projectPath, 10);
       expect(sessions).toHaveLength(1);
       expect(sessions[0]?.latestPrompt).toBe('assistant: Here is the real reply');
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+      rmSync(tempHome, { recursive: true, force: true });
+    }
+  });
+
+  it('uses size-first fallback labels when gemini chat files have no meaningful preview', () => {
+    const tempHome = mkdtempSync(join(tmpdir(), 'gemini-preview-fallback-'));
+    const projectPath = join(tempHome, 'repo');
+    mkdirSync(projectPath, { recursive: true });
+
+    const projectKey = projectPath.replace(/[\\/]/g, '-');
+    const chatsDir = join(tempHome, '.gemini', 'tmp', projectKey, 'chats');
+    const historyDir = join(tempHome, '.gemini', 'history', projectKey);
+    mkdirSync(chatsDir, { recursive: true });
+    mkdirSync(historyDir, { recursive: true });
+    writeFileSync(join(historyDir, '.project_root'), projectPath);
+
+    writeFileSync(
+      join(chatsDir, 'session-2.json'),
+      JSON.stringify({
+        sessionId: 'gemini-session-2',
+        startTime: '2026-03-10T08:15:00.000Z',
+        lastUpdated: '2026-03-10T08:15:03.000Z',
+        messages: [{ type: 'assistant', content: '   ' }],
+      })
+    );
+
+    const originalHome = process.env.HOME;
+    process.env.HOME = tempHome;
+
+    try {
+      const sessions = getGeminiLocalSessionsForProject(projectPath, 10);
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0]?.latestPrompt).toMatch(/ · \(session\)$/);
+      expect(sessions[0]?.latestPrompt).not.toContain('(session) ·');
     } finally {
       if (originalHome === undefined) {
         delete process.env.HOME;

--- a/packages/cli/src/commands/claude.test.ts
+++ b/packages/cli/src/commands/claude.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'os';
 import {
   extractClaudeHistorySessionsForProject,
   extractBackendSessionOverrideId,
+  extractLatestPreviewFromClaudeSessionJsonl,
   extractSessionFromStartSessionResponse,
   filterUntrackedLocalBackendSessions,
   filterPcpSessionsForContext,
@@ -1060,6 +1061,100 @@ describe('getClaudeLocalSessionsForProject previews', () => {
       }
       rmSync(tempRoot, { recursive: true, force: true });
     }
+  });
+});
+
+describe('extractLatestPreviewFromClaudeSessionJsonl', () => {
+  it('ignores claude tool_result chatter and keeps meaningful assistant text', () => {
+    const sessionId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+    const preview = extractLatestPreviewFromClaudeSessionJsonl(
+      [
+        JSON.stringify({
+          type: 'user',
+          sessionId,
+          timestamp: '2026-03-10T07:57:00.000Z',
+          message: { role: 'user', content: 'Hi Wren' },
+        }),
+        JSON.stringify({
+          type: 'assistant',
+          sessionId,
+          timestamp: '2026-03-10T07:57:01.000Z',
+          message: {
+            role: 'assistant',
+            content: [{ type: 'text', text: 'Let me check that for you.' }],
+          },
+        }),
+        JSON.stringify({
+          type: 'user',
+          sessionId,
+          timestamp: '2026-03-10T07:57:02.000Z',
+          message: {
+            role: 'user',
+            content: [
+              {
+                type: 'tool_result',
+                content:
+                  '<local-command-stdout>Authentication successful. Connected to supabase.</local-command-stdout>',
+              },
+            ],
+          },
+        }),
+        JSON.stringify({
+          type: 'assistant',
+          sessionId,
+          timestamp: '2026-03-10T07:57:03.000Z',
+          message: {
+            role: 'assistant',
+            content: [{ type: 'text', text: 'All set — authentication worked.' }],
+          },
+        }),
+      ].join('\n')
+    );
+
+    expect(preview).toEqual({
+      role: 'assistant',
+      content: 'All set — authentication worked.',
+      ts: '2026-03-10T07:57:03.000Z',
+    });
+  });
+
+  it('falls back to the last real conversational message when latest entry is tool noise', () => {
+    const sessionId = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+    const preview = extractLatestPreviewFromClaudeSessionJsonl(
+      [
+        JSON.stringify({
+          type: 'user',
+          sessionId,
+          timestamp: '2026-03-10T08:00:00.000Z',
+          message: { role: 'user', content: 'Can you check auth?' },
+        }),
+        JSON.stringify({
+          type: 'assistant',
+          sessionId,
+          timestamp: '2026-03-10T08:00:01.000Z',
+          message: {
+            role: 'assistant',
+            content: [{ type: 'text', text: 'Running the command now.' }],
+          },
+        }),
+        JSON.stringify({
+          type: 'user',
+          sessionId,
+          timestamp: '2026-03-10T08:00:02.000Z',
+          message: {
+            role: 'user',
+            content:
+              '<local-command-stdout>Authentication successful. Connected to supabase.</local-command-stdout>',
+          },
+        }),
+      ].join('\n')
+    );
+
+    expect(preview).toEqual({
+      role: 'assistant',
+      content: 'Running the command now.',
+      ts: '2026-03-10T08:00:01.000Z',
+    });
   });
 });
 

--- a/packages/cli/src/commands/claude.test.ts
+++ b/packages/cli/src/commands/claude.test.ts
@@ -28,6 +28,7 @@ import {
   sortSessionEntriesByRecency,
   shouldRetryWithFreshBackendSession,
   shouldAutoResumeRuntimeSession,
+  withSessionFileSize,
 } from './claude.js';
 
 describe('hasBackendSessionOverride', () => {
@@ -146,6 +147,18 @@ describe('buildSessionPickerLabel', () => {
     expect(label).toContain('↳');
     expect(label).toContain('PCP');
     expect(label).toContain('c4ec2f5e');
+  });
+});
+
+describe('withSessionFileSize', () => {
+  it('prefixes file size before the preview text', () => {
+    expect(withSessionFileSize('you: Nah just run it again as is', 8.55 * 1024 * 1024)).toBe(
+      '8.55 MB · you: Nah just run it again as is'
+    );
+  });
+
+  it('shows file size before the session fallback label', () => {
+    expect(withSessionFileSize(undefined, 648)).toBe('648 B · (session)');
   });
 });
 

--- a/packages/cli/src/commands/claude.test.ts
+++ b/packages/cli/src/commands/claude.test.ts
@@ -26,7 +26,6 @@ import {
   shouldRetryWithFreshBackendSession,
   shouldAutoResumeRuntimeSession,
 } from './claude.js';
-import { setCurrentRuntimeSession, upsertRuntimeSession } from '../session/runtime.js';
 
 describe('hasBackendSessionOverride', () => {
   it('detects explicit Codex resume subcommand in positional prompt parts', () => {
@@ -969,94 +968,6 @@ describe('resolveCapturedBackendSessionIdFromRuntime', () => {
       });
 
       expect(resolved).toBe(existingSessionId);
-    } finally {
-      if (oldHome === undefined) {
-        delete process.env.HOME;
-      } else {
-        process.env.HOME = oldHome;
-      }
-      rmSync(tempRoot, { recursive: true, force: true });
-    }
-  });
-
-  it('ignores stale runtime-linked backend ids and waits for a newly created local session id', async () => {
-    const tempRoot = mkdtempSync(join(tmpdir(), 'sb-claude-runtime-stale-'));
-    const tempHome = join(tempRoot, 'home');
-    const tempRepo = join(tempRoot, 'repo');
-    mkdirSync(tempHome, { recursive: true });
-    mkdirSync(tempRepo, { recursive: true });
-
-    const projectDirName = tempRepo.replace(/[\\/]/g, '-');
-    const projectKeyDir = join(tempHome, '.claude', 'projects', projectDirName);
-    mkdirSync(projectKeyDir, { recursive: true });
-
-    const oldHome = process.env.HOME;
-    process.env.HOME = tempHome;
-
-    try {
-      const pcpSessionId = 'pcp-session-stale-1';
-      const staleSessionId = '44444444-4444-4444-8444-444444444444';
-      const newSessionId = '55555555-5555-4555-8555-555555555555';
-      const stalePath = join(projectKeyDir, `${staleSessionId}.jsonl`);
-      writeFileSync(
-        stalePath,
-        JSON.stringify({
-          type: 'progress',
-          sessionId: staleSessionId,
-          timestamp: '2026-03-10T00:00:00.000Z',
-        }) + '\n'
-      );
-
-      const staleModified = '2000-01-01T00:00:00.000Z';
-      const snapshot = new Map([[staleSessionId, staleModified]]);
-
-      // Runtime cache still points at a stale backend id from a failed resume attempt.
-      upsertRuntimeSession(tempRepo, {
-        pcpSessionId,
-        backend: 'claude',
-        agentId: 'wren',
-        backendSessionId: staleSessionId,
-      });
-      setCurrentRuntimeSession(tempRepo, pcpSessionId, 'claude', { agentId: 'wren' });
-
-      const timer = setTimeout(() => {
-        // Old stale session gets touched first (e.g., resume error side-effect).
-        writeFileSync(
-          stalePath,
-          JSON.stringify({
-            type: 'progress',
-            sessionId: staleSessionId,
-            timestamp: '2026-03-10T00:00:01.000Z',
-          }) + '\n'
-        );
-      }, 30);
-      const timer2 = setTimeout(() => {
-        // Fresh fallback session appears slightly later.
-        writeFileSync(
-          join(projectKeyDir, `${newSessionId}.jsonl`),
-          JSON.stringify({
-            type: 'progress',
-            sessionId: newSessionId,
-            timestamp: '2026-03-10T00:00:02.000Z',
-          }) + '\n'
-        );
-      }, 120);
-
-      const resolved = await resolveCapturedBackendSessionIdWithRetry({
-        cwd: tempRepo,
-        backend: 'claude',
-        pcpSessionId,
-        agentId: 'wren',
-        knownLocalSessionSnapshot: snapshot,
-        fallbackBackendSessionId: staleSessionId,
-        ignoredBackendSessionIds: [staleSessionId],
-        attempts: 12,
-        intervalMs: 40,
-      });
-
-      clearTimeout(timer);
-      clearTimeout(timer2);
-      expect(resolved).toBe(newSessionId);
     } finally {
       if (oldHome === undefined) {
         delete process.env.HOME;

--- a/packages/cli/src/commands/claude.test.ts
+++ b/packages/cli/src/commands/claude.test.ts
@@ -16,6 +16,7 @@ import {
   hasBackendSessionOverride,
   renderSessionCandidatesTable,
   resolveCapturedBackendSessionIdFromRuntime,
+  resolveCapturedBackendSessionIdWithRetry,
   resolveAdoptableLocalBackendSessionId,
   resolveBackendSessionIdForResume,
   resolveBackendSessionSeedId,
@@ -813,6 +814,54 @@ describe('resolveCapturedBackendSessionIdFromRuntime', () => {
       });
 
       expect(resolved).toBe(newSessionId);
+    } finally {
+      if (oldHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = oldHome;
+      }
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('retries local session detection to handle delayed transcript flushes', async () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), 'sb-claude-runtime-retry-'));
+    const tempHome = join(tempRoot, 'home');
+    const tempRepo = join(tempRoot, 'repo');
+    mkdirSync(tempHome, { recursive: true });
+    mkdirSync(tempRepo, { recursive: true });
+
+    const projectDirName = tempRepo.replace(/[\\/]/g, '-');
+    const projectKeyDir = join(tempHome, '.claude', 'projects', projectDirName);
+    mkdirSync(projectKeyDir, { recursive: true });
+
+    const oldHome = process.env.HOME;
+    process.env.HOME = tempHome;
+
+    try {
+      const delayedSessionId = '20202020-2020-4020-8020-202020202020';
+      const timer = setTimeout(() => {
+        writeFileSync(
+          join(projectKeyDir, `${delayedSessionId}.jsonl`),
+          JSON.stringify({
+            type: 'progress',
+            sessionId: delayedSessionId,
+            timestamp: '2026-03-09T00:03:00.000Z',
+          }) + '\n'
+        );
+      }, 120);
+
+      const resolved = await resolveCapturedBackendSessionIdWithRetry({
+        cwd: tempRepo,
+        backend: 'claude',
+        pcpSessionId: 'pcp-session-retry',
+        knownLocalSessionSnapshot: new Map(),
+        attempts: 10,
+        intervalMs: 40,
+      });
+
+      clearTimeout(timer);
+      expect(resolved).toBe(delayedSessionId);
     } finally {
       if (oldHome === undefined) {
         delete process.env.HOME;

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -1921,7 +1921,9 @@ export function getBackendLocalSessionsForProject(
 }
 
 function printPcpUnavailableWarning(reason: string, cwd = process.cwd()): void {
+  const serverUrl = getPcpServerUrl();
   console.log(chalk.yellow(`\n⚠ PCP session service unavailable (${reason}).`));
+  console.log(chalk.yellow(`  PCP_SERVER_URL: ${serverUrl}`));
   const mcpPath = join(cwd, '.mcp.json');
   if (!existsSync(mcpPath)) {
     console.log(chalk.yellow('  .mcp.json not found in this repo.'));
@@ -1938,6 +1940,7 @@ function printPcpUnavailableWarning(reason: string, cwd = process.cwd()): void {
     }
   }
   console.log(chalk.dim('  To reconnect PCP features:'));
+  console.log(chalk.dim(`    curl -sS ${serverUrl.replace(/\/+$/, '')}/health`));
   console.log(chalk.dim('    sb auth login'));
   console.log(chalk.dim('    sb init'));
   console.log(chalk.dim('    sb status'));

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -1135,6 +1135,7 @@ export function resolveCapturedBackendSessionIdFromRuntime(options: {
   studioId?: string;
   knownLocalSessionSnapshot?: Map<string, string>;
   fallbackBackendSessionId?: string;
+  ignoredBackendSessionIds?: Iterable<string>;
 }): string | undefined {
   const {
     cwd = process.cwd(),
@@ -1145,18 +1146,48 @@ export function resolveCapturedBackendSessionIdFromRuntime(options: {
     studioId,
     knownLocalSessionSnapshot,
     fallbackBackendSessionId,
+    ignoredBackendSessionIds,
   } = options;
+
+  const ignoredSessionIds = new Set(
+    Array.from(ignoredBackendSessionIds || [])
+      .map((value) => value.trim())
+      .filter(Boolean)
+  );
+  const isIgnored = (value: string | undefined): boolean =>
+    Boolean(value && ignoredSessionIds.has(value));
 
   const resolveFromRecord = (
     record?: { backendSessionId?: string; backendSessionIds?: string[] } | null
   ): string | undefined => {
     if (!record) return undefined;
-    if (record.backendSessionId) return record.backendSessionId;
+    if (record.backendSessionId && !isIgnored(record.backendSessionId)) {
+      return record.backendSessionId;
+    }
     const last = record.backendSessionIds?.at(-1);
-    return typeof last === 'string' && last.trim() ? last : undefined;
+    return typeof last === 'string' && last.trim() && !isIgnored(last.trim())
+      ? last.trim()
+      : undefined;
   };
 
   if (!pcpSessionId) return fallbackBackendSessionId;
+
+  if (knownLocalSessionSnapshot) {
+    const postRunLocalSessions = getBackendLocalSessionsForProject(backend, cwd, 50);
+    const newLocalSession = postRunLocalSessions.find(
+      (session) =>
+        !knownLocalSessionSnapshot.has(session.sessionId) && !isIgnored(session.sessionId)
+    );
+    if (newLocalSession?.sessionId) return newLocalSession.sessionId;
+
+    const updatedExistingSession = postRunLocalSessions.find((session) => {
+      const previousModified = knownLocalSessionSnapshot.get(session.sessionId);
+      if (!previousModified) return false;
+      if (isIgnored(session.sessionId)) return false;
+      return previousModified !== session.modified;
+    });
+    if (updatedExistingSession?.sessionId) return updatedExistingSession.sessionId;
+  }
 
   const scopedRecords = listRuntimeSessions(cwd, backend).filter(
     (record) =>
@@ -1181,22 +1212,12 @@ export function resolveCapturedBackendSessionIdFromRuntime(options: {
     if (currentSessionId) return currentSessionId;
   }
 
-  if (knownLocalSessionSnapshot) {
-    const postRunLocalSessions = getBackendLocalSessionsForProject(backend, cwd, 50);
-    const newLocalSession = postRunLocalSessions.find(
-      (session) => !knownLocalSessionSnapshot.has(session.sessionId)
-    );
-    if (newLocalSession?.sessionId) return newLocalSession.sessionId;
-
-    const updatedExistingSession = postRunLocalSessions.find((session) => {
-      const previousModified = knownLocalSessionSnapshot.get(session.sessionId);
-      if (!previousModified) return false;
-      return previousModified !== session.modified;
-    });
-    if (updatedExistingSession?.sessionId) return updatedExistingSession.sessionId;
-  }
-
-  return resolveFromRecord(scopedRecords[0]) || fallbackBackendSessionId;
+  return (
+    resolveFromRecord(scopedRecords[0]) ||
+    (fallbackBackendSessionId && !isIgnored(fallbackBackendSessionId)
+      ? fallbackBackendSessionId
+      : undefined)
+  );
 }
 
 export async function resolveCapturedBackendSessionIdWithRetry(options: {
@@ -1208,6 +1229,7 @@ export async function resolveCapturedBackendSessionIdWithRetry(options: {
   studioId?: string;
   knownLocalSessionSnapshot?: Map<string, string>;
   fallbackBackendSessionId?: string;
+  ignoredBackendSessionIds?: Iterable<string>;
   attempts?: number;
   intervalMs?: number;
 }): Promise<string | undefined> {
@@ -3483,6 +3505,7 @@ export async function runClaudeInteractive(
   let attemptBackendSessionId = sessionContext.backendSessionId;
   let attemptBackendSessionSeedId = sessionContext.backendSessionSeedId;
   let finalCapturedBackendSessionId = sessionContext.backendSessionId;
+  const ignoredBackendSessionIds = new Set<string>();
 
   const runAttempt = async (): Promise<{ code: number | null; stderrText: string }> => {
     const prepared = adapter.prepare({
@@ -3549,6 +3572,7 @@ export async function runClaudeInteractive(
           studioId,
           knownLocalSessionSnapshot,
           fallbackBackendSessionId: finalCapturedBackendSessionId,
+          ignoredBackendSessionIds,
         });
 
         await logBackendExecutionResult({
@@ -3589,6 +3613,13 @@ export async function runClaudeInteractive(
 
     if (shouldRetry) {
       if (attemptBackendSessionId) {
+        ignoredBackendSessionIds.add(attemptBackendSessionId);
+        sbDebugLog('claude', 'interactive_retry_ignore_backend_session', {
+          backend: options.backend,
+          agentId,
+          pcpSessionId: sessionContext.pcpSessionId || null,
+          staleBackendSessionId: attemptBackendSessionId,
+        });
         console.log(
           chalk.yellow(
             `\nLinked Claude session ${attemptBackendSessionId.slice(0, 8)} failed to resume; retrying once with a fresh backend session.`
@@ -3597,7 +3628,8 @@ export async function runClaudeInteractive(
       }
       attempt += 1;
       attemptBackendSessionId = undefined;
-      attemptBackendSessionSeedId = undefined;
+      attemptBackendSessionSeedId = sessionContext.pcpSessionId;
+      finalCapturedBackendSessionId = undefined;
       continue;
     }
 

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -707,6 +707,33 @@ function normalizePreviewLeafText(value: string): string | undefined {
   return compact;
 }
 
+function extractPreviewText(value: unknown): string | undefined {
+  if (typeof value === 'string') {
+    return normalizePreviewLeafText(value);
+  }
+  if (Array.isArray(value)) {
+    const chunks: string[] = [];
+    for (const item of value) {
+      const chunk = extractPreviewText(item);
+      if (chunk) chunks.push(chunk);
+    }
+    if (chunks.length === 0) return undefined;
+    return chunks.join(' ');
+  }
+  if (value && typeof value === 'object') {
+    const record = value as Record<string, unknown>;
+    const textLikeKeys = ['text', 'message', 'content', 'output', 'input'];
+    const chunks: string[] = [];
+    for (const key of textLikeKeys) {
+      const chunk = extractPreviewText(record[key]);
+      if (chunk) chunks.push(chunk);
+    }
+    if (chunks.length === 0) return undefined;
+    return chunks.join(' ');
+  }
+  return undefined;
+}
+
 function extractClaudePreviewText(value: unknown): string | undefined {
   if (typeof value === 'string') {
     return normalizePreviewLeafText(value);
@@ -832,7 +859,7 @@ function extractLatestPreviewFromCodexRolloutJsonl(
 
       const role = roleFromUnknown(payload.role);
       if (!role || role === 'inbox') continue;
-      const content = extractMessageText(payload.content);
+      const content = extractPreviewText(payload.content);
       if (!content) continue;
       latest = { role, content, ts };
       continue;
@@ -845,10 +872,10 @@ function extractLatestPreviewFromCodexRolloutJsonl(
           : undefined;
       if (!payload) continue;
       if (payload.type === 'user_message') {
-        const content = extractMessageText(payload.message);
+        const content = extractPreviewText(payload.message);
         if (content) latest = { role: 'user', content, ts };
       } else if (payload.type === 'agent_message') {
-        const content = extractMessageText(payload.message);
+        const content = extractPreviewText(payload.message);
         if (content) latest = { role: 'assistant', content, ts };
       }
     }
@@ -856,7 +883,7 @@ function extractLatestPreviewFromCodexRolloutJsonl(
   return latest;
 }
 
-function extractLatestPreviewFromPcpTranscriptJsonl(
+export function extractLatestPreviewFromPcpTranscriptJsonl(
   jsonl: string
 ): SessionPreviewSummary | undefined {
   const events = parseJsonl(jsonl);
@@ -864,7 +891,7 @@ function extractLatestPreviewFromPcpTranscriptJsonl(
   for (const event of events) {
     const type = typeof event.type === 'string' ? event.type : '';
     if (type === 'user') {
-      const content = extractMessageText(event.content);
+      const content = extractPreviewText(event.content);
       if (!content) continue;
       latest = {
         role: 'user',
@@ -874,7 +901,7 @@ function extractLatestPreviewFromPcpTranscriptJsonl(
       continue;
     }
     if (type === 'assistant') {
-      const content = extractMessageText(event.content);
+      const content = extractPreviewText(event.content);
       if (!content) continue;
       latest = {
         role: 'assistant',
@@ -884,7 +911,7 @@ function extractLatestPreviewFromPcpTranscriptJsonl(
       continue;
     }
     if (type === 'inbox') {
-      const content = extractMessageText(event.rendered) || extractMessageText(event.content);
+      const content = extractPreviewText(event.rendered) || extractPreviewText(event.content);
       if (!content) continue;
       latest = {
         role: 'inbox',
@@ -1882,9 +1909,10 @@ function getGeminiSessionsForProjectKey(projectKey: string): BackendLocalSession
       })();
 
       const firstUserMessage = (parsed.messages || []).find((message) => message.type === 'user');
-      const latestMessage = [...(parsed.messages || [])]
-        .reverse()
-        .find((message) => Boolean(message?.content?.trim()));
+      const latestMessage = [...(parsed.messages || [])].reverse().find((message) => {
+        if (typeof message?.content !== 'string') return false;
+        return Boolean(extractPreviewText(message.content));
+      });
       const firstPrompt =
         parsed.summary ||
         (typeof firstUserMessage?.content === 'string'
@@ -1892,10 +1920,14 @@ function getGeminiSessionsForProjectKey(projectKey: string): BackendLocalSession
           : undefined);
       const latestPrompt =
         latestMessage && typeof latestMessage.content === 'string'
-          ? formatSessionPreviewText({
-              role: latestMessage.type === 'user' ? 'user' : 'assistant',
-              content: latestMessage.content,
-            })
+          ? (() => {
+              const content = extractPreviewText(latestMessage.content);
+              if (!content) return undefined;
+              return formatSessionPreviewText({
+                role: latestMessage.type === 'user' ? 'user' : 'assistant',
+                content,
+              });
+            })()
           : undefined;
       const latestPromptWithFallback =
         latestPrompt ||

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -1428,8 +1428,7 @@ export function getClaudeLocalSessionsForProject(
         }
 
         if (!latestPrompt) {
-          const size = formatFileSize(stats.size);
-          if (size) latestPrompt = `(session) · ${size}`;
+          latestPrompt = withSessionFileSize(undefined, stats.size);
         }
 
         results.push({
@@ -1672,8 +1671,7 @@ LIMIT 200;
     }
 
     if (!latestPrompt) {
-      const size = formatFileSize(fileSizeBytes);
-      if (size) latestPrompt = `(session) · ${size}`;
+      latestPrompt = withSessionFileSize(undefined, fileSizeBytes);
     }
 
     sessions.push({
@@ -1799,8 +1797,7 @@ function getCodexLocalSessionsFromJsonl(
         transcriptPath: sessionFile.path,
       };
       if (!matched.latestPrompt) {
-        const size = formatFileSize(matched.fileSizeBytes);
-        if (size) matched.latestPrompt = `(session) · ${size}`;
+        matched.latestPrompt = withSessionFileSize(undefined, matched.fileSizeBytes);
       }
       break;
     }
@@ -1930,11 +1927,7 @@ function getGeminiSessionsForProjectKey(projectKey: string): BackendLocalSession
             })()
           : undefined;
       const latestPromptWithFallback =
-        latestPrompt ||
-        (() => {
-          const size = formatFileSize(fileSizeBytes);
-          return size ? `(session) · ${size}` : undefined;
-        })();
+        latestPrompt || withSessionFileSize(undefined, fileSizeBytes);
 
       sessions.push({
         backend: 'gemini',

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -1211,8 +1211,8 @@ export async function resolveCapturedBackendSessionIdWithRetry(options: {
   attempts?: number;
   intervalMs?: number;
 }): Promise<string | undefined> {
-  const attempts = Math.max(1, options.attempts ?? 6);
-  const intervalMs = Math.max(10, options.intervalMs ?? 75);
+  const attempts = Math.max(1, options.attempts ?? 20);
+  const intervalMs = Math.max(10, options.intervalMs ?? 100);
 
   let resolved = resolveCapturedBackendSessionIdFromRuntime(options);
   if (resolved) return resolved;

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -809,7 +809,7 @@ function withAgentPreviewSpeaker(
   return preview;
 }
 
-function withSessionFileSize(
+export function withSessionFileSize(
   preview: string | undefined,
   fileSizeBytes: number | undefined
 ): string | undefined {
@@ -817,9 +817,9 @@ function withSessionFileSize(
   if (!size) return preview;
 
   const normalized = preview?.trim();
-  if (!normalized) return `(session) · ${size}`;
+  if (!normalized) return `${size} · (session)`;
   if (normalized.includes(size)) return normalized;
-  return `${normalized} · ${size}`;
+  return `${size} · ${normalized}`;
 }
 
 function getSessionPhaseLabel(session: PcpSessionSummary): string | undefined {

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -1135,7 +1135,6 @@ export function resolveCapturedBackendSessionIdFromRuntime(options: {
   studioId?: string;
   knownLocalSessionSnapshot?: Map<string, string>;
   fallbackBackendSessionId?: string;
-  ignoredBackendSessionIds?: Iterable<string>;
 }): string | undefined {
   const {
     cwd = process.cwd(),
@@ -1146,48 +1145,18 @@ export function resolveCapturedBackendSessionIdFromRuntime(options: {
     studioId,
     knownLocalSessionSnapshot,
     fallbackBackendSessionId,
-    ignoredBackendSessionIds,
   } = options;
-
-  const ignoredSessionIds = new Set(
-    Array.from(ignoredBackendSessionIds || [])
-      .map((value) => value.trim())
-      .filter(Boolean)
-  );
-  const isIgnored = (value: string | undefined): boolean =>
-    Boolean(value && ignoredSessionIds.has(value));
 
   const resolveFromRecord = (
     record?: { backendSessionId?: string; backendSessionIds?: string[] } | null
   ): string | undefined => {
     if (!record) return undefined;
-    if (record.backendSessionId && !isIgnored(record.backendSessionId)) {
-      return record.backendSessionId;
-    }
+    if (record.backendSessionId) return record.backendSessionId;
     const last = record.backendSessionIds?.at(-1);
-    return typeof last === 'string' && last.trim() && !isIgnored(last.trim())
-      ? last.trim()
-      : undefined;
+    return typeof last === 'string' && last.trim() ? last : undefined;
   };
 
   if (!pcpSessionId) return fallbackBackendSessionId;
-
-  if (knownLocalSessionSnapshot) {
-    const postRunLocalSessions = getBackendLocalSessionsForProject(backend, cwd, 50);
-    const newLocalSession = postRunLocalSessions.find(
-      (session) =>
-        !knownLocalSessionSnapshot.has(session.sessionId) && !isIgnored(session.sessionId)
-    );
-    if (newLocalSession?.sessionId) return newLocalSession.sessionId;
-
-    const updatedExistingSession = postRunLocalSessions.find((session) => {
-      const previousModified = knownLocalSessionSnapshot.get(session.sessionId);
-      if (!previousModified) return false;
-      if (isIgnored(session.sessionId)) return false;
-      return previousModified !== session.modified;
-    });
-    if (updatedExistingSession?.sessionId) return updatedExistingSession.sessionId;
-  }
 
   const scopedRecords = listRuntimeSessions(cwd, backend).filter(
     (record) =>
@@ -1212,12 +1181,22 @@ export function resolveCapturedBackendSessionIdFromRuntime(options: {
     if (currentSessionId) return currentSessionId;
   }
 
-  return (
-    resolveFromRecord(scopedRecords[0]) ||
-    (fallbackBackendSessionId && !isIgnored(fallbackBackendSessionId)
-      ? fallbackBackendSessionId
-      : undefined)
-  );
+  if (knownLocalSessionSnapshot) {
+    const postRunLocalSessions = getBackendLocalSessionsForProject(backend, cwd, 50);
+    const newLocalSession = postRunLocalSessions.find(
+      (session) => !knownLocalSessionSnapshot.has(session.sessionId)
+    );
+    if (newLocalSession?.sessionId) return newLocalSession.sessionId;
+
+    const updatedExistingSession = postRunLocalSessions.find((session) => {
+      const previousModified = knownLocalSessionSnapshot.get(session.sessionId);
+      if (!previousModified) return false;
+      return previousModified !== session.modified;
+    });
+    if (updatedExistingSession?.sessionId) return updatedExistingSession.sessionId;
+  }
+
+  return resolveFromRecord(scopedRecords[0]) || fallbackBackendSessionId;
 }
 
 export async function resolveCapturedBackendSessionIdWithRetry(options: {
@@ -1229,7 +1208,6 @@ export async function resolveCapturedBackendSessionIdWithRetry(options: {
   studioId?: string;
   knownLocalSessionSnapshot?: Map<string, string>;
   fallbackBackendSessionId?: string;
-  ignoredBackendSessionIds?: Iterable<string>;
   attempts?: number;
   intervalMs?: number;
 }): Promise<string | undefined> {
@@ -3505,7 +3483,6 @@ export async function runClaudeInteractive(
   let attemptBackendSessionId = sessionContext.backendSessionId;
   let attemptBackendSessionSeedId = sessionContext.backendSessionSeedId;
   let finalCapturedBackendSessionId = sessionContext.backendSessionId;
-  const ignoredBackendSessionIds = new Set<string>();
 
   const runAttempt = async (): Promise<{ code: number | null; stderrText: string }> => {
     const prepared = adapter.prepare({
@@ -3572,7 +3549,6 @@ export async function runClaudeInteractive(
           studioId,
           knownLocalSessionSnapshot,
           fallbackBackendSessionId: finalCapturedBackendSessionId,
-          ignoredBackendSessionIds,
         });
 
         await logBackendExecutionResult({
@@ -3613,13 +3589,6 @@ export async function runClaudeInteractive(
 
     if (shouldRetry) {
       if (attemptBackendSessionId) {
-        ignoredBackendSessionIds.add(attemptBackendSessionId);
-        sbDebugLog('claude', 'interactive_retry_ignore_backend_session', {
-          backend: options.backend,
-          agentId,
-          pcpSessionId: sessionContext.pcpSessionId || null,
-          staleBackendSessionId: attemptBackendSessionId,
-        });
         console.log(
           chalk.yellow(
             `\nLinked Claude session ${attemptBackendSessionId.slice(0, 8)} failed to resume; retrying once with a fresh backend session.`
@@ -3628,8 +3597,7 @@ export async function runClaudeInteractive(
       }
       attempt += 1;
       attemptBackendSessionId = undefined;
-      attemptBackendSessionSeedId = sessionContext.pcpSessionId;
-      finalCapturedBackendSessionId = undefined;
+      attemptBackendSessionSeedId = undefined;
       continue;
     }
 

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -1199,6 +1199,33 @@ export function resolveCapturedBackendSessionIdFromRuntime(options: {
   return resolveFromRecord(scopedRecords[0]) || fallbackBackendSessionId;
 }
 
+export async function resolveCapturedBackendSessionIdWithRetry(options: {
+  cwd?: string;
+  backend: string;
+  pcpSessionId?: string;
+  runtimeLinkId?: string;
+  agentId?: string;
+  studioId?: string;
+  knownLocalSessionSnapshot?: Map<string, string>;
+  fallbackBackendSessionId?: string;
+  attempts?: number;
+  intervalMs?: number;
+}): Promise<string | undefined> {
+  const attempts = Math.max(1, options.attempts ?? 6);
+  const intervalMs = Math.max(10, options.intervalMs ?? 75);
+
+  let resolved = resolveCapturedBackendSessionIdFromRuntime(options);
+  if (resolved) return resolved;
+
+  for (let attempt = 1; attempt < attempts; attempt += 1) {
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+    resolved = resolveCapturedBackendSessionIdFromRuntime(options);
+    if (resolved) return resolved;
+  }
+
+  return resolved;
+}
+
 export function extractSessionFromStartSessionResponse(
   payload: unknown
 ): PcpSessionSummary | undefined {
@@ -3333,7 +3360,7 @@ export async function runClaude(
       if (parsedSessionId) capturedBackendSessionId = parsedSessionId;
     }
     if (!capturedBackendSessionId) {
-      capturedBackendSessionId = resolveCapturedBackendSessionIdFromRuntime({
+      capturedBackendSessionId = await resolveCapturedBackendSessionIdWithRetry({
         backend: options.backend,
         pcpSessionId: sessionContext.pcpSessionId,
         runtimeLinkId,
@@ -3511,7 +3538,7 @@ export async function runClaudeInteractive(
 
       child.on('close', async (code) => {
         prepared.cleanup();
-        finalCapturedBackendSessionId = resolveCapturedBackendSessionIdFromRuntime({
+        finalCapturedBackendSessionId = await resolveCapturedBackendSessionIdWithRetry({
           backend: options.backend,
           pcpSessionId: sessionContext.pcpSessionId,
           runtimeLinkId,

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -698,6 +698,58 @@ function extractMessageText(value: unknown): string | undefined {
   return undefined;
 }
 
+function normalizePreviewLeafText(value: string): string | undefined {
+  const compact = value.replace(/\s+/g, ' ').trim();
+  if (!compact) return undefined;
+  if (/^<(local-command|tool[_-]?result|tool[_-]?use|bash-command)[^>]*>/i.test(compact)) {
+    return undefined;
+  }
+  return compact;
+}
+
+function extractClaudePreviewText(value: unknown): string | undefined {
+  if (typeof value === 'string') {
+    return normalizePreviewLeafText(value);
+  }
+
+  if (Array.isArray(value)) {
+    const chunks: string[] = [];
+    for (const item of value) {
+      const chunk = extractClaudePreviewText(item);
+      if (chunk) chunks.push(chunk);
+    }
+    if (chunks.length === 0) return undefined;
+    return chunks.join(' ');
+  }
+
+  if (value && typeof value === 'object') {
+    const record = value as Record<string, unknown>;
+    const blockType = typeof record.type === 'string' ? record.type.toLowerCase() : '';
+    if (
+      blockType === 'tool_result' ||
+      blockType === 'tool_use' ||
+      blockType === 'server_tool_use'
+    ) {
+      return undefined;
+    }
+
+    if (blockType === 'text' || blockType === 'input_text' || blockType === 'output_text') {
+      return extractClaudePreviewText(record.text);
+    }
+
+    const textLikeKeys = ['text', 'message', 'content', 'output', 'input'];
+    const chunks: string[] = [];
+    for (const key of textLikeKeys) {
+      const chunk = extractClaudePreviewText(record[key]);
+      if (chunk) chunks.push(chunk);
+    }
+    if (chunks.length === 0) return undefined;
+    return chunks.join(' ');
+  }
+
+  return undefined;
+}
+
 function roleFromUnknown(value: unknown): SessionPreviewSummary['role'] | undefined {
   if (value === 'user') return 'user';
   if (value === 'assistant' || value === 'model') return 'assistant';
@@ -844,7 +896,7 @@ function extractLatestPreviewFromPcpTranscriptJsonl(
   return latest;
 }
 
-function extractLatestPreviewFromClaudeSessionJsonl(
+export function extractLatestPreviewFromClaudeSessionJsonl(
   jsonl: string
 ): SessionPreviewSummary | undefined {
   const events = parseJsonl(jsonl);
@@ -859,7 +911,7 @@ function extractLatestPreviewFromClaudeSessionJsonl(
     const role = roleFromUnknown(message?.role || event.role || event.type);
     if (!role || role === 'inbox') continue;
 
-    const content = extractMessageText(message?.content || event.content || message);
+    const content = extractClaudePreviewText(message?.content || event.content || message);
     if (!content) continue;
     latest = { role, content, ts };
   }

--- a/packages/cli/src/commands/status.test.ts
+++ b/packages/cli/src/commands/status.test.ts
@@ -1,0 +1,82 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { afterEach, describe, expect, it } from 'vitest';
+import { getClaudePermissionsStatus, getMcpConfigStatus } from './status.js';
+
+const cleanupPaths: string[] = [];
+
+afterEach(() => {
+  while (cleanupPaths.length > 0) {
+    const path = cleanupPaths.pop();
+    if (!path) continue;
+    rmSync(path, { recursive: true, force: true });
+  }
+});
+
+describe('status helpers', () => {
+  it('reports missing claude permissions config', () => {
+    const root = mkdtempSync(join(tmpdir(), 'sb-status-'));
+    cleanupPaths.push(root);
+
+    const status = getClaudePermissionsStatus(root);
+    expect(status.configExists).toBe(false);
+    expect(status.hasPermissions).toBe(false);
+    expect(status.hasPcpMcpAllowance).toBe(false);
+  });
+
+  it('detects configured claude permissions and MCP PCP allowance', () => {
+    const root = mkdtempSync(join(tmpdir(), 'sb-status-'));
+    cleanupPaths.push(root);
+    const claudeDir = join(root, '.claude');
+    mkdirSync(claudeDir, { recursive: true });
+    writeFileSync(
+      join(claudeDir, 'settings.local.json'),
+      JSON.stringify({
+        permissions: {
+          allow: ['Bash(*)', 'mcp__pcp__*'],
+          deny: ['Bash(rm -rf *)'],
+        },
+      })
+    );
+
+    const status = getClaudePermissionsStatus(root);
+    expect(status.configExists).toBe(true);
+    expect(status.parseError).toBe(false);
+    expect(status.hasPermissions).toBe(true);
+    expect(status.allowCount).toBe(2);
+    expect(status.denyCount).toBe(1);
+    expect(status.hasPcpMcpAllowance).toBe(true);
+  });
+
+  it('reports mcp config with pcp server url', () => {
+    const root = mkdtempSync(join(tmpdir(), 'sb-status-'));
+    cleanupPaths.push(root);
+    writeFileSync(
+      join(root, '.mcp.json'),
+      JSON.stringify({
+        mcpServers: {
+          pcp: { type: 'http', url: 'http://localhost:3001/mcp' },
+          github: { type: 'http', url: 'https://api.githubcopilot.com/mcp/' },
+        },
+      })
+    );
+
+    const status = getMcpConfigStatus(root);
+    expect(status.configExists).toBe(true);
+    expect(status.parseError).toBe(false);
+    expect(status.hasPcpServer).toBe(true);
+    expect(status.pcpUrl).toBe('http://localhost:3001/mcp');
+  });
+
+  it('reports parse errors in mcp config', () => {
+    const root = mkdtempSync(join(tmpdir(), 'sb-status-'));
+    cleanupPaths.push(root);
+    writeFileSync(join(root, '.mcp.json'), '{bad-json');
+
+    const status = getMcpConfigStatus(root);
+    expect(status.configExists).toBe(true);
+    expect(status.parseError).toBe(true);
+    expect(status.hasPcpServer).toBe(false);
+  });
+});

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -12,6 +12,7 @@ import { join } from 'path';
 import { decodeJwtPayload, isTokenExpired, loadAuth } from '../auth/tokens.js';
 import { resolveAgentId, resolveBackend } from '../backends/index.js';
 import { readIdentityJson } from '../backends/identity.js';
+import { getPcpServerUrl } from '../lib/pcp-mcp.js';
 
 type StatusBackend = 'claude' | 'codex' | 'gemini';
 
@@ -90,6 +91,98 @@ function getHooksInstalled(
   }
 }
 
+interface ClaudePermissionsStatus {
+  configExists: boolean;
+  parseError: boolean;
+  hasPermissions: boolean;
+  allowCount: number;
+  denyCount: number;
+  hasPcpMcpAllowance: boolean;
+}
+
+function hasPcpMcpAllowRule(rule: string): boolean {
+  const normalized = rule.trim();
+  return (
+    normalized === 'mcp__pcp__*' ||
+    normalized === 'mcp__*' ||
+    normalized === '*' ||
+    normalized.startsWith('mcp__pcp__')
+  );
+}
+
+export function getClaudePermissionsStatus(cwd: string): ClaudePermissionsStatus {
+  const settingsPath = join(cwd, '.claude', 'settings.local.json');
+  if (!existsSync(settingsPath)) {
+    return {
+      configExists: false,
+      parseError: false,
+      hasPermissions: false,
+      allowCount: 0,
+      denyCount: 0,
+      hasPcpMcpAllowance: false,
+    };
+  }
+
+  try {
+    const parsed = JSON.parse(readFileSync(settingsPath, 'utf-8')) as {
+      permissions?: { allow?: unknown; deny?: unknown };
+    };
+    const allow = Array.isArray(parsed.permissions?.allow)
+      ? parsed.permissions?.allow.filter((rule): rule is string => typeof rule === 'string')
+      : [];
+    const deny = Array.isArray(parsed.permissions?.deny)
+      ? parsed.permissions?.deny.filter((rule): rule is string => typeof rule === 'string')
+      : [];
+    return {
+      configExists: true,
+      parseError: false,
+      hasPermissions: allow.length > 0 || deny.length > 0,
+      allowCount: allow.length,
+      denyCount: deny.length,
+      hasPcpMcpAllowance: allow.some((rule) => hasPcpMcpAllowRule(rule)),
+    };
+  } catch {
+    return {
+      configExists: true,
+      parseError: true,
+      hasPermissions: false,
+      allowCount: 0,
+      denyCount: 0,
+      hasPcpMcpAllowance: false,
+    };
+  }
+}
+
+interface McpConfigStatus {
+  configExists: boolean;
+  parseError: boolean;
+  hasPcpServer: boolean;
+  pcpUrl?: string;
+}
+
+export function getMcpConfigStatus(cwd: string): McpConfigStatus {
+  const mcpPath = join(cwd, '.mcp.json');
+  if (!existsSync(mcpPath)) {
+    return { configExists: false, parseError: false, hasPcpServer: false };
+  }
+
+  try {
+    const parsed = JSON.parse(readFileSync(mcpPath, 'utf-8')) as {
+      mcpServers?: Record<string, { url?: unknown }>;
+    };
+    const pcpServer = parsed.mcpServers?.pcp;
+    const pcpUrl = typeof pcpServer?.url === 'string' ? pcpServer.url : undefined;
+    return {
+      configExists: true,
+      parseError: false,
+      hasPcpServer: Boolean(pcpServer),
+      ...(pcpUrl ? { pcpUrl } : {}),
+    };
+  } catch {
+    return { configExists: true, parseError: true, hasPcpServer: false };
+  }
+}
+
 async function statusCommand(options: { backend?: string }): Promise<void> {
   const cwd = process.cwd();
   const identity = readIdentityJson(cwd);
@@ -102,6 +195,9 @@ async function statusCommand(options: { backend?: string }): Promise<void> {
   const expired = auth ? isTokenExpired(auth, 0) : false;
 
   const hooks = getHooksInstalled(cwd, backend);
+  const claudePermissions = backend === 'claude' ? getClaudePermissionsStatus(cwd) : undefined;
+  const mcpConfig = getMcpConfigStatus(cwd);
+  const pcpServerUrl = getPcpServerUrl();
 
   console.log(chalk.bold('\nSB Status\n'));
   console.log(`  ${chalk.bold('Agent:')}   ${agentId}`);
@@ -143,10 +239,61 @@ async function statusCommand(options: { backend?: string }): Promise<void> {
   }
   console.log('');
 
-  if (!auth || expired || !hooks.installed) {
+  console.log(chalk.bold('Permissions'));
+  if (backend !== 'claude') {
+    console.log(chalk.dim('  Managed by backend runtime (no local allow/deny file).'));
+  } else if (!claudePermissions?.configExists) {
+    console.log(chalk.yellow('  .claude/settings.local.json missing'));
+    console.log(chalk.dim('  Run: sb permissions auto'));
+  } else if (claudePermissions.parseError) {
+    console.log(chalk.red('  .claude/settings.local.json parse error'));
+  } else if (!claudePermissions.hasPermissions) {
+    console.log(chalk.yellow('  No explicit permission rules configured'));
+    console.log(chalk.dim('  Run: sb permissions auto'));
+  } else {
+    console.log(
+      `  ${chalk.green('Configured')} (${claudePermissions.allowCount} allow, ${claudePermissions.denyCount} deny)`
+    );
+    if (!claudePermissions.hasPcpMcpAllowance) {
+      console.log(chalk.yellow('  No MCP PCP allow rule detected (mcp__pcp__*)'));
+    }
+  }
+  console.log('');
+
+  console.log(chalk.bold('MCP Config'));
+  console.log(`  ${chalk.dim('.mcp.json')}`);
+  if (!mcpConfig.configExists) {
+    console.log(chalk.yellow('  Missing'));
+    console.log(chalk.dim('  Run: sb init'));
+  } else if (mcpConfig.parseError) {
+    console.log(chalk.red('  Parse error'));
+  } else if (!mcpConfig.hasPcpServer) {
+    console.log(chalk.yellow('  Missing mcpServers.pcp'));
+    console.log(chalk.dim('  Run: sb init'));
+  } else {
+    console.log(
+      `  ${chalk.green('PCP server configured')} (${mcpConfig.pcpUrl || chalk.dim('<url not set>')})`
+    );
+  }
+  console.log(`  ${chalk.dim('PCP_SERVER_URL')} ${pcpServerUrl}`);
+  console.log('');
+
+  const permissionsHealthy =
+    backend !== 'claude'
+      ? true
+      : Boolean(
+          claudePermissions &&
+          claudePermissions.configExists &&
+          !claudePermissions.parseError &&
+          claudePermissions.hasPermissions &&
+          claudePermissions.hasPcpMcpAllowance
+        );
+  const mcpHealthy =
+    mcpConfig.configExists && !mcpConfig.parseError && mcpConfig.hasPcpServer === true;
+  if (!auth || expired || !hooks.installed || !permissionsHealthy || !mcpHealthy) {
     console.log(
       chalk.yellow(
-        '  Attention: auth + hooks should both be healthy for reliable trigger/session behavior.'
+        '  Attention: auth + hooks + permissions + mcp config should all be healthy for reliable trigger/session behavior.'
       )
     );
     console.log('');

--- a/packages/cli/src/lib/pcp-mcp.test.ts
+++ b/packages/cli/src/lib/pcp-mcp.test.ts
@@ -135,4 +135,24 @@ describe('pcp-mcp callPcpTool', () => {
       'x-pcp-caller-profile': 'runtime',
     });
   });
+
+  it('reports fetch failures with PCP url and network diagnostics', async () => {
+    const fetchError = new TypeError('fetch failed', {
+      cause: Object.assign(new Error('connect ECONNREFUSED 127.0.0.1:3999'), {
+        code: 'ECONNREFUSED',
+        address: '127.0.0.1',
+        port: 3999,
+      }),
+    });
+    const fetchSpy = vi.fn().mockRejectedValue(fetchError);
+    vi.stubGlobal('fetch', fetchSpy);
+
+    await expect(callPcpTool('list_sessions', { limit: 1 })).rejects.toThrow(
+      'PCP fetch failed for http://localhost:3999/mcp'
+    );
+    await expect(callPcpTool('list_sessions', { limit: 1 })).rejects.toThrow('ECONNREFUSED');
+    await expect(callPcpTool('list_sessions', { limit: 1 })).rejects.toThrow(
+      'Ensure PCP server is running and PCP_SERVER_URL is correct.'
+    );
+  });
 });

--- a/packages/cli/src/lib/pcp-mcp.ts
+++ b/packages/cli/src/lib/pcp-mcp.ts
@@ -26,6 +26,29 @@ export function getPcpServerUrl(): string {
   return process.env.PCP_SERVER_URL || 'http://localhost:3001';
 }
 
+function formatPcpFetchFailure(url: string, error: unknown): string {
+  const base =
+    error instanceof Error ? error.message.trim() || error.name : String(error || 'fetch failed');
+  const err = error as { cause?: unknown } | undefined;
+  const cause = err?.cause as
+    | { code?: string; errno?: string | number; address?: string; port?: number; message?: string }
+    | undefined;
+  const causeParts: string[] = [];
+  if (typeof cause?.code === 'string' && cause.code.trim()) causeParts.push(cause.code.trim());
+  if (cause?.errno !== undefined && cause.errno !== null)
+    causeParts.push(`errno=${String(cause.errno)}`);
+  if (typeof cause?.address === 'string' && cause.address.trim())
+    causeParts.push(`address=${cause.address.trim()}`);
+  if (typeof cause?.port === 'number' && Number.isFinite(cause.port))
+    causeParts.push(`port=${cause.port}`);
+  if (typeof cause?.message === 'string' && cause.message.trim() && cause.message.trim() !== base) {
+    causeParts.push(cause.message.trim());
+  }
+
+  const causeSuffix = causeParts.length > 0 ? ` (${causeParts.join(', ')})` : '';
+  return `PCP fetch failed for ${url}: ${base}${causeSuffix}`;
+}
+
 export async function callPcpTool<T = Record<string, unknown>>(
   tool: string,
   args: Record<string, unknown>,
@@ -69,12 +92,19 @@ export async function callPcpTool<T = Record<string, unknown>>(
       ...(options?.timeoutMs ? { signal: AbortSignal.timeout(options.timeoutMs) } : {}),
     });
   } catch (error) {
+    const diagnostic = formatPcpFetchFailure(url, error);
     sbDebugLog('pcp-mcp', 'call_fetch_error', {
       tool,
       serverUrl,
+      url,
       error: error instanceof Error ? error.message : String(error),
+      diagnostic,
+      cause:
+        error && typeof error === 'object' && 'cause' in error
+          ? String((error as { cause?: unknown }).cause)
+          : null,
     });
-    throw error;
+    throw new Error(`${diagnostic}. Ensure PCP server is running and PCP_SERVER_URL is correct.`);
   }
 
   if (!response.ok) {


### PR DESCRIPTION
## Summary
- add a short retry window when reconciling Claude backend session IDs after process close
- use retry-based capture in both `runClaude` and `runClaudeInteractive` close paths
- add a unit test that simulates delayed `.jsonl` transcript creation and verifies the captured backend session ID is eventually resolved

## Why
In immediate cancel/exit flows, Claude transcript files can appear slightly after the close event. A one-shot post-close scan can miss the new local session, leaving the PCP session unlinked.

## Testing
- `npx vitest run packages/cli/src/commands/claude.test.ts`
- `yarn workspace @personal-context/cli type-check`
- `npx vitest run packages/cli/src/commands/studio-new.test.ts`
