### PR TITLE
feat: add manual session transcript sync and archive flow (by Lumen)

### DIFF
--- a/packages/api/src/data/supabase/types.ts
+++ b/packages/api/src/data/supabase/types.ts
@@ -2410,6 +2410,66 @@ export type Database = {
           },
         ];
       };
+      session_transcript_archives: {
+        Row: {
+          backend: string | null;
+          backend_session_id: string | null;
+          byte_count: number;
+          created_at: string;
+          id: string;
+          line_count: number;
+          payload: Json;
+          session_id: string;
+          source_path: string | null;
+          synced_at: string;
+          updated_at: string;
+          user_id: string;
+        };
+        Insert: {
+          backend?: string | null;
+          backend_session_id?: string | null;
+          byte_count?: number;
+          created_at?: string;
+          id?: string;
+          line_count?: number;
+          payload: Json;
+          session_id: string;
+          source_path?: string | null;
+          synced_at?: string;
+          updated_at?: string;
+          user_id: string;
+        };
+        Update: {
+          backend?: string | null;
+          backend_session_id?: string | null;
+          byte_count?: number;
+          created_at?: string;
+          id?: string;
+          line_count?: number;
+          payload?: Json;
+          session_id?: string;
+          source_path?: string | null;
+          synced_at?: string;
+          updated_at?: string;
+          user_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'session_transcript_archives_session_id_fkey';
+            columns: ['session_id'];
+            isOneToOne: false;
+            referencedRelation: 'sessions';
+            referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'session_transcript_archives_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
       session_logs: {
         Row: {
           compacted_at: string | null;

--- a/packages/api/src/routes/admin-auth.test.ts
+++ b/packages/api/src/routes/admin-auth.test.ts
@@ -341,6 +341,30 @@ describe('adminAuthMiddleware', () => {
       expect(res._status).toBe(401);
       expect(next).not.toHaveBeenCalled();
     });
+
+    it('should accept mcp_access tokens only for transcript sync route', async () => {
+      mockVerifyPcpAccessToken
+        .mockReturnValueOnce(null) // pcp_admin check
+        .mockReturnValueOnce({
+          type: 'mcp_access',
+          sub: 'user-mcp',
+          email: 'mcp@example.com',
+          scope: 'mcp:tools',
+        });
+
+      const req = createMockReq({
+        method: 'POST',
+        path: '/sessions/session-123/sync-transcript',
+      });
+      const res = createMockRes();
+      const next = vi.fn();
+
+      await middleware(req, res, next);
+
+      expect(next).toHaveBeenCalled();
+      expect(mockGetUser).not.toHaveBeenCalled();
+      expect((req as any).pcpUserId).toBe('user-mcp');
+    });
   });
 
   // =========================================================================

--- a/packages/api/src/routes/admin-auth.test.ts
+++ b/packages/api/src/routes/admin-auth.test.ts
@@ -365,6 +365,48 @@ describe('adminAuthMiddleware', () => {
       expect(mockGetUser).not.toHaveBeenCalled();
       expect((req as any).pcpUserId).toBe('user-mcp');
     });
+
+    it('should accept mcp_access tokens for transcript list/export routes', async () => {
+      mockVerifyPcpAccessToken.mockReturnValueOnce(null).mockReturnValueOnce({
+        type: 'mcp_access',
+        sub: 'user-mcp',
+        email: 'mcp@example.com',
+        scope: 'mcp:tools',
+      });
+
+      const listReq = createMockReq({
+        method: 'GET',
+        path: '/sessions/synced',
+      });
+      const listRes = createMockRes();
+      const listNext = vi.fn();
+
+      await middleware(listReq, listRes, listNext);
+
+      expect(listNext).toHaveBeenCalled();
+      expect(mockGetUser).not.toHaveBeenCalled();
+
+      mockVerifyPcpAccessToken.mockReset();
+      mockVerifyPcpAccessToken.mockReturnValueOnce(null).mockReturnValueOnce({
+        type: 'mcp_access',
+        sub: 'user-mcp',
+        email: 'mcp@example.com',
+        scope: 'mcp:tools',
+      });
+
+      const exportReq = createMockReq({
+        method: 'GET',
+        path: '/sessions/session-123/transcript',
+      });
+      const exportRes = createMockRes();
+      const exportNext = vi.fn();
+
+      await middleware(exportReq, exportRes, exportNext);
+
+      expect(exportNext).toHaveBeenCalled();
+      expect(mockGetUser).not.toHaveBeenCalled();
+      expect((exportReq as any).pcpUserId).toBe('user-mcp');
+    });
   });
 
   // =========================================================================

