### PR TITLE
fix: make memory embeddings opt-in by default (by Lumen)

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Your SB now has persistent identity, memory, and session continuity across every
 
 ### Optional: enable semantic memory embeddings
 
-PCP's memory system works **without** local embeddings — `remember`/`recall` still function with text-based retrieval and the embedding write path is best-effort. If you want local semantic recall on top of that, install Ollama-backed embeddings:
+PCP's memory system works **without** local embeddings — `remember`/`recall` still function with text-based retrieval, and semantic embeddings are **disabled by default** until you opt in. If you want local semantic recall on top of that, install Ollama-backed embeddings:
 
 ```bash
 sb memory install
@@ -126,7 +126,7 @@ If you already have the model:
 sb memory install --skip-pull
 ```
 
-If you want to keep using PCP memory **without** embeddings, set:
+If you want to explicitly keep PCP memory in text-only mode, set:
 
 ```bash
 MEMORY_EMBEDDINGS_ENABLED=false

--- a/packages/api/src/config/env.ts
+++ b/packages/api/src/config/env.ts
@@ -169,7 +169,7 @@ const envSchema = z.object({
   // Embeddings
   MEMORY_EMBEDDINGS_ENABLED: z
     .enum(['true', 'false'])
-    .default(nodeEnv === 'test' ? 'false' : 'true')
+    .default('false')
     .transform((v) => v === 'true'),
   MEMORY_EMBEDDING_PROVIDER: z.enum(['ollama', 'openai']).optional(),
   MEMORY_EMBEDDING_MODEL: optionalString,

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -212,7 +212,7 @@ sb --help                       # Full help
 
 ### Optional: local semantic memory embeddings
 
-The PCP memory system does **not** require embeddings to work. Without them, `remember` and `recall` still work via text retrieval.
+The PCP memory system does **not** require embeddings to work. Without them, `remember` and `recall` still work via text retrieval. Semantic embeddings are **disabled by default** until you opt in.
 
 If you want local semantic recall via Ollama:
 


### PR DESCRIPTION
## Summary
- default MEMORY_EMBEDDINGS_ENABLED to false in server config
- clarify in root and CLI READMEs that semantic embeddings are opt-in
- keep sb memory install as the activation path for local Ollama embeddings

## Why
The previous default would attempt semantic embeddings even when Ollama/OpenAI had not been configured, which is resilient but noisy and product-confusing. Text memory recall already works without embeddings, so opt-in is the cleaner default.

## Validation
- npx vitest run packages/api/src/services/embeddings/router.test.ts packages/api/src/data/repositories/memory-repository.test.ts
