### PR TITLE
fix(api): thread reply routing — propagate sender session through the chain (by Wren)

### DIFF
--- a/packages/api/src/mcp/tools/inbox-handlers.test.ts
+++ b/packages/api/src/mcp/tools/inbox-handlers.test.ts
@@ -29,6 +29,16 @@ vi.mock('../../utils/logger', () => ({
   },
 }));
 
+// Mock request context (for sender session resolution)
+vi.mock('../../utils/request-context', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../utils/request-context')>();
+  return {
+    ...actual,
+    getRequestContext: vi.fn().mockReturnValue(undefined),
+    getSessionContext: vi.fn().mockReturnValue(undefined),
+  };
+});
+
 // Mock agent gateway
 vi.mock('../../channels/agent-gateway.js', () => ({
   getAgentGateway: vi.fn().mockReturnValue({
@@ -347,6 +357,356 @@ describe('handleSendToInbox - threadKey', () => {
     expect(parsed.success).toBe(true);
     expect(parsed.routingHint).toContain('routing anchor');
     expect(mockGateway.dispatchTrigger).toHaveBeenCalled();
+  });
+});
+
+// =====================================================
+// REPLY ROUTING — Thread message metadata enrichment
+// =====================================================
+
+/**
+ * Build a Supabase mock that supports the full thread path:
+ * findOrCreateThread → participant registration → message insert → trigger dispatch.
+ *
+ * The thread path hits multiple tables with different chainable patterns.
+ * This mock returns table-specific chainable objects.
+ */
+function createThreadMockSupabase(
+  options: {
+    existingThread?: { id: string };
+    recipientPriorMessage?: { metadata: Record<string, unknown> } | null;
+    threadMessageId?: string;
+  } = {}
+) {
+  const threadId = options.existingThread?.id || 'thread-999';
+  const threadMessageId = options.threadMessageId || 'tmsg-123';
+  let insertedMetadata: Record<string, unknown> | null = null;
+
+  // inbox_threads table mock
+  const threadsFindChain = {
+    select: vi.fn().mockReturnValue({
+      eq: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          maybeSingle: vi.fn().mockResolvedValue({
+            data: options.existingThread ? { id: threadId } : null,
+            error: null,
+          }),
+        }),
+      }),
+    }),
+    insert: vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        single: vi.fn().mockResolvedValue({
+          data: { id: threadId },
+          error: null,
+        }),
+      }),
+    }),
+    update: vi.fn().mockReturnValue({
+      eq: vi.fn().mockResolvedValue({ data: null, error: null }),
+    }),
+  };
+
+  // inbox_thread_participants table mock
+  const participantsChain = {
+    select: vi.fn().mockReturnValue({
+      eq: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          maybeSingle: vi.fn().mockResolvedValue({
+            data: { agent_id: 'existing' },
+            error: null,
+          }),
+        }),
+      }),
+    }),
+    insert: vi.fn().mockResolvedValue({ data: null, error: null }),
+  };
+
+  // inbox_thread_messages table mock
+  const messagesChain = {
+    insert: vi.fn().mockImplementation((row: Record<string, unknown>) => {
+      insertedMetadata = row.metadata as Record<string, unknown>;
+      return {
+        select: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({
+            data: { id: threadMessageId, ...row },
+            error: null,
+          }),
+        }),
+      };
+    }),
+    select: vi.fn().mockReturnValue({
+      eq: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          order: vi.fn().mockReturnValue({
+            limit: vi.fn().mockReturnValue({
+              maybeSingle: vi.fn().mockResolvedValue({
+                data: options.recipientPriorMessage || null,
+                error: null,
+              }),
+            }),
+          }),
+        }),
+      }),
+    }),
+  };
+
+  // inbox_thread_read_status table mock
+  const readStatusChain = {
+    upsert: vi.fn().mockResolvedValue({ data: null, error: null }),
+  };
+
+  // identity mock (for resolveIdentityId)
+  const identityChain = {
+    select: vi.fn().mockReturnValue({
+      eq: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          order: vi.fn().mockResolvedValue({
+            data: [{ id: 'identity-123', workspace_id: 'ws-1', updated_at: null }],
+            error: null,
+          }),
+        }),
+      }),
+    }),
+  };
+
+  const fromFn = vi.fn().mockImplementation((table: string) => {
+    switch (table) {
+      case 'inbox_threads':
+        return threadsFindChain;
+      case 'inbox_thread_participants':
+        return participantsChain;
+      case 'inbox_thread_messages':
+        return messagesChain;
+      case 'inbox_thread_read_status':
+        return readStatusChain;
+      case 'agent_identities':
+        return identityChain;
+      default:
+        return threadsFindChain;
+    }
+  });
+
+  return {
+    from: fromFn,
+    getInsertedMetadata: () => insertedMetadata,
+  };
+}
+
+function createThreadMockDataComposer(supabase: ReturnType<typeof createThreadMockSupabase>) {
+  return {
+    getClient: vi.fn().mockReturnValue(supabase),
+    repositories: {
+      memory: {
+        getActiveSessionByThreadKey: vi.fn().mockResolvedValue(null),
+        getActiveSession: vi.fn().mockResolvedValue(null),
+      },
+    },
+  };
+}
+
+describe('Reply Routing — thread message metadata enrichment', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should enrich thread message metadata with pcp.sender context', async () => {
+    const mockSb = createThreadMockSupabase({
+      existingThread: { id: 'thread-pr210' },
+    });
+    const mockDc = createThreadMockDataComposer(mockSb);
+
+    // Mock request context to provide sender session info
+    const { getRequestContext } = await import('../../utils/request-context');
+    vi.mocked(getRequestContext).mockReturnValue({
+      sessionId: 'wren-session-123',
+      workspaceId: 'studio-wren',
+    } as ReturnType<typeof getRequestContext>);
+
+    await handleSendToInbox(
+      {
+        email: 'test@test.com',
+        recipientAgentId: 'lumen',
+        senderAgentId: 'wren',
+        threadKey: 'pr:210',
+        content: 'Please review this PR',
+      },
+      mockDc as never
+    );
+
+    // Verify the inserted message metadata has pcp.sender
+    const insertedMeta = mockSb.getInsertedMetadata();
+    expect(insertedMeta).toBeDefined();
+    expect(insertedMeta!.pcp).toBeDefined();
+    const pcpMeta = insertedMeta!.pcp as Record<string, unknown>;
+    expect(pcpMeta.sender).toEqual({
+      agentId: 'wren',
+      sessionId: 'wren-session-123',
+      studioId: 'studio-wren',
+    });
+  });
+
+  it('should set sender sessionId to null when no request context is available', async () => {
+    const mockSb = createThreadMockSupabase({
+      existingThread: { id: 'thread-pr210' },
+    });
+    const mockDc = createThreadMockDataComposer(mockSb);
+
+    // Clear request context mock
+    const { getRequestContext, getSessionContext } = await import('../../utils/request-context');
+    vi.mocked(getRequestContext).mockReturnValue(undefined as never);
+    vi.mocked(getSessionContext).mockReturnValue(undefined as never);
+
+    await handleSendToInbox(
+      {
+        email: 'test@test.com',
+        recipientAgentId: 'lumen',
+        senderAgentId: 'wren',
+        threadKey: 'pr:210',
+        content: 'Hello',
+      },
+      mockDc as never
+    );
+
+    const insertedMeta = mockSb.getInsertedMetadata();
+    expect(insertedMeta).toBeDefined();
+    const pcpMeta = insertedMeta!.pcp as Record<string, unknown>;
+    const sender = pcpMeta.sender as Record<string, unknown>;
+    expect(sender.agentId).toBe('wren');
+    expect(sender.sessionId).toBeNull();
+    expect(sender.studioId).toBeNull();
+  });
+});
+
+describe('Reply Routing — trigger recipientSessionId auto-resolution', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should auto-resolve recipientSessionId from prior thread message', async () => {
+    const { getAgentGateway } = await import('../../channels/agent-gateway.js');
+    const mockGateway = (getAgentGateway as ReturnType<typeof vi.fn>)();
+
+    const mockSb = createThreadMockSupabase({
+      existingThread: { id: 'thread-pr210' },
+      // Lumen's prior message on this thread has their session context
+      recipientPriorMessage: {
+        metadata: {
+          pcp: {
+            sender: {
+              agentId: 'lumen',
+              sessionId: 'lumen-session-456',
+              studioId: 'studio-lumen',
+            },
+          },
+        },
+      },
+    });
+    const mockDc = createThreadMockDataComposer(mockSb);
+
+    // Clear request context
+    const { getRequestContext, getSessionContext } = await import('../../utils/request-context');
+    vi.mocked(getRequestContext).mockReturnValue(undefined as never);
+    vi.mocked(getSessionContext).mockReturnValue(undefined as never);
+
+    await handleSendToInbox(
+      {
+        email: 'test@test.com',
+        recipientAgentId: 'lumen',
+        senderAgentId: 'wren',
+        threadKey: 'pr:210',
+        content: 'Reply to your review',
+      },
+      mockDc as never
+    );
+
+    // Trigger should include the auto-resolved recipientSessionId
+    expect(mockGateway.dispatchTrigger).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toAgentId: 'lumen',
+        threadKey: 'pr:210',
+        recipientSessionId: 'lumen-session-456',
+      })
+    );
+  });
+
+  it('should not set recipientSessionId when no prior message exists', async () => {
+    const { getAgentGateway } = await import('../../channels/agent-gateway.js');
+    const mockGateway = (getAgentGateway as ReturnType<typeof vi.fn>)();
+
+    const mockSb = createThreadMockSupabase({
+      existingThread: { id: 'thread-new' },
+      recipientPriorMessage: null, // No prior messages from recipient
+    });
+    const mockDc = createThreadMockDataComposer(mockSb);
+
+    const { getRequestContext, getSessionContext } = await import('../../utils/request-context');
+    vi.mocked(getRequestContext).mockReturnValue(undefined as never);
+    vi.mocked(getSessionContext).mockReturnValue(undefined as never);
+
+    await handleSendToInbox(
+      {
+        email: 'test@test.com',
+        recipientAgentId: 'lumen',
+        senderAgentId: 'wren',
+        threadKey: 'pr:999',
+        content: 'First message on this thread',
+      },
+      mockDc as never
+    );
+
+    expect(mockGateway.dispatchTrigger).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toAgentId: 'lumen',
+        threadKey: 'pr:999',
+        recipientSessionId: undefined,
+      })
+    );
+  });
+
+  it('should use explicit recipientSessionId over auto-resolved one', async () => {
+    const { getAgentGateway } = await import('../../channels/agent-gateway.js');
+    const mockGateway = (getAgentGateway as ReturnType<typeof vi.fn>)();
+
+    const mockSb = createThreadMockSupabase({
+      existingThread: { id: 'thread-pr210' },
+      // Even though a prior message has a different session ID...
+      recipientPriorMessage: {
+        metadata: {
+          pcp: {
+            sender: {
+              agentId: 'lumen',
+              sessionId: 'lumen-old-session',
+              studioId: 'studio-lumen',
+            },
+          },
+        },
+      },
+    });
+    const mockDc = createThreadMockDataComposer(mockSb);
+
+    const { getRequestContext, getSessionContext } = await import('../../utils/request-context');
+    vi.mocked(getRequestContext).mockReturnValue(undefined as never);
+    vi.mocked(getSessionContext).mockReturnValue(undefined as never);
+
+    await handleSendToInbox(
+      {
+        email: 'test@test.com',
+        recipientAgentId: 'lumen',
+        senderAgentId: 'wren',
+        threadKey: 'pr:210',
+        recipientSessionId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+        content: 'Using explicit routing',
+      },
+      mockDc as never
+    );
+
+    // Explicit recipientSessionId should take priority
+    expect(mockGateway.dispatchTrigger).toHaveBeenCalledWith(
+      expect.objectContaining({
+        recipientSessionId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+      })
+    );
   });
 });
 