--- a/packages/api/src/routes/admin-endpoints.test.ts
+++ b/packages/api/src/routes/admin-endpoints.test.ts
@@ -645,6 +645,29 @@ describe('admin endpoint handlers (no-500 regression)', () => {
       const handler = findRouteHandler('get', '/sessions/synced');
       expect(handler).not.toBeNull();
 
+      const archiveQuery = createQueryChain([
+        {
+          id: 'archive-1',
+          session_id: 'session-in-workspace',
+          backend: 'claude',
+          backend_session_id: 'backend-1',
+          line_count: 42,
+          byte_count: 4200,
+          source_path: '/tmp/backend-1.jsonl',
+          synced_at: '2026-03-11T10:00:00Z',
+        },
+        {
+          id: 'archive-2',
+          session_id: 'session-outside-workspace',
+          backend: 'claude',
+          backend_session_id: 'backend-2',
+          line_count: 12,
+          byte_count: 1200,
+          source_path: '/tmp/backend-2.jsonl',
+          synced_at: '2026-03-10T10:00:00Z',
+        },
+      ]);
+
       mockSupabaseFrom.mockImplementation((table: string) => {
         if (table === 'agent_identities') {
           return createQueryChain([
@@ -653,30 +676,7 @@ describe('admin endpoint handlers (no-500 regression)', () => {
         }
 
         if (table === 'session_transcript_archives') {
-          return createQueryChain([
-            {
-              id: 'archive-1',
-              session_id: 'session-in-workspace',
-              backend: 'claude',
-              backend_session_id: 'backend-1',
-              line_count: 42,
-              byte_count: 4200,
-              source_path: '/tmp/backend-1.jsonl',
-              synced_at: '2026-03-11T10:00:00Z',
-              payload: { format: 'jsonl' },
-            },
-            {
-              id: 'archive-2',
-              session_id: 'session-outside-workspace',
-              backend: 'claude',
-              backend_session_id: 'backend-2',
-              line_count: 12,
-              byte_count: 1200,
-              source_path: '/tmp/backend-2.jsonl',
-              synced_at: '2026-03-10T10:00:00Z',
-              payload: { format: 'jsonl' },
-            },
-          ]);
+          return archiveQuery;
         }
 
         if (table === 'sessions') {
@@ -722,6 +722,9 @@ describe('admin endpoint handlers (no-500 regression)', () => {
       await handler!(req, res);
 
       expect(res._status).toBe(200);
+      expect((archiveQuery.select as ReturnType<typeof vi.fn>).mock.calls[0]?.[0]).toBe(
+        'id, session_id, backend, backend_session_id, line_count, byte_count, source_path, synced_at'
+      );
       expect(res._json).toEqual({
         archives: [
           {

--- a/packages/api/src/routes/admin-endpoints.test.ts
+++ b/packages/api/src/routes/admin-endpoints.test.ts
@@ -122,6 +122,7 @@ function createQueryChain(resolvedData: unknown[] | null = [], error: unknown = 
   const chain: Record<string, any> = {};
   chain.select = vi.fn(() => chain);
   chain.insert = vi.fn(() => chain);
+  chain.upsert = vi.fn(() => chain);
   chain.update = vi.fn(() => chain);
   chain.delete = vi.fn(() => chain);
   chain.eq = vi.fn(() => chain);
@@ -623,6 +624,48 @@ describe('admin endpoint handlers (no-500 regression)', () => {
       expect(json.sessions.map((s: any) => s.id)).toEqual(['session-identity', 'session-legacy']);
       expect(json.sessions[0].agentName).toBe('Wren');
       expect(json.stats.total).toBe(2);
+    });
+  });
+
+  // =========================================================================
+  // POST /sessions/:id/sync-transcript — manual transcript archive sync
+  // =========================================================================
+
+  describe('POST /sessions/:id/sync-transcript', () => {
+    it('returns 404 when session identity is outside active workspace', async () => {
+      const handler = findRouteHandler('post', '/sessions/:id/sync-transcript');
+      expect(handler).not.toBeNull();
+
+      mockSupabaseFrom.mockImplementation((table: string) => {
+        if (table === 'agent_identities') {
+          return createQueryChain([{ id: 'identity-1', agent_id: 'wren' }]);
+        }
+
+        if (table === 'sessions') {
+          return createQueryChain([
+            {
+              id: 'session-other-workspace',
+              identity_id: 'identity-other',
+              agent_id: 'wren',
+              backend: 'claude',
+              backend_session_id: 'backend-2',
+              claude_session_id: null,
+            },
+          ]);
+        }
+
+        return createQueryChain([]);
+      });
+
+      const req = createAuthenticatedReq({
+        params: { id: 'session-other-workspace' },
+        body: {},
+      });
+      const res = createMockRes();
+      await handler!(req, res);
+
+      expect(res._status).toBe(404);
+      expect(res._json).toEqual({ error: 'Session not found' });
     });
   });
 

--- a/packages/api/src/routes/admin-endpoints.test.ts
+++ b/packages/api/src/routes/admin-endpoints.test.ts
@@ -194,6 +194,8 @@ function createAuthenticatedReq(overrides: Record<string, unknown> = {}): Reques
 interface MockResponse extends Response {
   _status: number;
   _json: unknown;
+  _sent: unknown;
+  _headers: Record<string, unknown>;
   _cookies: Record<string, unknown>;
 }
 
@@ -201,6 +203,8 @@ function createMockRes(): MockResponse {
   const res: Record<string, unknown> = {
     _status: 200,
     _json: null,
+    _sent: null,
+    _headers: {},
     _cookies: {},
     status(code: number) {
       res._status = code;
@@ -214,7 +218,12 @@ function createMockRes(): MockResponse {
       (res._cookies as Record<string, unknown>)[name] = { value, options };
       return res;
     },
-    setHeader() {
+    setHeader(name: string, value: unknown) {
+      (res._headers as Record<string, unknown>)[name] = value;
+      return res;
+    },
+    send(payload: unknown) {
+      res._sent = payload;
       return res;
     },
     write() {
@@ -624,6 +633,187 @@ describe('admin endpoint handlers (no-500 regression)', () => {
       expect(json.sessions.map((s: any) => s.id)).toEqual(['session-identity', 'session-legacy']);
       expect(json.sessions[0].agentName).toBe('Wren');
       expect(json.stats.total).toBe(2);
+    });
+  });
+
+  // =========================================================================
+  // GET /sessions/synced — list transcript archives available in workspace
+  // =========================================================================
+
+  describe('GET /sessions/synced', () => {
+    it('returns only archives whose sessions are scoped to the active workspace', async () => {
+      const handler = findRouteHandler('get', '/sessions/synced');
+      expect(handler).not.toBeNull();
+
+      mockSupabaseFrom.mockImplementation((table: string) => {
+        if (table === 'agent_identities') {
+          return createQueryChain([
+            { id: 'identity-1', agent_id: 'wren', name: 'Wren', role: 'SB' },
+          ]);
+        }
+
+        if (table === 'session_transcript_archives') {
+          return createQueryChain([
+            {
+              id: 'archive-1',
+              session_id: 'session-in-workspace',
+              backend: 'claude',
+              backend_session_id: 'backend-1',
+              line_count: 42,
+              byte_count: 4200,
+              source_path: '/tmp/backend-1.jsonl',
+              synced_at: '2026-03-11T10:00:00Z',
+              payload: { format: 'jsonl' },
+            },
+            {
+              id: 'archive-2',
+              session_id: 'session-outside-workspace',
+              backend: 'claude',
+              backend_session_id: 'backend-2',
+              line_count: 12,
+              byte_count: 1200,
+              source_path: '/tmp/backend-2.jsonl',
+              synced_at: '2026-03-10T10:00:00Z',
+              payload: { format: 'jsonl' },
+            },
+          ]);
+        }
+
+        if (table === 'sessions') {
+          return createQueryChain([
+            {
+              id: 'session-in-workspace',
+              identity_id: 'identity-1',
+              agent_id: 'wren',
+              backend: 'claude',
+              backend_session_id: 'backend-1',
+              claude_session_id: null,
+              thread_key: 'pr:219',
+              started_at: '2026-03-11T09:00:00Z',
+              updated_at: '2026-03-11T10:05:00Z',
+              working_dir: '/repo',
+              studio_id: 'studio-1',
+              workspace_id: 'studio-1',
+            },
+            {
+              id: 'session-outside-workspace',
+              identity_id: 'identity-other',
+              agent_id: 'wren',
+              backend: 'claude',
+              backend_session_id: 'backend-2',
+              claude_session_id: null,
+              thread_key: 'pr:999',
+              started_at: '2026-03-10T09:00:00Z',
+              updated_at: '2026-03-10T10:05:00Z',
+              working_dir: '/other',
+              studio_id: null,
+              workspace_id: null,
+            },
+          ]);
+        }
+
+        return createQueryChain([]);
+      });
+
+      const req = createAuthenticatedReq({
+        query: { limit: '10' },
+      });
+      const res = createMockRes();
+      await handler!(req, res);
+
+      expect(res._status).toBe(200);
+      expect(res._json).toEqual({
+        archives: [
+          {
+            archiveId: 'archive-1',
+            sessionId: 'session-in-workspace',
+            backend: 'claude',
+            backendSessionId: 'backend-1',
+            format: 'jsonl',
+            lineCount: 42,
+            byteCount: 4200,
+            sourcePath: '/tmp/backend-1.jsonl',
+            syncedAt: '2026-03-11T10:00:00Z',
+            session: {
+              id: 'session-in-workspace',
+              agentId: 'wren',
+              agentName: 'Wren',
+              agentRole: 'SB',
+              backend: 'claude',
+              backendSessionId: 'backend-1',
+              threadKey: 'pr:219',
+              startedAt: '2026-03-11T09:00:00Z',
+              updatedAt: '2026-03-11T10:05:00Z',
+              workingDir: '/repo',
+              studioId: 'studio-1',
+            },
+          },
+        ],
+        count: 1,
+      });
+    });
+  });
+
+  // =========================================================================
+  // GET /sessions/:id/transcript — export synced transcript archive
+  // =========================================================================
+
+  describe('GET /sessions/:id/transcript', () => {
+    it('exports jsonl payload for a workspace-scoped session', async () => {
+      const handler = findRouteHandler('get', '/sessions/:id/transcript');
+      expect(handler).not.toBeNull();
+
+      mockSupabaseFrom.mockImplementation((table: string) => {
+        if (table === 'agent_identities') {
+          return createQueryChain([
+            { id: 'identity-1', agent_id: 'wren', name: 'Wren', role: 'SB' },
+          ]);
+        }
+
+        if (table === 'sessions') {
+          return createQueryChain([
+            {
+              id: 'session-123',
+              identity_id: 'identity-1',
+              agent_id: 'wren',
+            },
+          ]);
+        }
+
+        if (table === 'session_transcript_archives') {
+          return createQueryChain([
+            {
+              payload: {
+                backend: 'claude',
+                backendSessionId: 'backend-1',
+                format: 'jsonl',
+                events: [
+                  { type: 'user', content: 'hello' },
+                  { type: 'assistant', content: 'hi' },
+                ],
+              },
+            },
+          ]);
+        }
+
+        return createQueryChain([]);
+      });
+
+      const req = createAuthenticatedReq({
+        params: { id: 'session-123' },
+        query: { format: 'jsonl', download: '1' },
+      });
+      const res = createMockRes();
+      await handler!(req, res);
+
+      expect(res._status).toBe(200);
+      expect(res._headers['Content-Type']).toBe('application/x-ndjson; charset=utf-8');
+      expect(res._headers['Content-Disposition']).toBe(
+        'attachment; filename="session-session-123-transcript.jsonl"'
+      );
+      expect(res._sent).toBe(
+        '{"type":"user","content":"hello"}\n{"type":"assistant","content":"hi"}\n'
+      );
     });
   });
 

--- a/packages/api/src/routes/admin-sync-transcript.test.ts
+++ b/packages/api/src/routes/admin-sync-transcript.test.ts
@@ -210,7 +210,9 @@ describe('POST /sessions/:id/sync-transcript', () => {
 
     mockSupabaseFrom.mockImplementation((table: string) => {
       if (table === 'agent_identities') {
-        return createQueryChain([{ id: 'identity-1', agent_id: 'lumen' }]);
+        return createQueryChain([
+          { id: 'identity-1', agent_id: 'lumen', name: 'Lumen', role: 'SB' },
+        ]);
       }
 
       if (table === 'sessions') {

--- a/packages/api/src/routes/admin-sync-transcript.test.ts
+++ b/packages/api/src/routes/admin-sync-transcript.test.ts
@@ -1,0 +1,328 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Request, Response } from 'express';
+import path from 'path';
+
+const mockVerifyPcpAccessToken = vi.fn();
+const mockExchangeRefreshToken = vi.fn();
+const mockSignPcpAccessToken = vi.fn();
+const mockCreateRefreshToken = vi.fn();
+
+vi.mock('../auth/pcp-tokens', () => ({
+  verifyPcpAccessToken: (...args: unknown[]) => mockVerifyPcpAccessToken(...args),
+  exchangeRefreshToken: (...args: unknown[]) => mockExchangeRefreshToken(...args),
+  signPcpAccessToken: (...args: unknown[]) => mockSignPcpAccessToken(...args),
+  createRefreshToken: (...args: unknown[]) => mockCreateRefreshToken(...args),
+}));
+
+const mockSupabaseFrom = vi.fn();
+const mockGetUser = vi.fn();
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(() => ({
+    auth: { getUser: mockGetUser },
+    from: (...args: unknown[]) => mockSupabaseFrom(...args),
+  })),
+}));
+
+const mockFindById = vi.fn();
+const mockFindRawById = vi.fn();
+const mockEnsurePersonalWorkspace = vi.fn();
+const mockListMembershipsByUser = vi.fn();
+const mockListTrustedUsers = vi.fn();
+
+vi.mock('../data/composer', () => ({
+  getDataComposer: vi.fn(async () => ({
+    repositories: {
+      workspaces: {
+        findById: mockFindById,
+        findRawById: mockFindRawById,
+        ensurePersonalWorkspace: mockEnsurePersonalWorkspace,
+        listMembershipsByUser: mockListMembershipsByUser,
+      },
+    },
+  })),
+}));
+
+vi.mock('../services/authorization', () => ({
+  getAuthorizationService: vi.fn(() => ({
+    listTrustedUsers: mockListTrustedUsers,
+  })),
+}));
+
+const mockGetConnectedAccounts = vi.fn();
+const mockGetSupportedProviders = vi.fn();
+const mockIsProviderConfigured = vi.fn();
+
+vi.mock('../services/oauth', () => ({
+  getOAuthService: vi.fn(() => ({
+    getConnectedAccounts: mockGetConnectedAccounts,
+    getSupportedProviders: mockGetSupportedProviders,
+    isProviderConfigured: mockIsProviderConfigured,
+  })),
+}));
+
+vi.mock('../config/env', () => ({
+  env: {
+    SUPABASE_URL: 'http://localhost:54321',
+    SUPABASE_SECRET_KEY: 'test-secret',
+    JWT_SECRET: 'test-jwt-secret-that-is-at-least-32-characters-long',
+    NODE_ENV: 'development',
+    MCP_HTTP_PORT: 3001,
+  },
+  isDevelopment: () => true,
+}));
+
+vi.mock('../utils/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock('../utils/request-context', () => ({
+  runWithRequestContext: (_context: Record<string, unknown>, fn: () => void) => {
+    fn();
+  },
+}));
+
+const mockFsReaddir = vi.fn();
+const mockFsReadFile = vi.fn();
+const mockFsStat = vi.fn();
+
+vi.mock('fs', () => ({
+  promises: {
+    readdir: (...args: unknown[]) => mockFsReaddir(...args),
+    readFile: (...args: unknown[]) => mockFsReadFile(...args),
+    stat: (...args: unknown[]) => mockFsStat(...args),
+  },
+}));
+
+import router from './admin';
+
+const TEST_USER_ID = 'user-test-123';
+const TEST_WORKSPACE_ID = 'workspace-test-456';
+
+function createQueryChain(resolvedData: unknown[] | null = [], error: unknown = null) {
+  const chain: Record<string, any> = {};
+  chain.select = vi.fn(() => chain);
+  chain.insert = vi.fn(() => chain);
+  chain.upsert = vi.fn(() => chain);
+  chain.update = vi.fn(() => chain);
+  chain.delete = vi.fn(() => chain);
+  chain.eq = vi.fn(() => chain);
+  chain.neq = vi.fn(() => chain);
+  chain.in = vi.fn(() => chain);
+  chain.is = vi.fn(() => chain);
+  chain.not = vi.fn(() => chain);
+  chain.or = vi.fn(() => chain);
+  chain.gte = vi.fn(() => chain);
+  chain.lte = vi.fn(() => chain);
+  chain.order = vi.fn(() => chain);
+  chain.limit = vi.fn(() => chain);
+  chain.range = vi.fn(() => chain);
+  chain.maybeSingle = vi.fn(() => Promise.resolve({ data: resolvedData?.[0] ?? null, error }));
+  chain.single = vi.fn(() =>
+    Promise.resolve({
+      data: resolvedData?.[0] ?? null,
+      error: resolvedData?.[0] ? null : { code: 'PGRST116', message: 'not found' },
+    })
+  );
+  chain.then = (resolve: (val: any) => any) => resolve({ data: resolvedData, error });
+  return chain;
+}
+
+function findRouteHandler(
+  method: 'post',
+  routePath: string
+): ((req: Request, res: Response) => Promise<void>) | null {
+  const layer = (router as any).stack.find(
+    (entry: any) => entry.route?.path === routePath && entry.route?.methods?.[method]
+  );
+  if (!layer) return null;
+  const handler = layer.route.stack.find((s: any) => s.handle && s.handle.length <= 3);
+  return handler?.handle ?? null;
+}
+
+function createAuthenticatedReq(overrides: Record<string, unknown> = {}): Request {
+  return {
+    headers: { authorization: 'Bearer test-token' },
+    cookies: {},
+    params: {},
+    body: {},
+    query: {},
+    path: '/test',
+    user: { email: 'test@example.com' },
+    pcpUserId: TEST_USER_ID,
+    pcpWorkspaceId: TEST_WORKSPACE_ID,
+    pcpWorkspaceRole: 'member',
+    header: vi.fn(() => undefined),
+    ...overrides,
+  } as unknown as Request;
+}
+
+interface MockResponse extends Response {
+  _status: number;
+  _json: unknown;
+}
+
+function createMockRes(): MockResponse {
+  const res: Record<string, unknown> = {
+    _status: 200,
+    _json: null,
+    status(code: number) {
+      res._status = code;
+      return res;
+    },
+    json(payload: unknown) {
+      res._json = payload;
+      return res;
+    },
+  };
+  return res as unknown as MockResponse;
+}
+
+describe('POST /sessions/:id/sync-transcript', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockVerifyPcpAccessToken.mockReturnValue({
+      type: 'pcp_admin',
+      sub: TEST_USER_ID,
+      email: 'test@example.com',
+      scope: 'admin',
+    });
+    mockEnsurePersonalWorkspace.mockResolvedValue({ id: TEST_WORKSPACE_ID });
+  });
+
+  it('upserts a synced transcript archive and returns sync metadata', async () => {
+    const handler = findRouteHandler('post', '/sessions/:id/sync-transcript');
+    expect(handler).not.toBeNull();
+
+    const transcriptFile = path.join(
+      process.cwd(),
+      '.pcp',
+      'runtime',
+      'repl',
+      'session-1-1700000000000.jsonl'
+    );
+    const archiveChain = createQueryChain([]);
+
+    mockSupabaseFrom.mockImplementation((table: string) => {
+      if (table === 'agent_identities') {
+        return createQueryChain([{ id: 'identity-1', agent_id: 'lumen' }]);
+      }
+
+      if (table === 'sessions') {
+        return createQueryChain([
+          {
+            id: 'session-1',
+            identity_id: 'identity-1',
+            agent_id: 'lumen',
+            backend: 'pcp',
+            backend_session_id: 'backend-1',
+            claude_session_id: null,
+          },
+        ]);
+      }
+
+      if (table === 'session_transcript_archives') {
+        return archiveChain;
+      }
+
+      return createQueryChain([]);
+    });
+
+    mockFsReaddir.mockImplementation(async (dir: string) => {
+      if (dir.endsWith(path.join('.pcp', 'runtime', 'repl'))) {
+        return [
+          {
+            name: 'session-1-1700000000000.jsonl',
+            isFile: () => true,
+            isDirectory: () => false,
+          },
+        ];
+      }
+      throw new Error(`ENOENT: ${dir}`);
+    });
+
+    mockFsStat.mockImplementation(async (filePath: string) => {
+      if (filePath === transcriptFile) {
+        return {
+          isFile: () => true,
+          mtimeMs: 1700000000000,
+        };
+      }
+      throw new Error(`ENOENT: ${filePath}`);
+    });
+
+    mockFsReadFile.mockImplementation(async (filePath: string) => {
+      if (filePath === transcriptFile) {
+        return [
+          JSON.stringify({
+            type: 'user',
+            content: 'hello from local transcript',
+            timestamp: '2026-03-11T15:00:00.000Z',
+          }),
+          JSON.stringify({
+            type: 'assistant',
+            content: 'hello from synced archive',
+            timestamp: '2026-03-11T15:00:05.000Z',
+          }),
+          '',
+        ].join('\n');
+      }
+      throw new Error(`ENOENT: ${filePath}`);
+    });
+
+    const req = createAuthenticatedReq({
+      params: { id: 'session-1' },
+      body: {},
+    });
+    const res = createMockRes();
+    await handler!(req, res);
+
+    expect(res._status).toBe(200);
+    expect(res._json).toMatchObject({
+      ok: true,
+      sessionId: 'session-1',
+      backend: 'pcp',
+      backendSessionId: 'backend-1',
+      format: 'jsonl',
+      sourcePath: transcriptFile,
+      resolvedBy: 'pcp-runtime',
+      lineCount: 2,
+    });
+
+    expect(archiveChain.upsert).toHaveBeenCalledTimes(1);
+    const [archiveRow, options] = archiveChain.upsert.mock.calls[0];
+    expect(options).toEqual({ onConflict: 'session_id' });
+    expect(archiveRow).toMatchObject({
+      user_id: TEST_USER_ID,
+      session_id: 'session-1',
+      backend: 'pcp',
+      backend_session_id: 'backend-1',
+      source_path: transcriptFile,
+      line_count: 2,
+    });
+    expect(archiveRow.payload).toMatchObject({
+      version: 1,
+      backend: 'pcp',
+      backendSessionId: 'backend-1',
+      format: 'jsonl',
+      sourcePath: transcriptFile,
+      events: [
+        {
+          type: 'user',
+          content: 'hello from local transcript',
+          timestamp: '2026-03-11T15:00:00.000Z',
+        },
+        {
+          type: 'assistant',
+          content: 'hello from synced archive',
+          timestamp: '2026-03-11T15:00:05.000Z',
+        },
+      ],
+    });
+  });
+});

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -92,10 +92,12 @@ type ChannelRouteRow = {
 const ADMIN_ACCESS_TOKEN_LIFETIME_SECONDS = 3600; // 1 hour
 const ADMIN_REFRESH_TOKEN_LIFETIME_DAYS = 90;
 const ADMIN_CLIENT_ID = 'dashboard';
+const MCP_SYNC_TRANSCRIPT_ROUTE = /^\/sessions\/[^/]+\/sync-transcript$/;
 const DEFAULT_SESSION_LOG_LIMIT = 50;
 const MAX_SESSION_LOG_LIMIT = 200;
 const ACTIVITY_PREVIEW_LIMIT_PER_SESSION = 3;
 const LOCAL_TRANSCRIPT_LINE_LIMIT = 200;
+const SYNCED_TRANSCRIPT_LINE_LIMIT = 5000;
 
 function formatCommentAuthorUserName(user: CommentAuthorUser | null): string | null {
   if (!user) return null;
@@ -107,7 +109,7 @@ function formatCommentAuthorUserName(user: CommentAuthorUser | null): string | n
 
 type SessionPreviewItem = {
   id: string;
-  source: 'activity_stream' | 'session_logs' | 'local_transcript';
+  source: 'activity_stream' | 'session_logs' | 'local_transcript' | 'synced_transcript';
   type: string;
   role: 'in' | 'out' | 'system';
   content: string;
@@ -342,88 +344,447 @@ async function findTranscriptFile(
   return walk(rootDir, 0);
 }
 
-async function tryReadLocalTranscript(
-  backendSessionId: string | null,
-  backend: string | null
-): Promise<SessionLogItem[]> {
-  if (!backendSessionId) return [];
+async function collectMatchingFiles(
+  rootDir: string,
+  maxDepth: number,
+  matcher: (entryName: string, fullPath: string) => boolean
+): Promise<string[]> {
+  const results: string[] = [];
+  const stack: Array<{ dir: string; depth: number }> = [{ dir: rootDir, depth: 0 }];
 
-  const transcriptFileName = `${backendSessionId}.jsonl`;
-  const roots = [path.join(os.homedir(), '.claude', 'projects')];
-  if (backend?.toLowerCase().includes('codex')) {
-    roots.push(path.join(os.homedir(), '.codex', 'sessions'));
-    roots.push(path.join(os.homedir(), '.codex', 'projects'));
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (!current || current.depth > maxDepth) continue;
+
+    let entries: Array<{
+      name: string;
+      isFile: () => boolean;
+      isDirectory: () => boolean;
+    }>;
+    try {
+      entries = (await fs.readdir(current.dir, {
+        withFileTypes: true,
+        encoding: 'utf8',
+      })) as unknown as Array<{
+        name: string;
+        isFile: () => boolean;
+        isDirectory: () => boolean;
+      }>;
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      const fullPath = path.join(current.dir, entry.name);
+      if (entry.isFile() && matcher(entry.name, fullPath)) {
+        results.push(fullPath);
+      }
+      if (entry.isDirectory()) {
+        stack.push({ dir: fullPath, depth: current.depth + 1 });
+      }
+    }
   }
 
-  let transcriptPath: string | null = null;
+  return results;
+}
+
+async function pickNewestPath(paths: string[]): Promise<string | null> {
+  let newest: { filePath: string; mtimeMs: number } | null = null;
+
+  for (const filePath of paths) {
+    try {
+      const stats = await fs.stat(filePath);
+      if (!stats.isFile()) continue;
+      if (!newest || stats.mtimeMs > newest.mtimeMs) {
+        newest = { filePath, mtimeMs: stats.mtimeMs };
+      }
+    } catch {
+      // Ignore missing/unreadable files.
+    }
+  }
+
+  return newest?.filePath || null;
+}
+
+function normalizeTranscriptTimestamp(candidate: unknown): string {
+  if (typeof candidate !== 'string' || !candidate.trim()) {
+    return new Date(0).toISOString();
+  }
+  const ms = Date.parse(candidate);
+  return Number.isFinite(ms) ? new Date(ms).toISOString() : new Date(0).toISOString();
+}
+
+function inferTranscriptType(payload: Record<string, unknown>): string {
+  const rawType =
+    (typeof payload.type === 'string' && payload.type.trim()) ||
+    (typeof payload.event === 'string' && payload.event.trim()) ||
+    (typeof payload.kind === 'string' && payload.kind.trim()) ||
+    null;
+  return rawType || 'transcript';
+}
+
+function inferTranscriptRole(
+  payload: Record<string, unknown>,
+  rawType: string
+): 'in' | 'out' | 'system' {
+  const roleCandidate = typeof payload.role === 'string' ? payload.role.toLowerCase() : '';
+  if (roleCandidate === 'user' || roleCandidate === 'in') return 'in';
+  if (roleCandidate === 'assistant' || roleCandidate === 'out' || roleCandidate === 'model') {
+    return 'out';
+  }
+
+  const loweredType = rawType.toLowerCase();
+  if (loweredType.includes('user') || loweredType.includes('input')) return 'in';
+  if (
+    loweredType.includes('assistant') ||
+    loweredType.includes('output') ||
+    loweredType.includes('model')
+  ) {
+    return 'out';
+  }
+  return 'system';
+}
+
+function parseJsonlEvents(fileContent: string): unknown[] {
+  const events: unknown[] = [];
+  const lines = fileContent
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  for (const line of lines) {
+    try {
+      events.push(JSON.parse(line) as unknown);
+    } catch {
+      events.push({ type: 'raw_line', text: line });
+    }
+  }
+
+  return events;
+}
+
+function parseJsonEvents(fileContent: string): unknown[] {
+  try {
+    const parsed = JSON.parse(fileContent) as unknown;
+    if (Array.isArray(parsed)) return parsed;
+    if (parsed && typeof parsed === 'object') {
+      const obj = parsed as Record<string, unknown>;
+      if (Array.isArray(obj.messages)) return obj.messages;
+      return [obj];
+    }
+    return [{ value: parsed }];
+  } catch {
+    return [{ type: 'raw_json', text: fileContent }];
+  }
+}
+
+function transcriptEventsToLogItems(options: {
+  events: unknown[];
+  source: 'local_transcript' | 'synced_transcript';
+  idPrefix: string;
+  truncateTo?: number;
+  metadata?: Record<string, unknown>;
+}): SessionLogItem[] {
+  const events = options.truncateTo
+    ? options.events.slice(Math.max(0, options.events.length - options.truncateTo))
+    : options.events;
+  const items: SessionLogItem[] = [];
+
+  for (let i = 0; i < events.length; i++) {
+    const event = events[i];
+    if (!event || typeof event !== 'object' || Array.isArray(event)) continue;
+    const payload = event as Record<string, unknown>;
+    const content = truncateText(pickContentFromUnknown(payload));
+    if (!content) continue;
+
+    const rawType = inferTranscriptType(payload);
+    const timestamp = normalizeTranscriptTimestamp(
+      payload.timestamp ||
+        payload.created_at ||
+        payload.createdAt ||
+        payload.time ||
+        payload.ts ||
+        payload.lastUpdated
+    );
+
+    items.push({
+      id: `${options.idPrefix}:${i}`,
+      source: options.source,
+      type: rawType,
+      role: inferTranscriptRole(payload, rawType),
+      content,
+      timestamp,
+      metadata: options.metadata
+        ? {
+            ...options.metadata,
+          }
+        : undefined,
+    });
+  }
+
+  return items;
+}
+
+type TranscriptFormat = 'jsonl' | 'json';
+
+type LocalTranscriptDescriptor = {
+  path: string;
+  format: TranscriptFormat;
+  backend: string | null;
+  backendSessionId: string | null;
+  resolvedBy: string;
+};
+
+type TranscriptReadResult = {
+  events: unknown[];
+  lineCount: number;
+  byteCount: number;
+};
+
+function getAncestorDirs(start: string, maxDepth = 6): string[] {
+  const resolved = path.resolve(start);
+  const out: string[] = [];
+  let current = resolved;
+
+  for (let i = 0; i <= maxDepth; i++) {
+    out.push(current);
+    const parent = path.dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+
+  return out;
+}
+
+async function findCodexTranscriptFile(backendSessionId: string): Promise<string | null> {
+  const roots = [
+    path.join(os.homedir(), '.codex', 'sessions'),
+    path.join(os.homedir(), '.codex', 'projects'),
+  ];
+  const matches: string[] = [];
+  const suffix = `${backendSessionId}.jsonl`;
+
   for (const root of roots) {
-    transcriptPath = await findTranscriptFile(root, transcriptFileName, 5);
-    if (transcriptPath) break;
+    const rootMatches = await collectMatchingFiles(root, 6, (name) => {
+      if (!name.endsWith('.jsonl')) return false;
+      return name === suffix || name.endsWith(`-${suffix}`) || name.includes(backendSessionId);
+    });
+    matches.push(...rootMatches);
   }
-  if (!transcriptPath) return [];
 
+  return pickNewestPath(matches);
+}
+
+async function findGeminiTranscriptFile(backendSessionId: string): Promise<string | null> {
+  const geminiTmp = path.join(os.homedir(), '.gemini', 'tmp');
+  const candidates = await collectMatchingFiles(geminiTmp, 7, (name) => {
+    return name.startsWith('session-') && name.endsWith('.json');
+  });
+  const ordered = (
+    await Promise.all(
+      candidates.map(async (filePath) => {
+        try {
+          const stats = await fs.stat(filePath);
+          return { filePath, mtimeMs: stats.mtimeMs };
+        } catch {
+          return null;
+        }
+      })
+    )
+  )
+    .filter((entry): entry is { filePath: string; mtimeMs: number } => Boolean(entry))
+    .sort((a, b) => b.mtimeMs - a.mtimeMs);
+
+  for (const candidate of ordered) {
+    try {
+      const content = await fs.readFile(candidate.filePath, 'utf8');
+      const parsed = JSON.parse(content) as { sessionId?: string };
+      if (parsed.sessionId === backendSessionId) return candidate.filePath;
+    } catch {
+      // Ignore unreadable/malformed files.
+    }
+  }
+
+  return null;
+}
+
+async function findPcpTranscriptFile(sessionId: string): Promise<string | null> {
+  const roots = new Set<string>();
+  for (const dir of getAncestorDirs(process.cwd(), 8)) {
+    roots.add(path.join(dir, '.pcp', 'runtime', 'repl'));
+  }
+  roots.add(path.join(os.homedir(), '.pcp', 'runtime', 'repl'));
+
+  const matches: string[] = [];
+  for (const root of roots) {
+    const rootMatches = await collectMatchingFiles(root, 0, (name) => {
+      return name.startsWith(`${sessionId}-`) && name.endsWith('.jsonl');
+    });
+    matches.push(...rootMatches);
+  }
+
+  return pickNewestPath(matches);
+}
+
+async function resolveLocalTranscriptDescriptor(options: {
+  sessionId: string;
+  backend: string | null;
+  backendSessionId: string | null;
+}): Promise<LocalTranscriptDescriptor | null> {
+  const normalizedBackend = options.backend?.toLowerCase() || '';
+  const backendSessionId = options.backendSessionId;
+
+  if (normalizedBackend.includes('pcp')) {
+    const pcpPath = await findPcpTranscriptFile(options.sessionId);
+    if (pcpPath) {
+      return {
+        path: pcpPath,
+        format: 'jsonl',
+        backend: options.backend,
+        backendSessionId,
+        resolvedBy: 'pcp-runtime',
+      };
+    }
+  }
+
+  if (normalizedBackend.includes('gemini') && backendSessionId) {
+    const geminiPath = await findGeminiTranscriptFile(backendSessionId);
+    if (geminiPath) {
+      return {
+        path: geminiPath,
+        format: 'json',
+        backend: options.backend,
+        backendSessionId,
+        resolvedBy: 'gemini-session-id',
+      };
+    }
+  }
+
+  if (normalizedBackend.includes('codex') && backendSessionId) {
+    const codexPath = await findCodexTranscriptFile(backendSessionId);
+    if (codexPath) {
+      return {
+        path: codexPath,
+        format: 'jsonl',
+        backend: options.backend,
+        backendSessionId,
+        resolvedBy: 'codex-session-id',
+      };
+    }
+  }
+
+  if (backendSessionId) {
+    const transcriptFileName = `${backendSessionId}.jsonl`;
+    const roots = [path.join(os.homedir(), '.claude', 'projects')];
+    if (normalizedBackend.includes('codex')) {
+      roots.push(path.join(os.homedir(), '.codex', 'sessions'));
+      roots.push(path.join(os.homedir(), '.codex', 'projects'));
+    }
+
+    for (const root of roots) {
+      const transcriptPath = await findTranscriptFile(root, transcriptFileName, 5);
+      if (transcriptPath) {
+        return {
+          path: transcriptPath,
+          format: 'jsonl',
+          backend: options.backend,
+          backendSessionId,
+          resolvedBy: 'exact-jsonl-name',
+        };
+      }
+    }
+  }
+
+  return null;
+}
+
+async function readTranscriptFromDescriptor(
+  descriptor: LocalTranscriptDescriptor
+): Promise<TranscriptReadResult | null> {
   let fileContent = '';
   try {
-    fileContent = await fs.readFile(transcriptPath, 'utf8');
+    fileContent = await fs.readFile(descriptor.path, 'utf8');
   } catch {
-    return [];
+    return null;
+  }
+
+  const byteCount = Buffer.byteLength(fileContent, 'utf8');
+  if (descriptor.format === 'json') {
+    const events = parseJsonEvents(fileContent);
+    return {
+      events,
+      lineCount: events.length,
+      byteCount,
+    };
   }
 
   const lines = fileContent
     .split('\n')
     .map((line) => line.trim())
     .filter(Boolean);
+  const events = parseJsonlEvents(fileContent);
+  return {
+    events,
+    lineCount: lines.length,
+    byteCount,
+  };
+}
 
-  const recent = lines.slice(-LOCAL_TRANSCRIPT_LINE_LIMIT);
-  const items: SessionLogItem[] = [];
+async function tryReadLocalTranscript(options: {
+  sessionId: string;
+  backendSessionId: string | null;
+  backend: string | null;
+}): Promise<SessionLogItem[]> {
+  const descriptor = await resolveLocalTranscriptDescriptor(options);
+  if (!descriptor) return [];
 
-  for (let i = 0; i < recent.length; i++) {
-    const line = recent[i];
-    try {
-      const parsed = JSON.parse(line) as Record<string, unknown>;
-      const timestampCandidate =
-        parsed.timestamp ||
-        parsed.created_at ||
-        parsed.createdAt ||
-        parsed.time ||
-        parsed.ts ||
-        null;
-      const timestamp =
-        typeof timestampCandidate === 'string' && timestampCandidate
-          ? timestampCandidate
-          : new Date(0).toISOString();
+  const parsed = await readTranscriptFromDescriptor(descriptor);
+  if (!parsed) return [];
 
-      const rawType =
-        (typeof parsed.type === 'string' && parsed.type) ||
-        (typeof parsed.event === 'string' && parsed.event) ||
-        'local';
-      const role: 'in' | 'out' | 'system' =
-        rawType.includes('user') || rawType.includes('input')
-          ? 'in'
-          : rawType.includes('assistant') || rawType.includes('output')
-            ? 'out'
-            : 'system';
+  return transcriptEventsToLogItems({
+    events: parsed.events,
+    source: 'local_transcript',
+    idPrefix: `local:${options.sessionId}`,
+    truncateTo: LOCAL_TRANSCRIPT_LINE_LIMIT,
+    metadata: {
+      path: descriptor.path,
+      format: descriptor.format,
+      resolvedBy: descriptor.resolvedBy,
+      backend: descriptor.backend || null,
+      backendSessionId: descriptor.backendSessionId,
+    },
+  }).sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
+}
 
-      const content = truncateText(pickContentFromUnknown(parsed));
-      if (!content) continue;
+function parseSyncedTranscriptEvents(payload: unknown): unknown[] {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return [];
+  const obj = payload as Record<string, unknown>;
+  if (Array.isArray(obj.events)) return obj.events;
+  return [];
+}
 
-      items.push({
-        id: `local:${i}`,
-        source: 'local_transcript',
-        type: rawType,
-        role,
-        content,
-        timestamp,
-        metadata: {
-          path: transcriptPath,
-        },
-      });
-    } catch {
-      // Ignore non-JSON lines.
-    }
-  }
-
-  return items.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
+function toSyncedTranscriptLogItems(row: {
+  id: string;
+  payload: unknown;
+  backend: string | null;
+  backend_session_id: string | null;
+  source_path: string | null;
+  synced_at: string;
+}): SessionLogItem[] {
+  const events = parseSyncedTranscriptEvents(row.payload);
+  return transcriptEventsToLogItems({
+    events,
+    source: 'synced_transcript',
+    idPrefix: `synced:${row.id}`,
+    truncateTo: SYNCED_TRANSCRIPT_LINE_LIMIT,
+    metadata: {
+      archiveId: row.id,
+      backend: row.backend,
+      backendSessionId: row.backend_session_id,
+      sourcePath: row.source_path,
+      syncedAt: row.synced_at,
+    },
+  }).sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
 }
 
 async function fetchCloudSessionLogs(
@@ -458,6 +819,24 @@ async function fetchCloudSessionLogs(
   return [...activityItems, ...sessionItems].sort(
     (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
   );
+}
+
+async function fetchSyncedTranscriptLogs(
+  supabase: SupabaseClient<Database>,
+  userId: string,
+  sessionId: string
+): Promise<SessionLogItem[]> {
+  const { data: archivedRows } = await supabase
+    .from('session_transcript_archives')
+    .select('id, payload, backend, backend_session_id, source_path, synced_at')
+    .eq('user_id', userId)
+    .eq('session_id', sessionId)
+    .order('synced_at', { ascending: false })
+    .limit(1);
+
+  const row = archivedRows?.[0];
+  if (!row) return [];
+  return toSyncedTranscriptLogItems(row);
 }
 
 /**
@@ -506,6 +885,16 @@ async function adminAuthMiddleware(req: Request, res: Response, next: NextFuncti
     if (payload) {
       pcpUserId = payload.sub;
       userEmail = payload.email;
+    }
+
+    // Convenience path: allow standard MCP access tokens for transcript sync,
+    // so CLI users can run sync without dashboard cookie auth.
+    if (!pcpUserId && req.method === 'POST' && MCP_SYNC_TRANSCRIPT_ROUTE.test(req.path)) {
+      const mcpPayload = verifyPcpAccessToken(token, 'mcp_access');
+      if (mcpPayload) {
+        pcpUserId = mcpPayload.sub;
+        userEmail = mcpPayload.email;
+      }
     }
 
     // --- Tier 2: Refresh token exchange (1 DB call, ~once/hour) ---
@@ -4530,8 +4919,146 @@ router.get('/studios', async (req: Request, res: Response) => {
 });
 
 /**
+ * POST /api/admin/sessions/:id/sync-transcript
+ * Sync full local backend transcript into Postgres jsonb for cross-server portability.
+ */
+router.post('/sessions/:id/sync-transcript', async (req: Request, res: Response) => {
+  try {
+    const sessionId = req.params.id;
+    const authReq = req as AdminAuthRequest;
+    const backendOverride = normalizeNullableText((req.body as Record<string, unknown>)?.backend);
+    const backendSessionOverride = normalizeNullableText(
+      (req.body as Record<string, unknown>)?.backendSessionId
+    );
+
+    const supabase = createClient(env.SUPABASE_URL, env.SUPABASE_SECRET_KEY, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+
+    const { data: scopedIdentities, error: scopedIdentityError } = await supabase
+      .from('agent_identities')
+      .select('id, agent_id')
+      .eq('user_id', authReq.pcpUserId)
+      .eq('workspace_id', authReq.pcpWorkspaceId);
+
+    if (scopedIdentityError) {
+      logger.error(
+        'Failed to resolve workspace identities for session transcript sync:',
+        scopedIdentityError
+      );
+      res.status(500).json(errorJson('Failed to sync transcript', scopedIdentityError));
+      return;
+    }
+
+    const scopedIdentityIds = (scopedIdentities || []).map((i) => i.id);
+    const scopedAgentIds = new Set(
+      (scopedIdentities || [])
+        .map((i) => i.agent_id)
+        .filter((agentId): agentId is string => Boolean(agentId))
+    );
+
+    if (scopedIdentityIds.length === 0) {
+      res.status(404).json({ error: 'Session not found' });
+      return;
+    }
+
+    const { data: session, error: sessionError } = await supabase
+      .from('sessions')
+      .select('id, identity_id, agent_id, backend, backend_session_id, claude_session_id')
+      .eq('id', sessionId)
+      .eq('user_id', authReq.pcpUserId)
+      .single();
+
+    const sessionInWorkspace =
+      session &&
+      ((session.identity_id && scopedIdentityIds.includes(session.identity_id)) ||
+        (!session.identity_id && session.agent_id && scopedAgentIds.has(session.agent_id)));
+
+    if (sessionError || !session || !sessionInWorkspace) {
+      res.status(404).json({ error: 'Session not found' });
+      return;
+    }
+
+    const backendSessionId =
+      backendSessionOverride || session.backend_session_id || session.claude_session_id || null;
+    const backend = backendOverride || session.backend || null;
+
+    const descriptor = await resolveLocalTranscriptDescriptor({
+      sessionId: session.id,
+      backend,
+      backendSessionId,
+    });
+
+    if (!descriptor) {
+      res.status(404).json({
+        error: 'Transcript source not found',
+        details: {
+          backend,
+          backendSessionId,
+        },
+      });
+      return;
+    }
+
+    const parsed = await readTranscriptFromDescriptor(descriptor);
+    if (!parsed) {
+      res.status(500).json({ error: 'Failed to read transcript source' });
+      return;
+    }
+
+    const syncedAt = new Date().toISOString();
+    const payload = {
+      version: 1,
+      backend,
+      backendSessionId,
+      format: descriptor.format,
+      sourcePath: descriptor.path,
+      syncedAt,
+      events: parsed.events,
+    };
+
+    const { error: archiveError } = await supabase.from('session_transcript_archives').upsert(
+      {
+        user_id: authReq.pcpUserId,
+        session_id: session.id,
+        backend,
+        backend_session_id: backendSessionId,
+        payload,
+        line_count: parsed.lineCount,
+        byte_count: parsed.byteCount,
+        source_path: descriptor.path,
+        synced_at: syncedAt,
+      },
+      { onConflict: 'session_id' }
+    );
+
+    if (archiveError) {
+      logger.error('Failed to upsert session transcript archive:', archiveError);
+      res.status(500).json(errorJson('Failed to sync transcript', archiveError));
+      return;
+    }
+
+    res.json({
+      ok: true,
+      sessionId: session.id,
+      backend,
+      backendSessionId,
+      format: descriptor.format,
+      sourcePath: descriptor.path,
+      resolvedBy: descriptor.resolvedBy,
+      lineCount: parsed.lineCount,
+      byteCount: parsed.byteCount,
+      syncedAt,
+    });
+  } catch (error) {
+    logger.error('Failed to sync session transcript:', error);
+    res.status(500).json(errorJson('Failed to sync transcript', error));
+  }
+});
+
+/**
  * GET /api/admin/sessions/:id/logs
- * Get merged session logs (activity stream + session_logs + optional local transcript fallback)
+ * Get merged session logs (activity stream + session_logs + synced transcript + optional local fallback)
  */
 router.get('/sessions/:id/logs', async (req: Request, res: Response) => {
   try {
@@ -4600,17 +5127,20 @@ router.get('/sessions/:id/logs', async (req: Request, res: Response) => {
       return;
     }
 
-    const [cloudLogs, localLogs] = await Promise.all([
+    const [cloudLogs, syncedLogs, localLogs] = await Promise.all([
       fetchCloudSessionLogs(supabase, authReq.pcpUserId, sessionId),
+      fetchSyncedTranscriptLogs(supabase, authReq.pcpUserId, sessionId),
       includeLocal
-        ? tryReadLocalTranscript(
-            session.backend_session_id || session.claude_session_id,
-            session.backend
-          )
+        ? tryReadLocalTranscript({
+            sessionId: session.id,
+            backendSessionId: session.backend_session_id || session.claude_session_id,
+            backend: session.backend,
+          })
         : Promise.resolve([]),
     ]);
 
-    const merged = [...cloudLogs, ...localLogs].sort(
+    const effectiveLocalLogs = syncedLogs.length > 0 ? [] : localLogs;
+    const merged = [...cloudLogs, ...syncedLogs, ...effectiveLocalLogs].sort(
       (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
     );
     const page = merged.slice(offset, offset + limit);
@@ -4636,7 +5166,8 @@ router.get('/sessions/:id/logs', async (req: Request, res: Response) => {
       },
       sources: {
         cloud: cloudLogs.length,
-        local: localLogs.length,
+        synced: syncedLogs.length,
+        local: effectiveLocalLogs.length,
       },
     });
   } catch (error) {

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -556,6 +556,7 @@ type TranscriptReadResult = {
   events: unknown[];
   lineCount: number;
   byteCount: number;
+  rawContent: string;
 };
 
 function getAncestorDirs(start: string, maxDepth = 6): string[] {
@@ -732,6 +733,7 @@ async function readTranscriptFromDescriptor(
       events,
       lineCount: events.length,
       byteCount,
+      rawContent: fileContent,
     };
   }
 
@@ -744,6 +746,7 @@ async function readTranscriptFromDescriptor(
     events,
     lineCount: lines.length,
     byteCount,
+    rawContent: fileContent,
   };
 }
 
@@ -5302,6 +5305,7 @@ router.post('/sessions/:id/sync-transcript', async (req: Request, res: Response)
       format: descriptor.format,
       sourcePath: descriptor.path,
       syncedAt,
+      rawContent: parsed.rawContent,
       events: parsed.events,
     };
 

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -905,10 +905,12 @@ function isSessionInWorkspace(
   return false;
 }
 
-function extractTranscriptFormat(payload: unknown): TranscriptFormat | null {
-  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return null;
-  const value = (payload as Record<string, unknown>).format;
-  if (value === 'json' || value === 'jsonl') return value;
+function inferTranscriptFormatFromPath(
+  sourcePath: string | null | undefined
+): TranscriptFormat | null {
+  if (!sourcePath) return null;
+  if (sourcePath.endsWith('.jsonl')) return 'jsonl';
+  if (sourcePath.endsWith('.json')) return 'json';
   return null;
 }
 
@@ -5034,7 +5036,7 @@ router.get('/sessions/synced', async (req: Request, res: Response) => {
     const { data: archiveRows, error: archiveError } = await supabase
       .from('session_transcript_archives')
       .select(
-        'id, session_id, backend, backend_session_id, line_count, byte_count, source_path, synced_at, payload'
+        'id, session_id, backend, backend_session_id, line_count, byte_count, source_path, synced_at'
       )
       .eq('user_id', authReq.pcpUserId)
       .order('synced_at', { ascending: false })
@@ -5101,7 +5103,7 @@ router.get('/sessions/synced', async (req: Request, res: Response) => {
         const session = sessionsById.get(row.session_id);
         if (!session || !isSessionInWorkspace(session, scope)) return null;
 
-        const format = extractTranscriptFormat(row.payload);
+        const format = inferTranscriptFormatFromPath(row.source_path);
         const identity = session.agent_id ? identityByAgentId.get(session.agent_id) : null;
         return {
           archiveId: row.id,

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -92,7 +92,7 @@ type ChannelRouteRow = {
 const ADMIN_ACCESS_TOKEN_LIFETIME_SECONDS = 3600; // 1 hour
 const ADMIN_REFRESH_TOKEN_LIFETIME_DAYS = 90;
 const ADMIN_CLIENT_ID = 'dashboard';
-const MCP_SYNC_TRANSCRIPT_ROUTE = /^\/sessions\/[^/]+\/sync-transcript$/;
+const MCP_CLI_TRANSCRIPT_ROUTE = /^\/sessions(?:\/synced|\/[^/]+\/(?:sync-transcript|transcript))$/;
 const DEFAULT_SESSION_LOG_LIMIT = 50;
 const MAX_SESSION_LOG_LIMIT = 200;
 const ACTIVITY_PREVIEW_LIMIT_PER_SESSION = 3;
@@ -118,6 +118,23 @@ type SessionPreviewItem = {
 
 type SessionLogItem = SessionPreviewItem & {
   metadata?: Record<string, unknown>;
+};
+
+type WorkspaceIdentityScope = {
+  rows: Array<{
+    id: string;
+    agent_id: string;
+    name: string;
+    role: string | null;
+  }>;
+  identityIds: string[];
+  agentIds: Set<string>;
+};
+
+type WorkspaceScopedSessionRow = {
+  id: string;
+  identity_id: string | null;
+  agent_id: string | null;
 };
 
 function truncateText(input: string, max = 280): string {
@@ -839,6 +856,59 @@ async function fetchSyncedTranscriptLogs(
   return toSyncedTranscriptLogItems(row);
 }
 
+async function resolveWorkspaceIdentityScope(
+  supabase: SupabaseClient<Database>,
+  userId: string,
+  workspaceId: string
+): Promise<{ scope: WorkspaceIdentityScope | null; error: unknown }> {
+  const { data: scopedIdentities, error } = await supabase
+    .from('agent_identities')
+    .select('id, agent_id, name, role')
+    .eq('user_id', userId)
+    .eq('workspace_id', workspaceId);
+
+  if (error) {
+    return { scope: null, error };
+  }
+
+  const rows = (scopedIdentities || []).filter(
+    (
+      row
+    ): row is {
+      id: string;
+      agent_id: string;
+      name: string;
+      role: string | null;
+    } => Boolean(row.id) && Boolean(row.agent_id) && Boolean(row.name)
+  );
+
+  return {
+    scope: {
+      rows,
+      identityIds: rows.map((row) => row.id),
+      agentIds: new Set(rows.map((row) => row.agent_id)),
+    },
+    error: null,
+  };
+}
+
+function isSessionInWorkspace(
+  session: WorkspaceScopedSessionRow | null | undefined,
+  scope: WorkspaceIdentityScope
+): boolean {
+  if (!session) return false;
+  if (session.identity_id && scope.identityIds.includes(session.identity_id)) return true;
+  if (!session.identity_id && session.agent_id && scope.agentIds.has(session.agent_id)) return true;
+  return false;
+}
+
+function extractTranscriptFormat(payload: unknown): TranscriptFormat | null {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return null;
+  const value = (payload as Record<string, unknown>).format;
+  if (value === 'json' || value === 'jsonl') return value;
+  return null;
+}
+
 /**
  * Set the WhatsApp listener for admin endpoints
  */
@@ -889,7 +959,11 @@ async function adminAuthMiddleware(req: Request, res: Response, next: NextFuncti
 
     // Convenience path: allow standard MCP access tokens for transcript sync,
     // so CLI users can run sync without dashboard cookie auth.
-    if (!pcpUserId && req.method === 'POST' && MCP_SYNC_TRANSCRIPT_ROUTE.test(req.path)) {
+    if (
+      !pcpUserId &&
+      (req.method === 'POST' || req.method === 'GET') &&
+      MCP_CLI_TRANSCRIPT_ROUTE.test(req.path)
+    ) {
       const mcpPayload = verifyPcpAccessToken(token, 'mcp_access');
       if (mcpPayload) {
         pcpUserId = mcpPayload.sub;
@@ -4919,6 +4993,232 @@ router.get('/studios', async (req: Request, res: Response) => {
 });
 
 /**
+ * GET /api/admin/sessions/synced
+ * List synced transcript archives available in the active workspace scope.
+ */
+router.get('/sessions/synced', async (req: Request, res: Response) => {
+  try {
+    const authReq = req as AdminAuthRequest;
+    const limit = Math.min(
+      200,
+      Math.max(1, Number.parseInt(String(req.query.limit || 50), 10) || 50)
+    );
+
+    const supabase = createClient(env.SUPABASE_URL, env.SUPABASE_SECRET_KEY, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+
+    const { scope, error: scopedIdentityError } = await resolveWorkspaceIdentityScope(
+      supabase,
+      authReq.pcpUserId,
+      authReq.pcpWorkspaceId
+    );
+
+    if (scopedIdentityError) {
+      logger.error(
+        'Failed to resolve workspace identities for synced transcripts:',
+        scopedIdentityError
+      );
+      res.status(500).json(errorJson('Failed to list synced transcripts', scopedIdentityError));
+      return;
+    }
+
+    if (!scope || scope.identityIds.length === 0) {
+      res.json({ archives: [], count: 0 });
+      return;
+    }
+
+    const { data: archiveRows, error: archiveError } = await supabase
+      .from('session_transcript_archives')
+      .select(
+        'id, session_id, backend, backend_session_id, line_count, byte_count, source_path, synced_at, payload'
+      )
+      .eq('user_id', authReq.pcpUserId)
+      .order('synced_at', { ascending: false })
+      .limit(limit);
+
+    if (archiveError) {
+      logger.error('Failed to list synced transcript archives:', archiveError);
+      res.status(500).json(errorJson('Failed to list synced transcripts', archiveError));
+      return;
+    }
+
+    const archiveSessionIds = Array.from(
+      new Set(
+        (archiveRows || [])
+          .map((row) => row.session_id)
+          .filter((sessionId): sessionId is string => Boolean(sessionId))
+      )
+    );
+
+    const sessionsById = new Map<
+      string,
+      {
+        id: string;
+        identity_id: string | null;
+        agent_id: string | null;
+        backend: string | null;
+        backend_session_id: string | null;
+        claude_session_id: string | null;
+        thread_key: string | null;
+        started_at: string;
+        updated_at: string;
+        working_dir: string | null;
+        studio_id: string | null;
+        workspace_id: string | null;
+      }
+    >();
+
+    if (archiveSessionIds.length > 0) {
+      const { data: sessionRows, error: sessionError } = await supabase
+        .from('sessions')
+        .select(
+          'id, identity_id, agent_id, backend, backend_session_id, claude_session_id, thread_key, started_at, updated_at, working_dir, studio_id, workspace_id'
+        )
+        .eq('user_id', authReq.pcpUserId)
+        .in('id', archiveSessionIds);
+
+      if (sessionError) {
+        logger.error('Failed to fetch sessions for synced transcript list:', sessionError);
+        res.status(500).json(errorJson('Failed to list synced transcripts', sessionError));
+        return;
+      }
+
+      for (const row of sessionRows || []) {
+        sessionsById.set(row.id, row);
+      }
+    }
+
+    const identityByAgentId = new Map(
+      scope.rows.map((row) => [row.agent_id, { name: row.name, role: row.role }])
+    );
+
+    const archives = (archiveRows || [])
+      .map((row) => {
+        const session = sessionsById.get(row.session_id);
+        if (!session || !isSessionInWorkspace(session, scope)) return null;
+
+        const format = extractTranscriptFormat(row.payload);
+        const identity = session.agent_id ? identityByAgentId.get(session.agent_id) : null;
+        return {
+          archiveId: row.id,
+          sessionId: row.session_id,
+          backend: row.backend,
+          backendSessionId: row.backend_session_id,
+          format,
+          lineCount: row.line_count,
+          byteCount: row.byte_count,
+          sourcePath: row.source_path,
+          syncedAt: row.synced_at,
+          session: {
+            id: session.id,
+            agentId: session.agent_id,
+            agentName: identity?.name || session.agent_id || 'Unknown',
+            agentRole: identity?.role || null,
+            backend: session.backend,
+            backendSessionId: session.backend_session_id || session.claude_session_id,
+            threadKey: session.thread_key,
+            startedAt: session.started_at,
+            updatedAt: session.updated_at,
+            workingDir: session.working_dir,
+            studioId: session.studio_id || session.workspace_id,
+          },
+        };
+      })
+      .filter((row): row is NonNullable<typeof row> => Boolean(row));
+
+    res.json({ archives, count: archives.length });
+  } catch (error) {
+    logger.error('Failed to list synced transcripts:', error);
+    res.status(500).json(errorJson('Failed to list synced transcripts', error));
+  }
+});
+
+/**
+ * GET /api/admin/sessions/:id/transcript
+ * Export the raw synced transcript archive for a single session.
+ */
+router.get('/sessions/:id/transcript', async (req: Request, res: Response) => {
+  try {
+    const sessionId = req.params.id;
+    const authReq = req as AdminAuthRequest;
+    const requestedFormat = String(req.query.format || 'json').toLowerCase();
+    const format: TranscriptFormat = requestedFormat === 'jsonl' ? 'jsonl' : 'json';
+    const download = req.query.download === '1' || req.query.download === 'true';
+
+    const supabase = createClient(env.SUPABASE_URL, env.SUPABASE_SECRET_KEY, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+
+    const { scope, error: scopedIdentityError } = await resolveWorkspaceIdentityScope(
+      supabase,
+      authReq.pcpUserId,
+      authReq.pcpWorkspaceId
+    );
+
+    if (scopedIdentityError) {
+      logger.error(
+        'Failed to resolve workspace identities for transcript export:',
+        scopedIdentityError
+      );
+      res.status(500).json(errorJson('Failed to export transcript', scopedIdentityError));
+      return;
+    }
+
+    if (!scope || scope.identityIds.length === 0) {
+      res.status(404).json({ error: 'Session not found' });
+      return;
+    }
+
+    const { data: session, error: sessionError } = await supabase
+      .from('sessions')
+      .select('id, identity_id, agent_id')
+      .eq('id', sessionId)
+      .eq('user_id', authReq.pcpUserId)
+      .single();
+
+    if (sessionError || !isSessionInWorkspace(session, scope)) {
+      res.status(404).json({ error: 'Session not found' });
+      return;
+    }
+
+    const { data: archive, error: archiveError } = await supabase
+      .from('session_transcript_archives')
+      .select('payload')
+      .eq('user_id', authReq.pcpUserId)
+      .eq('session_id', sessionId)
+      .single();
+
+    if (archiveError || !archive?.payload || typeof archive.payload !== 'object') {
+      res.status(404).json({ error: 'Synced transcript not found' });
+      return;
+    }
+
+    const payload = archive.payload as Record<string, unknown>;
+    if (download) {
+      const extension = format === 'jsonl' ? 'jsonl' : 'json';
+      res.setHeader(
+        'Content-Disposition',
+        `attachment; filename=\"session-${sessionId}-transcript.${extension}\"`
+      );
+    }
+
+    if (format === 'jsonl') {
+      const events = Array.isArray(payload.events) ? payload.events : [];
+      const body = events.map((event) => JSON.stringify(event)).join('\n');
+      res.setHeader('Content-Type', 'application/x-ndjson; charset=utf-8');
+      res.send(body.length > 0 ? `${body}\n` : '');
+      return;
+    }
+
+    res.json(payload);
+  } catch (error) {
+    logger.error('Failed to export transcript:', error);
+    res.status(500).json(errorJson('Failed to export transcript', error));
+  }
+});
+
+/**
  * POST /api/admin/sessions/:id/sync-transcript
  * Sync full local backend transcript into Postgres jsonb for cross-server portability.
  */
@@ -4935,13 +5235,13 @@ router.post('/sessions/:id/sync-transcript', async (req: Request, res: Response)
       auth: { autoRefreshToken: false, persistSession: false },
     });
 
-    const { data: scopedIdentities, error: scopedIdentityError } = await supabase
-      .from('agent_identities')
-      .select('id, agent_id')
-      .eq('user_id', authReq.pcpUserId)
-      .eq('workspace_id', authReq.pcpWorkspaceId);
+    const { scope, error: scopedIdentityError } = await resolveWorkspaceIdentityScope(
+      supabase,
+      authReq.pcpUserId,
+      authReq.pcpWorkspaceId
+    );
 
-    if (scopedIdentityError) {
+    if (scopedIdentityError || !scope) {
       logger.error(
         'Failed to resolve workspace identities for session transcript sync:',
         scopedIdentityError
@@ -4950,14 +5250,7 @@ router.post('/sessions/:id/sync-transcript', async (req: Request, res: Response)
       return;
     }
 
-    const scopedIdentityIds = (scopedIdentities || []).map((i) => i.id);
-    const scopedAgentIds = new Set(
-      (scopedIdentities || [])
-        .map((i) => i.agent_id)
-        .filter((agentId): agentId is string => Boolean(agentId))
-    );
-
-    if (scopedIdentityIds.length === 0) {
+    if (scope.identityIds.length === 0) {
       res.status(404).json({ error: 'Session not found' });
       return;
     }
@@ -4969,12 +5262,7 @@ router.post('/sessions/:id/sync-transcript', async (req: Request, res: Response)
       .eq('user_id', authReq.pcpUserId)
       .single();
 
-    const sessionInWorkspace =
-      session &&
-      ((session.identity_id && scopedIdentityIds.includes(session.identity_id)) ||
-        (!session.identity_id && session.agent_id && scopedAgentIds.has(session.agent_id)));
-
-    if (sessionError || !session || !sessionInWorkspace) {
+    if (sessionError || !isSessionInWorkspace(session, scope)) {
       res.status(404).json({ error: 'Session not found' });
       return;
     }

--- a/packages/cli/src/commands/session.sync.test.ts
+++ b/packages/cli/src/commands/session.sync.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { resolveSyncWorkspaceId } from './session.js';
+
+describe('resolveSyncWorkspaceId', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('prefers an explicit workspace id over local identity.json', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'pcp-session-sync-'));
+    tempDirs.push(cwd);
+    mkdirSync(join(cwd, '.pcp'), { recursive: true });
+    writeFileSync(
+      join(cwd, '.pcp', 'identity.json'),
+      JSON.stringify({ workspaceId: 'workspace-from-file' })
+    );
+
+    expect(resolveSyncWorkspaceId('workspace-from-flag', cwd)).toBe('workspace-from-flag');
+  });
+
+  it('falls back to workspaceId from .pcp/identity.json', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'pcp-session-sync-'));
+    tempDirs.push(cwd);
+    mkdirSync(join(cwd, '.pcp'), { recursive: true });
+    writeFileSync(
+      join(cwd, '.pcp', 'identity.json'),
+      JSON.stringify({ workspaceId: 'workspace-from-file' })
+    );
+
+    expect(resolveSyncWorkspaceId(undefined, cwd)).toBe('workspace-from-file');
+  });
+
+  it('supports canonical studioId-only identity files', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'pcp-session-sync-'));
+    tempDirs.push(cwd);
+    mkdirSync(join(cwd, '.pcp'), { recursive: true });
+    writeFileSync(
+      join(cwd, '.pcp', 'identity.json'),
+      JSON.stringify({ studioId: 'studio-from-file' })
+    );
+
+    expect(resolveSyncWorkspaceId(undefined, cwd)).toBe('studio-from-file');
+  });
+});

--- a/packages/cli/src/commands/session.test.ts
+++ b/packages/cli/src/commands/session.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { renderSessionsByAgent, type Session } from './session.js';
+import {
+  buildTranscriptInstallPlan,
+  materializeSyncedTranscriptContent,
+  renderSessionsByAgent,
+  renderSyncedTranscriptArchives,
+  type Session,
+} from './session.js';
 
 function stripAnsi(value: string): string {
   return value.replace(/\u001b\[[0-9;]*m/g, '');
@@ -35,9 +41,13 @@ describe('renderSessionsByAgent', () => {
     const output = stripAnsi(renderSessionsByAgent(sessions).join('\n'));
     expect(output).toContain('lumen (1 session, 1 active)');
     expect(output).toContain('wren (1 session, 0 active)');
-    expect(output).toContain('Attach:  sb chat -a lumen --attach aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee');
+    expect(output).toContain(
+      'Attach:  sb chat -a lumen --attach aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
+    );
     expect(output).toContain('Thread:  pr:61');
-    expect(output).toContain('Path:    /Users/conormclaughlin/ws/pcp/personal-context-protocol--lumen');
+    expect(output).toContain(
+      'Path:    /Users/conormclaughlin/ws/pcp/personal-context-protocol--lumen'
+    );
     expect(output).toContain('Branch:  lumen/feat/pcp-first-class-repl-remote');
   });
 
@@ -57,7 +67,131 @@ describe('renderSessionsByAgent', () => {
         true
       ).join('\n')
     );
-    expect(flatOutput).toContain('Attach:  sb chat -a aster --attach 11111111-2222-3333-4444-555555555555');
+    expect(flatOutput).toContain(
+      'Attach:  sb chat -a aster --attach 11111111-2222-3333-4444-555555555555'
+    );
     expect(flatOutput).not.toContain('(1 session,');
+  });
+});
+
+describe('renderSyncedTranscriptArchives', () => {
+  it('renders synced transcript summaries', () => {
+    const output = stripAnsi(
+      renderSyncedTranscriptArchives([
+        {
+          archiveId: 'archive-1',
+          sessionId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+          backend: 'claude',
+          backendSessionId: 'backend-1',
+          format: 'jsonl',
+          lineCount: 321,
+          byteCount: 45678,
+          sourcePath: '/tmp/backend-1.jsonl',
+          syncedAt: new Date('2026-03-11T20:00:00.000Z').toISOString(),
+          session: {
+            id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+            agentId: 'lumen',
+            agentName: 'Lumen',
+            threadKey: 'pr:219',
+            startedAt: new Date('2026-03-11T19:00:00.000Z').toISOString(),
+            updatedAt: new Date('2026-03-11T20:00:00.000Z').toISOString(),
+            workingDir: '/repo',
+          },
+        },
+      ]).join('\n')
+    );
+
+    expect(output).toContain('aaaaaaaa (claude)');
+    expect(output).toContain('Agent:   Lumen');
+    expect(output).toContain('Thread:  pr:219');
+    expect(output).toContain('Source:  /tmp/backend-1.jsonl');
+    expect(output).toContain('Path:    /repo');
+  });
+});
+
+describe('materializeSyncedTranscriptContent', () => {
+  it('prefers rawContent when present', () => {
+    expect(
+      materializeSyncedTranscriptContent({
+        format: 'jsonl',
+        rawContent: '{"type":"user"}\n',
+        events: [{ type: 'assistant' }],
+      })
+    ).toEqual({
+      content: '{"type":"user"}\n',
+      format: 'jsonl',
+      restoredFrom: 'raw',
+    });
+  });
+
+  it('falls back to event reconstruction', () => {
+    expect(
+      materializeSyncedTranscriptContent({
+        format: 'jsonl',
+        events: [{ type: 'user', content: 'hello' }],
+      })
+    ).toEqual({
+      content: '{"type":"user","content":"hello"}\n',
+      format: 'jsonl',
+      restoredFrom: 'events',
+    });
+  });
+});
+
+describe('buildTranscriptInstallPlan', () => {
+  it('uses the current project context for Claude installs', () => {
+    const plan = buildTranscriptInstallPlan({
+      sessionId: 'session-1',
+      backend: 'claude',
+      backendSessionId: 'backend-1',
+      format: 'jsonl',
+      targetCwd: '/Users/conormclaughlin/ws/pcp/personal-context-protocol',
+      resolvedBy: 'cwd',
+    });
+
+    expect(plan.destinationPath).toContain(
+      '/.claude/projects/Users-conormclaughlin-ws-pcp-personal-context-protocol/backend-1.jsonl'
+    );
+    expect(plan.targetCwd).toBe('/Users/conormclaughlin/ws/pcp/personal-context-protocol');
+  });
+
+  it('creates gemini project-root sidecars for cwd installs', () => {
+    const plan = buildTranscriptInstallPlan({
+      sessionId: 'session-2',
+      backend: 'gemini',
+      backendSessionId: 'gemini-2',
+      format: 'json',
+      targetCwd: '/Users/conormclaughlin/ws/pcp/personal-context-protocol',
+      resolvedBy: 'implicit-cwd',
+    });
+
+    expect(plan.destinationPath).toContain(
+      '/.gemini/tmp/Users-conormclaughlin-ws-pcp-personal-context-protocol/chats/session-import-gemini-2.json'
+    );
+    expect(plan.sidecarFiles).toEqual([
+      {
+        path: expect.stringContaining(
+          '/.gemini/history/Users-conormclaughlin-ws-pcp-personal-context-protocol/.project_root'
+        ),
+        content: '/Users/conormclaughlin/ws/pcp/personal-context-protocol\n',
+      },
+    ]);
+  });
+
+  it('supports explicit path installs', () => {
+    const plan = buildTranscriptInstallPlan({
+      sessionId: 'session-3',
+      backend: 'claude',
+      backendSessionId: 'backend-3',
+      format: 'jsonl',
+      targetPath: '/tmp/session-3.jsonl',
+      resolvedBy: 'path',
+    });
+
+    expect(plan).toEqual({
+      destinationPath: '/tmp/session-3.jsonl',
+      sidecarFiles: [],
+      resolvedBy: 'path',
+    });
   });
 });

--- a/packages/cli/src/commands/session.ts
+++ b/packages/cli/src/commands/session.ts
@@ -15,7 +15,8 @@ import chalk from 'chalk';
 import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
-import { callPcpTool } from '../lib/pcp-mcp.js';
+import { callPcpTool, getPcpServerUrl } from '../lib/pcp-mcp.js';
+import { getValidAccessToken } from '../auth/tokens.js';
 
 interface PcpConfig {
   userId?: string;
@@ -47,6 +48,19 @@ export interface Session {
 
 export interface SessionListResult {
   sessions: Session[];
+}
+
+interface SyncTranscriptResult {
+  ok: boolean;
+  sessionId: string;
+  backend: string | null;
+  backendSessionId: string | null;
+  format: string;
+  sourcePath: string;
+  resolvedBy: string;
+  lineCount: number;
+  byteCount: number;
+  syncedAt: string;
 }
 
 // ============================================================================
@@ -308,6 +322,77 @@ async function endCommand(sessionId?: string): Promise<void> {
   }
 }
 
+async function syncTranscriptCommand(
+  sessionId: string,
+  options: {
+    backend?: string;
+    backendSessionId?: string;
+    workspaceId?: string;
+    json?: boolean;
+  }
+): Promise<void> {
+  const serverUrl = getPcpServerUrl().replace(/\/+$/, '');
+  const token = await getValidAccessToken(serverUrl);
+  if (!token) {
+    console.error(chalk.red('Not authenticated. Run: sb auth login'));
+    process.exit(1);
+  }
+
+  const payload: Record<string, unknown> = {};
+  if (options.backend) payload.backend = options.backend;
+  if (options.backendSessionId) payload.backendSessionId = options.backendSessionId;
+
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${token}`,
+    'Content-Type': 'application/json',
+  };
+  if (options.workspaceId) {
+    headers['x-pcp-workspace-id'] = options.workspaceId;
+  }
+
+  const response = await fetch(
+    `${serverUrl}/api/admin/sessions/${encodeURIComponent(sessionId)}/sync-transcript`,
+    {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(payload),
+    }
+  );
+
+  const responseText = await response.text();
+  let parsed: Record<string, unknown> = {};
+  if (responseText.trim()) {
+    try {
+      parsed = JSON.parse(responseText) as Record<string, unknown>;
+    } catch {
+      parsed = { error: responseText };
+    }
+  }
+
+  if (!response.ok) {
+    const errorMessage =
+      (typeof parsed.error === 'string' && parsed.error) ||
+      `HTTP ${response.status} ${response.statusText}`;
+    console.error(chalk.red(`Failed to sync transcript: ${errorMessage}`));
+    process.exit(1);
+  }
+
+  const result = parsed as unknown as SyncTranscriptResult;
+  if (options.json) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  console.log(chalk.green(`Synced transcript for session ${sessionId.substring(0, 8)}.`));
+  console.log(chalk.dim(`  Backend:     ${result.backend || 'unknown'}`));
+  console.log(chalk.dim(`  Session:     ${result.backendSessionId || 'n/a'}`));
+  console.log(chalk.dim(`  Format:      ${result.format}`));
+  console.log(chalk.dim(`  Lines:       ${result.lineCount.toLocaleString()}`));
+  console.log(chalk.dim(`  Bytes:       ${result.byteCount.toLocaleString()}`));
+  console.log(chalk.dim(`  Source path: ${result.sourcePath}`));
+  console.log(chalk.dim(`  Synced at:   ${formatDate(new Date(result.syncedAt))}`));
+}
+
 // ============================================================================
 // Utilities
 // ============================================================================
@@ -352,4 +437,13 @@ export function registerSessionCommands(program: Command): void {
   session.command('resume <id>').description('Resume a session').action(resumeCommand);
 
   session.command('end [id]').description('End a session').action(endCommand);
+
+  session
+    .command('sync <id>')
+    .description('Sync full backend transcript to cloud archive')
+    .option('--backend <backend>', 'Override backend resolver (claude|codex|gemini|pcp)')
+    .option('--backend-session-id <id>', 'Override backend session id used for transcript lookup')
+    .option('--workspace-id <id>', 'Workspace scope override for the admin API call')
+    .option('--json', 'Print raw JSON response')
+    .action(syncTranscriptCommand);
 }

--- a/packages/cli/src/commands/session.ts
+++ b/packages/cli/src/commands/session.ts
@@ -15,6 +15,7 @@ import chalk from 'chalk';
 import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
+import { readIdentityJson } from '../backends/identity.js';
 import { callPcpTool, getPcpServerUrl } from '../lib/pcp-mcp.js';
 import { getValidAccessToken } from '../auth/tokens.js';
 
@@ -77,6 +78,16 @@ function getPcpConfig(): PcpConfig | null {
     }
   }
   return null;
+}
+
+export function resolveSyncWorkspaceId(
+  explicitWorkspaceId?: string,
+  cwd = process.cwd()
+): string | undefined {
+  if (explicitWorkspaceId?.trim()) return explicitWorkspaceId.trim();
+
+  const identity = readIdentityJson(cwd);
+  return identity?.workspaceId || identity?.studioId || undefined;
 }
 
 // ============================================================================
@@ -346,8 +357,9 @@ async function syncTranscriptCommand(
     Authorization: `Bearer ${token}`,
     'Content-Type': 'application/json',
   };
-  if (options.workspaceId) {
-    headers['x-pcp-workspace-id'] = options.workspaceId;
+  const workspaceId = resolveSyncWorkspaceId(options.workspaceId);
+  if (workspaceId) {
+    headers['x-pcp-workspace-id'] = workspaceId;
   }
 
   const response = await fetch(

--- a/packages/cli/src/commands/session.ts
+++ b/packages/cli/src/commands/session.ts
@@ -12,10 +12,11 @@
 
 import { Command } from 'commander';
 import chalk from 'chalk';
-import { existsSync, readFileSync } from 'fs';
-import { join } from 'path';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { basename, dirname, join, resolve as resolvePath } from 'path';
 import { homedir } from 'os';
 import { readIdentityJson } from '../backends/identity.js';
+import { createInterface } from 'readline/promises';
 import { callPcpTool, getPcpServerUrl } from '../lib/pcp-mcp.js';
 import { getValidAccessToken } from '../auth/tokens.js';
 
@@ -64,6 +65,59 @@ interface SyncTranscriptResult {
   syncedAt: string;
 }
 
+interface SyncedTranscriptArchiveSummary {
+  archiveId: string;
+  sessionId: string;
+  backend: string | null;
+  backendSessionId: string | null;
+  format: 'json' | 'jsonl' | null;
+  lineCount: number;
+  byteCount: number;
+  sourcePath: string | null;
+  syncedAt: string;
+  session: {
+    id: string;
+    agentId?: string | null;
+    agentName?: string | null;
+    agentRole?: string | null;
+    backend?: string | null;
+    backendSessionId?: string | null;
+    threadKey?: string | null;
+    startedAt: string;
+    updatedAt: string;
+    workingDir?: string | null;
+    studioId?: string | null;
+  };
+}
+
+interface SyncedTranscriptListResult {
+  archives: SyncedTranscriptArchiveSummary[];
+  count: number;
+}
+
+interface SyncedTranscriptPayload {
+  version?: number;
+  backend?: string | null;
+  backendSessionId?: string | null;
+  format?: 'json' | 'jsonl' | null;
+  sourcePath?: string | null;
+  syncedAt?: string | null;
+  rawContent?: string | null;
+  events?: unknown[];
+}
+
+interface StudioLookupResult {
+  id?: string;
+  worktreePath?: string | null;
+}
+
+interface TranscriptInstallPlan {
+  destinationPath: string;
+  sidecarFiles: Array<{ path: string; content: string }>;
+  resolvedBy: 'path' | 'cwd' | 'studio' | 'implicit-cwd';
+  targetCwd?: string;
+}
+
 // ============================================================================
 // Helpers
 // ============================================================================
@@ -88,6 +142,288 @@ export function resolveSyncWorkspaceId(
 
   const identity = readIdentityJson(cwd);
   return identity?.workspaceId || identity?.studioId || undefined;
+}
+
+function normalizePath(input: string): string {
+  return resolvePath(input);
+}
+
+function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes < 1024) return `${bytes} B`;
+  const units = ['KB', 'MB', 'GB', 'TB'];
+  let size = bytes / 1024;
+  let unitIndex = 0;
+  while (size >= 1024 && unitIndex < units.length - 1) {
+    size /= 1024;
+    unitIndex += 1;
+  }
+  const decimals = size >= 10 ? 1 : 2;
+  return `${size.toFixed(decimals)} ${units[unitIndex]}`;
+}
+
+export function materializeSyncedTranscriptContent(payload: SyncedTranscriptPayload): {
+  content: string;
+  format: 'json' | 'jsonl';
+  restoredFrom: 'raw' | 'events';
+} {
+  const format = payload.format === 'json' ? 'json' : 'jsonl';
+  if (typeof payload.rawContent === 'string' && payload.rawContent.length > 0) {
+    return {
+      content: payload.rawContent,
+      format,
+      restoredFrom: 'raw',
+    };
+  }
+
+  if (format === 'json') {
+    return {
+      content: JSON.stringify(Array.isArray(payload.events) ? payload.events : [], null, 2),
+      format,
+      restoredFrom: 'events',
+    };
+  }
+
+  const jsonl = (Array.isArray(payload.events) ? payload.events : [])
+    .map((event) => JSON.stringify(event))
+    .join('\n');
+  return {
+    content: jsonl.length > 0 ? `${jsonl}\n` : '',
+    format,
+    restoredFrom: 'events',
+  };
+}
+
+function buildProjectScopedKey(cwd: string): string {
+  const normalized = normalizePath(cwd).replace(/[\\/]/g, '-').replace(/^-+/, '');
+  return normalized || basename(cwd) || 'project';
+}
+
+export function buildTranscriptInstallPlan(options: {
+  sessionId: string;
+  backend?: string | null;
+  backendSessionId?: string | null;
+  format?: 'json' | 'jsonl' | null;
+  targetPath?: string;
+  targetCwd?: string;
+  resolvedBy: 'path' | 'cwd' | 'studio' | 'implicit-cwd';
+}): TranscriptInstallPlan {
+  const format = options.format === 'json' ? 'json' : 'jsonl';
+
+  if (options.targetPath) {
+    const normalizedPath = normalizePath(options.targetPath);
+    return {
+      destinationPath: normalizedPath,
+      sidecarFiles: [],
+      resolvedBy: 'path',
+    };
+  }
+
+  if (!options.targetCwd) {
+    throw new Error('A target cwd is required for backend-native transcript installs.');
+  }
+
+  const backend = (options.backend || '').toLowerCase();
+  const targetCwd = normalizePath(options.targetCwd);
+  const backendSessionId = options.backendSessionId || options.sessionId;
+
+  if (backend.includes('claude')) {
+    return {
+      destinationPath: join(
+        homedir(),
+        '.claude',
+        'projects',
+        buildProjectScopedKey(targetCwd),
+        `${backendSessionId}.jsonl`
+      ),
+      sidecarFiles: [],
+      resolvedBy: options.resolvedBy,
+      targetCwd,
+    };
+  }
+
+  if (backend.includes('codex')) {
+    return {
+      destinationPath: join(
+        homedir(),
+        '.codex',
+        'sessions',
+        buildProjectScopedKey(targetCwd),
+        `${backendSessionId}.jsonl`
+      ),
+      sidecarFiles: [],
+      resolvedBy: options.resolvedBy,
+      targetCwd,
+    };
+  }
+
+  if (backend.includes('gemini')) {
+    const projectKey = buildProjectScopedKey(targetCwd);
+    return {
+      destinationPath: join(
+        homedir(),
+        '.gemini',
+        'tmp',
+        projectKey,
+        'chats',
+        `session-import-${backendSessionId}.json`
+      ),
+      sidecarFiles: [
+        {
+          path: join(homedir(), '.gemini', 'history', projectKey, '.project_root'),
+          content: `${targetCwd}\n`,
+        },
+      ],
+      resolvedBy: options.resolvedBy,
+      targetCwd,
+    };
+  }
+
+  if (backend.includes('pcp')) {
+    return {
+      destinationPath: join(
+        targetCwd,
+        '.pcp',
+        'runtime',
+        'repl',
+        `${options.sessionId}-synced-${backendSessionId}.${format === 'json' ? 'json' : 'jsonl'}`
+      ),
+      sidecarFiles: [],
+      resolvedBy: options.resolvedBy,
+      targetCwd,
+    };
+  }
+
+  throw new Error(
+    `Cannot infer a backend-native install target for backend "${options.backend || 'unknown'}". Use --path instead.`
+  );
+}
+
+export function renderSyncedTranscriptArchives(
+  archives: SyncedTranscriptArchiveSummary[]
+): string[] {
+  if (archives.length === 0) return [chalk.dim('  No synced transcripts found')];
+
+  return archives.flatMap((archive) => {
+    const header = `  ${chalk.cyan(archive.sessionId.substring(0, 8))} ${chalk.dim(`(${archive.backend || 'unknown'})`)}`;
+    const thread = archive.session.threadKey || '-';
+    const agent = archive.session.agentName || archive.session.agentId || 'Unknown';
+    const lines = [
+      header,
+      chalk.dim(`      Agent:   ${agent}`),
+      chalk.dim(
+        `      Synced:  ${formatDate(new Date(archive.syncedAt))}  Size: ${formatBytes(archive.byteCount)}  Lines: ${archive.lineCount.toLocaleString()}`
+      ),
+      chalk.dim(`      Thread:  ${thread}`),
+      chalk.dim(`      Source:  ${archive.sourcePath || 'n/a'}`),
+    ];
+
+    if (archive.session.workingDir) {
+      lines.push(chalk.dim(`      Path:    ${archive.session.workingDir}`));
+    }
+
+    return [...lines, ''];
+  });
+}
+
+async function fetchAdminJson<T>(options: {
+  path: string;
+  method?: 'GET' | 'POST';
+  body?: Record<string, unknown>;
+  workspaceId?: string;
+}): Promise<T> {
+  const serverUrl = getPcpServerUrl().replace(/\/+$/, '');
+  const token = await getValidAccessToken(serverUrl);
+  if (!token) {
+    throw new Error('Not authenticated. Run: sb auth login');
+  }
+
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${token}`,
+  };
+  const workspaceId = resolveSyncWorkspaceId(options.workspaceId);
+  if (workspaceId) {
+    headers['x-pcp-workspace-id'] = workspaceId;
+  }
+  if (options.body) {
+    headers['Content-Type'] = 'application/json';
+  }
+
+  const response = await fetch(`${serverUrl}${options.path}`, {
+    method: options.method || 'GET',
+    headers,
+    body: options.body ? JSON.stringify(options.body) : undefined,
+  });
+
+  const text = await response.text();
+  const parsed = text.trim() ? (JSON.parse(text) as Record<string, unknown>) : {};
+  if (!response.ok) {
+    const message =
+      (typeof parsed.error === 'string' && parsed.error) ||
+      `HTTP ${response.status} ${response.statusText}`;
+    throw new Error(message);
+  }
+
+  return parsed as T;
+}
+
+async function maybeConfirmImplicitCwd(cwd: string, skipConfirmation?: boolean): Promise<void> {
+  if (skipConfirmation || !process.stdin.isTTY || !process.stdout.isTTY) return;
+
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const answer = (
+      await rl.question(
+        `Use current directory as the install target context?\n  ${cwd}\nProceed? [Y/n] `
+      )
+    )
+      .trim()
+      .toLowerCase();
+
+    if (answer && answer !== 'y' && answer !== 'yes') {
+      console.log(chalk.yellow('Cancelled transcript pull.'));
+      process.exit(0);
+    }
+  } finally {
+    rl.close();
+  }
+}
+
+async function resolvePullTarget(options: {
+  config: PcpConfig | null;
+  studio?: string;
+  cwd?: string;
+  path?: string;
+  yes?: boolean;
+}): Promise<{
+  resolvedBy: 'path' | 'cwd' | 'studio' | 'implicit-cwd';
+  targetPath?: string;
+  targetCwd?: string;
+}> {
+  if (options.path) {
+    return { resolvedBy: 'path', targetPath: options.path };
+  }
+
+  if (options.cwd) {
+    return { resolvedBy: 'cwd', targetCwd: options.cwd };
+  }
+
+  if (options.studio) {
+    if (!options.config?.email) {
+      throw new Error('PCP not configured. Run: sb init');
+    }
+    const studio = await callPcpTool<StudioLookupResult>('get_studio', {
+      email: options.config.email,
+      studioId: options.studio,
+    });
+    if (!studio?.worktreePath) {
+      throw new Error(`Studio ${options.studio} does not have a worktree path.`);
+    }
+    return { resolvedBy: 'studio', targetCwd: studio.worktreePath };
+  }
+
+  const cwd = process.cwd();
+  await maybeConfirmImplicitCwd(cwd, options.yes);
+  return { resolvedBy: 'implicit-cwd', targetCwd: cwd };
 }
 
 // ============================================================================
@@ -342,54 +678,23 @@ async function syncTranscriptCommand(
     json?: boolean;
   }
 ): Promise<void> {
-  const serverUrl = getPcpServerUrl().replace(/\/+$/, '');
-  const token = await getValidAccessToken(serverUrl);
-  if (!token) {
-    console.error(chalk.red('Not authenticated. Run: sb auth login'));
-    process.exit(1);
-  }
-
   const payload: Record<string, unknown> = {};
   if (options.backend) payload.backend = options.backend;
   if (options.backendSessionId) payload.backendSessionId = options.backendSessionId;
 
-  const headers: Record<string, string> = {
-    Authorization: `Bearer ${token}`,
-    'Content-Type': 'application/json',
-  };
-  const workspaceId = resolveSyncWorkspaceId(options.workspaceId);
-  if (workspaceId) {
-    headers['x-pcp-workspace-id'] = workspaceId;
-  }
-
-  const response = await fetch(
-    `${serverUrl}/api/admin/sessions/${encodeURIComponent(sessionId)}/sync-transcript`,
-    {
+  let result: SyncTranscriptResult;
+  try {
+    result = await fetchAdminJson<SyncTranscriptResult>({
+      path: `/api/admin/sessions/${encodeURIComponent(sessionId)}/sync-transcript`,
       method: 'POST',
-      headers,
-      body: JSON.stringify(payload),
-    }
-  );
-
-  const responseText = await response.text();
-  let parsed: Record<string, unknown> = {};
-  if (responseText.trim()) {
-    try {
-      parsed = JSON.parse(responseText) as Record<string, unknown>;
-    } catch {
-      parsed = { error: responseText };
-    }
-  }
-
-  if (!response.ok) {
-    const errorMessage =
-      (typeof parsed.error === 'string' && parsed.error) ||
-      `HTTP ${response.status} ${response.statusText}`;
-    console.error(chalk.red(`Failed to sync transcript: ${errorMessage}`));
+      body: payload,
+      workspaceId: options.workspaceId,
+    });
+  } catch (error) {
+    console.error(chalk.red(`Failed to sync transcript: ${error}`));
     process.exit(1);
   }
 
-  const result = parsed as unknown as SyncTranscriptResult;
   if (options.json) {
     console.log(JSON.stringify(result, null, 2));
     return;
@@ -403,6 +708,209 @@ async function syncTranscriptCommand(
   console.log(chalk.dim(`  Bytes:       ${result.byteCount.toLocaleString()}`));
   console.log(chalk.dim(`  Source path: ${result.sourcePath}`));
   console.log(chalk.dim(`  Synced at:   ${formatDate(new Date(result.syncedAt))}`));
+}
+
+async function listSyncedTranscriptsCommand(options: {
+  limit?: string;
+  workspaceId?: string;
+  json?: boolean;
+}): Promise<void> {
+  try {
+    const params = new URLSearchParams();
+    if (options.limit) params.set('limit', options.limit);
+    const suffix = params.toString() ? `?${params.toString()}` : '';
+    const result = await fetchAdminJson<SyncedTranscriptListResult>({
+      path: `/api/admin/sessions/synced${suffix}`,
+      workspaceId: options.workspaceId,
+    });
+
+    if (options.json) {
+      console.log(JSON.stringify(result, null, 2));
+      return;
+    }
+
+    console.log(chalk.bold('\nSynced Transcripts:\n'));
+    for (const line of renderSyncedTranscriptArchives(result.archives || [])) {
+      console.log(line);
+    }
+  } catch (error) {
+    console.error(chalk.red(`Failed to list synced transcripts: ${error}`));
+    process.exit(1);
+  }
+}
+
+async function pullSyncedTranscriptCommand(
+  sessionId: string,
+  options: {
+    path?: string;
+    studio?: string;
+    cwd?: string;
+    workspaceId?: string;
+    overwrite?: boolean;
+    yes?: boolean;
+    json?: boolean;
+  }
+): Promise<void> {
+  const config = getPcpConfig();
+  try {
+    const payload = await fetchAdminJson<SyncedTranscriptPayload>({
+      path: `/api/admin/sessions/${encodeURIComponent(sessionId)}/transcript?format=json`,
+      workspaceId: options.workspaceId,
+    });
+
+    const target = await resolvePullTarget({
+      config,
+      studio: options.studio,
+      cwd: options.cwd,
+      path: options.path,
+      yes: options.yes,
+    });
+
+    const plan = buildTranscriptInstallPlan({
+      sessionId,
+      backend: payload.backend,
+      backendSessionId: payload.backendSessionId,
+      format: payload.format,
+      targetPath: target.targetPath,
+      targetCwd: target.targetCwd,
+      resolvedBy: target.resolvedBy,
+    });
+
+    const materialized = materializeSyncedTranscriptContent(payload);
+    const destinationDir = dirname(plan.destinationPath);
+    mkdirSync(destinationDir, { recursive: true });
+
+    if (existsSync(plan.destinationPath)) {
+      const existingContent = readFileSync(plan.destinationPath, 'utf-8');
+      if (existingContent === materialized.content) {
+        if (options.json) {
+          console.log(
+            JSON.stringify(
+              {
+                ok: true,
+                sessionId,
+                destinationPath: plan.destinationPath,
+                status: 'already_present',
+                resolvedBy: plan.resolvedBy,
+                targetCwd: plan.targetCwd || null,
+              },
+              null,
+              2
+            )
+          );
+          return;
+        }
+
+        console.log(
+          chalk.green(`Transcript already present for session ${sessionId.substring(0, 8)}.`)
+        );
+        console.log(chalk.dim(`  Destination: ${plan.destinationPath}`));
+        return;
+      }
+
+      if (!options.overwrite) {
+        throw new Error(
+          `Destination already exists with different content: ${plan.destinationPath}. Re-run with --overwrite or use --path.`
+        );
+      }
+    }
+
+    writeFileSync(plan.destinationPath, materialized.content);
+    for (const sidecar of plan.sidecarFiles) {
+      mkdirSync(dirname(sidecar.path), { recursive: true });
+      writeFileSync(sidecar.path, sidecar.content);
+    }
+
+    if (options.json) {
+      console.log(
+        JSON.stringify(
+          {
+            ok: true,
+            sessionId,
+            backend: payload.backend || null,
+            backendSessionId: payload.backendSessionId || null,
+            format: materialized.format,
+            restoredFrom: materialized.restoredFrom,
+            destinationPath: plan.destinationPath,
+            resolvedBy: plan.resolvedBy,
+            targetCwd: plan.targetCwd || null,
+            sidecarFiles: plan.sidecarFiles.map((file) => file.path),
+          },
+          null,
+          2
+        )
+      );
+      return;
+    }
+
+    console.log(chalk.green(`Pulled transcript for session ${sessionId.substring(0, 8)}.`));
+    console.log(chalk.dim(`  Backend:      ${payload.backend || 'unknown'}`));
+    console.log(chalk.dim(`  Destination:  ${plan.destinationPath}`));
+    if (plan.targetCwd) {
+      console.log(chalk.dim(`  Target cwd:   ${plan.targetCwd}`));
+    }
+    console.log(chalk.dim(`  Resolved by:  ${plan.resolvedBy}`));
+    console.log(chalk.dim(`  Restored via: ${materialized.restoredFrom}`));
+    if (plan.sidecarFiles.length > 0) {
+      console.log(
+        chalk.dim(`  Sidecars:     ${plan.sidecarFiles.map((file) => file.path).join(', ')}`)
+      );
+    }
+  } catch (error) {
+    console.error(chalk.red(`Failed to pull synced transcript: ${error}`));
+    process.exit(1);
+  }
+}
+
+async function syncCommandDispatcher(
+  target: string | undefined,
+  value: string | undefined,
+  options: {
+    backend?: string;
+    backendSessionId?: string;
+    workspaceId?: string;
+    limit?: string;
+    path?: string;
+    studio?: string;
+    cwd?: string;
+    overwrite?: boolean;
+    yes?: boolean;
+    json?: boolean;
+  }
+): Promise<void> {
+  if (target === 'list') {
+    await listSyncedTranscriptsCommand(options);
+    return;
+  }
+
+  if (target === 'pull') {
+    if (!value) {
+      console.error(chalk.red('Missing session ID. Use: sb session sync pull <id>'));
+      process.exit(1);
+    }
+    await pullSyncedTranscriptCommand(value, options);
+    return;
+  }
+
+  if (target === 'push') {
+    if (!value) {
+      console.error(chalk.red('Missing session ID. Use: sb session sync push <id>'));
+      process.exit(1);
+    }
+    await syncTranscriptCommand(value, options);
+    return;
+  }
+
+  if (!target) {
+    console.error(
+      chalk.red(
+        'Missing sync action. Use: sb session sync <id>, sb session sync list, or sb session sync pull <id>'
+      )
+    );
+    process.exit(1);
+  }
+
+  await syncTranscriptCommand(target, options);
 }
 
 // ============================================================================
@@ -451,11 +959,30 @@ export function registerSessionCommands(program: Command): void {
   session.command('end [id]').description('End a session').action(endCommand);
 
   session
-    .command('sync <id>')
-    .description('Sync full backend transcript to cloud archive')
+    .command('sync [target] [value]')
+    .description('Push, list, and pull synced session transcripts')
     .option('--backend <backend>', 'Override backend resolver (claude|codex|gemini|pcp)')
     .option('--backend-session-id <id>', 'Override backend session id used for transcript lookup')
+    .option('--limit <n>', 'Number of synced archives to list', '20')
+    .option('--path <path>', 'Write pulled transcript to an explicit file path')
+    .option('--studio <id>', 'Resolve pull install target from a studio worktree')
+    .option('--cwd <path>', 'Resolve pull install target from a working directory')
     .option('--workspace-id <id>', 'Workspace scope override for the admin API call')
+    .option('--overwrite', 'Overwrite pulled transcript destination if content differs')
+    .option('--yes', 'Skip confirmation when defaulting pull installs to the current directory')
     .option('--json', 'Print raw JSON response')
-    .action(syncTranscriptCommand);
+    .addHelpText(
+      'after',
+      `
+Examples:
+  sb session sync <id>               Push a local transcript to the server archive
+  sb session sync push <id>          Explicit push form
+  sb session sync list               Show synced transcripts available on the server
+  sb session sync pull <id>          Pull into the current directory context
+  sb session sync pull <id> --path /tmp/transcript.jsonl
+  sb session sync pull <id> --studio <studio-id>
+  sb session sync pull <id> --cwd /path/to/project
+`
+    )
+    .action(syncCommandDispatcher);
 }

--- a/packages/web/src/app/(dashboard)/sessions/[sessionId]/page.tsx
+++ b/packages/web/src/app/(dashboard)/sessions/[sessionId]/page.tsx
@@ -14,7 +14,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
-import { useApiQuery } from '@/lib/api';
+import { useApiPost, useApiQuery, useQueryClient } from '@/lib/api';
 import clsx from 'clsx';
 
 interface SessionLogsResponse {
@@ -31,7 +31,7 @@ interface SessionLogsResponse {
   };
   logs: Array<{
     id: string;
-    source: 'activity_stream' | 'session_logs' | 'local_transcript';
+    source: 'activity_stream' | 'session_logs' | 'local_transcript' | 'synced_transcript';
     type: string;
     role: 'in' | 'out' | 'system';
     content: string;
@@ -46,6 +46,7 @@ interface SessionLogsResponse {
   };
   sources: {
     cloud: number;
+    synced: number;
     local: number;
   };
 }
@@ -203,6 +204,7 @@ export default function SessionLogsPage() {
     type: string;
     json: string;
   } | null>(null);
+  const queryClient = useQueryClient();
   const limit = 50;
 
   const queryPath = useMemo(
@@ -215,6 +217,18 @@ export default function SessionLogsPage() {
     queryPath,
     { refetchInterval: 15000 }
   );
+
+  const syncTranscript = useApiPost<
+    {
+      ok: boolean;
+      lineCount: number;
+    },
+    Record<string, never>
+  >(`/api/admin/sessions/${sessionId}/sync-transcript`, {
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ['session-logs', sessionId] });
+    },
+  });
 
   const logs = data?.logs || [];
   const pagination = data?.pagination;
@@ -264,11 +278,29 @@ export default function SessionLogsPage() {
         <CardHeader>
           <CardTitle>Timeline</CardTitle>
           <CardDescription>
-            Latest activity, session logs, and local transcript fallback when available.
+            Latest activity, session logs, synced transcript archive, and local fallback when
+            available.
           </CardDescription>
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => syncTranscript.mutate({})}
+              disabled={syncTranscript.isPending}
+            >
+              {syncTranscript.isPending ? 'Syncing…' : 'Sync full transcript'}
+            </Button>
+            {syncTranscript.isSuccess ? (
+              <span className="text-xs text-emerald-700">Synced transcript to cloud archive.</span>
+            ) : null}
+            {syncTranscript.error ? (
+              <span className="text-xs text-red-600">{syncTranscript.error.message}</span>
+            ) : null}
+          </div>
           {data && (
             <div className="flex flex-wrap gap-2 text-xs text-gray-500">
               <Badge variant="outline">Cloud: {data.sources.cloud}</Badge>
+              <Badge variant="outline">Synced: {data.sources.synced}</Badge>
               <Badge variant="outline">Local: {data.sources.local}</Badge>
               <Badge variant="outline">Total: {data.pagination.total}</Badge>
             </div>

--- a/packages/web/src/app/(dashboard)/sessions/page.tsx
+++ b/packages/web/src/app/(dashboard)/sessions/page.tsx
@@ -51,7 +51,7 @@ interface Session {
   studio: SessionWorkspace | null;
   preview: Array<{
     id: string;
-    source: 'activity_stream' | 'session_logs' | 'local_transcript';
+    source: 'activity_stream' | 'session_logs' | 'local_transcript' | 'synced_transcript';
     type: string;
     role: 'in' | 'out' | 'system';
     content: string;

--- a/supabase/migrations/20260310010206_add_session_transcript_archives.sql
+++ b/supabase/migrations/20260310010206_add_session_transcript_archives.sql
@@ -1,0 +1,70 @@
+-- Persist full backend transcripts in Postgres for cross-server session log portability.
+-- Stores one jsonb payload per PCP session (manual sync on demand).
+
+CREATE TABLE IF NOT EXISTS session_transcript_archives (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  session_id uuid NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+  backend text,
+  backend_session_id text,
+  payload jsonb NOT NULL,
+  line_count integer NOT NULL DEFAULT 0,
+  byte_count integer NOT NULL DEFAULT 0,
+  source_path text,
+  synced_at timestamptz NOT NULL DEFAULT now(),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT session_transcript_archives_line_count_non_negative CHECK (line_count >= 0),
+  CONSTRAINT session_transcript_archives_byte_count_non_negative CHECK (byte_count >= 0)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_session_transcript_archives_session_id
+  ON session_transcript_archives(session_id);
+
+CREATE INDEX IF NOT EXISTS idx_session_transcript_archives_user_synced_at
+  ON session_transcript_archives(user_id, synced_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_session_transcript_archives_backend_session
+  ON session_transcript_archives(backend, backend_session_id)
+  WHERE backend_session_id IS NOT NULL;
+
+DROP TRIGGER IF EXISTS session_transcript_archives_updated_at ON session_transcript_archives;
+CREATE TRIGGER session_transcript_archives_updated_at
+  BEFORE UPDATE ON session_transcript_archives
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_updated_at_column();
+
+ALTER TABLE session_transcript_archives ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Service role full access to session_transcript_archives" ON session_transcript_archives;
+CREATE POLICY "Service role full access to session_transcript_archives"
+  ON session_transcript_archives FOR ALL
+  USING ((auth.jwt() ->> 'role') = 'service_role')
+  WITH CHECK ((auth.jwt() ->> 'role') = 'service_role');
+
+DROP POLICY IF EXISTS "Users can view own session transcript archives" ON session_transcript_archives;
+CREATE POLICY "Users can view own session transcript archives"
+  ON session_transcript_archives FOR SELECT
+  USING (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS "Users can insert own session transcript archives" ON session_transcript_archives;
+CREATE POLICY "Users can insert own session transcript archives"
+  ON session_transcript_archives FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS "Users can update own session transcript archives" ON session_transcript_archives;
+CREATE POLICY "Users can update own session transcript archives"
+  ON session_transcript_archives FOR UPDATE
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS "Users can delete own session transcript archives" ON session_transcript_archives;
+CREATE POLICY "Users can delete own session transcript archives"
+  ON session_transcript_archives FOR DELETE
+  USING (auth.uid() = user_id);
+
+COMMENT ON TABLE session_transcript_archives IS
+  'Full backend transcript snapshots synced on demand for cross-server portability.';
+
+COMMENT ON COLUMN session_transcript_archives.payload IS
+  'Full transcript payload stored as jsonb (JSONL lines parsed into JSON objects when possible).';


### PR DESCRIPTION
## Summary

Add a manual transcript sync flow that captures full backend session logs into Postgres for cross-server portability.

### What this adds

- `session_transcript_archives` migration storing the full transcript payload as JSONB
- `POST /api/admin/sessions/:id/sync-transcript`
- session log viewer support for a new `synced_transcript` source
- a dashboard **Sync full transcript** action on the session detail page
- a CLI convenience command: `sb session sync <id>`
- admin auth support for using an `mcp_access` token on the sync endpoint so the CLI can call it directly

### Current behavior

- sync is primarily **local transcript -> server archive**
- merged log reads prefer:
  1. cloud activity/session logs
  2. synced transcript archive
  3. local fallback (when no synced archive exists)
- synced transcript display is paginated/normalized in the existing session logs view

## Testing

Passed:
- `npx vitest run packages/api/src/routes/admin-auth.test.ts packages/api/src/routes/admin-endpoints.test.ts packages/cli/src/commands/session.test.ts`
- `yarn workspace @personal-context/web type-check`

Notes:
- `yarn workspace @personal-context/cli type-check` currently fails on pre-existing unrelated `@personal-context/shared` export/type issues on `main`
- `yarn workspace @personal-context/api type-check` still has the existing CommonJS/ESM issue already present outside this change

## Follow-ups I expect on top of this PR

- `--path` / `--studio` transcript source ergonomics
- download/export endpoint for synced transcript payloads
- possible share-link flow for moving synced logs between environments

— Lumen