### PR TITLE
fix(cli): robust session linkage for picker resume and PCP-triggered sessions (by Wren)

### DIFF
--- a/packages/api/src/services/sessions/claude-runner.ts
+++ b/packages/api/src/services/sessions/claude-runner.ts
@@ -6,6 +6,8 @@
  */
 
 import { spawn, type ChildProcess } from 'child_process';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
 import { randomUUID } from 'crypto';
 import type {
   InjectedContext,
@@ -19,6 +21,75 @@ import type {
 import { formatInjectedContext } from './context-builder.js';
 import { logger } from '../../utils/logger.js';
 import { resolveBinaryPath, buildSpawnPath } from './resolve-binary.js';
+
+/**
+ * Write a minimal runtime session hint so the on-session-start hook can find
+ * the correct PCP session ID for this server-spawned run.
+ *
+ * The CLI hooks call resolveActivePcpSessionId() which reads from the local
+ * .pcp/runtime/sessions.json file. Without this hint, the hook picks up the
+ * last sb-launched session (wrong) instead of the server-triggered one.
+ */
+function writeRuntimeSessionHint(
+  workingDirectory: string,
+  pcpSessionId: string,
+  agentId: string,
+  backend: string,
+  runtimeLinkId: string
+): void {
+  try {
+    const runtimeDir = join(workingDirectory, '.pcp', 'runtime');
+    mkdirSync(runtimeDir, { recursive: true });
+
+    const sessionsPath = join(runtimeDir, 'sessions.json');
+    let state: {
+      version: 1;
+      current?: Record<string, unknown>;
+      sessions: Array<Record<string, unknown>>;
+    } = { version: 1, sessions: [] };
+
+    if (existsSync(sessionsPath)) {
+      try {
+        const raw = JSON.parse(readFileSync(sessionsPath, 'utf-8')) as typeof state;
+        if (raw.version === 1 && Array.isArray(raw.sessions)) {
+          state = raw;
+        }
+      } catch {
+        // Corrupt file — start fresh.
+      }
+    }
+
+    const now = new Date().toISOString();
+    const record: Record<string, unknown> = {
+      pcpSessionId,
+      backend,
+      agentId,
+      runtimeLinkId,
+      updatedAt: now,
+      startedAt: now,
+    };
+
+    const idx = state.sessions.findIndex(
+      (s) =>
+        s['pcpSessionId'] === pcpSessionId && s['backend'] === backend && s['agentId'] === agentId
+    );
+    if (idx >= 0) {
+      state.sessions[idx] = { ...state.sessions[idx], ...record };
+    } else {
+      state.sessions.push(record);
+    }
+
+    state.current = { pcpSessionId, backend, agentId, updatedAt: now };
+    writeFileSync(sessionsPath, JSON.stringify(state, null, 2));
+  } catch (err) {
+    // Best-effort only — hook will fall back to sessions.json current pointer.
+    logger.debug('Failed to write runtime session hint', {
+      workingDirectory,
+      pcpSessionId,
+      error: String(err),
+    });
+  }
+}
 
 /** Maximum time (ms) to wait for a Claude Code subprocess before killing it.
  *  Override with CLAUDE_PROCESS_TIMEOUT_MS env var. */
@@ -164,6 +235,20 @@ export class ClaudeRunner implements IClaudeRunner {
     toolCalls: ToolCall[];
   }> {
     const claudeBin = await resolveBinaryPath('claude');
+
+    // Write runtime hint files before spawning so the on-session-start hook
+    // picks up the correct PCP session ID (not the last sb-launched session).
+    const runtimeLinkId = randomUUID();
+    if (config.pcpSessionId && config.workingDirectory) {
+      writeRuntimeSessionHint(
+        config.workingDirectory,
+        config.pcpSessionId,
+        config.agentId || 'unknown',
+        'claude',
+        runtimeLinkId
+      );
+    }
+
     return new Promise((resolve, reject) => {
       // Strip CLAUDECODE to prevent "nested session" detection when PCP is
       // launched from inside a Claude Code session (e.g., via PM2).
@@ -175,6 +260,9 @@ export class ClaudeRunner implements IClaudeRunner {
           // Ensure Claude Code uses correct paths
           HOME: process.env.HOME,
           PATH: buildSpawnPath(claudeBin),
+          // Pass runtime link ID so the on-session-start hook can find this
+          // PCP session in the runtime hint files we wrote above.
+          ...(config.pcpSessionId ? { PCP_RUNTIME_LINK_ID: runtimeLinkId } : {}),
         },
         stdio: ['pipe', 'pipe', 'pipe'],
       });

--- a/packages/api/src/services/sessions/claude-runner.ts
+++ b/packages/api/src/services/sessions/claude-runner.ts
@@ -35,7 +35,8 @@ function writeRuntimeSessionHint(
   pcpSessionId: string,
   agentId: string,
   backend: string,
-  runtimeLinkId: string
+  runtimeLinkId: string,
+  studioId?: string
 ): void {
   try {
     const runtimeDir = join(workingDirectory, '.pcp', 'runtime');
@@ -65,6 +66,7 @@ function writeRuntimeSessionHint(
       backend,
       agentId,
       runtimeLinkId,
+      ...(studioId ? { studioId } : {}),
       updatedAt: now,
       startedAt: now,
     };
@@ -79,7 +81,13 @@ function writeRuntimeSessionHint(
       state.sessions.push(record);
     }
 
-    state.current = { pcpSessionId, backend, agentId, updatedAt: now };
+    state.current = {
+      pcpSessionId,
+      backend,
+      agentId,
+      ...(studioId ? { studioId } : {}),
+      updatedAt: now,
+    };
     writeFileSync(sessionsPath, JSON.stringify(state, null, 2));
   } catch (err) {
     // Best-effort only — hook will fall back to sessions.json current pointer.
@@ -245,7 +253,8 @@ export class ClaudeRunner implements IClaudeRunner {
         config.pcpSessionId,
         config.agentId || 'unknown',
         'claude',
-        runtimeLinkId
+        runtimeLinkId,
+        config.studioId
       );
     }
 

--- a/packages/api/src/services/sessions/codex-runner.ts
+++ b/packages/api/src/services/sessions/codex-runner.ts
@@ -7,7 +7,7 @@
 
 import { spawn, type ChildProcess } from 'child_process';
 import { randomUUID } from 'crypto';
-import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import type {
@@ -22,6 +22,56 @@ import type {
 import { formatInjectedContext } from './context-builder.js';
 import { logger } from '../../utils/logger.js';
 import { resolveBinaryPath, buildSpawnPath } from './resolve-binary.js';
+
+/** Write runtime hint files so the on-session-start hook finds the right PCP session. */
+function writeRuntimeSessionHint(
+  workingDirectory: string,
+  pcpSessionId: string,
+  agentId: string,
+  backend: string,
+  runtimeLinkId: string
+): void {
+  try {
+    const runtimeDir = join(workingDirectory, '.pcp', 'runtime');
+    mkdirSync(runtimeDir, { recursive: true });
+    const sessionsPath = join(runtimeDir, 'sessions.json');
+    let state: {
+      version: 1;
+      current?: Record<string, unknown>;
+      sessions: Array<Record<string, unknown>>;
+    } = { version: 1, sessions: [] };
+    if (existsSync(sessionsPath)) {
+      try {
+        const raw = JSON.parse(readFileSync(sessionsPath, 'utf-8')) as typeof state;
+        if (raw.version === 1 && Array.isArray(raw.sessions)) state = raw;
+      } catch {
+        // Corrupt file — start fresh.
+      }
+    }
+    const now = new Date().toISOString();
+    const record: Record<string, unknown> = {
+      pcpSessionId,
+      backend,
+      agentId,
+      runtimeLinkId,
+      updatedAt: now,
+      startedAt: now,
+    };
+    const idx = state.sessions.findIndex(
+      (s) =>
+        s['pcpSessionId'] === pcpSessionId && s['backend'] === backend && s['agentId'] === agentId
+    );
+    if (idx >= 0) {
+      state.sessions[idx] = { ...state.sessions[idx], ...record };
+    } else {
+      state.sessions.push(record);
+    }
+    state.current = { pcpSessionId, backend, agentId, updatedAt: now };
+    writeFileSync(sessionsPath, JSON.stringify(state, null, 2));
+  } catch {
+    // Best-effort only.
+  }
+}
 
 /** Maximum time (ms) to wait for a Codex CLI subprocess before killing it.
  *  Override with CODEX_PROCESS_TIMEOUT_MS env var. */
@@ -139,6 +189,18 @@ export class CodexRunner implements IClaudeRunner {
     sessionId?: string;
   }> {
     const codexBin = await resolveBinaryPath('codex');
+
+    const runtimeLinkId = randomUUID();
+    if (config.pcpSessionId && config.workingDirectory) {
+      writeRuntimeSessionHint(
+        config.workingDirectory,
+        config.pcpSessionId,
+        config.agentId || 'unknown',
+        'codex',
+        runtimeLinkId
+      );
+    }
+
     return new Promise((resolve, reject) => {
       // Strip CLAUDECODE to prevent env leaking into subprocess
       const { CLAUDECODE, ...cleanEnv } = process.env;
@@ -149,6 +211,7 @@ export class CodexRunner implements IClaudeRunner {
           HOME: process.env.HOME,
           PATH: buildSpawnPath(codexBin),
           ...(config.pcpAccessToken ? { PCP_ACCESS_TOKEN: config.pcpAccessToken } : {}),
+          ...(config.pcpSessionId ? { PCP_RUNTIME_LINK_ID: runtimeLinkId } : {}),
         },
         stdio: ['ignore', 'pipe', 'pipe'],
       });

--- a/packages/api/src/services/sessions/codex-runner.ts
+++ b/packages/api/src/services/sessions/codex-runner.ts
@@ -29,7 +29,8 @@ function writeRuntimeSessionHint(
   pcpSessionId: string,
   agentId: string,
   backend: string,
-  runtimeLinkId: string
+  runtimeLinkId: string,
+  studioId?: string
 ): void {
   try {
     const runtimeDir = join(workingDirectory, '.pcp', 'runtime');
@@ -54,6 +55,7 @@ function writeRuntimeSessionHint(
       backend,
       agentId,
       runtimeLinkId,
+      ...(studioId ? { studioId } : {}),
       updatedAt: now,
       startedAt: now,
     };
@@ -66,7 +68,13 @@ function writeRuntimeSessionHint(
     } else {
       state.sessions.push(record);
     }
-    state.current = { pcpSessionId, backend, agentId, updatedAt: now };
+    state.current = {
+      pcpSessionId,
+      backend,
+      agentId,
+      ...(studioId ? { studioId } : {}),
+      updatedAt: now,
+    };
     writeFileSync(sessionsPath, JSON.stringify(state, null, 2));
   } catch {
     // Best-effort only.
@@ -197,7 +205,8 @@ export class CodexRunner implements IClaudeRunner {
         config.pcpSessionId,
         config.agentId || 'unknown',
         'codex',
-        runtimeLinkId
+        runtimeLinkId,
+        config.studioId
       );
     }
 

--- a/packages/api/src/services/sessions/session-service.ts
+++ b/packages/api/src/services/sessions/session-service.ts
@@ -363,6 +363,8 @@ export class SessionService implements ISessionService {
       ),
       ...(runtimeModel ? { model: runtimeModel } : {}),
       ...(pcpAccessToken ? { pcpAccessToken } : {}),
+      pcpSessionId: session.id,
+      agentId,
     };
 
     // 5. Run with selected backend

--- a/packages/api/src/services/sessions/session-service.ts
+++ b/packages/api/src/services/sessions/session-service.ts
@@ -365,6 +365,7 @@ export class SessionService implements ISessionService {
       ...(pcpAccessToken ? { pcpAccessToken } : {}),
       pcpSessionId: session.id,
       agentId,
+      ...(session.studioId ? { studioId: session.studioId } : {}),
     };
 
     // 5. Run with selected backend

--- a/packages/api/src/services/sessions/types.ts
+++ b/packages/api/src/services/sessions/types.ts
@@ -395,6 +395,8 @@ export interface ClaudeRunnerConfig {
   pcpSessionId?: string;
   /** Agent ID for this run — written to runtime hint files */
   agentId?: string;
+  /** Studio/worktree scope — written to runtime hint so findRuntimeSessionByLinkId matches */
+  studioId?: string;
 }
 
 export interface ClaudeRunnerResult {

--- a/packages/api/src/services/sessions/types.ts
+++ b/packages/api/src/services/sessions/types.ts
@@ -391,6 +391,10 @@ export interface ClaudeRunnerConfig {
   systemPrompt?: string;
   appendSystemPrompt?: string;
   pcpAccessToken?: string;
+  /** PCP session ID for this run — written to runtime hint files so hooks link correctly */
+  pcpSessionId?: string;
+  /** Agent ID for this run — written to runtime hint files */
+  agentId?: string;
 }
 
 export interface ClaudeRunnerResult {

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -1136,6 +1136,8 @@ export function resolveBackendSessionIdForResume(options: {
   selectedLocalBackendSessionId?: string;
   localBackendSessionIds: Set<string>;
   knownBackendSessionIds?: Set<string>;
+  /** Fallback from local runtime cache (sessions.json) when server-side backendSessionId is null */
+  runtimeCachedSessionId?: string;
 }): {
   backendSessionId?: string;
   staleTrackedBackendSessionId?: string;
@@ -1147,6 +1149,7 @@ export function resolveBackendSessionIdForResume(options: {
     selectedLocalBackendSessionId,
     localBackendSessionIds,
     knownBackendSessionIds,
+    runtimeCachedSessionId,
   } = options;
   const normalizedBackend = normalizeSessionBackendName(backend);
 
@@ -1161,7 +1164,8 @@ export function resolveBackendSessionIdForResume(options: {
     return {};
   }
 
-  const candidate = chosen.backendSessionId || chosen.claudeSessionId || undefined;
+  const candidate =
+    chosen.backendSessionId || chosen.claudeSessionId || runtimeCachedSessionId || undefined;
   if (!candidate) return {};
 
   if (localBackendSessionIds.size > 0 && !localBackendSessionIds.has(candidate)) {
@@ -3161,6 +3165,9 @@ async function ensurePcpSessionContext(
       selectedLocalBackendSessionId,
       localBackendSessionIds,
       knownBackendSessionIds,
+      runtimeCachedSessionId: chosen?.id
+        ? runtimeBackendSessionIdByPcpSessionId.get(chosen.id)
+        : undefined,
     });
   const preserveTrackedBackendSessionId = !createdNewPcpSession || backend === 'claude';
   const resolvedTrackedBackendSessionId = preserveTrackedBackendSessionId

--- a/packages/cli/src/commands/hooks.ts
+++ b/packages/cli/src/commands/hooks.ts
@@ -427,9 +427,10 @@ function resolveActivePcpSessionId(cwd: string): string | undefined {
   const { studioId } = getIdentitySessionContext(cwd);
   const agentId = resolveAgentId() || 'unknown';
 
-  const current = getCurrentRuntimeSession(cwd, sessionBackend);
-  if (current?.pcpSessionId) return current.pcpSessionId;
-
+  // Check PCP_RUNTIME_LINK_ID first — it's set by both the sb launch path and
+  // the server-side runner (claude-runner/codex-runner) before spawning. This
+  // ensures server-triggered sessions are linked to the correct PCP session
+  // rather than the last sb-launched session recorded in sessions.json.
   const runtimeLinkId = process.env.PCP_RUNTIME_LINK_ID;
   if (runtimeLinkId) {
     const linked = findRuntimeSessionByLinkId(cwd, runtimeLinkId, {
@@ -439,6 +440,9 @@ function resolveActivePcpSessionId(cwd: string): string | undefined {
     });
     if (linked?.pcpSessionId) return linked.pcpSessionId;
   }
+
+  const current = getCurrentRuntimeSession(cwd, sessionBackend);
+  if (current?.pcpSessionId) return current.pcpSessionId;
 
   const fromLegacyFile = readRuntimeFile(cwd, 'pcp-session-id');
   if (fromLegacyFile) return fromLegacyFile;


### PR DESCRIPTION
## Summary

Fixes two related session linkage bugs in the `sb` CLI and server-side runners:

- **Bug 1 (session picker)**: Selecting a PCP session in the interactive picker (`sb -a lumen -b codex`) previewed the last message correctly but failed to resume the backend session. `resolveBackendSessionIdForResume()` didn't fall back to the local `runtimeBackendSessionIdByPcpSessionId` cache when `chosen.backendSessionId` was null. Added `runtimeCachedSessionId` parameter and wired it through the call site.

- **Bug 2 (PCP-triggered sessions)**: Sessions spawned by the server-side `claude-runner`/`codex-runner` (via `trigger_agent`) didn't write `.pcp/runtime/sessions.json` hints or set `PCP_RUNTIME_LINK_ID`. The `on-session-start` hook then resolved the wrong PCP session (stale "current" from the last `sb`-launched run). Fixed by:
  - Adding `writeRuntimeSessionHint()` to both runners, called before spawn with a fresh `runtimeLinkId`
  - Setting `PCP_RUNTIME_LINK_ID` in the spawned process env
  - Passing `pcpSessionId` + `agentId` from `session-service.ts` through `ClaudeRunnerConfig`
  - Moving the `PCP_RUNTIME_LINK_ID` check to highest priority in `resolveActivePcpSessionId()` (before `getCurrentRuntimeSession`)

## Changes

- `packages/api/src/services/sessions/types.ts` — add `pcpSessionId` + `agentId` to `ClaudeRunnerConfig`
- `packages/api/src/services/sessions/claude-runner.ts` — `writeRuntimeSessionHint()` + `PCP_RUNTIME_LINK_ID` env
- `packages/api/src/services/sessions/codex-runner.ts` — same as claude-runner
- `packages/api/src/services/sessions/session-service.ts` — pass `pcpSessionId`/`agentId` to runner config
- `packages/cli/src/commands/hooks.ts` — prioritize `PCP_RUNTIME_LINK_ID` in `resolveActivePcpSessionId()`
- `packages/cli/src/commands/claude.ts` — add `runtimeCachedSessionId` fallback to `resolveBackendSessionIdForResume()`

## Test plan

- [ ] `yarn workspace @personal-context/cli test` — 68 claude.test.ts + 52 hooks.test.ts pass
- [ ] Session picker: select a PCP session, confirm backend session resumes (correct log loads)
- [ ] `trigger_agent` → confirm spawned session hooks link to the triggered PCP session, not a stale one
- [ ] `sb -a wren -b claude resume <id>` still works as before

— Wren