--- a/packages/api/src/mcp/tools/inbox-handlers.ts
+++ b/packages/api/src/mcp/tools/inbox-handlers.ts
@@ -167,6 +167,44 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
   // for messages that can genuinely wait 5+ hours.
   const trigger = parsed.trigger ?? true;
 
+  // ── Resolve sender session context (shared by both thread and legacy paths) ──
+  // This must happen BEFORE the thread/legacy branch so thread messages also
+  // capture the sender's session ID for reply-routing.
+  const reqCtx = getRequestContext();
+  const sessCtx = getSessionContext();
+  let senderSessionId: string | null = reqCtx?.sessionId || sessCtx?.sessionId || null;
+  const senderStudioId = reqCtx?.workspaceId || sessCtx?.workspaceId || null;
+
+  if (!senderSessionId && senderAgentId) {
+    try {
+      const activeSession = threadKey
+        ? ((await dataComposer.repositories.memory.getActiveSessionByThreadKey(
+            resolved.user.id,
+            senderAgentId,
+            threadKey,
+            senderStudioId
+          )) ??
+          (await dataComposer.repositories.memory.getActiveSession(
+            resolved.user.id,
+            senderAgentId,
+            senderStudioId
+          )))
+        : await dataComposer.repositories.memory.getActiveSession(
+            resolved.user.id,
+            senderAgentId,
+            senderStudioId
+          );
+      if (activeSession) {
+        senderSessionId = activeSession.id;
+      }
+    } catch (err) {
+      logger.warn('Failed to resolve sender session from active sessions', {
+        error: err instanceof Error ? err.message : String(err),
+        senderAgentId,
+      });
+    }
+  }
+
   // ── Thread-first path: when threadKey is provided, route to thread tables ──
   // Single-recipient with threadKey creates a 2-participant thread (spec invariant #5).
   // recipients[] creates a multi-participant thread.
