### PR TITLE
feat: add Gemini CLI hook support for session ID capture and compression (by Wren)

### DIFF
--- a/packages/cli/src/commands/hooks.test.ts
+++ b/packages/cli/src/commands/hooks.test.ts
@@ -194,7 +194,11 @@ describe('installHooks: Gemini', () => {
     expect(existsSync(configPath)).toBe(true);
 
     const config = JSON.parse(readFileSync(configPath, 'utf-8'));
-    expect(config.hooks.SessionStart[0].hooks[0].command).toContain('hooks on-session-start');
+    // SessionStart[0] = compress matcher (post-compact), SessionStart[1] = startup matcher
+    expect(config.hooks.SessionStart[0].matcher).toBe('compress');
+    expect(config.hooks.SessionStart[0].hooks[0].command).toContain('hooks post-compact');
+    expect(config.hooks.SessionStart[1].matcher).toBe('startup');
+    expect(config.hooks.SessionStart[1].hooks[0].command).toContain('hooks on-session-start');
     expect(config.hooks.BeforeAgent[0].hooks[0].command).toContain('hooks on-prompt');
     expect(config.hooks.AfterAgent[0].hooks[0].command).toContain('hooks on-stop');
     expect(config.hooks.PreCompress[0].hooks[0].command).toContain('hooks pre-compact');

--- a/packages/cli/src/commands/hooks.ts
+++ b/packages/cli/src/commands/hooks.ts
@@ -93,7 +93,7 @@ const GEMINI: HookCapabilities = {
   events: {
     sessionStart: 'SessionStart',
     preCompact: 'PreCompress',
-    postCompact: null,
+    postCompact: 'SessionStart', // uses "compress" matcher on SessionStart (Gemini uses "compress", not Claude's "compact")
     onPrompt: 'BeforeAgent',
     onStop: 'AfterAgent',
   },
@@ -1115,8 +1115,20 @@ function installGemini(cwd: string, force: boolean): InstallResult {
 
   const sbPath = resolveSbBinaryPath(cwd);
   const pcpHooks: Record<string, unknown> = {
+    // SessionStart: two matchers — "compress" for post-compression identity re-injection,
+    // "startup" for initial session setup. Gemini uses "compress" (not Claude's "compact").
     [GEMINI.events.sessionStart!]: [
       {
+        matcher: 'compress',
+        hooks: [
+          {
+            type: 'command',
+            command: buildManagedHookCommand(sbPath, 'post-compact', GEMINI.name),
+          },
+        ],
+      },
+      {
+        matcher: 'startup',
         hooks: [
           {
             type: 'command',
@@ -1187,13 +1199,13 @@ function installGemini(cwd: string, force: boolean): InstallResult {
     const allPresent = Object.entries(pcpHooks).every(([event, targetEntries]) => {
       const existingEntries = hooksObj[event];
       if (!Array.isArray(existingEntries)) return false;
-      const targetCmd = (
-        (targetEntries as Array<Record<string, unknown>>)[0]?.hooks as
-          | Array<Record<string, unknown>>
-          | undefined
-      )?.[0]?.command as string | undefined;
-      if (!targetCmd) return false;
-      return existingEntries.some((entry) => entryHasCommand(entry, targetCmd));
+      // Verify ALL target entries are present (e.g. SessionStart has both compress + startup)
+      return (targetEntries as Array<Record<string, unknown>>).every((targetEntry) => {
+        const targetCmd = (targetEntry.hooks as Array<Record<string, unknown>> | undefined)?.[0]
+          ?.command as string | undefined;
+        if (!targetCmd) return false;
+        return existingEntries.some((entry) => entryHasCommand(entry, targetCmd));
+      });
     });
 
     if (allPresent) {
@@ -1327,12 +1339,14 @@ function printInstallResult(
     console.log(
       chalk.dim(`      ${events.preCompact} → ${formatHookHint(backend.name, 'pre-compact')}`)
     );
-  if (events.postCompact)
+  if (events.postCompact) {
+    const compactMatcher = backend.name === 'gemini' ? 'compress' : 'compact';
     console.log(
       chalk.dim(
-        `      ${events.postCompact} (compact) → ${formatHookHint(backend.name, 'post-compact')}`
+        `      ${events.postCompact} (${compactMatcher}) → ${formatHookHint(backend.name, 'post-compact')}`
       )
     );
+  }
   if (events.sessionStart)
     console.log(
       chalk.dim(
@@ -1418,12 +1432,14 @@ async function installCommand(options: {
       console.log(
         chalk.dim(`  ${events.preCompact} → ${formatHookHint(backend.name, 'pre-compact')}`)
       );
-    if (events.postCompact)
+    if (events.postCompact) {
+      const compactMatcher = backend.name === 'gemini' ? 'compress' : 'compact';
       console.log(
         chalk.dim(
-          `  ${events.postCompact} (compact) → ${formatHookHint(backend.name, 'post-compact')}`
+          `  ${events.postCompact} (${compactMatcher}) → ${formatHookHint(backend.name, 'post-compact')}`
         )
       );
+    }
     if (events.sessionStart)
       console.log(
         chalk.dim(


### PR DESCRIPTION
## Summary

- **Gemini compression hooks**: Gemini CLI uses `source: "compress"` (not Claude's `"compact"`) for post-compression `SessionStart` events. Updated `sb hooks install` to generate the correct `matcher: "compress"` entry alongside the `matcher: "startup"` entry under `SessionStart`.
- **PostCompact capability**: Changed Gemini's `postCompact` from `null` to `SessionStart` (with compress matcher), enabling early backend session ID capture during compression events.
- **Fixed `allPresent` check**: The hook presence detection now verifies ALL target entries for a given event (not just the first), so `sb hooks check` correctly reports missing hooks when only one of multiple SessionStart entries is installed.

## Details

Gemini CLI passes `session_id` in all hook stdin payloads, which means `extractBackendSessionId` in our hooks already works for Gemini (unlike Claude, which is blocked). With compression hooks properly installed, Gemini sessions can capture backend session IDs earlier — on the first `BeforeAgent` hook rather than waiting for process close. This improves reply routing accuracy and session state tracking.

Reference: https://github.com/google-gemini/gemini-cli/issues/14724

## Test plan

- [x] All 56 hooks tests pass (`yarn vitest run packages/cli/src/commands/hooks.test.ts`)
- [x] Gemini install test updated to verify both SessionStart entries (compress + startup matchers)
- [ ] Manual: `sb hooks install --backend gemini` in a fresh worktree produces correct `.gemini/settings.json`
- [ ] Manual: Gemini CLI compression triggers `post-compact` hook correctly


🤖 Generated with [Claude Code](https://claude.com/claude-code)