### PR TITLE
fix(api): resolve sender sessionId in send_to_inbox (by Wren)

### DIFF
--- a/packages/api/src/mcp/server.ts
+++ b/packages/api/src/mcp/server.ts
@@ -283,12 +283,19 @@ export class MCPServer {
         : {};
       const callerProfileHeader = req.header('x-pcp-caller-profile')?.trim().toLowerCase();
       // Trust boundary note:
-      // `x-pcp-caller-profile` is only consumed on the MCP transport entrypoint.
-      // Supported MCP clients in our stack do not expose arbitrary header injection to model prompts,
-      // so this remains a runtime/server-controlled signal rather than an LLM-controlled parameter.
+      // `x-pcp-caller-profile`, `x-pcp-session-id`, and `x-pcp-studio-id` are only consumed
+      // on the MCP transport entrypoint. Supported MCP clients in our stack do not expose
+      // arbitrary header injection to model prompts, so these remain runtime/server-controlled
+      // signals rather than LLM-controlled parameters.
       const callerProfile: 'agent' | 'runtime' =
         callerProfileHeader === 'runtime' ? 'runtime' : 'agent';
-      Object.assign(ctx, { callerProfile });
+      const sessionIdHeader = req.header('x-pcp-session-id')?.trim();
+      const studioIdHeader = req.header('x-pcp-studio-id')?.trim();
+      Object.assign(ctx, {
+        callerProfile,
+        ...(sessionIdHeader ? { sessionId: sessionIdHeader } : {}),
+        ...(studioIdHeader ? { workspaceId: studioIdHeader } : {}),
+      });
 
       if (userData) {
         try {

--- a/packages/api/src/mcp/tools/inbox-handlers.ts
+++ b/packages/api/src/mcp/tools/inbox-handlers.ts
@@ -158,13 +158,27 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
   // Fallback: resolve sender's active session from the database when no header/context
   // provides it. This covers the common case where an agent calls send_to_inbox via
   // StreamableHTTP MCP and the client doesn't inject x-pcp-session-id.
+  // Prefer threadKey-specific lookup to avoid cross-thread misrouting when an agent
+  // has multiple active sessions.
   if (!senderSessionId && senderAgentId) {
     try {
-      const activeSession = await dataComposer.repositories.memory.getActiveSession(
-        resolved.user.id,
-        senderAgentId,
-        senderStudioId
-      );
+      const activeSession = threadKey
+        ? ((await dataComposer.repositories.memory.getActiveSessionByThreadKey(
+            resolved.user.id,
+            senderAgentId,
+            threadKey,
+            senderStudioId
+          )) ??
+          (await dataComposer.repositories.memory.getActiveSession(
+            resolved.user.id,
+            senderAgentId,
+            senderStudioId
+          )))
+        : await dataComposer.repositories.memory.getActiveSession(
+            resolved.user.id,
+            senderAgentId,
+            senderStudioId
+          );
       if (activeSession) {
         senderSessionId = activeSession.id;
       }

--- a/packages/api/src/mcp/tools/inbox-handlers.ts
+++ b/packages/api/src/mcp/tools/inbox-handlers.ts
@@ -152,8 +152,29 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
 
   const reqCtx = getRequestContext();
   const sessCtx = getSessionContext();
-  const senderSessionId = reqCtx?.sessionId || sessCtx?.sessionId || null;
+  let senderSessionId: string | null = reqCtx?.sessionId || sessCtx?.sessionId || null;
   const senderStudioId = reqCtx?.workspaceId || sessCtx?.workspaceId || null;
+
+  // Fallback: resolve sender's active session from the database when no header/context
+  // provides it. This covers the common case where an agent calls send_to_inbox via
+  // StreamableHTTP MCP and the client doesn't inject x-pcp-session-id.
+  if (!senderSessionId && senderAgentId) {
+    try {
+      const activeSession = await dataComposer.repositories.memory.getActiveSession(
+        resolved.user.id,
+        senderAgentId,
+        senderStudioId
+      );
+      if (activeSession) {
+        senderSessionId = activeSession.id;
+      }
+    } catch (err) {
+      logger.warn('Failed to resolve sender session from active sessions', {
+        error: err instanceof Error ? err.message : String(err),
+        senderAgentId,
+      });
+    }
+  }
   const metadataRecord =
     metadata && typeof metadata === 'object' ? (metadata as Record<string, unknown>) : {};
   const existingPcp =

--- a/packages/cli/src/lib/pcp-mcp.ts
+++ b/packages/cli/src/lib/pcp-mcp.ts
@@ -29,7 +29,12 @@ export function getPcpServerUrl(): string {
 export async function callPcpTool<T = Record<string, unknown>>(
   tool: string,
   args: Record<string, unknown>,
-  options?: { timeoutMs?: number; callerProfile?: 'agent' | 'runtime' }
+  options?: {
+    timeoutMs?: number;
+    callerProfile?: 'agent' | 'runtime';
+    sessionId?: string;
+    studioId?: string;
+  }
 ): Promise<T> {
   const serverUrl = getPcpServerUrl();
   const url = `${serverUrl}/mcp`;
@@ -45,6 +50,12 @@ export async function callPcpTool<T = Record<string, unknown>>(
   }
   if (options?.callerProfile) {
     headers['x-pcp-caller-profile'] = options.callerProfile;
+  }
+  if (options?.sessionId) {
+    headers['x-pcp-session-id'] = options.sessionId;
+  }
+  if (options?.studioId) {
+    headers['x-pcp-studio-id'] = options.studioId;
   }
 
   sbDebugLog('pcp-mcp', 'call_start', {


### PR DESCRIPTION
## Summary

- **Server-side session resolution**: When an agent calls `send_to_inbox` via StreamableHTTP MCP, the sender's session ID was always `null` in `metadata.pcp.sender.sessionId`. This broke response routing — recipients couldn't reply back to the correct session.
- **Root cause**: HTTP request context never included `sessionId` because no header carried it, and stdio session context isn't used in HTTP mode.
- **Three-part fix**:
  1. Server extracts `x-pcp-session-id` and `x-pcp-studio-id` headers into request context (explicit injection path)
  2. CLI `callPcpTool()` accepts `sessionId`/`studioId` options and sends them as `x-pcp-*` headers
  3. `send_to_inbox` falls back to querying the active session from the database when no header/context provides the sender's sessionId — this covers the common case where agents call MCP tools via `.mcp.json` (static headers, no dynamic session injection)

## Test plan

- [ ] Call `send_to_inbox` from an agent session → verify `metadata.pcp.sender.sessionId` is now populated (was previously always `null`)
- [ ] Verify the resolved session matches the agent's current active session
- [ ] Confirm no regression when `x-pcp-session-id` header IS explicitly provided (header takes precedence over DB fallback)
- [ ] Type check passes (`npx tsc --noEmit` — no new errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)