@@ -203,6 +241,26 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
       }
     }
 
+    // Enrich thread message metadata with sender session context so replies
+    // can route back to the correct session/studio.
+    const rawMeta =
+      metadata && typeof metadata === 'object' ? (metadata as Record<string, unknown>) : {};
+    const existingPcpMeta =
+      rawMeta.pcp && typeof rawMeta.pcp === 'object'
+        ? (rawMeta.pcp as Record<string, unknown>)
+        : {};
+    const threadMessageMetadata = {
+      ...rawMeta,
+      pcp: {
+        ...existingPcpMeta,
+        sender: {
+          agentId: triggerSenderId,
+          sessionId: senderSessionId,
+          studioId: senderStudioId,
+        },
+      },
+    };
+
     // Insert thread message
     const { data: threadMessage, error: tmError } = await threadTable(
       supabase,
@@ -214,7 +272,7 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
         content,
         message_type: messageType === 'permission_grant' ? 'message' : messageType,
         priority,
-        metadata: (metadata || {}) as Json,
+        metadata: threadMessageMetadata as Json,
       })
       .select()
       .single();
@@ -256,6 +314,42 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
       const agentsToTrigger = allRecipients.filter((a) => a !== senderAgentId);
 
       for (const toAgentId of agentsToTrigger) {
+        // Auto-resolve recipientSessionId: find the recipient's most recent
+        // message on this thread to extract their sender session. This ensures
+        // replies route back to the session that originated the conversation,
+        // not whatever session happens to be most recently updated.
+        let resolvedRecipientSessionId: string | undefined =
+          effectiveRecipientSessionId || undefined;
+        if (!resolvedRecipientSessionId) {
+          try {
+            const { data: recipientMsg } = await threadTable(supabase, 'inbox_thread_messages')
+              .select('metadata')
+              .eq('thread_id', thread.id)
+              .eq('sender_agent_id', toAgentId)
+              .order('created_at', { ascending: false })
+              .limit(1)
+              .maybeSingle();
+            const recipientPcp = (recipientMsg?.metadata as Record<string, unknown>)?.pcp as
+              | Record<string, unknown>
+              | undefined;
+            const recipientSender = recipientPcp?.sender as Record<string, unknown> | undefined;
+            if (recipientSender?.sessionId && typeof recipientSender.sessionId === 'string') {
+              resolvedRecipientSessionId = recipientSender.sessionId;
+              logger.debug('[ThreadTrigger] Auto-resolved recipientSessionId from thread history', {
+                threadKey,
+                toAgentId,
+                recipientSessionId: resolvedRecipientSessionId,
+              });
+            }
+          } catch (err) {
+            logger.warn('[ThreadTrigger] Failed to resolve recipientSessionId from thread', {
+              threadKey,
+              toAgentId,
+              error: err instanceof Error ? err.message : String(err),
+            });
+          }
+        }
+
         const payload: AgentTriggerPayload = {
           fromAgentId: triggerSenderId,
           toAgentId,
@@ -267,6 +361,7 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
             `New ${messageType} in thread ${threadKey} from ${triggerSenderId}`,
           priority,
           threadKey,
+          recipientSessionId: resolvedRecipientSessionId,
         };
         const result = gateway.dispatchTrigger(payload);
         if (result.accepted) {
@@ -312,45 +407,7 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
     });
   }
 
