### PR TITLE
feat: tasks dashboard, comments, and enriched MCP tools (by Wren)

### DIFF
--- a/packages/api/src/data/repositories/project-tasks.repository.ts
+++ b/packages/api/src/data/repositories/project-tasks.repository.ts
@@ -145,6 +145,7 @@ export class ProjectTasksRepository {
     options?: {
       status?: TaskStatus | TaskStatus[];
       projectId?: string;
+      groupId?: string;
       limit?: number;
     }
   ): Promise<ProjectTask[]> {
@@ -164,6 +165,10 @@ export class ProjectTasksRepository {
 
     if (options?.projectId) {
       query = query.eq('project_id', options.projectId);
+    }
+
+    if (options?.groupId) {
+      query = query.eq('task_group_id', options.groupId);
     }
 
     if (options?.limit) {

--- a/packages/api/src/mcp/tools/index.ts
+++ b/packages/api/src/mcp/tools/index.ts
@@ -22,6 +22,7 @@ import {
   handleUpdateTask,
   handleCompleteTask,
   handleGetTaskStats,
+  handleAddTaskComment,
 } from './task-handlers';
 
 import { handleSendResponse, handleGetPendingMessages, handleMarkRead } from './response-handlers';
@@ -772,12 +773,13 @@ User can be identified by ONE of: userId, email, phone, or platform + platformId
   server.registerTool(
     'list_tasks',
     {
-      description: `List tasks for a user, optionally filtered by project or status.
+      description: `List tasks for a user, optionally filtered by project, task group, or status. Returns task group info, creator, blocked-by, due dates, and metadata.
 
 User can be identified by ONE of: userId, email, phone, or platform + platformId`,
       inputSchema: {
         ...userIdentifierFields,
         projectId: z.string().uuid().optional().describe('Filter by project'),
+        groupId: z.string().uuid().optional().describe('Filter by task group'),
         status: z.enum(['pending', 'in_progress', 'completed', 'blocked']).optional(),
         activeOnly: z
           .boolean()
@@ -896,6 +898,45 @@ User can be identified by ONE of: userId, email, phone, or platform + platformId
         return await handleGetTaskStats(args, dataComposer);
       } catch (error) {
         logger.error('Error in get_task_stats:', error);
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                success: false,
+                error: error instanceof Error ? error.message : 'Unknown error',
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // Register add_task_comment tool
+  server.registerTool(
+    'add_task_comment',
+    {
+      description: `Add a comment to a task. Comments are attributed to the calling agent automatically. Use this to leave notes, context, or discussion on tasks.
+
+User can be identified by ONE of: userId, email, phone, or platform + platformId`,
+      inputSchema: {
+        ...userIdentifierFields,
+        taskId: z.string().uuid().describe('Task ID to comment on'),
+        content: z.string().min(1).max(5000).describe('Comment content'),
+        parentCommentId: z
+          .string()
+          .uuid()
+          .optional()
+          .describe('Parent comment ID for threaded replies'),
+      },
+    },
+    async (args) => {
+      try {
+        return await handleAddTaskComment(args, dataComposer);
+      } catch (error) {
+        logger.error('Error in add_task_comment:', error);
         return {
           content: [
             {

--- a/packages/api/src/mcp/tools/task-handlers.test.ts
+++ b/packages/api/src/mcp/tools/task-handlers.test.ts
@@ -525,6 +525,7 @@ describe('handleUpdateTask', () => {
       title: 'New title',
       description: 'Updated description',
       status: 'in_progress',
+      completed_at: null,
       priority: 'high',
       tags: ['updated'],
     });
@@ -556,9 +557,10 @@ describe('handleUpdateTask', () => {
       dc as any
     );
 
-    // Only status should be in the updates object
+    // Status + completed_at clearing for non-completed transitions
     expect(dc.repositories.tasks.update).toHaveBeenCalledWith('task-1', {
       status: 'in_progress',
+      completed_at: null,
     });
   });
 

--- a/packages/api/src/mcp/tools/task-handlers.ts
+++ b/packages/api/src/mcp/tools/task-handlers.ts
@@ -10,6 +10,7 @@ import type { DataComposer } from '../../data/composer';
 import type { TaskStatus, TaskPriority } from '../../data/repositories/project-tasks.repository';
 import { resolveUser, type UserIdentifier } from '../../services/user-resolver';
 import { getEffectiveAgentId } from '../../auth/enforce-identity';
+import { getRequestContext } from '../../utils/request-context';
 import { logger } from '../../utils/logger';
 
 // Common user identifier schema
@@ -240,7 +241,14 @@ export async function handleUpdateTask(
     const updates: Record<string, unknown> = {};
     if (args.title !== undefined) updates.title = args.title;
     if (args.description !== undefined) updates.description = args.description;
-    if (args.status !== undefined) updates.status = args.status;
+    if (args.status !== undefined) {
+      updates.status = args.status;
+      // Clear completed_at when reopening a task (non-completed status).
+      // Without this, reopened tasks retain the green "done" badge.
+      if (args.status !== 'completed') {
+        updates.completed_at = null;
+      }
+    }
     if (args.priority !== undefined) updates.priority = args.priority;
     if (args.tags !== undefined) updates.tags = args.tags;
 
@@ -401,6 +409,7 @@ export const addTaskCommentSchema = z.object({
   taskId: z.string().uuid().describe('Task ID to comment on'),
   content: z.string().min(1).max(5000).describe('Comment content'),
   parentCommentId: z.string().uuid().optional().describe('Parent comment ID for threaded replies'),
+  agentId: z.string().optional().describe('Agent ID for identity attribution'),
 });
 
 export async function handleAddTaskComment(
@@ -422,19 +431,23 @@ export async function handleAddTaskComment(
       return mcpResponse({ success: false, error: 'Task does not belong to this user' }, true);
     }
 
-    const agentId = getEffectiveAgentId(undefined);
+    const agentId = getEffectiveAgentId(args.agentId);
+    const reqCtx = getRequestContext();
+    const workspaceId = reqCtx?.workspaceId;
 
-    // Resolve agent identity ID if we have an agentId
+    // Resolve agent identity ID with workspace scoping when available
     let identityId: string | null = null;
     if (agentId) {
-      const { data: identity } = await dataComposer
+      let identityQuery = dataComposer
         .getClient()
         .from('agent_identities')
         .select('id')
         .eq('agent_id', agentId)
-        .eq('user_id', resolved.user.id)
-        .limit(1)
-        .single();
+        .eq('user_id', resolved.user.id);
+      if (workspaceId) {
+        identityQuery = identityQuery.eq('workspace_id', workspaceId);
+      }
+      const { data: identity } = await identityQuery.limit(1).single();
       if (identity) identityId = identity.id;
     }
 

--- a/packages/api/src/mcp/tools/task-handlers.ts
+++ b/packages/api/src/mcp/tools/task-handlers.ts
@@ -119,7 +119,8 @@ export async function handleCreateTask(
 
 export const listTasksSchema = z.object({
   ...userIdentifierSchema.shape,
-  projectId: z.string().uuid().optional().describe('Filter by project (optional)'),
+  projectId: z.string().uuid().optional().describe('Filter by project'),
+  groupId: z.string().uuid().optional().describe('Filter by task group'),
   status: z.enum(['pending', 'in_progress', 'completed', 'blocked']).optional(),
   activeOnly: z.boolean().optional().default(false).describe('Only show pending/in_progress tasks'),
   limit: z.number().optional().default(50),
@@ -145,16 +146,31 @@ export async function handleListTasks(
       tasks = await dataComposer.repositories.tasks.listByUser(resolved.user.id, {
         status: args.status as TaskStatus | undefined,
         projectId: args.projectId,
+        groupId: args.groupId,
         limit: args.limit,
       });
     }
 
-    // Get project names for context
+    // Resolve project names
     const projectIds = [...new Set(tasks.map((t) => t.project_id).filter(Boolean))] as string[];
     const projects = await Promise.all(
       projectIds.map((id) => dataComposer.repositories.projects.findById(id))
     );
     const projectMap = new Map(projects.filter(Boolean).map((p) => [p!.id, p!.name]));
+
+    // Resolve task group names
+    const groupIds = [...new Set(tasks.map((t) => t.task_group_id).filter(Boolean))] as string[];
+    const groupMap = new Map<string, string>();
+    if (groupIds.length > 0) {
+      const { data: groups } = await dataComposer
+        .getClient()
+        .from('task_groups' as never)
+        .select('id, title')
+        .in('id', groupIds as never);
+      for (const g of (groups || []) as Array<{ id: string; title: string }>) {
+        groupMap.set(g.id, g.title);
+      }
+    }
 
     return mcpResponse({
       success: true,
@@ -167,6 +183,12 @@ export async function handleListTasks(
         tags: task.tags,
         projectId: task.project_id,
         projectName: task.project_id ? projectMap.get(task.project_id) || 'Unknown' : null,
+        taskGroupId: task.task_group_id || null,
+        taskGroupTitle: task.task_group_id ? groupMap.get(task.task_group_id) || null : null,
+        createdBy: task.created_by || null,
+        blockedBy: task.blocked_by || null,
+        dueDate: task.due_date || null,
+        metadata: task.metadata || null,
         createdAt: task.created_at,
         completedAt: task.completed_at,
       })),
@@ -364,6 +386,101 @@ export async function handleGetTaskStats(
       {
         success: false,
         error: error instanceof Error ? error.message : 'Failed to get task stats',
+      },
+      true
+    );
+  }
+}
+
+// ============================================================================
+// ADD TASK COMMENT
+// ============================================================================
+
+export const addTaskCommentSchema = z.object({
+  ...userIdentifierSchema.shape,
+  taskId: z.string().uuid().describe('Task ID to comment on'),
+  content: z.string().min(1).max(5000).describe('Comment content'),
+  parentCommentId: z.string().uuid().optional().describe('Parent comment ID for threaded replies'),
+});
+
+export async function handleAddTaskComment(
+  args: z.infer<typeof addTaskCommentSchema>,
+  dataComposer: DataComposer
+): Promise<McpResponse> {
+  try {
+    const resolved = await resolveUser(args as UserIdentifier, dataComposer);
+    if (!resolved) {
+      return mcpResponse({ success: false, error: 'User not found' }, true);
+    }
+
+    // Verify task exists and belongs to user
+    const existing = await dataComposer.repositories.tasks.findById(args.taskId);
+    if (!existing) {
+      return mcpResponse({ success: false, error: 'Task not found' }, true);
+    }
+    if (existing.user_id !== resolved.user.id) {
+      return mcpResponse({ success: false, error: 'Task does not belong to this user' }, true);
+    }
+
+    const agentId = getEffectiveAgentId(undefined);
+
+    // Resolve agent identity ID if we have an agentId
+    let identityId: string | null = null;
+    if (agentId) {
+      const { data: identity } = await dataComposer
+        .getClient()
+        .from('agent_identities')
+        .select('id')
+        .eq('agent_id', agentId)
+        .eq('user_id', resolved.user.id)
+        .limit(1)
+        .single();
+      if (identity) identityId = identity.id;
+    }
+
+    const { data: rawComment, error } = await dataComposer
+      .getClient()
+      .from('task_comments' as never)
+      .insert({
+        task_id: args.taskId,
+        user_id: resolved.user.id,
+        content: args.content.trim(),
+        parent_comment_id: args.parentCommentId || null,
+        created_by_agent_id: agentId || null,
+        created_by_identity_id: identityId,
+      } as never)
+      .select()
+      .single();
+
+    if (error) {
+      return mcpResponse(
+        { success: false, error: `Failed to add comment: ${error.message}` },
+        true
+      );
+    }
+
+    const comment = rawComment as unknown as {
+      id: string;
+      task_id: string;
+      content: string;
+      created_at: string;
+    };
+
+    return mcpResponse({
+      success: true,
+      comment: {
+        id: comment.id,
+        taskId: comment.task_id,
+        content: comment.content,
+        authorAgentId: agentId || null,
+        createdAt: comment.created_at,
+      },
+    });
+  } catch (error) {
+    return mcpResponse(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to add task comment',
       },
       true
     );

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -5235,6 +5235,10 @@ router.put('/tasks/:id', async (req: Request, res: Response) => {
 
     if ('status' in body && body.status !== undefined) {
       updates.status = body.status;
+      // Clear completed_at when reopening a task
+      if (body.status !== 'completed') {
+        updates.completed_at = null;
+      }
     }
     if ('priority' in body && body.priority !== undefined) {
       updates.priority = body.priority;

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -5114,4 +5114,465 @@ router.post('/skills/manage/:skillId/fork', async (req: Request, res: Response) 
   }
 });
 
+// =============================================================================
+// Tasks
+// =============================================================================
+
+/**
+ * GET /api/admin/tasks
+ * List tasks for the active user with optional filters
+ */
+router.get('/tasks', async (req: Request, res: Response) => {
+  try {
+    const supabase = createClient(env.SUPABASE_URL, env.SUPABASE_SECRET_KEY, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+    const authReq = req as AdminAuthRequest;
+
+    let query = supabase
+      .from('tasks')
+      .select('*, projects(name), task_groups(title)')
+      .eq('user_id', authReq.pcpUserId);
+
+    // Optional filters
+    const { status, projectId, groupId, activeOnly } = req.query;
+    if (status) {
+      query = query.eq('status', status as string);
+    }
+    if (projectId) {
+      query = query.eq('project_id', projectId as string);
+    }
+    if (groupId) {
+      query = query.eq('task_group_id', groupId as string);
+    }
+    if (activeOnly === 'true') {
+      query = query.in('status', ['pending', 'in_progress', 'blocked']);
+    }
+
+    const { data, error } = await query.limit(200);
+
+    if (error) {
+      res.status(500).json(errorJson('Failed to list tasks', error));
+      return;
+    }
+
+    const tasks = data || [];
+
+    // Sort: status priority (in_progress, pending, blocked, completed),
+    // then by priority (critical, high, medium, low), then by created_at desc
+    const statusOrder: Record<string, number> = {
+      in_progress: 0,
+      pending: 1,
+      blocked: 2,
+      completed: 3,
+    };
+    const priorityOrder: Record<string, number> = {
+      critical: 0,
+      high: 1,
+      medium: 2,
+      low: 3,
+    };
+
+    tasks.sort((a, b) => {
+      const statusDiff = (statusOrder[a.status] ?? 99) - (statusOrder[b.status] ?? 99);
+      if (statusDiff !== 0) return statusDiff;
+      const priorityDiff = (priorityOrder[a.priority] ?? 99) - (priorityOrder[b.priority] ?? 99);
+      if (priorityDiff !== 0) return priorityDiff;
+      return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
+    });
+
+    // Compute stats
+    const stats = {
+      total: tasks.length,
+      pending: tasks.filter((t) => t.status === 'pending').length,
+      inProgress: tasks.filter((t) => t.status === 'in_progress').length,
+      completed: tasks.filter((t) => t.status === 'completed').length,
+      blocked: tasks.filter((t) => t.status === 'blocked').length,
+    };
+
+    res.json({
+      tasks: tasks.map((t) => ({
+        id: t.id,
+        title: t.title,
+        description: t.description,
+        status: t.status,
+        priority: t.priority,
+        tags: t.tags,
+        projectId: t.project_id,
+        projectName: (t.projects as { name: string } | null)?.name ?? null,
+        taskGroupId: t.task_group_id,
+        taskGroupTitle: (t.task_groups as { title: string } | null)?.title ?? null,
+        blockedBy: t.blocked_by,
+        createdBy: t.created_by,
+        completedAt: t.completed_at,
+        dueDate: t.due_date,
+        metadata: t.metadata,
+        createdAt: t.created_at,
+        updatedAt: t.updated_at,
+      })),
+      stats,
+    });
+  } catch (error) {
+    logger.error('Failed to list tasks:', error);
+    res.status(500).json(errorJson('Failed to list tasks', error));
+  }
+});
+
+/**
+ * PUT /api/admin/tasks/:id
+ * Update a task's status, priority, title, description, or tags
+ */
+router.put('/tasks/:id', async (req: Request, res: Response) => {
+  try {
+    const { id } = req.params;
+    const supabase = createClient(env.SUPABASE_URL, env.SUPABASE_SECRET_KEY, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+    const authReq = req as AdminAuthRequest;
+
+    const body = (req.body || {}) as Record<string, unknown>;
+    const updates: Record<string, unknown> = {};
+
+    if ('status' in body && body.status !== undefined) {
+      updates.status = body.status;
+    }
+    if ('priority' in body && body.priority !== undefined) {
+      updates.priority = body.priority;
+    }
+    if ('title' in body && body.title !== undefined) {
+      updates.title = body.title;
+    }
+    if ('description' in body && body.description !== undefined) {
+      updates.description = body.description;
+    }
+    if ('tags' in body && body.tags !== undefined) {
+      updates.tags = body.tags;
+    }
+
+    if (Object.keys(updates).length === 0) {
+      res
+        .status(400)
+        .json(
+          errorJson(
+            'No valid fields to update',
+            'Request body is empty or contains no recognized fields'
+          )
+        );
+      return;
+    }
+
+    // If status is being set to completed, set completed_at
+    if (updates.status === 'completed') {
+      updates.completed_at = new Date().toISOString();
+    }
+
+    const { data, error } = await supabase
+      .from('tasks')
+      .update(updates)
+      .eq('id', id)
+      .eq('user_id', authReq.pcpUserId)
+      .select('*, projects(name), task_groups(title)')
+      .single();
+
+    if (error) {
+      res.status(500).json(errorJson('Failed to update task', error));
+      return;
+    }
+
+    if (!data) {
+      res.status(404).json(errorJson('Task not found', `No task with id ${id} for this user`));
+      return;
+    }
+
+    res.json({
+      task: {
+        id: data.id,
+        title: data.title,
+        description: data.description,
+        status: data.status,
+        priority: data.priority,
+        tags: data.tags,
+        projectId: data.project_id,
+        projectName: (data.projects as { name: string } | null)?.name ?? null,
+        taskGroupId: data.task_group_id,
+        taskGroupTitle: (data.task_groups as { title: string } | null)?.title ?? null,
+        blockedBy: data.blocked_by,
+        createdBy: data.created_by,
+        completedAt: data.completed_at,
+        dueDate: data.due_date,
+        metadata: data.metadata,
+        createdAt: data.created_at,
+        updatedAt: data.updated_at,
+      },
+    });
+  } catch (error) {
+    logger.error('Failed to update task:', error);
+    res.status(500).json(errorJson('Failed to update task', error));
+  }
+});
+
+// =============================================================================
+// Task Groups
+// =============================================================================
+
+/**
+ * GET /api/admin/task-groups
+ * List task groups for the active user
+ */
+router.get('/task-groups', async (req: Request, res: Response) => {
+  try {
+    const supabase = createClient(env.SUPABASE_URL, env.SUPABASE_SECRET_KEY, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+    const authReq = req as AdminAuthRequest;
+
+    // Fetch task groups with joined agent identity and project
+    const { data, error } = await supabase
+      .from('task_groups')
+      .select('*, agent_identities(agent_id, name), projects(name)')
+      .eq('user_id', authReq.pcpUserId)
+      .order('created_at', { ascending: false })
+      .limit(200);
+
+    if (error) {
+      res.status(500).json(errorJson('Failed to list task groups', error));
+      return;
+    }
+
+    const groups = data || [];
+
+    // Fetch task counts per group in a separate query
+    const groupIds = groups.map((g) => g.id);
+    let taskCountMap: Record<string, number> = {};
+
+    if (groupIds.length > 0) {
+      const { data: taskCountData, error: taskCountError } = await supabase
+        .from('tasks')
+        .select('task_group_id')
+        .eq('user_id', authReq.pcpUserId)
+        .in('task_group_id', groupIds);
+
+      if (!taskCountError && taskCountData) {
+        for (const row of taskCountData) {
+          if (row.task_group_id) {
+            taskCountMap[row.task_group_id] = (taskCountMap[row.task_group_id] || 0) + 1;
+          }
+        }
+      }
+    }
+
+    res.json({
+      groups: groups.map((g) => ({
+        id: g.id,
+        title: g.title,
+        description: g.description,
+        status: g.status,
+        priority: g.priority,
+        tags: g.tags,
+        autonomous: g.autonomous,
+        maxSessions: g.max_sessions,
+        sessionsUsed: g.sessions_used,
+        contextSummary: g.context_summary,
+        nextRunAfter: g.next_run_after,
+        outputTarget: g.output_target,
+        outputStatus: g.output_status,
+        threadKey: g.thread_key,
+        projectId: g.project_id,
+        projectName: (g.projects as { name: string } | null)?.name ?? null,
+        identityId: g.identity_id,
+        agentId:
+          (g.agent_identities as { agent_id: string; name: string } | null)?.agent_id ?? null,
+        agentName: (g.agent_identities as { agent_id: string; name: string } | null)?.name ?? null,
+        taskCount: taskCountMap[g.id] || 0,
+        metadata: g.metadata,
+        createdAt: g.created_at,
+        updatedAt: g.updated_at,
+      })),
+    });
+  } catch (error) {
+    logger.error('Failed to list task groups:', error);
+    res.status(500).json(errorJson('Failed to list task groups', error));
+  }
+});
+
+/**
+ * GET /api/admin/tasks/:id/comments
+ * List comments for a task
+ */
+router.get('/tasks/:id/comments', async (req: Request, res: Response) => {
+  try {
+    const { id } = req.params;
+    const supabase = createClient(env.SUPABASE_URL, env.SUPABASE_SECRET_KEY, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+    const authReq = req as AdminAuthRequest;
+
+    // Verify task belongs to user
+    const { data: task } = await supabase
+      .from('tasks')
+      .select('id')
+      .eq('id', id)
+      .eq('user_id', authReq.pcpUserId)
+      .single();
+
+    if (!task) {
+      res.status(404).json({ error: 'Task not found' });
+      return;
+    }
+
+    const { data: comments, error } = await supabase
+      .from('task_comments')
+      .select('*')
+      .eq('task_id', id)
+      .eq('user_id', authReq.pcpUserId)
+      .is('deleted_at', null)
+      .order('created_at', { ascending: true });
+
+    if (error) {
+      logger.error('Failed to list task comments:', error);
+      res.status(500).json(errorJson('Failed to list task comments', error));
+      return;
+    }
+
+    // Resolve agent identity names for comment authors
+    const identityIds = Array.from(
+      new Set((comments || []).map((c) => c.created_by_identity_id).filter(Boolean) as string[])
+    );
+    const identitiesById = new Map<string, { agent_id: string; name: string }>();
+
+    if (identityIds.length > 0) {
+      const { data: identities } = await supabase
+        .from('agent_identities')
+        .select('id, agent_id, name')
+        .in('id', identityIds);
+
+      for (const ident of identities || []) {
+        identitiesById.set(ident.id, { agent_id: ident.agent_id, name: ident.name });
+      }
+    }
+
+    res.json({
+      comments: (comments || []).map((c) => {
+        const identity = c.created_by_identity_id
+          ? identitiesById.get(c.created_by_identity_id)
+          : null;
+        return {
+          id: c.id,
+          taskId: c.task_id,
+          parentCommentId: c.parent_comment_id,
+          content: c.content,
+          authorAgentId: c.created_by_agent_id || identity?.agent_id || null,
+          authorName: identity?.name || c.created_by_agent_id || 'Unknown',
+          metadata: c.metadata,
+          createdAt: c.created_at,
+          updatedAt: c.updated_at,
+        };
+      }),
+    });
+  } catch (error) {
+    logger.error('Failed to list task comments:', error);
+    res.status(500).json(errorJson('Failed to list task comments', error));
+  }
+});
+
+/**
+ * POST /api/admin/tasks/:id/comments
+ * Add a comment to a task
+ */
+router.post('/tasks/:id/comments', async (req: Request, res: Response) => {
+  try {
+    const { id } = req.params;
+    const { content, parentCommentId } = req.body;
+    const supabase = createClient(env.SUPABASE_URL, env.SUPABASE_SECRET_KEY, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+    const authReq = req as AdminAuthRequest;
+
+    if (!content || typeof content !== 'string' || content.trim().length === 0) {
+      res.status(400).json({ error: 'Content is required' });
+      return;
+    }
+
+    // Verify task belongs to user
+    const { data: task } = await supabase
+      .from('tasks')
+      .select('id')
+      .eq('id', id)
+      .eq('user_id', authReq.pcpUserId)
+      .single();
+
+    if (!task) {
+      res.status(404).json({ error: 'Task not found' });
+      return;
+    }
+
+    const { data: comment, error } = await supabase
+      .from('task_comments')
+      .insert({
+        task_id: id,
+        user_id: authReq.pcpUserId,
+        workspace_id: authReq.pcpWorkspaceId || null,
+        parent_comment_id: parentCommentId || null,
+        content: content.trim(),
+      } as never)
+      .select()
+      .single();
+
+    if (error) {
+      logger.error('Failed to create task comment:', error);
+      res.status(500).json(errorJson('Failed to create task comment', error));
+      return;
+    }
+
+    res.status(201).json({
+      comment: {
+        id: comment.id,
+        taskId: comment.task_id,
+        parentCommentId: comment.parent_comment_id,
+        content: comment.content,
+        authorAgentId: null,
+        authorName: 'You',
+        metadata: comment.metadata,
+        createdAt: comment.created_at,
+        updatedAt: comment.updated_at,
+      },
+    });
+  } catch (error) {
+    logger.error('Failed to create task comment:', error);
+    res.status(500).json(errorJson('Failed to create task comment', error));
+  }
+});
+
+/**
+ * DELETE /api/admin/tasks/:taskId/comments/:commentId
+ * Soft-delete a comment
+ */
+router.delete('/tasks/:taskId/comments/:commentId', async (req: Request, res: Response) => {
+  try {
+    const { taskId, commentId } = req.params;
+    const supabase = createClient(env.SUPABASE_URL, env.SUPABASE_SECRET_KEY, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+    const authReq = req as AdminAuthRequest;
+
+    const { error } = await supabase
+      .from('task_comments')
+      .update({ deleted_at: new Date().toISOString() } as never)
+      .eq('id', commentId)
+      .eq('task_id', taskId)
+      .eq('user_id', authReq.pcpUserId);
+
+    if (error) {
+      logger.error('Failed to delete task comment:', error);
+      res.status(500).json(errorJson('Failed to delete task comment', error));
+      return;
+    }
+
+    res.json({ success: true });
+  } catch (error) {
+    logger.error('Failed to delete task comment:', error);
+    res.status(500).json(errorJson('Failed to delete task comment', error));
+  }
+});
+
 export default router;

--- a/packages/api/src/skills/builtin/playwright-mcp/SKILL.md
+++ b/packages/api/src/skills/builtin/playwright-mcp/SKILL.md
@@ -78,7 +78,16 @@ browser_navigate → browser_type (fields) → browser_click (submit) → browse
 ### Screenshot a page
 
 ```
-browser_navigate → browser_snapshot
+browser_resize (1440x900+) → browser_navigate → browser_take_screenshot
+```
+
+For desktop screenshots, always set the viewport to at least **1440x900** before capturing. This ensures UI elements render at a realistic desktop size and avoids narrow/mobile layouts that misrepresent the actual design.
+
+```
+browser_resize({ width: 1440, height: 900 })
+browser_navigate({ url: "..." })
+browser_take_screenshot({ filename: "page.png" })        # viewport
+browser_take_screenshot({ filename: "full.png", fullPage: true })  # full page
 ```
 
 ## Options

--- a/packages/web/src/app/(dashboard)/tasks/page.tsx
+++ b/packages/web/src/app/(dashboard)/tasks/page.tsx
@@ -1,0 +1,932 @@
+'use client';
+
+import { useState, useMemo, useCallback, useRef } from 'react';
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import {
+  CheckCircle2,
+  Circle,
+  Clock,
+  AlertCircle,
+  Layers,
+  FolderOpen,
+  Tag,
+  ChevronDown,
+  ChevronRight,
+  ListTodo,
+  ArrowUpCircle,
+  User,
+  Calendar,
+  Bot,
+  Zap,
+  MessageCircle,
+  Send,
+  Loader2,
+} from 'lucide-react';
+import { useApiQuery, useApiPost, useApiPut, useQueryClient } from '@/lib/api';
+import clsx from 'clsx';
+
+// ─── Types ───
+
+interface Task {
+  id: string;
+  title: string;
+  description: string | null;
+  status: 'pending' | 'in_progress' | 'completed' | 'blocked';
+  priority: 'low' | 'medium' | 'high' | 'critical';
+  tags: string[];
+  projectId: string | null;
+  projectName: string | null;
+  taskGroupId: string | null;
+  taskGroupTitle: string | null;
+  blockedBy: string[] | null;
+  createdBy: string | null;
+  completedAt: string | null;
+  dueDate: string | null;
+  metadata: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface TasksResponse {
+  tasks: Task[];
+  stats: {
+    total: number;
+    pending: number;
+    inProgress: number;
+    completed: number;
+    blocked: number;
+  };
+}
+
+interface TaskGroupData {
+  id: string;
+  title: string;
+  description: string | null;
+  status: string;
+  priority: string;
+  tags: string[];
+  autonomous: boolean;
+  agentId: string | null;
+  agentName: string | null;
+  projectName: string | null;
+  taskCount: number;
+  contextSummary: string | null;
+  outputTarget: string | null;
+  outputStatus: string | null;
+  threadKey: string | null;
+  createdAt: string;
+}
+
+interface TaskGroupsResponse {
+  groups: TaskGroupData[];
+}
+
+interface TaskComment {
+  id: string;
+  taskId: string;
+  parentCommentId: string | null;
+  content: string;
+  authorAgentId: string | null;
+  authorName: string;
+  metadata: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface CommentsResponse {
+  comments: TaskComment[];
+}
+
+type StatusFilter = 'all' | 'active' | 'completed' | 'blocked';
+
+// ─── Constants ───
+
+const statusConfig = {
+  in_progress: {
+    icon: ArrowUpCircle,
+    label: 'In Progress',
+    color: 'text-emerald-700',
+    bgColor: 'bg-emerald-50',
+    borderColor: 'border-emerald-200',
+    accentColor: 'text-emerald-600',
+    dotColor: 'bg-emerald-500',
+  },
+  pending: {
+    icon: Circle,
+    label: 'Pending',
+    color: 'text-blue-700',
+    bgColor: 'bg-blue-50',
+    borderColor: 'border-blue-200',
+    accentColor: 'text-blue-600',
+    dotColor: 'bg-blue-500',
+  },
+  blocked: {
+    icon: AlertCircle,
+    label: 'Blocked',
+    color: 'text-red-700',
+    bgColor: 'bg-red-50',
+    borderColor: 'border-red-200',
+    accentColor: 'text-red-600',
+    dotColor: 'bg-red-500',
+  },
+  completed: {
+    icon: CheckCircle2,
+    label: 'Completed',
+    color: 'text-gray-500',
+    bgColor: 'bg-gray-50',
+    borderColor: 'border-gray-200',
+    accentColor: 'text-gray-400',
+    dotColor: 'bg-gray-400',
+  },
+} as const;
+
+const priorityConfig = {
+  critical: {
+    label: 'Critical',
+    color: 'text-red-700',
+    bgColor: 'bg-red-50',
+    borderColor: 'border-red-200',
+    dotColor: 'bg-red-500',
+  },
+  high: {
+    label: 'High',
+    color: 'text-orange-700',
+    bgColor: 'bg-orange-50',
+    borderColor: 'border-orange-200',
+    dotColor: 'bg-orange-500',
+  },
+  medium: {
+    label: 'Medium',
+    color: 'text-gray-600',
+    bgColor: 'bg-gray-50',
+    borderColor: 'border-gray-200',
+    dotColor: 'bg-gray-400',
+  },
+  low: {
+    label: 'Low',
+    color: 'text-slate-500',
+    bgColor: 'bg-slate-50',
+    borderColor: 'border-slate-200',
+    dotColor: 'bg-slate-400',
+  },
+} as const;
+
+const PRIORITY_ORDER: Record<string, number> = { critical: 0, high: 1, medium: 2, low: 3 };
+const STATUS_ORDER: Record<string, number> = {
+  in_progress: 0,
+  pending: 1,
+  blocked: 2,
+  completed: 3,
+};
+
+// ─── Helpers ───
+
+function formatRelativeTime(date: string): string {
+  const diffMs = Date.now() - new Date(date).getTime();
+  const abs = Math.abs(diffMs);
+  const mins = Math.round(abs / 60000);
+  const hours = Math.round(abs / 3600000);
+  const days = Math.round(abs / 86400000);
+  if (diffMs >= 0) {
+    if (mins < 60) return `${mins}m ago`;
+    if (hours < 24) return `${hours}h ago`;
+    if (days === 1) return 'yesterday';
+    return `${days}d ago`;
+  }
+  if (mins < 60) return `in ${mins}m`;
+  if (hours < 24) return `in ${hours}h`;
+  return `in ${days}d`;
+}
+
+function formatDate(date: string): string {
+  return new Date(date).toLocaleDateString([], { month: 'short', day: 'numeric' });
+}
+
+function sortTasks(tasks: Task[]): Task[] {
+  return [...tasks].sort((a, b) => {
+    // Status first
+    const sd = (STATUS_ORDER[a.status] ?? 9) - (STATUS_ORDER[b.status] ?? 9);
+    if (sd !== 0) return sd;
+    // Then priority
+    const pd = (PRIORITY_ORDER[a.priority] ?? 9) - (PRIORITY_ORDER[b.priority] ?? 9);
+    if (pd !== 0) return pd;
+    // Then due date
+    if (a.dueDate && b.dueDate)
+      return new Date(a.dueDate).getTime() - new Date(b.dueDate).getTime();
+    if (a.dueDate) return -1;
+    if (b.dueDate) return 1;
+    return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+  });
+}
+
+function statusSummary(tasks: Task[]): { active: number; completed: number; blocked: number } {
+  let active = 0,
+    completed = 0,
+    blocked = 0;
+  for (const t of tasks) {
+    if (t.status === 'completed') completed++;
+    else if (t.status === 'blocked') blocked++;
+    else active++;
+  }
+  return { active, completed, blocked };
+}
+
+// ─── Comment Thread ───
+
+const AGENT_COLORS: Record<string, string> = {
+  wren: 'bg-sky-100 text-sky-700',
+  lumen: 'bg-amber-100 text-amber-700',
+  myra: 'bg-rose-100 text-rose-700',
+  benson: 'bg-violet-100 text-violet-700',
+  aster: 'bg-emerald-100 text-emerald-700',
+};
+
+function CommentThread({ taskId }: { taskId: string }) {
+  const [draft, setDraft] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
+  const queryClient = useQueryClient();
+
+  const { data, isLoading } = useApiQuery<CommentsResponse>(
+    ['task-comments', taskId],
+    `/api/admin/tasks/${taskId}/comments`
+  );
+
+  const addComment = useApiPost<{ comment: TaskComment }, { content: string }>(
+    `/api/admin/tasks/${taskId}/comments`,
+    { onSuccess: () => queryClient.invalidateQueries({ queryKey: ['task-comments', taskId] }) }
+  );
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!draft.trim() || addComment.isPending) return;
+    addComment.mutate({ content: draft.trim() });
+    setDraft('');
+    inputRef.current?.focus();
+  };
+
+  const comments = data?.comments ?? [];
+
+  return (
+    <div className="mt-3 pt-3 border-t border-gray-100">
+      {/* Comment list */}
+      {isLoading ? (
+        <div className="text-[11px] text-gray-400 flex items-center gap-1">
+          <Loader2 className="h-3 w-3 animate-spin" /> Loading comments...
+        </div>
+      ) : comments.length > 0 ? (
+        <div className="space-y-2 mb-3">
+          {comments.map((c) => {
+            const agentColor = c.authorAgentId
+              ? (AGENT_COLORS[c.authorAgentId] ?? 'bg-gray-100 text-gray-600')
+              : 'bg-gray-100 text-gray-600';
+            return (
+              <div key={c.id} className="flex gap-2">
+                <div
+                  className={clsx(
+                    'h-5 w-5 rounded-full flex items-center justify-center text-[9px] font-bold shrink-0 mt-0.5',
+                    agentColor
+                  )}
+                >
+                  {(c.authorName || '?')[0].toUpperCase()}
+                </div>
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-baseline gap-2">
+                    <span className="text-xs font-medium text-gray-700">{c.authorName}</span>
+                    <span className="text-[10px] text-gray-400">
+                      {formatRelativeTime(c.createdAt)}
+                    </span>
+                  </div>
+                  <p className="text-xs text-gray-600 mt-0.5 whitespace-pre-wrap">{c.content}</p>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      ) : null}
+
+      {/* Input */}
+      <form onSubmit={handleSubmit} className="flex gap-2">
+        <input
+          ref={inputRef}
+          type="text"
+          placeholder="Add a comment..."
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          className="flex-1 text-xs rounded-lg border border-gray-200 px-3 py-1.5 focus:outline-none focus:ring-1 focus:ring-gray-300 focus:border-gray-300 placeholder:text-gray-400"
+        />
+        <button
+          type="submit"
+          disabled={!draft.trim() || addComment.isPending}
+          className={clsx(
+            'rounded-lg px-2.5 py-1.5 transition-colors',
+            draft.trim()
+              ? 'bg-gray-900 text-white hover:bg-gray-800'
+              : 'bg-gray-100 text-gray-400 cursor-not-allowed'
+          )}
+        >
+          {addComment.isPending ? (
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <Send className="h-3.5 w-3.5" />
+          )}
+        </button>
+      </form>
+    </div>
+  );
+}
+
+// ─── Sub-components ───
+
+function PriorityBadge({ priority }: { priority: Task['priority'] }) {
+  const config = priorityConfig[priority];
+  if (priority === 'medium') return null;
+  return (
+    <Badge
+      className={clsx(
+        'text-[10px] font-medium border gap-1',
+        config.bgColor,
+        config.color,
+        config.borderColor
+      )}
+    >
+      <span className={clsx('inline-block h-1.5 w-1.5 rounded-full', config.dotColor)} />
+      {config.label}
+    </Badge>
+  );
+}
+
+function StatusDot({ status }: { status: Task['status'] }) {
+  return (
+    <span
+      className={clsx('inline-block h-1.5 w-1.5 rounded-full', statusConfig[status].dotColor)}
+    />
+  );
+}
+
+function TaskCard({
+  task,
+  onStatusChange,
+  compact,
+}: {
+  task: Task;
+  onStatusChange: (id: string, status: Task['status']) => void;
+  compact?: boolean;
+}) {
+  const [showComments, setShowComments] = useState(false);
+  const config = statusConfig[task.status];
+  const StatusIcon = config.icon;
+  const isDone = task.status === 'completed';
+  const isOverdue = task.dueDate && !isDone && new Date(task.dueDate) < new Date();
+
+  const handleToggle = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onStatusChange(task.id, isDone ? 'pending' : 'completed');
+  };
+
+  return (
+    <div
+      className={clsx(
+        'rounded-lg border p-3 transition-all',
+        showComments ? 'shadow-md border-gray-300' : 'hover:shadow-md hover:border-gray-300',
+        task.status === 'in_progress' && 'border-emerald-200 bg-emerald-50/20',
+        task.status === 'pending' && 'border-blue-100 bg-blue-50/10',
+        task.status === 'blocked' && 'border-red-200 bg-red-50/20',
+        task.status === 'completed' && 'border-gray-100 bg-gray-50/30'
+      )}
+    >
+      <div className="flex items-start gap-3">
+        {/* Status toggle */}
+        <button
+          onClick={handleToggle}
+          className={clsx(
+            'mt-0.5 shrink-0 rounded-full p-0.5 transition-colors',
+            task.status === 'blocked' ? 'cursor-default' : 'hover:bg-gray-100 cursor-pointer'
+          )}
+          title={isDone ? 'Reopen task' : task.status === 'blocked' ? 'Blocked' : 'Mark complete'}
+          disabled={task.status === 'blocked'}
+        >
+          <StatusIcon className={clsx('h-4 w-4', config.accentColor)} />
+        </button>
+
+        <div className="flex-1 min-w-0">
+          {/* Title + badges */}
+          <div className="flex items-center gap-2 flex-wrap">
+            <h4
+              className={clsx(
+                'font-medium text-sm',
+                isDone ? 'text-gray-400 line-through' : 'text-gray-900'
+              )}
+            >
+              {task.title}
+            </h4>
+            <PriorityBadge priority={task.priority} />
+          </div>
+
+          {/* Description */}
+          {!compact && task.description && (
+            <p className="text-xs text-gray-500 mt-1 line-clamp-2">{task.description}</p>
+          )}
+
+          {/* Tags */}
+          {task.tags.length > 0 && (
+            <div className="flex items-center gap-1.5 mt-1.5 flex-wrap">
+              <Tag className="h-3 w-3 text-gray-300" />
+              {task.tags.map((tag) => (
+                <span
+                  key={tag}
+                  className="inline-flex items-center rounded-md bg-gray-100 px-1.5 py-0.5 text-[10px] font-medium text-gray-600"
+                >
+                  {tag}
+                </span>
+              ))}
+            </div>
+          )}
+
+          {/* Metadata row */}
+          <div className="flex items-center gap-3 mt-1.5 text-[11px] text-gray-400 flex-wrap">
+            {task.createdBy && (
+              <span className="flex items-center gap-1">
+                <User className="h-3 w-3" />
+                {task.createdBy}
+              </span>
+            )}
+            {!compact && task.projectName && (
+              <span className="flex items-center gap-1">
+                <FolderOpen className="h-3 w-3" />
+                {task.projectName}
+              </span>
+            )}
+            <span className="flex items-center gap-1">
+              <Clock className="h-3 w-3" />
+              {formatRelativeTime(task.createdAt)}
+            </span>
+            {task.completedAt && (
+              <span className="flex items-center gap-1 text-green-500">
+                <CheckCircle2 className="h-3 w-3" />
+                done {formatRelativeTime(task.completedAt)}
+              </span>
+            )}
+            {task.dueDate && (
+              <span
+                className={clsx(
+                  'flex items-center gap-1',
+                  isOverdue
+                    ? 'text-red-600 font-medium'
+                    : isDone
+                      ? 'text-gray-400'
+                      : 'text-gray-500'
+                )}
+              >
+                <Calendar className="h-3 w-3" />
+                {formatDate(task.dueDate)}
+                {isOverdue && ' (overdue)'}
+              </span>
+            )}
+            <button
+              onClick={() => setShowComments(!showComments)}
+              className="flex items-center gap-1 hover:text-gray-600 transition-colors cursor-pointer"
+            >
+              <MessageCircle className="h-3 w-3" />
+              {showComments ? 'hide' : 'comment'}
+            </button>
+          </div>
+
+          {/* Blocked reason */}
+          {task.status === 'blocked' && task.blockedBy && task.blockedBy.length > 0 && (
+            <div className="mt-1.5 text-[11px] text-red-500 flex items-center gap-1">
+              <AlertCircle className="h-3 w-3" />
+              Blocked by: {task.blockedBy.join(', ')}
+            </div>
+          )}
+
+          {/* Comments */}
+          {showComments && <CommentThread taskId={task.id} />}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function TaskGroupSection({
+  group,
+  tasks,
+  onStatusChange,
+  defaultCollapsed,
+}: {
+  group: TaskGroupData;
+  tasks: Task[];
+  onStatusChange: (id: string, status: Task['status']) => void;
+  defaultCollapsed?: boolean;
+}) {
+  const [collapsed, setCollapsed] = useState(defaultCollapsed ?? false);
+  const sorted = useMemo(() => sortTasks(tasks), [tasks]);
+  const summary = useMemo(() => statusSummary(tasks), [tasks]);
+  const allDone = summary.active === 0 && summary.blocked === 0 && summary.completed > 0;
+
+  return (
+    <div className="rounded-xl border bg-white overflow-hidden">
+      {/* Group header */}
+      <button
+        onClick={() => setCollapsed(!collapsed)}
+        className={clsx(
+          'flex items-center gap-3 w-full px-5 py-3.5 text-left transition-colors',
+          'bg-gradient-to-r from-slate-50 to-white',
+          'hover:from-slate-100/60',
+          'border-b',
+          collapsed ? 'border-transparent' : 'border-gray-100'
+        )}
+      >
+        <div className="h-8 w-8 rounded-lg bg-indigo-50 flex items-center justify-center shrink-0">
+          <Layers className="h-4 w-4 text-indigo-500" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2">
+            <span
+              className={clsx('font-semibold text-sm', allDone ? 'text-gray-400' : 'text-gray-900')}
+            >
+              {group.title}
+            </span>
+            {group.autonomous && (
+              <Badge className="text-[10px] font-medium border bg-violet-50 text-violet-700 border-violet-200 gap-1">
+                <Zap className="h-2.5 w-2.5" />
+                Autonomous
+              </Badge>
+            )}
+          </div>
+          <div className="flex items-center gap-2 mt-0.5 text-[11px] text-gray-400">
+            {group.agentName && (
+              <span className="flex items-center gap-1">
+                <Bot className="h-3 w-3" />
+                {group.agentName}
+              </span>
+            )}
+            {group.projectName && (
+              <span className="flex items-center gap-1">
+                <FolderOpen className="h-3 w-3" />
+                {group.projectName}
+              </span>
+            )}
+          </div>
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          {/* Mini status summary */}
+          {summary.active > 0 && (
+            <span className="flex items-center gap-1 text-[10px] text-blue-600 font-medium">
+              <StatusDot status="pending" /> {summary.active}
+            </span>
+          )}
+          {summary.blocked > 0 && (
+            <span className="flex items-center gap-1 text-[10px] text-red-600 font-medium">
+              <StatusDot status="blocked" /> {summary.blocked}
+            </span>
+          )}
+          {summary.completed > 0 && (
+            <span className="flex items-center gap-1 text-[10px] text-gray-400 font-medium">
+              <StatusDot status="completed" /> {summary.completed}
+            </span>
+          )}
+          {collapsed ? (
+            <ChevronRight className="h-4 w-4 text-gray-400 ml-1" />
+          ) : (
+            <ChevronDown className="h-4 w-4 text-gray-400 ml-1" />
+          )}
+        </div>
+      </button>
+
+      {/* Group description */}
+      {!collapsed && group.description && (
+        <div className="px-5 pt-3 pb-0">
+          <p className="text-xs text-gray-500">{group.description}</p>
+        </div>
+      )}
+
+      {/* Tasks */}
+      {!collapsed && (
+        <div className="px-5 pb-4 pt-3 space-y-2">
+          {sorted.map((task) => (
+            <TaskCard key={task.id} task={task} onStatusChange={onStatusChange} compact />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function UngroupedStatusSection({
+  status,
+  tasks,
+  onStatusChange,
+  defaultCollapsed,
+}: {
+  status: Task['status'];
+  tasks: Task[];
+  onStatusChange: (id: string, status: Task['status']) => void;
+  defaultCollapsed?: boolean;
+}) {
+  const [collapsed, setCollapsed] = useState(defaultCollapsed ?? false);
+  const config = statusConfig[status];
+  const StatusIcon = config.icon;
+  const sorted = useMemo(() => sortTasks(tasks), [tasks]);
+
+  if (tasks.length === 0) return null;
+
+  return (
+    <div className="rounded-xl border bg-white overflow-hidden">
+      <button
+        onClick={() => setCollapsed(!collapsed)}
+        className={clsx(
+          'flex items-center gap-3 w-full px-5 py-3.5 text-left transition-colors',
+          'bg-gradient-to-r from-gray-50 to-white',
+          'hover:from-gray-100/60',
+          'border-b',
+          collapsed ? 'border-transparent' : 'border-gray-100'
+        )}
+      >
+        <div
+          className={clsx(
+            'h-8 w-8 rounded-lg flex items-center justify-center shrink-0',
+            config.bgColor
+          )}
+        >
+          <StatusIcon className={clsx('h-4 w-4', config.accentColor)} />
+        </div>
+        <div className="flex-1 min-w-0">
+          <span className="font-semibold text-gray-900 text-sm">{config.label}</span>
+        </div>
+        <div className="flex items-center gap-3 shrink-0">
+          <Badge
+            className={clsx(
+              'text-[10px] font-medium border',
+              config.bgColor,
+              config.color,
+              config.borderColor
+            )}
+          >
+            {tasks.length}
+          </Badge>
+          {collapsed ? (
+            <ChevronRight className="h-4 w-4 text-gray-400" />
+          ) : (
+            <ChevronDown className="h-4 w-4 text-gray-400" />
+          )}
+        </div>
+      </button>
+      {!collapsed && (
+        <div className="px-5 pb-4 pt-3 space-y-2">
+          {sorted.map((task) => (
+            <TaskCard key={task.id} task={task} onStatusChange={onStatusChange} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Main Page ───
+
+const STATUS_DISPLAY_ORDER: Task['status'][] = ['in_progress', 'pending', 'blocked', 'completed'];
+
+export default function TasksPage() {
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
+  const queryClient = useQueryClient();
+
+  const { data, isLoading, error } = useApiQuery<TasksResponse>(['tasks'], '/api/admin/tasks', {
+    refetchInterval: 30000,
+  });
+
+  const { data: groupsData } = useApiQuery<TaskGroupsResponse>(
+    ['task-groups'],
+    '/api/admin/task-groups'
+  );
+
+  const updateTask = useApiPut<Task, { id: string; body: { status: Task['status'] } }>(
+    ({ id }) => `/api/admin/tasks/${id}`,
+    ({ body }) => body,
+    { onSuccess: () => queryClient.invalidateQueries({ queryKey: ['tasks'] }) }
+  );
+
+  const handleStatusChange = useCallback(
+    (id: string, status: Task['status']) => {
+      updateTask.mutate({ id, body: { status } });
+    },
+    [updateTask]
+  );
+
+  const allTasks = data?.tasks ?? [];
+  const groupsMap = useMemo(() => {
+    const m = new Map<string, TaskGroupData>();
+    for (const g of groupsData?.groups ?? []) m.set(g.id, g);
+    return m;
+  }, [groupsData]);
+
+  const stats = useMemo(() => {
+    if (data?.stats) return data.stats;
+    return {
+      total: allTasks.length,
+      pending: allTasks.filter((t) => t.status === 'pending').length,
+      inProgress: allTasks.filter((t) => t.status === 'in_progress').length,
+      completed: allTasks.filter((t) => t.status === 'completed').length,
+      blocked: allTasks.filter((t) => t.status === 'blocked').length,
+    };
+  }, [data, allTasks]);
+
+  // Apply status filter
+  const filtered = useMemo(() => {
+    if (statusFilter === 'active')
+      return allTasks.filter((t) => t.status === 'pending' || t.status === 'in_progress');
+    if (statusFilter === 'completed') return allTasks.filter((t) => t.status === 'completed');
+    if (statusFilter === 'blocked') return allTasks.filter((t) => t.status === 'blocked');
+    return allTasks;
+  }, [allTasks, statusFilter]);
+
+  // Split into grouped and ungrouped
+  const { grouped, ungrouped } = useMemo(() => {
+    const grouped = new Map<string, Task[]>();
+    const ungrouped: Task[] = [];
+
+    for (const task of filtered) {
+      if (task.taskGroupId && groupsMap.has(task.taskGroupId)) {
+        const list = grouped.get(task.taskGroupId) ?? [];
+        list.push(task);
+        grouped.set(task.taskGroupId, list);
+      } else {
+        ungrouped.push(task);
+      }
+    }
+
+    return { grouped, ungrouped };
+  }, [filtered, groupsMap]);
+
+  // Sort groups: active work first, then by task count
+  const sortedGroupIds = useMemo(() => {
+    return [...grouped.keys()].sort((a, b) => {
+      const aTasks = grouped.get(a) ?? [];
+      const bTasks = grouped.get(b) ?? [];
+      const aActive = aTasks.filter((t) => t.status !== 'completed').length;
+      const bActive = bTasks.filter((t) => t.status !== 'completed').length;
+      if (aActive > 0 && bActive === 0) return -1;
+      if (bActive > 0 && aActive === 0) return 1;
+      return bTasks.length - aTasks.length;
+    });
+  }, [grouped]);
+
+  // Group ungrouped by status
+  const ungroupedByStatus = useMemo(() => {
+    const groups: Record<Task['status'], Task[]> = {
+      in_progress: [],
+      pending: [],
+      blocked: [],
+      completed: [],
+    };
+    for (const task of ungrouped) groups[task.status].push(task);
+    return groups;
+  }, [ungrouped]);
+
+  const filterButtons: { key: StatusFilter; label: string; count: number }[] = [
+    { key: 'all', label: 'All', count: stats.total },
+    { key: 'active', label: 'Active', count: stats.pending + stats.inProgress },
+    { key: 'completed', label: 'Completed', count: stats.completed },
+    { key: 'blocked', label: 'Blocked', count: stats.blocked },
+  ];
+
+  const hasVisibleTasks = filtered.length > 0;
+
+  return (
+    <div className="max-w-6xl">
+      {/* Header */}
+      <div>
+        <h1 className="text-3xl font-bold text-gray-900">Tasks</h1>
+        <p className="mt-1 text-gray-500">Track work across projects and agents.</p>
+      </div>
+
+      {error && (
+        <div className="mt-4 rounded-lg bg-red-50 border border-red-200 p-4 text-sm text-red-800">
+          {error.message}
+        </div>
+      )}
+
+      {/* Stats row */}
+      <div className="mt-6 grid grid-cols-2 gap-3 sm:grid-cols-4">
+        {[
+          {
+            label: 'Pending',
+            value: stats.pending,
+            color: 'text-blue-700',
+            dotColor: 'bg-blue-500',
+          },
+          {
+            label: 'In Progress',
+            value: stats.inProgress,
+            color: 'text-emerald-700',
+            dotColor: 'bg-emerald-500',
+          },
+          {
+            label: 'Completed',
+            value: stats.completed,
+            color: 'text-gray-500',
+            dotColor: 'bg-gray-400',
+          },
+          { label: 'Blocked', value: stats.blocked, color: 'text-red-700', dotColor: 'bg-red-500' },
+        ].map((stat) => (
+          <div
+            key={stat.label}
+            className="rounded-lg border bg-white p-3 transition-all hover:shadow-sm"
+          >
+            <div className="flex items-center gap-1.5">
+              <span className={clsx('inline-block h-2 w-2 rounded-full', stat.dotColor)} />
+              <span className="text-xs text-gray-500">{stat.label}</span>
+            </div>
+            <div className={clsx('text-2xl font-semibold mt-0.5', stat.color)}>{stat.value}</div>
+          </div>
+        ))}
+      </div>
+
+      {/* Filter pills */}
+      <div className="mt-6 flex items-center">
+        <div className="flex gap-1">
+          {filterButtons.map((btn) => (
+            <button
+              key={btn.key}
+              onClick={() => setStatusFilter(btn.key)}
+              className={clsx(
+                'px-3 py-1.5 text-xs font-medium rounded-full transition-colors',
+                statusFilter === btn.key
+                  ? 'bg-gray-900 text-white'
+                  : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+              )}
+            >
+              {btn.label}
+              {btn.count > 0 && (
+                <span
+                  className={clsx(
+                    'ml-1.5 tabular-nums',
+                    statusFilter === btn.key ? 'text-gray-300' : 'text-gray-400'
+                  )}
+                >
+                  {btn.count}
+                </span>
+              )}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="mt-4 space-y-3">
+        {isLoading ? (
+          <Card>
+            <CardContent className="py-12 text-center text-gray-500">Loading...</CardContent>
+          </Card>
+        ) : !hasVisibleTasks ? (
+          <Card>
+            <CardContent className="py-12 text-center">
+              <ListTodo className="h-10 w-10 mx-auto text-gray-300 mb-3" />
+              <p className="text-gray-500">No tasks yet.</p>
+              <p className="text-sm text-gray-400 mt-1">
+                Use <code className="bg-gray-100 px-1.5 py-0.5 rounded text-xs">create_task</code>{' '}
+                to create one.
+              </p>
+            </CardContent>
+          </Card>
+        ) : (
+          <>
+            {/* Task Groups */}
+            {sortedGroupIds.map((groupId) => {
+              const group = groupsMap.get(groupId)!;
+              const tasks = grouped.get(groupId) ?? [];
+              const allComplete = tasks.every((t) => t.status === 'completed');
+              return (
+                <TaskGroupSection
+                  key={groupId}
+                  group={group}
+                  tasks={tasks}
+                  onStatusChange={handleStatusChange}
+                  defaultCollapsed={allComplete}
+                />
+              );
+            })}
+
+            {/* Ungrouped tasks by status */}
+            {ungrouped.length > 0 && sortedGroupIds.length > 0 && (
+              <div className="pt-2">
+                <h3 className="text-xs font-medium text-gray-400 uppercase tracking-wider mb-2 px-1">
+                  Ungrouped
+                </h3>
+              </div>
+            )}
+            {STATUS_DISPLAY_ORDER.map((status) => (
+              <UngroupedStatusSection
+                key={status}
+                status={status}
+                tasks={ungroupedByStatus[status]}
+                onStatusChange={handleStatusChange}
+                defaultCollapsed={status === 'completed'}
+              />
+            ))}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/layout/sidebar.tsx
+++ b/packages/web/src/components/layout/sidebar.tsx
@@ -20,6 +20,7 @@ import {
   Activity,
   Route,
   MessageSquare,
+  ListTodo,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useRouter } from 'next/navigation';
@@ -57,6 +58,7 @@ const mainNav: NavGroup[] = [
     label: 'Team',
     items: [
       { name: 'Individuals', href: '/individuals', icon: Bot },
+      { name: 'Tasks', href: '/tasks', icon: ListTodo },
       { name: 'Documents', href: '/artifacts', icon: FileText },
       { name: 'Messaging', href: '/messaging', icon: MessageSquare },
       { name: 'Skills', href: '/skills', icon: Puzzle },

--- a/packages/web/src/lib/api/hooks.ts
+++ b/packages/web/src/lib/api/hooks.ts
@@ -5,7 +5,7 @@ import {
   type UseQueryOptions,
   type UseMutationOptions,
 } from '@tanstack/react-query';
-import { apiGet, apiPost, apiDelete, type ApiError } from './client';
+import { apiGet, apiPost, apiPut, apiDelete, type ApiError } from './client';
 
 /**
  * Hook for authenticated GET requests with React Query caching.
@@ -63,6 +63,27 @@ export function useApiDelete<TResponse = void>(
 ) {
   return useMutation<TResponse, ApiError, string>({
     mutationFn: (id) => apiDelete<TResponse>(`${basePath}/${id}`),
+    ...options,
+  });
+}
+
+/**
+ * Hook for authenticated PUT mutations with dynamic path.
+ *
+ * @example
+ * const mutation = useApiPut<Task, { id: string; body: UpdateInput }>(
+ *   ({ id }) => `/api/admin/tasks/${id}`,
+ *   ({ body }) => body,
+ *   { onSuccess: () => queryClient.invalidateQueries(['tasks']) }
+ * );
+ */
+export function useApiPut<TResponse, TInput>(
+  pathFn: (input: TInput) => string,
+  bodyFn: (input: TInput) => unknown,
+  options?: Omit<UseMutationOptions<TResponse, ApiError, TInput>, 'mutationFn'>
+) {
+  return useMutation<TResponse, ApiError, TInput>({
+    mutationFn: (input) => apiPut<TResponse>(pathFn(input), bodyFn(input)),
     ...options,
   });
 }

--- a/supabase/migrations/20260317190300_task_comments.sql
+++ b/supabase/migrations/20260317190300_task_comments.sql
@@ -1,0 +1,37 @@
+-- Task comments: threaded discussion on individual tasks
+-- Follows the same pattern as artifact_comments
+
+CREATE TABLE IF NOT EXISTS public.task_comments (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  task_id uuid NOT NULL REFERENCES public.tasks(id) ON DELETE CASCADE,
+  user_id uuid NOT NULL REFERENCES public.users(id),
+  workspace_id uuid REFERENCES public.workspaces(id),
+  parent_comment_id uuid REFERENCES public.task_comments(id) ON DELETE CASCADE,
+  content text NOT NULL,
+  created_by_agent_id text,
+  created_by_identity_id uuid REFERENCES public.agent_identities(id),
+  metadata jsonb DEFAULT '{}'::jsonb,
+  deleted_at timestamptz,
+  created_at timestamptz DEFAULT now(),
+  updated_at timestamptz DEFAULT now(),
+  PRIMARY KEY (id)
+);
+
+-- Indexes
+CREATE INDEX IF NOT EXISTS idx_task_comments_task_id ON public.task_comments(task_id);
+CREATE INDEX IF NOT EXISTS idx_task_comments_user_id ON public.task_comments(user_id);
+CREATE INDEX IF NOT EXISTS idx_task_comments_parent ON public.task_comments(parent_comment_id);
+
+-- updated_at trigger
+CREATE TRIGGER set_task_comments_updated_at
+  BEFORE UPDATE ON public.task_comments
+  FOR EACH ROW EXECUTE FUNCTION public.update_updated_at_column();
+
+-- RLS
+ALTER TABLE public.task_comments ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "task_comments_service_full_access"
+  ON public.task_comments FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);


### PR DESCRIPTION
## Summary

- **Tasks dashboard** (`/tasks`) — gorgeous new page with stats row, status filter pills, task group nesting with collapsible sections, and clickable status toggle (complete/reopen tasks inline)
- **Task comments** — inline comment thread on each task card with agent-colored avatars (wren=sky, myra=rose, lumen=amber, etc.), text input + send button, real-time updates
- **`task_comments` migration** — new table following artifact_comments pattern, with agent attribution, threading via parent_comment_id, soft-delete
- **3 admin API endpoints** — `GET /tasks/:id/comments`, `POST /tasks/:id/comments`, `DELETE /tasks/:taskId/comments/:commentId`
- **Enriched `list_tasks` MCP tool** — now returns `taskGroupId`, `taskGroupTitle`, `createdBy`, `blockedBy`, `dueDate`, `metadata`; supports new `groupId` filter parameter
- **New `add_task_comment` MCP tool** — SBs can comment on tasks with automatic agent identity attribution
- **`useApiPut` hook** — new frontend mutation hook for PUT requests
- **Sidebar** — Tasks moved from Platform to Team section
- **Playwright SKILL.md** — added 1440x900 minimum viewport guidance for desktop screenshots

## Test plan

- [ ] Navigate to `/tasks` — verify stats row, filter pills, task cards render with real data
- [ ] Click status icon on a pending task — verify it marks as completed and moves to Completed section
- [ ] Click "comment" on a task — verify inline thread expands with input
- [ ] Post a comment — verify it appears with author avatar and timestamp
- [ ] Filter by Completed/Active/Blocked — verify correct tasks shown
- [ ] Verify `list_tasks` MCP tool returns new fields (taskGroupId, createdBy, blockedBy, dueDate, metadata)
- [ ] Verify `add_task_comment` MCP tool creates comment with agent attribution
- [ ] Type-check passes: `npx tsc --noEmit` for both web and api packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Wren