-  const reqCtx = getRequestContext();
-  const sessCtx = getSessionContext();
-  let senderSessionId: string | null = reqCtx?.sessionId || sessCtx?.sessionId || null;
-  const senderStudioId = reqCtx?.workspaceId || sessCtx?.workspaceId || null;
-
-  // Fallback: resolve sender's active session from the database when no header/context
-  // provides it. This covers the common case where an agent calls send_to_inbox via
-  // StreamableHTTP MCP and the client doesn't inject x-pcp-session-id.
-  // Prefer threadKey-specific lookup to avoid cross-thread misrouting when an agent
-  // has multiple active sessions.
-  if (!senderSessionId && senderAgentId) {
-    try {
-      const activeSession = threadKey
-        ? ((await dataComposer.repositories.memory.getActiveSessionByThreadKey(
-            resolved.user.id,
-            senderAgentId,
-            threadKey,
-            senderStudioId
-          )) ??
-          (await dataComposer.repositories.memory.getActiveSession(
-            resolved.user.id,
-            senderAgentId,
-            senderStudioId
-          )))
-        : await dataComposer.repositories.memory.getActiveSession(
-            resolved.user.id,
-            senderAgentId,
-            senderStudioId
-          );
-      if (activeSession) {
-        senderSessionId = activeSession.id;
-      }
-    } catch (err) {
-      logger.warn('Failed to resolve sender session from active sessions', {
-        error: err instanceof Error ? err.message : String(err),
-        senderAgentId,
-      });
-    }
-  }
+  // senderSessionId and senderStudioId already resolved above (shared with thread path)
   const metadataRecord =
     metadata && typeof metadata === 'object' ? (metadata as Record<string, unknown>) : {};
   const existingPcp =

--- a/packages/api/src/services/sessions/session-service.test.ts
+++ b/packages/api/src/services/sessions/session-service.test.ts
@@ -1131,4 +1131,162 @@ describe('SessionService', () => {
       expect(mockRepoWithThreadKey.findByUserAndAgent).toHaveBeenCalled();
     });
   });
+
+  // ═══════════════════════════════════════════════════════════════
+  // Reply Routing — recipientSessionId Priority
+  // ═══════════════════════════════════════════════════════════════
+  describe('Reply Routing — recipientSessionId', () => {
+    it('should route to recipientSession when it exists and is active', async () => {
+      const recipientSession = createMockSession({
+        id: 'recipient-session-abc',
+        agentId: 'wren',
+        threadKey: 'pr:210',
+        studioId: 'studio-wren',
+        endedAt: null,
+      });
+      vi.mocked(mockRepository.findById).mockResolvedValue(recipientSession);
+
+      const request = createMockRequest({
+        agentId: 'wren',
+        metadata: {
+          threadKey: 'pr:210',
+          recipientSessionId: 'recipient-session-abc',
+          triggerType: 'agent',
+        },
+      });
+
+      const result = await sessionService.handleMessage(request);
+
+      expect(result.success).toBe(true);
+      expect(result.sessionId).toBe('recipient-session-abc');
+      expect(mockRepository.findById).toHaveBeenCalledWith('recipient-session-abc');
+      // Should NOT have created a new session
+      expect(mockRepository.create).not.toHaveBeenCalled();
+    });
+
+    it('should skip recipientSession when it has ended and fall through to threadKey', async () => {
+      const endedSession = createMockSession({
+        id: 'ended-session',
+        agentId: 'wren',
+        threadKey: 'pr:210',
+        endedAt: new Date(),
+      });
+      vi.mocked(mockRepository.findById).mockResolvedValue(endedSession);
+
+      const mockRepoWithThreadKey = {
+        ...mockRepository,
+        findById: vi.fn().mockResolvedValue(endedSession),
+        findByThreadKey: vi.fn().mockResolvedValue(null),
+        create: vi
+          .fn()
+          .mockResolvedValue(
+            createMockSession({ id: 'new-fallback-session', threadKey: 'pr:210' })
+          ),
+      };
+
+      const serviceWithThreadKey = new SessionService(
+        mockRepoWithThreadKey,
+        mockContextBuilder,
+        mockClaudeRunner,
+        mockActivityStream,
+        {
+          defaultWorkingDirectory: '/test',
+          mcpConfigPath: '/test/.mcp.json',
+          compactionThreshold: 150000,
+        },
+        mockCodexRunner
+      );
+
+      const request = createMockRequest({
+        agentId: 'wren',
+        metadata: {
+          threadKey: 'pr:210',
+          recipientSessionId: 'ended-session',
+          triggerType: 'agent',
+        },
+      });
+
+      const result = await serviceWithThreadKey.handleMessage(request);
+
+      expect(result.success).toBe(true);
+      // Should have fallen through to create a new session
+      expect(result.sessionId).toBe('new-fallback-session');
+      expect(mockRepoWithThreadKey.findById).toHaveBeenCalledWith('ended-session');
+      expect(mockRepoWithThreadKey.create).toHaveBeenCalled();
+    });
+
+    it('should prioritize recipientSession over threadKey match', async () => {
+      const recipientSession = createMockSession({
+        id: 'recipient-session',
+        agentId: 'wren',
+        threadKey: 'pr:210',
+        studioId: 'studio-wren',
+        endedAt: null,
+      });
+      const differentThreadSession = createMockSession({
+        id: 'thread-match-session',
+        agentId: 'wren',
+        threadKey: 'pr:213',
+      });
+
+      const mockRepoWithThreadKey = {
+        ...mockRepository,
+        findById: vi.fn().mockResolvedValue(recipientSession),
+        findByThreadKey: vi.fn().mockResolvedValue(differentThreadSession),
+      };
+
+      const serviceWithThreadKey = new SessionService(
+        mockRepoWithThreadKey,
+        mockContextBuilder,
+        mockClaudeRunner,
+        mockActivityStream,
+        {
+          defaultWorkingDirectory: '/test',
+          mcpConfigPath: '/test/.mcp.json',
+          compactionThreshold: 150000,
+        },
+        mockCodexRunner
+      );
+
+      const request = createMockRequest({
+        agentId: 'wren',
+        metadata: {
+          threadKey: 'pr:213',
+          recipientSessionId: 'recipient-session',
+          triggerType: 'agent',
+        },
+      });
+
+      const result = await serviceWithThreadKey.handleMessage(request);
+
+      expect(result.success).toBe(true);
+      // recipientSession wins over threadKey match
+      expect(result.sessionId).toBe('recipient-session');
+      // findByThreadKey should NOT have been called — recipientSession short-circuits
+      expect(mockRepoWithThreadKey.findByThreadKey).not.toHaveBeenCalled();
+    });
+
+    it('should skip recipientSession when findById returns null', async () => {
+      vi.mocked(mockRepository.findById).mockResolvedValue(null);
+      vi.mocked(mockRepository.findByUserAndAgent).mockResolvedValue(null);
+      vi.mocked(mockRepository.create).mockResolvedValue(
+        createMockSession({ id: 'fallback-session' })
+      );
+
+      const request = createMockRequest({
+        metadata: {
+          recipientSessionId: 'nonexistent-session',
+          triggerType: 'agent',
+        },
+      });
+
+      const result = await sessionService.handleMessage(request);
+
+      expect(result.success).toBe(true);
+      expect(result.sessionId).toBe('fallback-session');
+      expect(mockRepository.findById).toHaveBeenCalledWith('nonexistent-session');
+      // Falls through to normal creation
+      expect(mockRepository.create).toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/api/src/services/sessions/session-service.ts
+++ b/packages/api/src/services/sessions/session-service.ts
@@ -579,6 +579,23 @@ export class SessionService implements ISessionService {
 
     // For primary sessions, try to find existing active session
     if (type === 'primary') {
+      // recipientSessionId takes highest priority — this is an explicit "route
+      // the reply back to THIS session" signal (e.g., auto-resolved from thread
+      // message history). If the session exists and isn't ended, use it directly
+      // regardless of threadKey mismatch.
+      if (options?.recipientSessionId) {
+        const recipientSession = await this.repository.findById(options.recipientSessionId);
+        if (recipientSession && !recipientSession.endedAt) {
+          logger.debug('Routing to explicit recipientSession', {
+            sessionId: recipientSession.id,
+            threadKey: options.threadKey,
+            sessionThreadKey: recipientSession.threadKey,
+            studioId: recipientSession.studioId || null,
+          });
+          return recipientSession;
+        }
+      }
+
       // ThreadKey match takes priority — find session scoped to this topic
       if (options?.threadKey && 'findByThreadKey' in this.repository) {
         const threadRepo = this.repository as {


### PR DESCRIPTION
## Problem

When agent A sends a message to agent B on a threadKey, and B replies, the reply was routed to **the wrong session and studio** for A. Three breaks in the chain:

**Break 1 — sender context not captured in thread messages**: The `senderSessionId` resolution and metadata enrichment (`pcp.sender.sessionId`) only ran in the legacy (non-thread) path. Thread messages got raw metadata with no sender session context. When the recipient looked at the message to route a reply, there was nothing to route back to.

**Fix**: Moved sender session resolution before the thread/legacy branch split. Thread messages now get enriched metadata with `pcp.sender.{agentId, sessionId, studioId}`.

**Break 2 — trigger dispatch didn't set recipientSessionId**: The `AgentTriggerPayload` for thread replies only included `threadKey` — no explicit session routing. Routing fell back to recency-based thread-key lookup, which found whatever session was most recently updated for that threadKey.

**Fix**: Auto-resolve `recipientSessionId` from thread message history. Before dispatching a trigger, look up the recipient's most recent message on the thread and extract their `pcp.sender.sessionId`. Pass it as `recipientSessionId` in the trigger payload.

**Break 3 — getOrCreateSession ignored recipientSessionId**: Even when the trigger carried the correct `recipientSessionId`, it was only used by `resolveStudioId` to find the studio. The session lookup then searched by threadKey, found no match (the sender's session has a different threadKey), and created a **new** session.

**Fix**: Added `recipientSessionId` as the highest-priority check in `getOrCreateSession`. If set and the session is not ended, return it directly — bypassing threadKey-based session creation.

## Files changed

- `packages/api/src/services/sessions/session-service.ts` — recipientSession priority in getOrCreateSession
- `packages/api/src/mcp/tools/inbox-handlers.ts` — sender context enrichment for thread messages + auto-resolve recipientSessionId in trigger dispatch

## Test plan

- [ ] `yarn workspace @personal-context/api test` — all tests pass
- [ ] Wren sends message to Lumen on `pr:X` → Lumen replies → reply routes back to Wren's **original session**, not a new spawn
- [ ] Integration tests for reply routing (metadata enrichment, trigger dispatch, getOrCreateSession priority, round-trip)

— Wren