### PR TITLE
feat: fix skill YAML sync and add chunked memory backfill tooling (by Lumen)

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,10 +120,22 @@ This:
 - pulls the default vetted model (`mxbai-embed-large`)
 - writes the needed memory embedding settings into `.env.local`
 
+To enable embeddings across every git worktree in the repo:
+
+```bash
+sb memory install --all
+```
+
 If you already have the model:
 
 ```bash
 sb memory install --skip-pull
+```
+
+To backfill embeddings for existing memories after enabling semantic recall:
+
+```bash
+sb memory backfill
 ```
 
 If you want to explicitly keep PCP memory in text-only mode, set:

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "test:integration:runtime": "yarn workspace @personal-context/api test:integration:runtime",
     "benchmark:memory-recall": "yarn workspace @personal-context/api benchmark:memory-recall",
     "benchmark:bootstrap-relevance": "yarn workspace @personal-context/api benchmark:bootstrap-relevance",
+    "backfill:memory-embeddings": "yarn workspace @personal-context/api backfill:memory-embeddings",
     "lint": "yarn workspaces foreach -A run lint",
     "type-check": "yarn workspaces foreach -A -t run type-check",
     "clean": "yarn workspaces foreach -A run clean && rm -rf node_modules",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -24,6 +24,7 @@
     "test:channels": "tsx src/test-channels.ts",
     "benchmark:memory-recall": "tsx src/scripts/benchmark-memory-recall.ts",
     "benchmark:bootstrap-relevance": "tsx src/scripts/benchmark-bootstrap-relevance.ts",
+    "backfill:memory-embeddings": "tsx src/scripts/backfill-memory-embeddings.ts",
     "lint": "eslint src --ext .ts",
     "type-check": "yarn workspace @personal-context/shared build && tsc --noEmit",
     "clean": "rm -rf dist"

--- a/packages/api/src/data/models/memory.ts
+++ b/packages/api/src/data/models/memory.ts
@@ -144,6 +144,8 @@ export interface MemoryRow {
   salience: Salience;
   topics: string[];
   agent_id: string | null;
+  embedding_chunks_version?: number | null;
+  embedding_chunk_count?: number | null;
   embedding: number[] | null;
   metadata: Record<string, unknown>;
   version: number;

--- a/packages/api/src/data/repositories/memory-repository.test.ts
+++ b/packages/api/src/data/repositories/memory-repository.test.ts
@@ -991,6 +991,99 @@ describe('MemoryRepository', () => {
       expect(result.summary).toBeUndefined();
       expect(result.topicKey).toBeUndefined();
     });
+
+    it('persists chunk embeddings and records chunked metadata when embeddings are enabled', async () => {
+      const mockRow = {
+        id: 'mem-hm-5',
+        user_id: 'user-456',
+        content: 'A'.repeat(1800),
+        summary: 'Chunked summary',
+        topic_key: 'project:pcp/memory',
+        source: 'observation',
+        salience: 'high',
+        topics: ['project:pcp/memory'],
+        agent_id: 'lumen',
+        embedding: null,
+        metadata: {},
+        version: 1,
+        created_at: '2026-02-18T12:00:00Z',
+        expires_at: null,
+      };
+
+      mockSupabase._setReturnData(mockRow);
+      const embedDocument = vi
+        .fn()
+        .mockResolvedValue({
+          vector: new Array(1024).fill(0.1),
+          provider: 'ollama',
+          model: 'mxbai-embed-large',
+          dimensions: 1024,
+        });
+      (repo as any).embeddingRouter = {
+        isEnabled: vi.fn().mockReturnValue(true),
+        embedDocument,
+        getRuntimeConfig: vi.fn().mockReturnValue({
+          enabled: true,
+          provider: 'ollama',
+          model: 'mxbai-embed-large',
+          dimensions: 1024,
+          queryThreshold: 0.2,
+          matchCountMultiplier: 5,
+          ollamaBaseUrl: 'http://localhost:11434',
+          openaiBaseUrl: 'https://api.openai.com',
+          hasOpenAIKey: false,
+        }),
+      };
+
+      const result = await repo.remember({
+        userId: 'user-456',
+        agentId: 'lumen',
+        content: 'A'.repeat(1800),
+        summary: 'Chunked summary',
+        topicKey: 'project:pcp/memory',
+        salience: 'high',
+      });
+
+      const chunkRows = mockSupabase._queryBuilder.upsert.mock.calls[0][0] as Array<
+        Record<string, unknown>
+      >;
+      expect(embedDocument).toHaveBeenCalledTimes(chunkRows.length);
+      expect(chunkRows.length).toBeGreaterThan(1);
+      expect(mockSupabase.from).toHaveBeenCalledWith('memory_embedding_chunks');
+      expect(mockSupabase._queryBuilder.upsert).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({
+            memory_id: 'mem-hm-5',
+            chunk_type: 'summary',
+            chunk_index: 0,
+            chunk_text: 'Chunked summary',
+          }),
+          expect.objectContaining({
+            memory_id: 'mem-hm-5',
+            chunk_type: 'content',
+            chunk_index: 1,
+          }),
+        ]),
+        expect.objectContaining({ onConflict: 'memory_id,chunk_index' })
+      );
+      expect(mockSupabase._queryBuilder.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          embedding_chunks_version: 1,
+          embedding_chunk_count: chunkRows.length,
+          metadata: expect.objectContaining({
+            embedding_chunks: expect.objectContaining({
+              chunkCount: chunkRows.length,
+              version: 1,
+            }),
+            embedding: expect.objectContaining({
+              provider: 'ollama',
+              model: 'mxbai-embed-large',
+            }),
+          }),
+        })
+      );
+      expect(result.embedding).toEqual(new Array(1024).fill(0.1));
+    });
   });
 
   describe('rowToMemory mapping for new fields', () => {
@@ -1239,7 +1332,7 @@ describe('MemoryRepository', () => {
   });
 
   describe('semantic recall integration', () => {
-    it('serializes query embeddings for match_memories RPC', async () => {
+    it('serializes query embeddings for chunk matcher RPC', async () => {
       const rpc = vi.fn().mockResolvedValue({
         data: [
           {
@@ -1258,6 +1351,8 @@ describe('MemoryRepository', () => {
             created_at: '2026-03-16T00:00:00Z',
             expires_at: null,
             identity_id: null,
+            matched_chunk_index: 0,
+            matched_chunk_text: 'Semantic memory',
             similarity: 0.9,
           },
         ],
@@ -1287,13 +1382,85 @@ describe('MemoryRepository', () => {
       const results = await repo.recall('user-456', 'semantic query', { recallMode: 'semantic' });
 
       expect(rpc).toHaveBeenCalledWith(
-        'match_memories',
+        'match_memory_embedding_chunks',
         expect.objectContaining({
           query_embedding: '[0.1,0.2,0.3]',
         })
       );
       expect(results).toHaveLength(1);
       expect(results[0].embedding).toEqual([0.1, 0.2, 0.3]);
+    });
+
+    it('falls back to legacy memory embeddings when chunk matches are empty', async () => {
+      const rpc = vi
+        .fn()
+        .mockResolvedValueOnce({
+          data: [],
+          error: null,
+        })
+        .mockResolvedValueOnce({
+          data: [
+            {
+              id: 'mem-sem-legacy',
+              user_id: 'user-456',
+              content: 'Legacy semantic memory',
+              summary: 'Legacy semantic memory',
+              topic_key: 'project:pcp/memory',
+              source: 'observation',
+              salience: 'high',
+              topics: ['project:pcp/memory'],
+              agent_id: 'lumen',
+              embedding: '[0.1,0.2,0.3]',
+              metadata: {},
+              version: 1,
+              created_at: '2026-03-16T00:00:00Z',
+              expires_at: null,
+              identity_id: null,
+              similarity: 0.88,
+            },
+          ],
+          error: null,
+        });
+
+      (mockSupabase as any).rpc = rpc;
+      (repo as any).embeddingRouter = {
+        embedQuery: vi.fn().mockResolvedValue({
+          vector: [0.1, 0.2, 0.3],
+          provider: 'openai',
+          model: 'text-embedding-3-small',
+          dimensions: 1024,
+        }),
+        getRuntimeConfig: vi.fn().mockReturnValue({
+          enabled: true,
+          provider: 'openai',
+          model: 'text-embedding-3-small',
+          dimensions: 1024,
+          queryThreshold: 0.2,
+          matchCountMultiplier: 5,
+          ollamaBaseUrl: 'http://localhost:11434',
+          openaiBaseUrl: 'https://api.openai.com',
+          hasOpenAIKey: true,
+        }),
+      };
+
+      const results = await repo.recall('user-456', 'semantic query', { recallMode: 'semantic' });
+
+      expect(rpc).toHaveBeenNthCalledWith(
+        1,
+        'match_memory_embedding_chunks',
+        expect.objectContaining({
+          query_embedding: '[0.1,0.2,0.3]',
+        })
+      );
+      expect(rpc).toHaveBeenNthCalledWith(
+        2,
+        'match_memories',
+        expect.objectContaining({
+          query_embedding: '[0.1,0.2,0.3]',
+        })
+      );
+      expect(results).toHaveLength(1);
+      expect(results[0].id).toBe('mem-sem-legacy');
     });
 
     it('skips RPC when query embedding dimensions do not match schema dimensions', async () => {

--- a/packages/api/src/data/repositories/memory-repository.ts
+++ b/packages/api/src/data/repositories/memory-repository.ts
@@ -6,7 +6,15 @@ import type { SupabaseClient } from '@supabase/supabase-js';
 import type { Database } from '../supabase/types';
 import { resolveIdentityId } from '../../auth/resolve-identity';
 import { logger } from '../../utils/logger';
+import {
+  buildChunkMetadataUpdate,
+  buildChunkRows,
+  buildMemoryEmbeddingChunks,
+  formatVectorLiteral,
+  MEMORY_EMBEDDING_CHUNKS_VERSION,
+} from '../../services/embeddings/memory-chunks';
 import { EmbeddingRouter } from '../../services/embeddings/router';
+import { getVettedEmbeddingModel } from '../../services/embeddings/vetted-models';
 import type {
   Memory,
   MemoryCreateInput,
@@ -37,26 +45,40 @@ interface RecallCandidate {
   finalScore: number;
 }
 
+type MatchMemoryEmbeddingChunksArgs =
+  Database['public']['Functions']['match_memory_embedding_chunks']['Args'];
+type MatchMemoryEmbeddingChunksReturn =
+  Database['public']['Functions']['match_memory_embedding_chunks']['Returns'][number];
 type MatchMemoriesArgs = Database['public']['Functions']['match_memories']['Args'];
 type MatchMemoriesReturn = Database['public']['Functions']['match_memories']['Returns'][number];
+type MatchMemoryEmbeddingChunksRpcResult = {
+  data: MatchMemoryEmbeddingChunksReturn[] | null;
+  error: { message: string } | null;
+};
 type MatchMemoriesRpcResult = {
   data: MatchMemoriesReturn[] | null;
   error: { message: string } | null;
 };
 type MatchMemoriesRpcClient = {
   rpc(fn: 'match_memories', args: MatchMemoriesArgs): Promise<MatchMemoriesRpcResult>;
+  rpc(
+    fn: 'match_memory_embedding_chunks',
+    args: MatchMemoryEmbeddingChunksArgs
+  ): Promise<MatchMemoryEmbeddingChunksRpcResult>;
 };
 
 type SemanticMatchRow = Omit<MemoryRow, 'embedding'> & {
   embedding: number[] | string | null;
   similarity?: number;
 };
+type SemanticChunkMatchRow = Omit<MemoryRow, 'embedding'> & {
+  embedding: number[] | string | null;
+  similarity?: number;
+  matched_chunk_index?: number | null;
+  matched_chunk_text?: string | null;
+};
 
 const DAY_MS = 24 * 60 * 60 * 1000;
-
-function formatVectorLiteral(vector: number[]): string {
-  return `[${vector.join(',')}]`;
-}
 
 function parseEmbeddingValue(value: MemoryRow['embedding'] | string | null): number[] | undefined {
   if (!value) return undefined;
@@ -489,6 +511,80 @@ export class MemoryRepository {
       (offset + limit) * Math.max(1, config.matchCountMultiplier || 1)
     );
 
+    const rpcArgs: MatchMemoryEmbeddingChunksArgs = {
+      query_embedding: formatVectorLiteral(queryEmbedding.vector),
+      match_threshold: config.queryThreshold,
+      match_count: matchCount,
+      p_user_id: userId,
+      p_source: options.source,
+      p_salience: options.salience,
+      p_topics: options.topics && options.topics.length > 0 ? options.topics : undefined,
+      p_agent_id: options.agentId,
+      p_include_shared: options.includeShared !== false,
+      p_include_expired: options.includeExpired === true,
+    };
+
+    const rpcClient = this.supabase as unknown as MatchMemoriesRpcClient;
+    const { data, error } = await rpcClient.rpc('match_memory_embedding_chunks', rpcArgs);
+
+    if (error) {
+      logger.warn(
+        'Chunked semantic memory recall failed, falling back to legacy memory embeddings',
+        {
+          error: error.message,
+        }
+      );
+      return this.tryLegacySemanticRecallCandidates(userId, options, limit, offset, queryEmbedding);
+    }
+
+    const rows = (data || []) as SemanticChunkMatchRow[];
+    if (rows.length === 0) {
+      return this.tryLegacySemanticRecallCandidates(userId, options, limit, offset, queryEmbedding);
+    }
+
+    const grouped = new Map<string, RecallCandidate>();
+
+    for (const row of rows) {
+      const memory = this.rowToMemory(row);
+      const semanticScore = Math.max(0, Math.min(1, row.similarity ?? 0));
+      const existing = grouped.get(memory.id);
+
+      if (!existing || semanticScore > (existing.semanticScore ?? 0)) {
+        grouped.set(memory.id, {
+          memory,
+          semanticScore,
+          finalScore: semanticScore,
+        });
+      }
+    }
+
+    return Array.from(grouped.values())
+      .sort(
+        (a, b) =>
+          (b.semanticScore ?? 0) - (a.semanticScore ?? 0) ||
+          b.memory.createdAt.getTime() - a.memory.createdAt.getTime()
+      )
+      .slice(offset, offset + limit);
+  }
+
+  private async tryLegacySemanticRecallCandidates(
+    userId: string,
+    options: MemorySearchOptions,
+    limit: number,
+    offset: number,
+    queryEmbedding: {
+      vector: number[];
+      provider: string;
+      model: string;
+      dimensions: number;
+    }
+  ): Promise<RecallCandidate[] | null> {
+    const config = this.embeddingRouter.getRuntimeConfig();
+    const matchCount = Math.max(
+      limit,
+      (offset + limit) * Math.max(1, config.matchCountMultiplier || 1)
+    );
+
     const rpcArgs: MatchMemoriesArgs = {
       query_embedding: formatVectorLiteral(queryEmbedding.vector),
       match_threshold: config.queryThreshold,
@@ -506,15 +602,14 @@ export class MemoryRepository {
     const { data, error } = await rpcClient.rpc('match_memories', rpcArgs);
 
     if (error) {
-      logger.warn('Semantic memory recall failed, falling back to text recall', {
+      logger.warn('Legacy semantic memory recall failed, falling back to text recall', {
         error: error.message,
       });
       return null;
     }
 
-    const rows = (data || []) as SemanticMatchRow[];
-    const pagedRows = rows.slice(offset, offset + limit);
-    return pagedRows.map((row) => {
+    const rows = ((data || []) as SemanticMatchRow[]).slice(offset, offset + limit);
+    return rows.map((row) => {
       const memory = this.rowToMemory(row);
       const semanticScore = Math.max(0, Math.min(1, row.similarity ?? 0));
       return {
@@ -528,25 +623,66 @@ export class MemoryRepository {
   private async tryEmbedMemory(memory: Memory, input: MemoryCreateInput): Promise<void> {
     if (!this.embeddingRouter.isEnabled()) return;
 
-    const sourceText = [input.summary, input.content].filter(Boolean).join('\n\n').trim();
-    if (!sourceText) return;
+    const config = this.embeddingRouter.getRuntimeConfig();
+    const vettedModel = getVettedEmbeddingModel(config.provider, config.model);
+    const chunks = buildMemoryEmbeddingChunks({
+      summary: input.summary,
+      content: input.content,
+      model: vettedModel,
+    });
+    if (chunks.length === 0) return;
 
-    const embedding = await this.embeddingRouter.embedDocument(sourceText);
-    if (!embedding) return;
+    const embeddedChunks = [];
+    for (const chunk of chunks) {
+      const embedding = await this.embeddingRouter.embedDocument(chunk.text);
+      if (!embedding) return;
+      embeddedChunks.push({ chunk, embedding });
+    }
+
+    if (embeddedChunks.length === 0) return;
+
+    const primaryChunk = embeddedChunks[0];
+    const primaryEmbedding = primaryChunk.embedding;
+    const chunkRows = buildChunkRows({
+      memoryId: memory.id,
+      userId: memory.userId,
+      chunks: embeddedChunks.map(({ chunk, embedding }) => ({ ...chunk, embedding })),
+    });
+
+    const { error: chunkError } = await this.supabase
+      .from('memory_embedding_chunks')
+      .upsert(chunkRows, {
+        onConflict: 'memory_id,chunk_index',
+      });
+
+    if (chunkError) {
+      logger.warn('Failed to persist memory embedding chunks', {
+        memoryId: memory.id,
+        error: chunkError.message,
+      });
+      return;
+    }
 
     const { error } = await this.supabase
       .from('memories')
       .update({
-        embedding: embedding.vector,
+        embedding: formatVectorLiteral(primaryEmbedding.vector),
+        embedding_chunks_version: MEMORY_EMBEDDING_CHUNKS_VERSION,
+        embedding_chunk_count: embeddedChunks.length,
         metadata: {
-          ...(memory.metadata || {}),
+          ...buildChunkMetadataUpdate({
+            provider: primaryEmbedding.provider,
+            model: primaryEmbedding.model,
+            chunkCount: embeddedChunks.length,
+            existingMetadata: memory.metadata || {},
+          }),
           embedding: {
-            provider: embedding.provider,
-            model: embedding.model,
-            dimensions: embedding.dimensions,
+            provider: primaryEmbedding.provider,
+            model: primaryEmbedding.model,
+            dimensions: primaryEmbedding.dimensions,
             updatedAt: new Date().toISOString(),
           },
-        },
+        } as Database['public']['Tables']['memories']['Update']['metadata'],
       })
       .eq('id', memory.id)
       .eq('user_id', memory.userId);
@@ -559,13 +695,18 @@ export class MemoryRepository {
       return;
     }
 
-    memory.embedding = embedding.vector;
+    memory.embedding = primaryEmbedding.vector;
     memory.metadata = {
-      ...(memory.metadata || {}),
+      ...buildChunkMetadataUpdate({
+        provider: primaryEmbedding.provider,
+        model: primaryEmbedding.model,
+        chunkCount: embeddedChunks.length,
+        existingMetadata: memory.metadata || {},
+      }),
       embedding: {
-        provider: embedding.provider,
-        model: embedding.model,
-        dimensions: embedding.dimensions,
+        provider: primaryEmbedding.provider,
+        model: primaryEmbedding.model,
+        dimensions: primaryEmbedding.dimensions,
       },
     };
   }
@@ -1368,7 +1509,7 @@ export class MemoryRepository {
 
   // ==================== HELPERS ====================
 
-  private rowToMemory(row: MemoryRow | SemanticMatchRow): Memory {
+  private rowToMemory(row: MemoryRow | SemanticChunkMatchRow): Memory {
     return {
       id: row.id,
       userId: row.user_id,

--- a/packages/api/src/data/supabase/types.ts
+++ b/packages/api/src/data/supabase/types.ts
@@ -1562,6 +1562,8 @@ export type Database = {
           agent_id: string | null;
           content: string;
           created_at: string | null;
+          embedding_chunk_count: number | null;
+          embedding_chunks_version: number | null;
           embedding: string | null;
           expires_at: string | null;
           id: string;
@@ -1579,6 +1581,8 @@ export type Database = {
           agent_id?: string | null;
           content: string;
           created_at?: string | null;
+          embedding_chunk_count?: number | null;
+          embedding_chunks_version?: number | null;
           embedding?: string | null;
           expires_at?: string | null;
           id?: string;
@@ -1596,6 +1600,8 @@ export type Database = {
           agent_id?: string | null;
           content?: string;
           created_at?: string | null;
+          embedding_chunk_count?: number | null;
+          embedding_chunks_version?: number | null;
           embedding?: string | null;
           expires_at?: string | null;
           id?: string;
@@ -1619,6 +1625,60 @@ export type Database = {
           },
           {
             foreignKeyName: 'memories_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
+      memory_embedding_chunks: {
+        Row: {
+          chunk_index: number;
+          chunk_text: string;
+          chunk_type: string;
+          created_at: string;
+          embedding: string;
+          id: string;
+          memory_id: string;
+          metadata: Json;
+          updated_at: string;
+          user_id: string;
+        };
+        Insert: {
+          chunk_index: number;
+          chunk_text: string;
+          chunk_type?: string;
+          created_at?: string;
+          embedding: string;
+          id?: string;
+          memory_id: string;
+          metadata?: Json;
+          updated_at?: string;
+          user_id: string;
+        };
+        Update: {
+          chunk_index?: number;
+          chunk_text?: string;
+          chunk_type?: string;
+          created_at?: string;
+          embedding?: string;
+          id?: string;
+          memory_id?: string;
+          metadata?: Json;
+          updated_at?: string;
+          user_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'memory_embedding_chunks_memory_id_fkey';
+            columns: ['memory_id'];
+            isOneToOne: false;
+            referencedRelation: 'memories';
+            referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'memory_embedding_chunks_user_id_fkey';
             columns: ['user_id'];
             isOneToOne: false;
             referencedRelation: 'users';
@@ -3515,6 +3575,40 @@ export type Database = {
           expires_at: string;
           id: string;
           identity_id: string;
+          metadata: Json;
+          salience: string;
+          similarity: number;
+          source: string;
+          summary: string;
+          topic_key: string;
+          topics: string[];
+          user_id: string;
+          version: number;
+        }[];
+      };
+      match_memory_embedding_chunks: {
+        Args: {
+          match_count?: number;
+          match_threshold?: number;
+          p_agent_id?: string;
+          p_include_expired?: boolean;
+          p_include_shared?: boolean;
+          p_salience?: string;
+          p_source?: string;
+          p_topics?: string[];
+          p_user_id?: string;
+          query_embedding: string;
+        };
+        Returns: {
+          agent_id: string;
+          content: string;
+          created_at: string;
+          embedding: string;
+          expires_at: string;
+          id: string;
+          identity_id: string;
+          matched_chunk_index: number;
+          matched_chunk_text: string;
           metadata: Json;
           salience: string;
           similarity: number;

--- a/packages/api/src/scripts/backfill-memory-embeddings.ts
+++ b/packages/api/src/scripts/backfill-memory-embeddings.ts
@@ -4,6 +4,7 @@ import {
   buildChunkMetadataUpdate,
   buildChunkRows,
   buildMemoryEmbeddingChunks,
+  formatVectorLiteral,
   MEMORY_EMBEDDING_CHUNKS_VERSION,
 } from '../services/embeddings/memory-chunks';
 import { EmbeddingRouter } from '../services/embeddings/router';
@@ -163,7 +164,7 @@ async function main() {
       const { error: updateError } = await supabase
         .from('memories')
         .update({
-          embedding: primaryEmbedding.vector,
+          embedding: formatVectorLiteral(primaryEmbedding.vector),
           embedding_chunks_version: MEMORY_EMBEDDING_CHUNKS_VERSION,
           embedding_chunk_count: embeddedChunks.length,
           metadata: {

--- a/packages/api/src/scripts/backfill-memory-embeddings.ts
+++ b/packages/api/src/scripts/backfill-memory-embeddings.ts
@@ -1,6 +1,13 @@
 import { createSupabaseClient } from '../data/supabase/client';
 import type { Database } from '../data/supabase/types';
+import {
+  buildChunkMetadataUpdate,
+  buildChunkRows,
+  buildMemoryEmbeddingChunks,
+  MEMORY_EMBEDDING_CHUNKS_VERSION,
+} from '../services/embeddings/memory-chunks';
 import { EmbeddingRouter } from '../services/embeddings/router';
+import { getVettedEmbeddingModel } from '../services/embeddings/vetted-models';
 
 type MemoryRow = Database['public']['Tables']['memories']['Row'];
 
@@ -15,14 +22,6 @@ function parsePositiveInt(raw: string | undefined, defaultValue: number): number
   if (!raw) return defaultValue;
   const parsed = Number.parseInt(raw, 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : defaultValue;
-}
-
-function buildEmbeddingText(memory: Pick<MemoryRow, 'summary' | 'content'>): string {
-  return [memory.summary, memory.content].filter(Boolean).join('\n\n').trim();
-}
-
-function toVectorLiteral(vector: number[]): string {
-  return `[${vector.join(',')}]`;
 }
 
 async function main() {
@@ -46,24 +45,28 @@ async function main() {
       'Memory embeddings are disabled. Run `sb memory install` or set MEMORY_EMBEDDINGS_ENABLED=true before backfilling.'
     );
   }
+  const config = router.getRuntimeConfig();
+  const vettedModel = getVettedEmbeddingModel(config.provider, config.model);
 
   const supabase = createSupabaseClient();
 
   let processed = 0;
   let updated = 0;
   let skipped = 0;
+  let scanned = 0;
 
-  while (limit === null || processed < limit) {
-    const remaining = limit === null ? batchSize : Math.min(batchSize, limit - processed);
+  while (limit === null || scanned < limit) {
+    const remaining = limit === null ? batchSize : Math.min(batchSize, limit - scanned);
     if (remaining <= 0) break;
 
     let query = supabase
       .from('memories')
-      .select('id,user_id,agent_id,content,summary,metadata')
+      .select(
+        'id,user_id,agent_id,content,summary,metadata,embedding,embedding_chunks_version,embedding_chunk_count'
+      )
       .eq('user_id', userId)
-      .is('embedding', null)
       .order('created_at', { ascending: true })
-      .limit(remaining);
+      .range(scanned, scanned + remaining - 1);
 
     if (agentId) {
       query = query.eq('agent_id', agentId);
@@ -76,48 +79,111 @@ async function main() {
 
     const rows = (data || []) as Pick<
       MemoryRow,
-      'id' | 'user_id' | 'agent_id' | 'content' | 'summary' | 'metadata'
+      | 'id'
+      | 'user_id'
+      | 'agent_id'
+      | 'content'
+      | 'summary'
+      | 'metadata'
+      | 'embedding'
+      | 'embedding_chunks_version'
+      | 'embedding_chunk_count'
     >[];
 
     if (rows.length === 0) break;
+    scanned += rows.length;
 
     for (const row of rows) {
-      const text = buildEmbeddingText(row);
       processed += 1;
+      const hasCurrentChunks =
+        row.embedding_chunks_version === MEMORY_EMBEDDING_CHUNKS_VERSION &&
+        (row.embedding_chunk_count || 0) > 0;
 
-      if (!text) {
+      if (hasCurrentChunks) {
         skipped += 1;
         continue;
       }
 
-      const embedding = await router.embedDocument(text);
-      if (!embedding) {
+      const chunks = buildMemoryEmbeddingChunks({
+        summary: row.summary,
+        content: row.content,
+        model: vettedModel,
+      });
+      if (chunks.length === 0) {
         skipped += 1;
         continue;
       }
+
+      const embeddedChunks = [];
+      for (const chunk of chunks) {
+        const embedding = await router.embedDocument(chunk.text);
+        if (!embedding) continue;
+        embeddedChunks.push({ chunk, embedding });
+      }
+
+      if (embeddedChunks.length === 0) {
+        skipped += 1;
+        continue;
+      }
+
+      const primaryEmbedding = embeddedChunks[0].embedding;
+      const chunkRows = buildChunkRows({
+        memoryId: row.id,
+        userId: row.user_id,
+        chunks: embeddedChunks.map(({ chunk, embedding }) => ({ ...chunk, embedding })),
+      });
 
       if (dryRun) {
         console.log(
-          `DRY RUN would backfill memory ${row.id} (${row.agent_id || 'shared'}) with ${embedding.dimensions}-dim ${embedding.provider}:${embedding.model}`
+          `DRY RUN would backfill memory ${row.id} (${row.agent_id || 'shared'}) with ${embeddedChunks.length} chunk(s) via ${primaryEmbedding.provider}:${primaryEmbedding.model}`
         );
         updated += 1;
         continue;
       }
 
+      const { error: chunkDeleteError } = await supabase
+        .from('memory_embedding_chunks')
+        .delete()
+        .eq('memory_id', row.id);
+
+      if (chunkDeleteError) {
+        throw new Error(`Failed to clear chunks for memory ${row.id}: ${chunkDeleteError.message}`);
+      }
+
+      const { error: chunkUpsertError } = await supabase
+        .from('memory_embedding_chunks')
+        .upsert(chunkRows, { onConflict: 'memory_id,chunk_index' });
+
+      if (chunkUpsertError) {
+        throw new Error(
+          `Failed to upsert chunks for memory ${row.id}: ${chunkUpsertError.message}`
+        );
+      }
+
       const { error: updateError } = await supabase
         .from('memories')
         .update({
-          embedding: toVectorLiteral(embedding.vector),
+          embedding: primaryEmbedding.vector,
+          embedding_chunks_version: MEMORY_EMBEDDING_CHUNKS_VERSION,
+          embedding_chunk_count: embeddedChunks.length,
           metadata: {
-            ...((row.metadata as Record<string, unknown> | null) || {}),
+            ...buildChunkMetadataUpdate({
+              provider: primaryEmbedding.provider,
+              model: primaryEmbedding.model,
+              chunkCount: embeddedChunks.length,
+              existingMetadata: ((row.metadata as Record<string, unknown> | null) || {}) as Record<
+                string,
+                unknown
+              > | null,
+            }),
             embedding: {
-              provider: embedding.provider,
-              model: embedding.model,
-              dimensions: embedding.dimensions,
+              provider: primaryEmbedding.provider,
+              model: primaryEmbedding.model,
+              dimensions: primaryEmbedding.dimensions,
               updatedAt: new Date().toISOString(),
               backfilled: true,
             },
-          },
+          } as Database['public']['Tables']['memories']['Update']['metadata'],
         })
         .eq('id', row.id)
         .eq('user_id', row.user_id);
@@ -128,13 +194,13 @@ async function main() {
 
       updated += 1;
       console.log(
-        `Backfilled memory ${row.id} (${row.agent_id || 'shared'}) with ${embedding.provider}:${embedding.model}`
+        `Backfilled memory ${row.id} (${row.agent_id || 'shared'}) with ${embeddedChunks.length} chunk(s) via ${primaryEmbedding.provider}:${primaryEmbedding.model}`
       );
     }
   }
 
   console.log(
-    `Backfill complete. processed=${processed} updated=${updated} skipped=${skipped} dryRun=${dryRun}`
+    `Backfill complete. scanned=${scanned} processed=${processed} updated=${updated} skipped=${skipped} dryRun=${dryRun}`
   );
 }
 

--- a/packages/api/src/scripts/backfill-memory-embeddings.ts
+++ b/packages/api/src/scripts/backfill-memory-embeddings.ts
@@ -1,0 +1,145 @@
+import { createSupabaseClient } from '../data/supabase/client';
+import type { Database } from '../data/supabase/types';
+import { EmbeddingRouter } from '../services/embeddings/router';
+
+type MemoryRow = Database['public']['Tables']['memories']['Row'];
+
+const DEFAULT_BATCH_SIZE = 100;
+
+function parseBoolean(raw: string | undefined, defaultValue: boolean): boolean {
+  if (raw === undefined) return defaultValue;
+  return ['1', 'true', 'yes', 'on'].includes(raw.toLowerCase());
+}
+
+function parsePositiveInt(raw: string | undefined, defaultValue: number): number {
+  if (!raw) return defaultValue;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : defaultValue;
+}
+
+function buildEmbeddingText(memory: Pick<MemoryRow, 'summary' | 'content'>): string {
+  return [memory.summary, memory.content].filter(Boolean).join('\n\n').trim();
+}
+
+function toVectorLiteral(vector: number[]): string {
+  return `[${vector.join(',')}]`;
+}
+
+async function main() {
+  const userId = process.env.BACKFILL_MEMORY_USER_ID;
+  if (!userId) {
+    throw new Error(
+      'BACKFILL_MEMORY_USER_ID is required. Example: BACKFILL_MEMORY_USER_ID=<uuid> yarn backfill:memory-embeddings'
+    );
+  }
+
+  const agentId = process.env.BACKFILL_MEMORY_AGENT_ID;
+  const batchSize = parsePositiveInt(process.env.BACKFILL_MEMORY_BATCH_SIZE, DEFAULT_BATCH_SIZE);
+  const limit = process.env.BACKFILL_MEMORY_LIMIT
+    ? parsePositiveInt(process.env.BACKFILL_MEMORY_LIMIT, batchSize)
+    : null;
+  const dryRun = parseBoolean(process.env.BACKFILL_MEMORY_DRY_RUN, false);
+
+  const router = new EmbeddingRouter();
+  if (!router.isEnabled()) {
+    throw new Error(
+      'Memory embeddings are disabled. Run `sb memory install` or set MEMORY_EMBEDDINGS_ENABLED=true before backfilling.'
+    );
+  }
+
+  const supabase = createSupabaseClient();
+
+  let processed = 0;
+  let updated = 0;
+  let skipped = 0;
+
+  while (limit === null || processed < limit) {
+    const remaining = limit === null ? batchSize : Math.min(batchSize, limit - processed);
+    if (remaining <= 0) break;
+
+    let query = supabase
+      .from('memories')
+      .select('id,user_id,agent_id,content,summary,metadata')
+      .eq('user_id', userId)
+      .is('embedding', null)
+      .order('created_at', { ascending: true })
+      .limit(remaining);
+
+    if (agentId) {
+      query = query.eq('agent_id', agentId);
+    }
+
+    const { data, error } = await query;
+    if (error) {
+      throw new Error(`Failed to fetch memories for backfill: ${error.message}`);
+    }
+
+    const rows = (data || []) as Pick<
+      MemoryRow,
+      'id' | 'user_id' | 'agent_id' | 'content' | 'summary' | 'metadata'
+    >[];
+
+    if (rows.length === 0) break;
+
+    for (const row of rows) {
+      const text = buildEmbeddingText(row);
+      processed += 1;
+
+      if (!text) {
+        skipped += 1;
+        continue;
+      }
+
+      const embedding = await router.embedDocument(text);
+      if (!embedding) {
+        skipped += 1;
+        continue;
+      }
+
+      if (dryRun) {
+        console.log(
+          `DRY RUN would backfill memory ${row.id} (${row.agent_id || 'shared'}) with ${embedding.dimensions}-dim ${embedding.provider}:${embedding.model}`
+        );
+        updated += 1;
+        continue;
+      }
+
+      const { error: updateError } = await supabase
+        .from('memories')
+        .update({
+          embedding: toVectorLiteral(embedding.vector),
+          metadata: {
+            ...((row.metadata as Record<string, unknown> | null) || {}),
+            embedding: {
+              provider: embedding.provider,
+              model: embedding.model,
+              dimensions: embedding.dimensions,
+              updatedAt: new Date().toISOString(),
+              backfilled: true,
+            },
+          },
+        })
+        .eq('id', row.id)
+        .eq('user_id', row.user_id);
+
+      if (updateError) {
+        throw new Error(`Failed to update memory ${row.id}: ${updateError.message}`);
+      }
+
+      updated += 1;
+      console.log(
+        `Backfilled memory ${row.id} (${row.agent_id || 'shared'}) with ${embedding.provider}:${embedding.model}`
+      );
+    }
+  }
+
+  console.log(
+    `Backfill complete. processed=${processed} updated=${updated} skipped=${skipped} dryRun=${dryRun}`
+  );
+}
+
+main().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(message);
+  process.exit(1);
+});

--- a/packages/api/src/services/embeddings/memory-chunks.ts
+++ b/packages/api/src/services/embeddings/memory-chunks.ts
@@ -1,0 +1,154 @@
+import type { Json, TablesInsert } from '../../data/supabase/types';
+import type { EmbeddingResult } from './router';
+import { type VettedEmbeddingModel } from './vetted-models';
+
+export const MEMORY_EMBEDDING_CHUNKS_VERSION = 1;
+const DEFAULT_MAX_CHARS = 1000;
+const DEFAULT_OVERLAP_CHARS = 150;
+
+export interface MemoryEmbeddingChunk {
+  chunkIndex: number;
+  chunkType: 'summary' | 'content';
+  text: string;
+  startOffset: number;
+  endOffset: number;
+}
+
+export interface EmbeddedMemoryChunk extends MemoryEmbeddingChunk {
+  embedding: EmbeddingResult;
+}
+
+function pickMaxChunkChars(model: VettedEmbeddingModel | null): number {
+  if (!model?.maxInputChars) return DEFAULT_MAX_CHARS;
+  return Math.max(200, model.maxInputChars - 100);
+}
+
+function findChunkBoundary(text: string, start: number, targetEnd: number): number {
+  if (targetEnd >= text.length) return text.length;
+
+  const minBoundary = Math.min(text.length, start + Math.floor((targetEnd - start) * 0.6));
+  const window = text.slice(minBoundary, targetEnd);
+  const breakCandidates = ['\n\n', '\n', '. ', ' '];
+
+  for (const delimiter of breakCandidates) {
+    const idx = window.lastIndexOf(delimiter);
+    if (idx !== -1) return minBoundary + idx + delimiter.length;
+  }
+
+  return targetEnd;
+}
+
+function buildContentChunks(
+  text: string,
+  maxChars: number,
+  overlapChars: number
+): MemoryEmbeddingChunk[] {
+  const normalized = text.trim();
+  if (!normalized) return [];
+
+  const chunks: MemoryEmbeddingChunk[] = [];
+  let start = 0;
+  let chunkIndex = 0;
+
+  while (start < normalized.length) {
+    const targetEnd = Math.min(normalized.length, start + maxChars);
+    const end = findChunkBoundary(normalized, start, targetEnd);
+    const chunkText = normalized.slice(start, end).trim();
+
+    if (chunkText) {
+      chunks.push({
+        chunkIndex,
+        chunkType: 'content',
+        text: chunkText,
+        startOffset: start,
+        endOffset: end,
+      });
+      chunkIndex += 1;
+    }
+
+    if (end >= normalized.length) break;
+    start = Math.max(end - overlapChars, start + 1);
+  }
+
+  return chunks;
+}
+
+export function buildMemoryEmbeddingChunks(params: {
+  summary?: string | null;
+  content: string;
+  model?: VettedEmbeddingModel | null;
+}): MemoryEmbeddingChunk[] {
+  const { summary, content, model = null } = params;
+  const chunks: MemoryEmbeddingChunk[] = [];
+  const maxChars = pickMaxChunkChars(model);
+
+  const normalizedSummary = summary?.trim();
+  if (normalizedSummary) {
+    chunks.push({
+      chunkIndex: 0,
+      chunkType: 'summary',
+      text: normalizedSummary,
+      startOffset: 0,
+      endOffset: normalizedSummary.length,
+    });
+  }
+
+  const contentChunks = buildContentChunks(content, maxChars, DEFAULT_OVERLAP_CHARS).map(
+    (chunk) => ({
+      ...chunk,
+      chunkIndex: chunk.chunkIndex + chunks.length,
+    })
+  );
+
+  return [...chunks, ...contentChunks];
+}
+
+export function formatVectorLiteral(vector: number[]): string {
+  return `[${vector.join(',')}]`;
+}
+
+export function buildChunkRows(params: {
+  memoryId: string;
+  userId: string;
+  chunks: EmbeddedMemoryChunk[];
+}): TablesInsert<'memory_embedding_chunks'>[] {
+  const { memoryId, userId, chunks } = params;
+
+  return chunks.map((chunk) => ({
+    memory_id: memoryId,
+    user_id: userId,
+    chunk_index: chunk.chunkIndex,
+    chunk_type: chunk.chunkType,
+    chunk_text: chunk.text,
+    embedding: formatVectorLiteral(chunk.embedding.vector),
+    metadata: {
+      embedding: {
+        provider: chunk.embedding.provider,
+        model: chunk.embedding.model,
+        dimensions: chunk.embedding.dimensions,
+      },
+      startOffset: chunk.startOffset,
+      endOffset: chunk.endOffset,
+      version: MEMORY_EMBEDDING_CHUNKS_VERSION,
+    } satisfies Json,
+  }));
+}
+
+export function buildChunkMetadataUpdate(params: {
+  provider: string;
+  model: string;
+  chunkCount: number;
+  existingMetadata?: Record<string, unknown> | null;
+}): Record<string, unknown> {
+  const { provider, model, chunkCount, existingMetadata } = params;
+  return {
+    ...(existingMetadata || {}),
+    embedding_chunks: {
+      provider,
+      model,
+      version: MEMORY_EMBEDDING_CHUNKS_VERSION,
+      chunkCount,
+      updatedAt: new Date().toISOString(),
+    },
+  };
+}

--- a/packages/api/src/services/embeddings/router.test.ts
+++ b/packages/api/src/services/embeddings/router.test.ts
@@ -68,4 +68,28 @@ describe('EmbeddingRouter', () => {
     const result = await router.embedDocument('doc');
     expect(result).toBeNull();
   });
+
+  it('clamps long Ollama inputs to the vetted model limit', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch' as any).mockResolvedValue({
+      ok: true,
+      json: async () => ({ embeddings: [new Array(1024).fill(0.1)] }),
+    } as Response);
+
+    const router = new EmbeddingRouter({
+      ...baseConfig,
+      provider: 'ollama',
+      model: 'mxbai-embed-large',
+      dimensions: 1024,
+      hasOpenAIKey: false,
+    });
+
+    await router.embedDocument('x'.repeat(2000));
+
+    const request = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined;
+    const body = request?.body;
+    expect(typeof body).toBe('string');
+    const parsed = JSON.parse(body as string) as { input: string[] };
+    expect(parsed.input[0].length).toBe(1203);
+    expect(parsed.input[0].endsWith('...')).toBe(true);
+  });
 });

--- a/packages/api/src/services/embeddings/router.ts
+++ b/packages/api/src/services/embeddings/router.ts
@@ -2,6 +2,7 @@ import { env } from '../../config/env';
 import { logger } from '../../utils/logger';
 import {
   getDefaultVettedModel,
+  getVettedEmbeddingModel,
   VETTED_EMBEDDING_MODELS,
   type EmbeddingProviderKind,
   type VettedEmbeddingModel,
@@ -28,17 +29,6 @@ export interface EmbeddingRuntimeConfig {
 
 const DEFAULT_OPENAI_BASE_URL = 'https://api.openai.com';
 const MEMORY_EMBEDDING_SCHEMA_DIMENSIONS = 1024;
-
-function findVettedModel(
-  provider: EmbeddingProviderKind,
-  model: string
-): VettedEmbeddingModel | null {
-  return (
-    VETTED_EMBEDDING_MODELS.find(
-      (candidate) => candidate.provider === provider && candidate.model === model
-    ) || null
-  );
-}
 
 function assertExpectedDimensions(
   vector: number[],
@@ -73,7 +63,7 @@ function buildRuntimeConfig(): EmbeddingRuntimeConfig {
     });
   }
 
-  const vettedModel = findVettedModel(provider, model);
+  const vettedModel = getVettedEmbeddingModel(provider, model);
   if (vettedModel && !vettedModel.dimensions.includes(dimensions)) {
     logger.warn('Selected embedding model does not advertise support for schema dimensions', {
       provider,
@@ -127,7 +117,7 @@ export class EmbeddingRouter {
     if (!this.config.enabled) return null;
     const input = text.trim();
     if (!input) return null;
-    const vettedModel = findVettedModel(this.config.provider, this.config.model);
+    const vettedModel = getVettedEmbeddingModel(this.config.provider, this.config.model);
     const providerInput = clampEmbeddingInput(input, vettedModel);
 
     if (providerInput !== input) {

--- a/packages/api/src/services/embeddings/router.ts
+++ b/packages/api/src/services/embeddings/router.ts
@@ -54,6 +54,12 @@ function assertExpectedDimensions(
   return vector;
 }
 
+function clampEmbeddingInput(text: string, vettedModel: VettedEmbeddingModel | null): string {
+  const maxInputChars = vettedModel?.maxInputChars;
+  if (!maxInputChars || text.length <= maxInputChars) return text;
+  return `${text.slice(0, maxInputChars)}...`;
+}
+
 function buildRuntimeConfig(): EmbeddingRuntimeConfig {
   const provider = env.MEMORY_EMBEDDING_PROVIDER || 'ollama';
   const model = env.MEMORY_EMBEDDING_MODEL || getDefaultVettedModel(provider);
@@ -121,12 +127,23 @@ export class EmbeddingRouter {
     if (!this.config.enabled) return null;
     const input = text.trim();
     if (!input) return null;
+    const vettedModel = findVettedModel(this.config.provider, this.config.model);
+    const providerInput = clampEmbeddingInput(input, vettedModel);
+
+    if (providerInput !== input) {
+      logger.info('Clamped embedding input to vetted model limit', {
+        provider: this.config.provider,
+        model: this.config.model,
+        originalChars: input.length,
+        clampedChars: providerInput.length,
+      });
+    }
 
     try {
       if (this.config.provider === 'openai') {
-        return await this.embedWithOpenAI(input);
+        return await this.embedWithOpenAI(providerInput);
       }
-      return await this.embedWithOllama(input);
+      return await this.embedWithOllama(providerInput);
     } catch (primaryError) {
       logger.warn('Primary embedding provider failed, attempting fallback', {
         provider: this.config.provider,
@@ -137,7 +154,7 @@ export class EmbeddingRouter {
       try {
         if (this.config.provider === 'ollama' && this.config.hasOpenAIKey) {
           const fallback = await this.embedWithOpenAI(
-            input,
+            providerInput,
             getDefaultVettedModel('openai'),
             this.config.dimensions
           );
@@ -151,7 +168,7 @@ export class EmbeddingRouter {
 
         if (this.config.provider === 'openai') {
           const fallback = await this.embedWithOllama(
-            input,
+            providerInput,
             getDefaultVettedModel('ollama'),
             this.config.dimensions
           );

--- a/packages/api/src/services/embeddings/vetted-models.ts
+++ b/packages/api/src/services/embeddings/vetted-models.ts
@@ -57,6 +57,17 @@ export const VETTED_EMBEDDING_MODELS: VettedEmbeddingModel[] = [
   },
 ];
 
+export function getVettedEmbeddingModel(
+  provider: EmbeddingProviderKind,
+  model: string
+): VettedEmbeddingModel | null {
+  return (
+    VETTED_EMBEDDING_MODELS.find(
+      (candidate) => candidate.provider === provider && candidate.model === model
+    ) || null
+  );
+}
+
 export function getDefaultVettedModel(provider: EmbeddingProviderKind): string {
   return (
     VETTED_EMBEDDING_MODELS.find((m) => m.provider === provider && m.default)?.model ||

--- a/packages/api/src/services/embeddings/vetted-models.ts
+++ b/packages/api/src/services/embeddings/vetted-models.ts
@@ -5,6 +5,7 @@ export interface VettedEmbeddingModel {
   model: string;
   recommendedFor: string;
   dimensions: number[];
+  maxInputChars?: number;
   notes: string;
   default?: boolean;
 }
@@ -19,6 +20,7 @@ export const VETTED_EMBEDDING_MODELS: VettedEmbeddingModel[] = [
     model: 'mxbai-embed-large',
     recommendedFor: 'Best local quality (recommended local default)',
     dimensions: [1024],
+    maxInputChars: 1200,
     notes: 'Higher quality local embeddings; larger model footprint.',
     default: true,
   },
@@ -27,6 +29,7 @@ export const VETTED_EMBEDDING_MODELS: VettedEmbeddingModel[] = [
     model: 'nomic-embed-text',
     recommendedFor: 'Balanced local quality/speed',
     dimensions: [768, 512, 256, 128, 64],
+    maxInputChars: 1200,
     notes: 'Good local option when lower dimensionality is desired.',
   },
   {
@@ -34,6 +37,7 @@ export const VETTED_EMBEDDING_MODELS: VettedEmbeddingModel[] = [
     model: 'all-minilm',
     recommendedFor: 'Fastest lightweight local baseline',
     dimensions: [384],
+    maxInputChars: 1200,
     notes: 'Small footprint; useful for quick experiments.',
   },
   {

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -226,10 +226,22 @@ This command:
 - pulls the default vetted embedding model (`mxbai-embed-large`)
 - writes the required memory embedding settings into `.env.local`
 
+To write the same config into every git worktree for the repo:
+
+```bash
+sb memory install --all
+```
+
 If the model is already present:
 
 ```bash
 sb memory install --skip-pull
+```
+
+To backfill embeddings for existing memories after enabling them:
+
+```bash
+sb memory backfill
 ```
 
 To explicitly disable embeddings and keep text-only recall:

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -28,7 +28,8 @@
     "commander": "^12.1.0",
     "ink": "npm:@jrichman/ink@6.4.11",
     "ora": "^8.0.1",
-    "react": "^19.2.4"
+    "react": "^19.2.4",
+    "yaml": "^2.8.2"
   },
   "devDependencies": {
     "@types/node": "^20.10.0",

--- a/packages/cli/src/commands/memory.ts
+++ b/packages/cli/src/commands/memory.ts
@@ -3,15 +3,26 @@ import chalk from 'chalk';
 import ora from 'ora';
 import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
-import { spawn } from 'child_process';
+import { homedir } from 'os';
+import { execSync, spawn } from 'child_process';
 import { parseEnvFile } from './mcp.js';
 
 const DEFAULT_OLLAMA_BASE_URL = 'http://127.0.0.1:11434';
 const DEFAULT_OLLAMA_MODEL = 'mxbai-embed-large';
+const DEFAULT_BACKFILL_BATCH_SIZE = 100;
 
 interface InstallOptions {
   model?: string;
   skipPull?: boolean;
+  all?: boolean;
+}
+
+interface BackfillOptions {
+  userId?: string;
+  agent?: string;
+  limit?: string;
+  batchSize?: string;
+  dryRun?: boolean;
 }
 
 function formatInstallInstructions(): string[] {
@@ -51,6 +62,37 @@ function upsertEnvFile(filePath: string, entries: Record<string, string>): void 
   writeFileSync(filePath, `${nextLines.filter(Boolean).join('\n')}\n`, 'utf-8');
 }
 
+function getWorktrees(cwd: string): string[] {
+  try {
+    const output = execSync('git worktree list --porcelain', {
+      cwd,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    return Array.from(
+      new Set(
+        output
+          .split('\n')
+          .filter((line) => line.startsWith('worktree '))
+          .map((line) => line.slice('worktree '.length))
+          .filter((worktreePath) => existsSync(worktreePath))
+      )
+    );
+  } catch {
+    return [cwd];
+  }
+}
+
+function readUserIdFromConfig(): string | undefined {
+  try {
+    const configPath = join(homedir(), '.pcp', 'config.json');
+    const raw = JSON.parse(readFileSync(configPath, 'utf-8')) as { userId?: string };
+    return raw.userId;
+  } catch {
+    return undefined;
+  }
+}
+
 async function commandExists(command: string): Promise<boolean> {
   return new Promise((resolve) => {
     const child = spawn(command, ['--version'], {
@@ -63,9 +105,15 @@ async function commandExists(command: string): Promise<boolean> {
   });
 }
 
-async function runStreamingCommand(command: string, args: string[]): Promise<void> {
+async function runStreamingCommand(
+  command: string,
+  args: string[],
+  options: { cwd?: string; env?: NodeJS.ProcessEnv } = {}
+): Promise<void> {
   await new Promise<void>((resolve, reject) => {
     const child = spawn(command, args, {
+      cwd: options.cwd,
+      env: options.env,
       stdio: 'inherit',
       shell: false,
     });
@@ -92,7 +140,6 @@ async function checkOllama(baseUrl: string): Promise<boolean> {
 async function installCommand(options: InstallOptions): Promise<void> {
   const model = options.model || DEFAULT_OLLAMA_MODEL;
   const cwd = process.env.INIT_CWD || process.cwd();
-  const envPath = join(cwd, '.env.local');
   const spinner = ora('Checking Ollama installation').start();
 
   if (!(await commandExists('ollama'))) {
@@ -105,7 +152,8 @@ async function installCommand(options: InstallOptions): Promise<void> {
 
   spinner.succeed('Ollama is installed');
 
-  const baseUrl = parseEnvFile(envPath).OLLAMA_BASE_URL || DEFAULT_OLLAMA_BASE_URL;
+  const worktrees = options.all ? getWorktrees(cwd) : [cwd];
+  const baseUrl = parseEnvFile(join(cwd, '.env.local')).OLLAMA_BASE_URL || DEFAULT_OLLAMA_BASE_URL;
 
   if (!options.skipPull) {
     console.log(chalk.bold(`\nPulling embedding model: ${model}\n`));
@@ -118,18 +166,53 @@ async function installCommand(options: InstallOptions): Promise<void> {
     console.log(chalk.dim('If Ollama is installed but not running, start it with `ollama serve`.'));
   }
 
-  upsertEnvFile(envPath, {
-    MEMORY_EMBEDDINGS_ENABLED: 'true',
-    MEMORY_EMBEDDING_PROVIDER: 'ollama',
-    MEMORY_EMBEDDING_MODEL: model,
-    OLLAMA_BASE_URL: baseUrl,
-  });
+  const updatedEnvPaths: string[] = [];
+  for (const worktree of worktrees) {
+    const envPath = join(worktree, '.env.local');
+    upsertEnvFile(envPath, {
+      MEMORY_EMBEDDINGS_ENABLED: 'true',
+      MEMORY_EMBEDDING_PROVIDER: 'ollama',
+      MEMORY_EMBEDDING_MODEL: model,
+      OLLAMA_BASE_URL: baseUrl,
+    });
+    updatedEnvPaths.push(envPath);
+  }
 
   console.log(chalk.green('\n✓ Memory embeddings configured\n'));
-  console.log(chalk.dim(`Updated: ${envPath}`));
+  for (const envPath of updatedEnvPaths) {
+    console.log(chalk.dim(`Updated: ${envPath}`));
+  }
   console.log(chalk.dim('Next useful commands:'));
+  console.log(chalk.dim('  sb memory backfill'));
   console.log(chalk.dim('  yarn benchmark:memory-recall'));
   console.log(chalk.dim('  yarn benchmark:bootstrap-relevance'));
+}
+
+async function backfillCommand(options: BackfillOptions): Promise<void> {
+  const cwd = process.env.INIT_CWD || process.cwd();
+  const userId = options.userId || readUserIdFromConfig();
+
+  if (!userId) {
+    throw new Error(
+      'Could not determine PCP userId. Pass --user-id <uuid> or ensure ~/.pcp/config.json contains userId.'
+    );
+  }
+
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    BACKFILL_MEMORY_USER_ID: userId,
+  };
+
+  if (options.agent) env.BACKFILL_MEMORY_AGENT_ID = options.agent;
+  if (options.limit) env.BACKFILL_MEMORY_LIMIT = options.limit;
+  if (options.batchSize) env.BACKFILL_MEMORY_BATCH_SIZE = options.batchSize;
+  if (options.dryRun) env.BACKFILL_MEMORY_DRY_RUN = 'true';
+
+  await runStreamingCommand(
+    'yarn',
+    ['workspace', '@personal-context/api', 'backfill:memory-embeddings'],
+    { cwd, env }
+  );
 }
 
 export function registerMemoryCommands(program: Command): void {
@@ -139,11 +222,32 @@ export function registerMemoryCommands(program: Command): void {
     .command('install')
     .description('Install and configure local memory embeddings via Ollama')
     .option('--model <name>', 'Ollama embedding model to pull', DEFAULT_OLLAMA_MODEL)
+    .option('--all', 'Write memory embedding config into every git worktree in this repo')
     .option('--skip-pull', 'Skip `ollama pull` if the model is already installed')
     .action((options: InstallOptions) => {
       installCommand(options).catch((error) => {
         const message = error instanceof Error ? error.message : String(error);
         console.error(chalk.red(`Memory install failed: ${message}`));
+        process.exit(1);
+      });
+    });
+
+  memory
+    .command('backfill')
+    .description('Generate embeddings for existing memories that do not have them yet')
+    .option('--user-id <uuid>', 'PCP user ID to backfill (defaults to ~/.pcp/config.json userId)')
+    .option('--agent <id>', 'Optional agent filter (e.g. lumen, wren)')
+    .option('--limit <n>', 'Maximum number of memories to backfill in this run')
+    .option(
+      '--batch-size <n>',
+      'Number of memories to process per DB fetch',
+      String(DEFAULT_BACKFILL_BATCH_SIZE)
+    )
+    .option('--dry-run', 'Show what would be backfilled without writing embeddings')
+    .action((options: BackfillOptions) => {
+      backfillCommand(options).catch((error) => {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error(chalk.red(`Memory backfill failed: ${message}`));
         process.exit(1);
       });
     });

--- a/packages/cli/src/commands/skills.test.ts
+++ b/packages/cli/src/commands/skills.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { buildSkillMd } from './skills.js';
+
+describe('buildSkillMd', () => {
+  it('serializes empty nested MCP env objects as valid YAML', () => {
+    const skillMd = buildSkillMd({
+      success: true,
+      skillName: 'playwright-mcp',
+      type: 'cli',
+      version: '1.0.0',
+      description: 'Playwright MCP',
+      content: '# Playwright MCP',
+      triggers: {
+        keywords: ['playwright', 'browser'],
+      },
+      mcp: {
+        name: 'playwright',
+        command: 'npx',
+        args: ['@playwright/mcp', '--headless'],
+        env: {},
+      },
+    });
+
+    expect(skillMd).toContain('env: {}');
+    expect(skillMd).not.toContain('env:\n{}');
+    expect(skillMd).toContain('env: {}\n---\n');
+  });
+});

--- a/packages/cli/src/commands/skills.ts
+++ b/packages/cli/src/commands/skills.ts
@@ -12,6 +12,7 @@
 
 import { Command } from 'commander';
 import chalk from 'chalk';
+import * as yaml from 'yaml';
 import {
   existsSync,
   lstatSync,
@@ -109,7 +110,7 @@ function getWorktrees(): string[] {
   }
 }
 
-function buildSkillMd(skill: GetSkillResponse): string {
+export function buildSkillMd(skill: GetSkillResponse): string {
   const frontmatter: Record<string, unknown> = {
     name: skill.skillName,
     description: skill.description,
@@ -126,40 +127,8 @@ function buildSkillMd(skill: GetSkillResponse): string {
     frontmatter.mcp = skill.mcp;
   }
 
-  const yamlLines = serializeYaml(frontmatter, 0);
-  return `---\n${yamlLines}---\n\n${skill.content}\n`;
-}
-
-function serializeYaml(obj: unknown, indent: number): string {
-  const prefix = '  '.repeat(indent);
-  if (obj === null || obj === undefined) return '';
-
-  if (Array.isArray(obj)) {
-    if (obj.length === 0) return '[]\n';
-    if (obj.every((v) => typeof v === 'string')) {
-      const items = obj.map((v) => JSON.stringify(v)).join(', ');
-      return `[${items}]\n`;
-    }
-    return obj.map((v) => `${prefix}- ${String(v)}`).join('\n') + '\n';
-  }
-
-  if (typeof obj === 'object') {
-    const entries = Object.entries(obj as Record<string, unknown>);
-    if (entries.length === 0) return '{}\n';
-    return entries
-      .map(([key, val]) => {
-        if (typeof val === 'object' && val !== null && !Array.isArray(val)) {
-          const nested = serializeYaml(val, indent + 1);
-          return `${prefix}${key}:\n${nested}`;
-        }
-        const serialized = serializeYaml(val, indent).trimEnd();
-        return `${prefix}${key}: ${serialized}\n`;
-      })
-      .join('');
-  }
-
-  if (typeof obj === 'string') return obj;
-  return String(obj);
+  const yamlLines = yaml.stringify(frontmatter).trimEnd();
+  return `---\n${yamlLines}\n---\n\n${skill.content}\n`;
 }
 
 function injectMcpServers(

--- a/supabase/migrations/20260318163759_memory_embedding_chunks.sql
+++ b/supabase/migrations/20260318163759_memory_embedding_chunks.sql
@@ -1,0 +1,143 @@
+-- Chunked semantic embeddings for memories so long memories keep full retrieval coverage.
+
+ALTER TABLE public.memories
+  ADD COLUMN IF NOT EXISTS embedding_chunks_version integer,
+  ADD COLUMN IF NOT EXISTS embedding_chunk_count integer;
+
+CREATE TABLE IF NOT EXISTS public.memory_embedding_chunks (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  memory_id uuid NOT NULL REFERENCES public.memories(id) ON DELETE CASCADE,
+  user_id uuid NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  chunk_index integer NOT NULL,
+  chunk_type text NOT NULL,
+  chunk_text text NOT NULL,
+  embedding vector(1024) NOT NULL,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT memory_embedding_chunks_memory_chunk_key UNIQUE (memory_id, chunk_index)
+);
+
+CREATE INDEX IF NOT EXISTS idx_memory_embedding_chunks_memory_id
+  ON public.memory_embedding_chunks(memory_id);
+
+CREATE INDEX IF NOT EXISTS idx_memory_embedding_chunks_user_id
+  ON public.memory_embedding_chunks(user_id);
+
+CREATE INDEX IF NOT EXISTS idx_memory_embedding_chunks_embedding
+  ON public.memory_embedding_chunks
+  USING hnsw (embedding vector_cosine_ops);
+
+DROP TRIGGER IF EXISTS set_memory_embedding_chunks_updated_at ON public.memory_embedding_chunks;
+CREATE TRIGGER set_memory_embedding_chunks_updated_at
+  BEFORE UPDATE ON public.memory_embedding_chunks
+  FOR EACH ROW EXECUTE FUNCTION public.update_updated_at_column();
+
+CREATE OR REPLACE FUNCTION public.match_memory_embedding_chunks(
+  query_embedding vector,
+  match_threshold double precision DEFAULT 0.2,
+  match_count integer DEFAULT 20,
+  p_user_id uuid DEFAULT NULL,
+  p_source text DEFAULT NULL,
+  p_salience text DEFAULT NULL,
+  p_topics text[] DEFAULT NULL,
+  p_agent_id text DEFAULT NULL,
+  p_include_shared boolean DEFAULT true,
+  p_include_expired boolean DEFAULT false
+)
+RETURNS TABLE (
+  id uuid,
+  user_id uuid,
+  content text,
+  summary text,
+  topic_key text,
+  source text,
+  salience text,
+  topics text[],
+  embedding vector,
+  metadata jsonb,
+  version integer,
+  created_at timestamptz,
+  expires_at timestamptz,
+  agent_id text,
+  identity_id uuid,
+  matched_chunk_text text,
+  matched_chunk_index integer,
+  similarity double precision
+)
+LANGUAGE sql
+STABLE
+AS $$
+  WITH ranked_matches AS (
+    SELECT
+      m.id,
+      m.user_id,
+      m.content,
+      m.summary,
+      m.topic_key,
+      m.source,
+      m.salience,
+      m.topics,
+      m.embedding,
+      m.metadata,
+      m.version,
+      m.created_at,
+      m.expires_at,
+      m.agent_id,
+      m.identity_id,
+      c.chunk_text AS matched_chunk_text,
+      c.chunk_index AS matched_chunk_index,
+      1 - (c.embedding <=> query_embedding) AS similarity,
+      row_number() OVER (
+        PARTITION BY m.id
+        ORDER BY c.embedding <=> query_embedding ASC, c.chunk_index ASC
+      ) AS rank_within_memory
+    FROM public.memory_embedding_chunks c
+    JOIN public.memories m ON m.id = c.memory_id
+    WHERE
+      (p_user_id IS NULL OR m.user_id = p_user_id)
+      AND (p_source IS NULL OR m.source = p_source)
+      AND (p_salience IS NULL OR m.salience = p_salience)
+      AND (p_topics IS NULL OR m.topics && p_topics)
+      AND (
+        p_agent_id IS NULL
+        OR (
+          p_include_shared
+          AND (m.agent_id = p_agent_id OR m.agent_id IS NULL)
+        )
+        OR (
+          NOT p_include_shared
+          AND m.agent_id = p_agent_id
+        )
+      )
+      AND (
+        p_include_expired
+        OR m.expires_at IS NULL
+        OR m.expires_at > now()
+      )
+      AND 1 - (c.embedding <=> query_embedding) > match_threshold
+  )
+  SELECT
+    id,
+    user_id,
+    content,
+    summary,
+    topic_key,
+    source,
+    salience,
+    topics,
+    embedding,
+    metadata,
+    version,
+    created_at,
+    expires_at,
+    agent_id,
+    identity_id,
+    matched_chunk_text,
+    matched_chunk_index,
+    similarity
+  FROM ranked_matches
+  WHERE rank_within_memory = 1
+  ORDER BY similarity DESC, created_at DESC
+  LIMIT match_count;
+$$;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2098,6 +2098,7 @@ __metadata:
     tsx: "npm:^4.7.0"
     typescript: "npm:^5.3.0"
     vitest: "npm:^4.0.18"
+    yaml: "npm:^2.8.2"
   bin:
     sb: dist/cli.js
   languageName: unknown
@@ -2192,73 +2193,6 @@ __metadata:
   version: 0.11.0
   resolution: "@pkgjs/parseargs@npm:0.11.0"
   checksum: 10/115e8ceeec6bc69dff2048b35c0ab4f8bbee12d8bb6c1f4af758604586d802b6e669dcb02dda61d078de42c2b4ddce41b3d9e726d7daa6b4b850f4adbf7333ff
-  languageName: node
-  linkType: hard
-
-"@pm2/agent@npm:~2.1.1":
-  version: 2.1.1
-  resolution: "@pm2/agent@npm:2.1.1"
-  dependencies:
-    async: "npm:~3.2.0"
-    chalk: "npm:~3.0.0"
-    dayjs: "npm:~1.8.24"
-    debug: "npm:~4.3.1"
-    eventemitter2: "npm:~5.0.1"
-    fast-json-patch: "npm:^3.1.0"
-    fclone: "npm:~1.0.11"
-    pm2-axon: "npm:~4.0.1"
-    pm2-axon-rpc: "npm:~0.7.0"
-    proxy-agent: "npm:~6.4.0"
-    semver: "npm:~7.5.0"
-    ws: "npm:~7.5.10"
-  checksum: 10/8adc4e087bb69c609e98d1895cf4185483f14d8a6ea25cc3b62e9c13c6aa974582709fe51909ee3580976306ab14f84546b8e0156fd19c562dcf4548297671f8
-  languageName: node
-  linkType: hard
-
-"@pm2/blessed@npm:0.1.81":
-  version: 0.1.81
-  resolution: "@pm2/blessed@npm:0.1.81"
-  bin:
-    blessed: bin/tput.js
-  checksum: 10/e83e4aaf390f8ff996eda7c59d6373fcf2e2508b8a5ccf9455d967f3dd85d7f9b6c43eaf205e237b121a7249b3d18875346beaf3c1c49c2824f46b614b3328c9
-  languageName: node
-  linkType: hard
-
-"@pm2/io@npm:~6.1.0":
-  version: 6.1.0
-  resolution: "@pm2/io@npm:6.1.0"
-  dependencies:
-    async: "npm:~2.6.1"
-    debug: "npm:~4.3.1"
-    eventemitter2: "npm:^6.3.1"
-    require-in-the-middle: "npm:^5.0.0"
-    semver: "npm:~7.5.4"
-    shimmer: "npm:^1.2.0"
-    signal-exit: "npm:^3.0.3"
-    tslib: "npm:1.9.3"
-  checksum: 10/c95a1b4cf0b16877a503ed4eddcb94353db7f0dcfb39f59cac70cbad5c530a05a0d337602d38a7d38ffc185b142ec99f2ddf714a48ab9e1ec62f39a5760c9d74
-  languageName: node
-  linkType: hard
-
-"@pm2/js-api@npm:~0.8.0":
-  version: 0.8.0
-  resolution: "@pm2/js-api@npm:0.8.0"
-  dependencies:
-    async: "npm:^2.6.3"
-    debug: "npm:~4.3.1"
-    eventemitter2: "npm:^6.3.1"
-    extrareqp2: "npm:^1.0.0"
-    ws: "npm:^7.0.0"
-  checksum: 10/b7c19a10d49f22ae39b52d3a45907b33d83680055a8359baf4c8cb7d82832fa7abdbea84e0105df4506b50d5972cd5a086d4d249ab0a7b54ea2748724d819427
-  languageName: node
-  linkType: hard
-
-"@pm2/pm2-version-check@npm:^1.0.4":
-  version: 1.0.4
-  resolution: "@pm2/pm2-version-check@npm:1.0.4"
-  dependencies:
-    debug: "npm:^4.3.1"
-  checksum: 10/663438d9154db3c11bc7d41a4838162542db9cb4cf989fe8936e9bd9e5b99e3a58d73c8888afa1180a8cb93375c1d165bb397939de8a5ab8507d13d2aed2a086
   languageName: node
   linkType: hard
 
@@ -3540,13 +3474,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tootallnate/quickjs-emscripten@npm:^0.23.0":
-  version: 0.23.0
-  resolution: "@tootallnate/quickjs-emscripten@npm:0.23.0"
-  checksum: 10/95cbad451d195b9d8f312103abafcc010741eb9256e98d7953e7c026d4c1ed4abb2248a14018bf49e3201c350104fc643137b23aa0bbed2744c795c39dc48a28
-  languageName: node
-  linkType: hard
-
 "@types/babel__core@npm:^7.1.14, @types/babel__core@npm:^7.20.5":
   version: 7.20.5
   resolution: "@types/babel__core@npm:7.20.5"
@@ -4480,7 +4407,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"agent-base@npm:^7.0.2, agent-base@npm:^7.1.0, agent-base@npm:^7.1.2":
+"agent-base@npm:^7.1.0, agent-base@npm:^7.1.2":
   version: 7.1.4
   resolution: "agent-base@npm:7.1.4"
   checksum: 10/79bef167247789f955aaba113bae74bf64aa1e1acca4b1d6bb444bdf91d82c3e07e9451ef6a6e2e35e8f71a6f97ce33e3d855a5328eb9fad1bc3cc4cfd031ed8
@@ -4522,29 +4449,6 @@ __metadata:
     json-schema-traverse: "npm:^1.0.0"
     require-from-string: "npm:^2.0.2"
   checksum: 10/ee3c62162c953e91986c838f004132b6a253d700f1e51253b99791e2dbfdb39161bc950ebdc2f156f8568035bb5ed8be7bd78289cd9ecbf3381fe8f5b82e3f33
-  languageName: node
-  linkType: hard
-
-"amp-message@npm:~0.1.1":
-  version: 0.1.2
-  resolution: "amp-message@npm:0.1.2"
-  dependencies:
-    amp: "npm:0.3.1"
-  checksum: 10/30c93c1118aa157b5762cdf026c994dc3ebc0391e96dd047e1fddc471f11a93e5868fa21df48c0bdbc6ef7444f6a75284f9a2be4bb7e1cfcf6b5943023710ddb
-  languageName: node
-  linkType: hard
-
-"amp@npm:0.3.1, amp@npm:~0.3.1":
-  version: 0.3.1
-  resolution: "amp@npm:0.3.1"
-  checksum: 10/d87c786ff03681b4a1d16396a84b9fefdbfc293d9aad4b2a10aa7ae53256f614ce103096b6e38f3cd93d5269fa13b152f9ce33f0f83551362530f4b8169c9ba2
-  languageName: node
-  linkType: hard
-
-"ansi-colors@npm:^4.1.1":
-  version: 4.1.3
-  resolution: "ansi-colors@npm:4.1.3"
-  checksum: 10/43d6e2fc7b1c6e4dc373de708ee76311ec2e0433e7e8bd3194e7ff123ea6a747428fc61afdcf5969da5be3a5f0fd054602bec56fc0ebe249ce2fcde6e649e3c2
   languageName: node
   linkType: hard
 
@@ -4600,13 +4504,6 @@ __metadata:
   version: 6.2.3
   resolution: "ansi-styles@npm:6.2.3"
   checksum: 10/c49dad7639f3e48859bd51824c93b9eb0db628afc243c51c3dd2410c4a15ede1a83881c6c7341aa2b159c4f90c11befb38f2ba848c07c66c9f9de4bcd7cb9f30
-  languageName: node
-  linkType: hard
-
-"ansis@npm:4.0.0-node10":
-  version: 4.0.0-node10
-  resolution: "ansis@npm:4.0.0-node10"
-  checksum: 10/6313038d9eb66e6d42e4b205f5d4242f161f5160a669ce4a9d12164ff5d241513a38a5019ee4c9a400da514375d8270e2211f895b5fe04bf86918d02db639140
   languageName: node
   linkType: hard
 
@@ -4697,15 +4594,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ast-types@npm:^0.13.4":
-  version: 0.13.4
-  resolution: "ast-types@npm:0.13.4"
-  dependencies:
-    tslib: "npm:^2.0.1"
-  checksum: 10/c55b375b9aaf44713d8c0f77a08215ab6d44f368b13e44f2141c421022af3c62b615a30c8ea629457f0cbaec409c713401c0188a124552c8fe4a5ad6b17ff3c3
-  languageName: node
-  linkType: hard
-
 "ast-v8-to-istanbul@npm:^0.3.10":
   version: 0.3.10
   resolution: "ast-v8-to-istanbul@npm:0.3.10"
@@ -4740,19 +4628,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"async@npm:3.2.6, async@npm:^3.2.0, async@npm:^3.2.3, async@npm:~3.2.0":
+"async@npm:^3.2.3":
   version: 3.2.6
   resolution: "async@npm:3.2.6"
   checksum: 10/cb6e0561a3c01c4b56a799cc8bab6ea5fef45f069ab32500b6e19508db270ef2dffa55e5aed5865c5526e9907b1f8be61b27530823b411ffafb5e1538c86c368
-  languageName: node
-  linkType: hard
-
-"async@npm:^2.6.3, async@npm:~2.6.1":
-  version: 2.6.4
-  resolution: "async@npm:2.6.4"
-  dependencies:
-    lodash: "npm:^4.17.14"
-  checksum: 10/df8e52817d74677ab50c438d618633b9450aff26deb274da6dfedb8014130909482acdc7753bce9b72e6171ce9a9f6a92566c4ced34c3cb3714d57421d58ad27
   languageName: node
   linkType: hard
 
@@ -4930,13 +4809,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"basic-ftp@npm:^5.0.2":
-  version: 5.2.0
-  resolution: "basic-ftp@npm:5.2.0"
-  checksum: 10/f5a15d789aa98859af4da9e976154b2aeae19052e1762dc68d259d2bce631dafa40c667aa06d7346cd630aa6f9cc9a26f515b468e0bd24243fbae2149c7d01ad
-  languageName: node
-  linkType: hard
-
 "bcrypt@npm:^5.1.1":
   version: 5.1.1
   resolution: "bcrypt@npm:5.1.1"
@@ -4958,13 +4830,6 @@ __metadata:
   version: 2.3.0
   resolution: "binary-extensions@npm:2.3.0"
   checksum: 10/bcad01494e8a9283abf18c1b967af65ee79b0c6a9e6fcfafebfe91dbe6e0fc7272bafb73389e198b310516ae04f7ad17d79aacf6cb4c0d5d5202a7e2e52c7d98
-  languageName: node
-  linkType: hard
-
-"bodec@npm:^0.1.0":
-  version: 0.1.0
-  resolution: "bodec@npm:0.1.0"
-  checksum: 10/caa05f96954e2d412ce9ac164612a8532387c412f4811acedb3b724bfc7a819d5b8527d533d002dae8c31dcdc070bb11d52a4978fb6d889c2ea7cd242034c0f0
   languageName: node
   linkType: hard
 
@@ -5226,16 +5091,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:3.0.0, chalk@npm:~3.0.0":
-  version: 3.0.0
-  resolution: "chalk@npm:3.0.0"
-  dependencies:
-    ansi-styles: "npm:^4.1.0"
-    supports-color: "npm:^7.1.0"
-  checksum: 10/37f90b31fd655fb49c2bd8e2a68aebefddd64522655d001ef417e6f955def0ed9110a867ffc878a533f2dafea5f2032433a37c8a7614969baa7f8a1cd424ddfc
-  languageName: node
-  linkType: hard
-
 "chalk@npm:4.1.2, chalk@npm:^4.0.0":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
@@ -5316,13 +5171,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"charm@npm:~0.1.1":
-  version: 0.1.2
-  resolution: "charm@npm:0.1.2"
-  checksum: 10/445eb994dffd15561f745bdb00dad1a7047ee9416359dd1ffe72b96cab8d0f24f403989cd5297165284d679cba89e740e29be7d385481df32e7e1529aca787ea
-  languageName: node
-  linkType: hard
-
 "cheerio-select@npm:^2.1.0":
   version: 2.1.0
   resolution: "cheerio-select@npm:2.1.0"
@@ -5353,7 +5201,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chokidar@npm:3.6.0, chokidar@npm:^3.6.0":
+"chokidar@npm:^3.6.0":
   version: 3.6.0
   resolution: "chokidar@npm:3.6.0"
   dependencies:
@@ -5438,15 +5286,6 @@ __metadata:
   version: 2.9.2
   resolution: "cli-spinners@npm:2.9.2"
   checksum: 10/a0a863f442df35ed7294424f5491fa1756bd8d2e4ff0c8736531d886cec0ece4d85e8663b77a5afaf1d296e3cbbebff92e2e99f52bbea89b667cbe789b994794
-  languageName: node
-  linkType: hard
-
-"cli-tableau@npm:2.0.1":
-  version: 2.0.1
-  resolution: "cli-tableau@npm:2.0.1"
-  dependencies:
-    chalk: "npm:3.0.0"
-  checksum: 10/9b9e6a979129f9f4061f9d9e8b1e3ff5f25509050ffffb12f65ce6c88a97ba5da3b7715a0defdb569bef56507dd306e814e7a06fb918166e05d9bb0089794629
   languageName: node
   linkType: hard
 
@@ -5616,13 +5455,6 @@ __metadata:
   version: 2.0.3
   resolution: "comma-separated-tokens@npm:2.0.3"
   checksum: 10/e3bf9e0332a5c45f49b90e79bcdb4a7a85f28d6a6f0876a94f1bb9b2bfbdbbb9292aac50e1e742d8c0db1e62a0229a106f57917e2d067fca951d81737651700d
-  languageName: node
-  linkType: hard
-
-"commander@npm:2.15.1":
-  version: 2.15.1
-  resolution: "commander@npm:2.15.1"
-  checksum: 10/6f4545833348d61dd0c3b285c7f0dc9bc8b1bdac38b512d263184918811382c646c38d58c1102caeff0eb57d4bbd526efc5e6116a78b6af7c1aad6fb628678a8
   languageName: node
   linkType: hard
 
@@ -5836,13 +5668,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"croner@npm:4.1.97":
-  version: 4.1.97
-  resolution: "croner@npm:4.1.97"
-  checksum: 10/ff605f231e358f1985ca2f6f1fed7fbf03de533227efd132e574af0c0f7d76391d45ab7a893351259bb9b79a36312221125950f16b42462f21d554915f54c5dc
-  languageName: node
-  linkType: hard
-
 "cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3, cross-spawn@npm:^7.0.5, cross-spawn@npm:^7.0.6":
   version: 7.0.6
   resolution: "cross-spawn@npm:7.0.6"
@@ -5890,38 +5715,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"culvert@npm:^0.1.2":
-  version: 0.1.2
-  resolution: "culvert@npm:0.1.2"
-  checksum: 10/86446c95b86bb3dec71503755b578db370a00397a332f9fd507b3cbbf514146535b840d5abf52611dcc84318004cfff3f00ef30549a3624c489d03fe2c1b1ef1
-  languageName: node
-  linkType: hard
-
 "data-uri-to-buffer@npm:^4.0.0":
   version: 4.0.1
   resolution: "data-uri-to-buffer@npm:4.0.1"
   checksum: 10/0d0790b67ffec5302f204c2ccca4494f70b4e2d940fea3d36b09f0bb2b8539c2e86690429eb1f1dc4bcc9e4df0644193073e63d9ee48ac9fce79ec1506e4aa4c
-  languageName: node
-  linkType: hard
-
-"data-uri-to-buffer@npm:^6.0.2":
-  version: 6.0.2
-  resolution: "data-uri-to-buffer@npm:6.0.2"
-  checksum: 10/8b6927c33f9b54037f442856be0aa20e5fd49fa6c9c8ceece408dc306445d593ad72d207d57037c529ce65f413b421da800c6827b1dbefb607b8056f17123a61
-  languageName: node
-  linkType: hard
-
-"dayjs@npm:1.11.15":
-  version: 1.11.15
-  resolution: "dayjs@npm:1.11.15"
-  checksum: 10/09e411cf71db962465563fa968276cf9162721bd5cff514bf94e6ed087b5e7d58135cbb5739ad380e44fa8148858378f3c36e2992e263dac64c06ba133a2ae8d
-  languageName: node
-  linkType: hard
-
-"dayjs@npm:~1.8.24":
-  version: 1.8.36
-  resolution: "dayjs@npm:1.8.36"
-  checksum: 10/f9f9343472eba0fc3cb4dbd3acc83c9de93d6aaff122f73699d3bdd02939601e36850d240080e26bf042b703aaf9a45b6cd130959902f6936fbbb7e1fc54c239
   languageName: node
   linkType: hard
 
@@ -5934,7 +5731,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:4.4.3, debug@npm:^4.0.0, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:^4.4.0, debug@npm:^4.4.3":
+"debug@npm:4, debug@npm:^4.0.0, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:^4.4.0, debug@npm:^4.4.3":
   version: 4.4.3
   resolution: "debug@npm:4.4.3"
   dependencies:
@@ -5943,27 +5740,6 @@ __metadata:
     supports-color:
       optional: true
   checksum: 10/9ada3434ea2993800bd9a1e320bd4aa7af69659fb51cca685d390949434bc0a8873c21ed7c9b852af6f2455a55c6d050aa3937d52b3c69f796dab666f762acad
-  languageName: node
-  linkType: hard
-
-"debug@npm:^3.2.6":
-  version: 3.2.7
-  resolution: "debug@npm:3.2.7"
-  dependencies:
-    ms: "npm:^2.1.1"
-  checksum: 10/d86fd7be2b85462297ea16f1934dc219335e802f629ca9a69b63ed8ed041dda492389bb2ee039217c02e5b54792b1c51aa96ae954cf28634d363a2360c7a1639
-  languageName: node
-  linkType: hard
-
-"debug@npm:~4.3.1":
-  version: 4.3.7
-  resolution: "debug@npm:4.3.7"
-  dependencies:
-    ms: "npm:^2.1.3"
-  peerDependenciesMeta:
-    supports-color:
-      optional: true
-  checksum: 10/71168908b9a78227ab29d5d25fe03c5867750e31ce24bf2c44a86efc5af041758bb56569b0a3d48a9b5344c00a24a777e6f4100ed6dfd9534a42c1dde285125a
   languageName: node
   linkType: hard
 
@@ -6006,17 +5782,6 @@ __metadata:
   version: 4.3.1
   resolution: "deepmerge@npm:4.3.1"
   checksum: 10/058d9e1b0ff1a154468bf3837aea436abcfea1ba1d165ddaaf48ca93765fdd01a30d33c36173da8fbbed951dd0a267602bc782fe288b0fc4b7e1e7091afc4529
-  languageName: node
-  linkType: hard
-
-"degenerator@npm:^5.0.0":
-  version: 5.0.1
-  resolution: "degenerator@npm:5.0.1"
-  dependencies:
-    ast-types: "npm:^0.13.4"
-    escodegen: "npm:^2.1.0"
-    esprima: "npm:^4.0.1"
-  checksum: 10/a64fa39cdf6c2edd75188157d32338ee9de7193d7dbb2aeb4acb1eb30fa4a15ed80ba8dae9bd4d7b085472cf174a5baf81adb761aaa8e326771392c922084152
   languageName: node
   linkType: hard
 
@@ -6310,15 +6075,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"enquirer@npm:2.3.6":
-  version: 2.3.6
-  resolution: "enquirer@npm:2.3.6"
-  dependencies:
-    ansi-colors: "npm:^4.1.1"
-  checksum: 10/751d14f037eb7683997e696fb8d5fe2675e0b0cde91182c128cf598acf3f5bd9005f35f7c2a9109e291140af496ebec237b6dac86067d59a9b44f3688107f426
-  languageName: node
-  linkType: hard
-
 "entities@npm:^4.2.0, entities@npm:^4.4.0":
   version: 4.5.0
   resolution: "entities@npm:4.5.0"
@@ -6541,24 +6297,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"escodegen@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "escodegen@npm:2.1.0"
-  dependencies:
-    esprima: "npm:^4.0.1"
-    estraverse: "npm:^5.2.0"
-    esutils: "npm:^2.0.2"
-    source-map: "npm:~0.6.1"
-  dependenciesMeta:
-    source-map:
-      optional: true
-  bin:
-    escodegen: bin/escodegen.js
-    esgenerate: bin/esgenerate.js
-  checksum: 10/47719a65b2888b4586e3fa93769068b275961c13089e90d5d01a96a6e8e95871b1c3893576814c8fbf08a4a31a496f37e7b2c937cf231270f4d81de012832c7c
-  languageName: node
-  linkType: hard
-
 "eslint-scope@npm:^7.2.2":
   version: 7.2.2
   resolution: "eslint-scope@npm:7.2.2"
@@ -6635,7 +6373,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esprima@npm:^4.0.0, esprima@npm:^4.0.1":
+"esprima@npm:^4.0.0":
   version: 4.0.1
   resolution: "esprima@npm:4.0.1"
   bin:
@@ -6704,20 +6442,6 @@ __metadata:
   version: 5.0.1
   resolution: "event-target-shim@npm:5.0.1"
   checksum: 10/49ff46c3a7facbad3decb31f597063e761785d7fdb3920d4989d7b08c97a61c2f51183e2f3a03130c9088df88d4b489b1b79ab632219901f184f85158508f4c8
-  languageName: node
-  linkType: hard
-
-"eventemitter2@npm:5.0.1, eventemitter2@npm:~5.0.1":
-  version: 5.0.1
-  resolution: "eventemitter2@npm:5.0.1"
-  checksum: 10/824cc9012c4b16022d9cd663ee67b978d816eb7969cf0a1ef91b6564bf62550a600e052007b27869c7fe1bf7c8e25885a6abc0c92c1b1432dfa0162a63486853
-  languageName: node
-  linkType: hard
-
-"eventemitter2@npm:^6.3.1":
-  version: 6.4.9
-  resolution: "eventemitter2@npm:6.4.9"
-  checksum: 10/b829b1c6b11e15926b635092b5ad62b4463d1c928859831dcae606e988cf41893059e3541f5a8209d21d2f15314422ddd4d84d20830b4bf44978608d15b06b08
   languageName: node
   linkType: hard
 
@@ -6904,15 +6628,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"extrareqp2@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "extrareqp2@npm:1.0.0"
-  dependencies:
-    follow-redirects: "npm:^1.14.0"
-  checksum: 10/b98d655d031d80a15b63eb9472693f0fb6cd0d7c00a5af23465064383cc0d67b52279ae1f6dea2828017de41e16725972f2429ac403093e7aaffafb6414a459d
-  languageName: node
-  linkType: hard
-
 "fast-deep-equal@npm:3.1.3, fast-deep-equal@npm:^3.1.1, fast-deep-equal@npm:^3.1.3":
   version: 3.1.3
   resolution: "fast-deep-equal@npm:3.1.3"
@@ -6937,13 +6652,6 @@ __metadata:
     merge2: "npm:^1.3.0"
     micromatch: "npm:^4.0.8"
   checksum: 10/dcc6432b269762dd47381d8b8358bf964d8f4f60286ac6aa41c01ade70bda459ff2001b516690b96d5365f68a49242966112b5d5cc9cd82395fa8f9d017c90ad
-  languageName: node
-  linkType: hard
-
-"fast-json-patch@npm:^3.1.0":
-  version: 3.1.1
-  resolution: "fast-json-patch@npm:3.1.1"
-  checksum: 10/3e56304e1c95ad1862a50e5b3f557a74c65c0ff2ba5b15caab983b43e70e86ddbc5bc887e9f7064f0aacfd0f0435a29ab2f000fe463379e72b906486345e6671
   languageName: node
   linkType: hard
 
@@ -6983,13 +6691,6 @@ __metadata:
   dependencies:
     bser: "npm:2.1.1"
   checksum: 10/4f95d336fb805786759e383fd7fff342ceb7680f53efcc0ef82f502eb479ce35b98e8b207b6dfdfeea0eba845862107dc73813775fc6b56b3098c6e90a2dad77
-  languageName: node
-  linkType: hard
-
-"fclone@npm:1.0.11, fclone@npm:~1.0.11":
-  version: 1.0.11
-  resolution: "fclone@npm:1.0.11"
-  checksum: 10/5f2b89aca797b9bdf314961226e5e9e1d9298e868d668bf9552a39ef498f236c3d7fc63637da923a945738bfa34911f65876495f71a7af1c1aa20fe0024d5dcc
   languageName: node
   linkType: hard
 
@@ -7126,7 +6827,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.14.0, follow-redirects@npm:^1.15.11":
+"follow-redirects@npm:^1.15.11":
   version: 1.15.11
   resolution: "follow-redirects@npm:1.15.11"
   peerDependenciesMeta:
@@ -7380,31 +7081,6 @@ __metadata:
   dependencies:
     resolve-pkg-maps: "npm:^1.0.0"
   checksum: 10/3603c6da30e312636e4c20461e779114c9126601d1eca70ee4e36e3e3c00e3c21892d2d920027333afa2cc9e20998a436b14abe03a53cde40742581cb0e9ceb2
-  languageName: node
-  linkType: hard
-
-"get-uri@npm:^6.0.1":
-  version: 6.0.5
-  resolution: "get-uri@npm:6.0.5"
-  dependencies:
-    basic-ftp: "npm:^5.0.2"
-    data-uri-to-buffer: "npm:^6.0.2"
-    debug: "npm:^4.3.4"
-  checksum: 10/6daa56eb367dc030ae7bf6db4b5d36f200c9bb47ab00593c142176e4f33f22e129a294ac94329c6bcaebda19b7506080267a336742d20a915fb2bef9c400347f
-  languageName: node
-  linkType: hard
-
-"git-node-fs@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "git-node-fs@npm:1.0.0"
-  checksum: 10/296b0c90e789de469879a924b8c0c10a2dd2821071fcf078621ff6203da7bd55dedf82a5143c4ed62f6f41a56567daf0313220865e649d8c35df7e7d48cb482e
-  languageName: node
-  linkType: hard
-
-"git-sha1@npm:^0.1.2":
-  version: 0.1.2
-  resolution: "git-sha1@npm:0.1.2"
-  checksum: 10/f34de0d11c02dd3131599022cec79b2920229745b4a757f3ad6141a752cf5b0af4e22a4d768229020616bf03099b4a6645496489232841f378a4953fb42848fc
   languageName: node
   linkType: hard
 
@@ -7738,7 +7414,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"http-proxy-agent@npm:^7.0.0, http-proxy-agent@npm:^7.0.1":
+"http-proxy-agent@npm:^7.0.0":
   version: 7.0.2
   resolution: "http-proxy-agent@npm:7.0.2"
   dependencies:
@@ -7758,7 +7434,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"https-proxy-agent@npm:^7.0.1, https-proxy-agent@npm:^7.0.3, https-proxy-agent@npm:^7.0.6":
+"https-proxy-agent@npm:^7.0.1":
   version: 7.0.6
   resolution: "https-proxy-agent@npm:7.0.6"
   dependencies:
@@ -7791,15 +7467,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"iconv-lite@npm:^0.4.4, iconv-lite@npm:~0.4.24":
-  version: 0.4.24
-  resolution: "iconv-lite@npm:0.4.24"
-  dependencies:
-    safer-buffer: "npm:>= 2.1.2 < 3"
-  checksum: 10/6d3a2dac6e5d1fb126d25645c25c3a1209f70cceecc68b8ef51ae0da3cdc078c151fade7524a30b12a3094926336831fca09c666ef55b37e2c69638b5d6bd2e3
-  languageName: node
-  linkType: hard
-
 "iconv-lite@npm:^0.6.2":
   version: 0.6.3
   resolution: "iconv-lite@npm:0.6.3"
@@ -7815,6 +7482,15 @@ __metadata:
   dependencies:
     safer-buffer: "npm:>= 2.1.2 < 3.0.0"
   checksum: 10/24c937b532f868e938386b62410b303b7c767ce3d08dc2829cbe59464d5a26ef86ae5ad1af6b34eec43ddfea39e7d101638644b0178d67262fa87015d59f983a
+  languageName: node
+  linkType: hard
+
+"iconv-lite@npm:~0.4.24":
+  version: 0.4.24
+  resolution: "iconv-lite@npm:0.4.24"
+  dependencies:
+    safer-buffer: "npm:>= 2.1.2 < 3"
+  checksum: 10/6d3a2dac6e5d1fb126d25645c25c3a1209f70cceecc68b8ef51ae0da3cdc078c151fade7524a30b12a3094926336831fca09c666ef55b37e2c69638b5d6bd2e3
   languageName: node
   linkType: hard
 
@@ -7882,13 +7558,6 @@ __metadata:
   version: 2.0.4
   resolution: "inherits@npm:2.0.4"
   checksum: 10/cd45e923bee15186c07fa4c89db0aace24824c482fb887b528304694b2aa6ff8a898da8657046a5dcf3e46cd6db6c61629551f9215f208d7c3f157cf9b290521
-  languageName: node
-  linkType: hard
-
-"ini@npm:^1.3.5":
-  version: 1.3.8
-  resolution: "ini@npm:1.3.8"
-  checksum: 10/314ae176e8d4deb3def56106da8002b462221c174ddb7ce0c49ee72c8cd1f9044f7b10cc555a7d8850982c3b9ca96fc212122749f5234bc2b6fb05fb942ed566
   languageName: node
   linkType: hard
 
@@ -8726,18 +8395,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-git@npm:^0.7.8":
-  version: 0.7.8
-  resolution: "js-git@npm:0.7.8"
-  dependencies:
-    bodec: "npm:^0.1.0"
-    culvert: "npm:^0.1.2"
-    git-sha1: "npm:^0.1.2"
-    pako: "npm:^0.2.5"
-  checksum: 10/c09322f4dffff8b33beea8b9189998e5c6c229ef7bc3ca52b1207642c96d524d09727b36c3941a22f9ca08dda06e60b74ef558e8a04a874fe0db4acd8aca68ee
-  languageName: node
-  linkType: hard
-
 "js-tokens@npm:^4.0.0":
   version: 4.0.0
   resolution: "js-tokens@npm:4.0.0"
@@ -8752,17 +8409,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:4.1.1, js-yaml@npm:^4.1.0":
-  version: 4.1.1
-  resolution: "js-yaml@npm:4.1.1"
-  dependencies:
-    argparse: "npm:^2.0.1"
-  bin:
-    js-yaml: bin/js-yaml.js
-  checksum: 10/a52d0519f0f4ef5b4adc1cde466cb54c50d56e2b4a983b9d5c9c0f2f99462047007a6274d7e95617a21d3c91fde3ee6115536ed70991cd645ba8521058b78f77
-  languageName: node
-  linkType: hard
-
 "js-yaml@npm:^3.13.1":
   version: 3.14.2
   resolution: "js-yaml@npm:3.14.2"
@@ -8772,6 +8418,17 @@ __metadata:
   bin:
     js-yaml: bin/js-yaml.js
   checksum: 10/172e0b6007b0bf0fc8d2469c94424f7dd765c64a047d2b790831fecef2204a4054eabf4d911eb73ab8c9a3256ab8ba1ee8d655b789bf24bf059c772acc2075a1
+  languageName: node
+  linkType: hard
+
+"js-yaml@npm:^4.1.0":
+  version: 4.1.1
+  resolution: "js-yaml@npm:4.1.1"
+  dependencies:
+    argparse: "npm:^2.0.1"
+  bin:
+    js-yaml: bin/js-yaml.js
+  checksum: 10/a52d0519f0f4ef5b4adc1cde466cb54c50d56e2b4a983b9d5c9c0f2f99462047007a6274d7e95617a21d3c91fde3ee6115536ed70991cd645ba8521058b78f77
   languageName: node
   linkType: hard
 
@@ -8842,13 +8499,6 @@ __metadata:
   version: 1.0.1
   resolution: "json-stable-stringify-without-jsonify@npm:1.0.1"
   checksum: 10/12786c2e2f22c27439e6db0532ba321f1d0617c27ad8cb1c352a0e9249a50182fd1ba8b52a18899291604b0c32eafa8afd09e51203f19109a0537f68db2b652d
-  languageName: node
-  linkType: hard
-
-"json-stringify-safe@npm:^5.0.1":
-  version: 5.0.1
-  resolution: "json-stringify-safe@npm:5.0.1"
-  checksum: 10/59169a081e4eeb6f9559ae1f938f656191c000e0512aa6df9f3c8b2437a4ab1823819c6b9fd1818a4e39593ccfd72e9a051fdd3e2d1e340ed913679e888ded8c
   languageName: node
   linkType: hard
 
@@ -9117,7 +8767,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.14, lodash@npm:^4.17.21":
+"lodash@npm:^4.17.21":
   version: 4.17.23
   resolution: "lodash@npm:4.17.23"
   checksum: 10/82504c88250f58da7a5a4289f57a4f759c44946c005dd232821c7688b5fcfbf4a6268f6a6cdde4b792c91edd2f3b5398c1d2a0998274432cff76def48735e233
@@ -9209,22 +8859,6 @@ __metadata:
   dependencies:
     yallist: "npm:^3.0.2"
   checksum: 10/951d2673dcc64a7fb888bf3d13bc2fdf923faca97d89cdb405ba3dfff77e2b26e5798d405e78fcd7094c9e7b8b4dab2ddc5a4f8a11928af24a207b7c738ca3f8
-  languageName: node
-  linkType: hard
-
-"lru-cache@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "lru-cache@npm:6.0.0"
-  dependencies:
-    yallist: "npm:^4.0.0"
-  checksum: 10/fc1fe2ee205f7c8855fa0f34c1ab0bcf14b6229e35579ec1fd1079f31d6fc8ef8eb6fd17f2f4d99788d7e339f50e047555551ebd5e434dda503696e7c6591825
-  languageName: node
-  linkType: hard
-
-"lru-cache@npm:^7.14.1":
-  version: 7.18.3
-  resolution: "lru-cache@npm:7.18.3"
-  checksum: 10/6029ca5aba3aacb554e919d7ef804fffd4adfc4c83db00fac8248c7c78811fb6d4b6f70f7fd9d55032b3823446546a007edaa66ad1f2377ae833bd983fac5d98
   languageName: node
   linkType: hard
 
@@ -10346,7 +9980,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mkdirp@npm:1.0.4, mkdirp@npm:^1.0.3":
+"mkdirp@npm:^1.0.3":
   version: 1.0.4
   resolution: "mkdirp@npm:1.0.4"
   bin:
@@ -10361,13 +9995,6 @@ __metadata:
   dependencies:
     obliterator: "npm:^2.0.4"
   checksum: 10/7f020f84a21929049ff0bdd75066e03da260253e66311fda6c25dc42b1064678d232d72464546b336a616fd3f9554c28f6942d069c2456d8edfb54f07c77d9b6
-  languageName: node
-  linkType: hard
-
-"module-details-from-path@npm:^1.0.3":
-  version: 1.0.4
-  resolution: "module-details-from-path@npm:1.0.4"
-  checksum: 10/2ebfada5358492f6ab496b70f70a1042f2ee7a4c79d29467f59ed6704f741fb4461d7cecb5082144ed39a05fec4d19e9ff38b731c76228151be97227240a05b2
   languageName: node
   linkType: hard
 
@@ -10417,13 +10044,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mute-stream@npm:~0.0.4":
-  version: 0.0.8
-  resolution: "mute-stream@npm:0.0.8"
-  checksum: 10/a2d2e79dde87e3424ffc8c334472c7f3d17b072137734ca46e6f221131f1b014201cc593b69a38062e974fb2394d3d1cb4349f80f012bbf8b8ac1b28033e515f
-  languageName: node
-  linkType: hard
-
 "mz@npm:^2.7.0":
   version: 2.7.0
   resolution: "mz@npm:2.7.0"
@@ -10458,19 +10078,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"needle@npm:2.4.0":
-  version: 2.4.0
-  resolution: "needle@npm:2.4.0"
-  dependencies:
-    debug: "npm:^3.2.6"
-    iconv-lite: "npm:^0.4.4"
-    sax: "npm:^1.2.4"
-  bin:
-    needle: ./bin/needle
-  checksum: 10/0f2de9406d07f05f89cae241594a2aa66ff0a371ead42c013942c4684f60c830d57066663a740ea6b524e7d031ec2fc8ebd9bf687c51b8936af12c5dc4f7e526
-  languageName: node
-  linkType: hard
-
 "negotiator@npm:0.6.3":
   version: 0.6.3
   resolution: "negotiator@npm:0.6.3"
@@ -10496,13 +10103,6 @@ __metadata:
   version: 2.6.2
   resolution: "neo-async@npm:2.6.2"
   checksum: 10/1a7948fea86f2b33ec766bc899c88796a51ba76a4afc9026764aedc6e7cde692a09067031e4a1bf6db4f978ccd99e7f5b6c03fe47ad9865c3d4f99050d67e002
-  languageName: node
-  linkType: hard
-
-"netmask@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "netmask@npm:2.0.2"
-  checksum: 10/375cabe898a5832816958664f26206f0a1e9f3605aa1816bfce803e060ff20f9d6ce56a2377e46f1470938358c31c27b3a8086f4a5e3ef678896147884d63ffa
   languageName: node
   linkType: hard
 
@@ -10956,43 +10556,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pac-proxy-agent@npm:^7.0.1":
-  version: 7.2.0
-  resolution: "pac-proxy-agent@npm:7.2.0"
-  dependencies:
-    "@tootallnate/quickjs-emscripten": "npm:^0.23.0"
-    agent-base: "npm:^7.1.2"
-    debug: "npm:^4.3.4"
-    get-uri: "npm:^6.0.1"
-    http-proxy-agent: "npm:^7.0.0"
-    https-proxy-agent: "npm:^7.0.6"
-    pac-resolver: "npm:^7.0.1"
-    socks-proxy-agent: "npm:^8.0.5"
-  checksum: 10/187656be62d5a6b983d90a86d64106a38b1a9ee78f591fabb27b3cf0d51e5d528456a9faaaf981c93dd54dc9c9ee8d33e35a51072b73a19ec1a8e0d0c36a2b99
-  languageName: node
-  linkType: hard
-
-"pac-resolver@npm:^7.0.1":
-  version: 7.0.1
-  resolution: "pac-resolver@npm:7.0.1"
-  dependencies:
-    degenerator: "npm:^5.0.0"
-    netmask: "npm:^2.0.2"
-  checksum: 10/839134328781b80d49f9684eae1f5c74f50a1d4482076d44c84fc2f3ca93da66fa11245a4725a057231e06b311c20c989fd0681e662a0792d17f644d8fe62a5e
-  languageName: node
-  linkType: hard
-
 "package-json-from-dist@npm:^1.0.0":
   version: 1.0.1
   resolution: "package-json-from-dist@npm:1.0.1"
   checksum: 10/58ee9538f2f762988433da00e26acc788036914d57c71c246bf0be1b60cdbd77dd60b6a3e1a30465f0b248aeb80079e0b34cb6050b1dfa18c06953bb1cbc7602
-  languageName: node
-  linkType: hard
-
-"pako@npm:^0.2.5":
-  version: 0.2.9
-  resolution: "pako@npm:0.2.9"
-  checksum: 10/627c6842e90af0b3a9ee47345bd66485a589aff9514266f4fa9318557ad819c46fedf97510f2cef9b6224c57913777966a05cb46caf6a9b31177a5401a06fe15
   languageName: node
   linkType: hard
 
@@ -11162,7 +10729,6 @@ __metadata:
     concurrently: "npm:^9.2.1"
     husky: "npm:^9.1.7"
     lint-staged: "npm:^16.2.7"
-    pm2: "npm:^6.0.14"
     prettier: "npm:^3.8.1"
   languageName: unknown
   linkType: soft
@@ -11194,24 +10760,6 @@ __metadata:
   bin:
     pidtree: bin/pidtree.js
   checksum: 10/ea67fb3159e170fd069020e0108ba7712df9f0fd13c8db9b2286762856ddce414fb33932e08df4bfe36e91fe860b51852aee49a6f56eb4714b69634343add5df
-  languageName: node
-  linkType: hard
-
-"pidusage@npm:3.0.2":
-  version: 3.0.2
-  resolution: "pidusage@npm:3.0.2"
-  dependencies:
-    safe-buffer: "npm:^5.2.1"
-  checksum: 10/cc486a918856f0761cedfa848b9758d42d3096c36b43ae2988f2fa18dbf533403184dd99a334c28a5d5d1b8c7e1710f7c07086892ae2606b11495f4dae946742
-  languageName: node
-  linkType: hard
-
-"pidusage@npm:^2.0.21":
-  version: 2.0.21
-  resolution: "pidusage@npm:2.0.21"
-  dependencies:
-    safe-buffer: "npm:^5.2.1"
-  checksum: 10/cce93c34d6885583c131b0681d1f46c97861f0b0c76f5665713fb643398be0144d6942632d7290e6258f5d52440226b7b875718d4ae7f321fafb822348258306
   languageName: node
   linkType: hard
 
@@ -11279,105 +10827,6 @@ __metadata:
   dependencies:
     find-up: "npm:^4.0.0"
   checksum: 10/9863e3f35132bf99ae1636d31ff1e1e3501251d480336edb1c211133c8d58906bed80f154a1d723652df1fda91e01c7442c2eeaf9dc83157c7ae89087e43c8d6
-  languageName: node
-  linkType: hard
-
-"pm2-axon-rpc@npm:~0.7.0, pm2-axon-rpc@npm:~0.7.1":
-  version: 0.7.1
-  resolution: "pm2-axon-rpc@npm:0.7.1"
-  dependencies:
-    debug: "npm:^4.3.1"
-  checksum: 10/22a6b645601c0fc0320d6c5e238cdc9bfb6d653ce9b9c15e5d9cb5d18697a76174f498bf81d7db43dbf8d221f7d12f4982131e8273982dd9ca7055bf9d7a6308
-  languageName: node
-  linkType: hard
-
-"pm2-axon@npm:~4.0.1":
-  version: 4.0.1
-  resolution: "pm2-axon@npm:4.0.1"
-  dependencies:
-    amp: "npm:~0.3.1"
-    amp-message: "npm:~0.1.1"
-    debug: "npm:^4.3.1"
-    escape-string-regexp: "npm:^4.0.0"
-  checksum: 10/d617fdcd71c02b63d24223e096b94dfc685771d6d72d17e2e1d6405431fd67fdb2cc6c810d8614d4ecb086bd492fc44788cfa1afb46bb5a0c5c530669bf435eb
-  languageName: node
-  linkType: hard
-
-"pm2-deploy@npm:~1.0.2":
-  version: 1.0.2
-  resolution: "pm2-deploy@npm:1.0.2"
-  dependencies:
-    run-series: "npm:^1.1.8"
-    tv4: "npm:^1.3.0"
-  checksum: 10/a47c00b7e8c31dfaf4c3d1dbe1ee5030a2d1c5b12d14715467ab247d71539cb138e2c666bfef98204cc1f9cce6ba81a880b91eb27d93d3fce381e895574ac196
-  languageName: node
-  linkType: hard
-
-"pm2-multimeter@npm:^0.1.2":
-  version: 0.1.2
-  resolution: "pm2-multimeter@npm:0.1.2"
-  dependencies:
-    charm: "npm:~0.1.1"
-  checksum: 10/abb62db075c7869b5181986d12b18d5c049e9e07ccaae8c96de4ad057469d237459d124817a0faa7ec0f635650c8bec268191fe76a78e6c396cb94521356c4fa
-  languageName: node
-  linkType: hard
-
-"pm2-sysmonit@npm:^1.2.8":
-  version: 1.2.8
-  resolution: "pm2-sysmonit@npm:1.2.8"
-  dependencies:
-    async: "npm:^3.2.0"
-    debug: "npm:^4.3.1"
-    pidusage: "npm:^2.0.21"
-    systeminformation: "npm:^5.7"
-    tx2: "npm:~1.0.4"
-  checksum: 10/210d6e9477881c150dfccee06f05c023ecd076a0bb0144ffc31e66be24ba5017ebdb93ed58fc681317cae3e8a275f01c5a70f0d77a87198133bc1738a1916f37
-  languageName: node
-  linkType: hard
-
-"pm2@npm:^6.0.14":
-  version: 6.0.14
-  resolution: "pm2@npm:6.0.14"
-  dependencies:
-    "@pm2/agent": "npm:~2.1.1"
-    "@pm2/blessed": "npm:0.1.81"
-    "@pm2/io": "npm:~6.1.0"
-    "@pm2/js-api": "npm:~0.8.0"
-    "@pm2/pm2-version-check": "npm:^1.0.4"
-    ansis: "npm:4.0.0-node10"
-    async: "npm:3.2.6"
-    chokidar: "npm:3.6.0"
-    cli-tableau: "npm:2.0.1"
-    commander: "npm:2.15.1"
-    croner: "npm:4.1.97"
-    dayjs: "npm:1.11.15"
-    debug: "npm:4.4.3"
-    enquirer: "npm:2.3.6"
-    eventemitter2: "npm:5.0.1"
-    fclone: "npm:1.0.11"
-    js-yaml: "npm:4.1.1"
-    mkdirp: "npm:1.0.4"
-    needle: "npm:2.4.0"
-    pidusage: "npm:3.0.2"
-    pm2-axon: "npm:~4.0.1"
-    pm2-axon-rpc: "npm:~0.7.1"
-    pm2-deploy: "npm:~1.0.2"
-    pm2-multimeter: "npm:^0.1.2"
-    pm2-sysmonit: "npm:^1.2.8"
-    promptly: "npm:2.2.0"
-    semver: "npm:7.7.2"
-    source-map-support: "npm:0.5.21"
-    sprintf-js: "npm:1.1.2"
-    vizion: "npm:~2.2.1"
-  dependenciesMeta:
-    pm2-sysmonit:
-      optional: true
-  bin:
-    pm2: bin/pm2
-    pm2-dev: bin/pm2-dev
-    pm2-docker: bin/pm2-docker
-    pm2-runtime: bin/pm2-runtime
-  checksum: 10/7211b4647c993d295e52f9a11fa2f604fd4dd1149b264beadde69d0c1739839230ce038c9081a9c8adaac8d632e0eb64ddcd02e10f9d8c2512da4e02e5d4df3b
   languageName: node
   linkType: hard
 
@@ -11543,15 +10992,6 @@ __metadata:
     err-code: "npm:^2.0.2"
     retry: "npm:^0.12.0"
   checksum: 10/96e1a82453c6c96eef53a37a1d6134c9f2482f94068f98a59145d0986ca4e497bf110a410adf73857e588165eab3899f0ebcf7b3890c1b3ce802abc0d65967d4
-  languageName: node
-  linkType: hard
-
-"promptly@npm:2.2.0":
-  version: 2.2.0
-  resolution: "promptly@npm:2.2.0"
-  dependencies:
-    read: "npm:^1.0.4"
-  checksum: 10/f9a996eb78d4a446e1f537c7ea90be306e0afada2e3884daf5020faab042bb79e6ef1f8bdcd5cc5a2108208f8989364ab054bce3aec67cfbf8c108394d0a1adf
   languageName: node
   linkType: hard
 
@@ -11817,22 +11257,6 @@ __metadata:
     forwarded: "npm:0.2.0"
     ipaddr.js: "npm:1.9.1"
   checksum: 10/f24a0c80af0e75d31e3451398670d73406ec642914da11a2965b80b1898ca6f66a0e3e091a11a4327079b2b268795f6fa06691923fef91887215c3d0e8ea3f68
-  languageName: node
-  linkType: hard
-
-"proxy-agent@npm:~6.4.0":
-  version: 6.4.0
-  resolution: "proxy-agent@npm:6.4.0"
-  dependencies:
-    agent-base: "npm:^7.0.2"
-    debug: "npm:^4.3.4"
-    http-proxy-agent: "npm:^7.0.1"
-    https-proxy-agent: "npm:^7.0.3"
-    lru-cache: "npm:^7.14.1"
-    pac-proxy-agent: "npm:^7.0.1"
-    proxy-from-env: "npm:^1.1.0"
-    socks-proxy-agent: "npm:^8.0.2"
-  checksum: 10/a22f202b74cc52f093efd9bfe52de8db08eda8bbc16b9d3d73acda2acc1b40223966e5521b1706788b06adf9265f093ed554d989b354e81b2d6ad482e5bd4d23
   languageName: node
   linkType: hard
 
@@ -12111,15 +11535,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"read@npm:^1.0.4":
-  version: 1.0.7
-  resolution: "read@npm:1.0.7"
-  dependencies:
-    mute-stream: "npm:~0.0.4"
-  checksum: 10/2777c254e5732cac96f5d0a1c0f6b836c89ae23d8febd405b206f6f24d5de1873420f1a0795e0e3721066650d19adf802c7882c4027143ee0acf942a4f34f97b
-  languageName: node
-  linkType: hard
-
 "readable-stream@npm:^3.4.0, readable-stream@npm:^3.6.0, readable-stream@npm:^3.6.2":
   version: 3.6.2
   resolution: "readable-stream@npm:3.6.2"
@@ -12256,17 +11671,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"require-in-the-middle@npm:^5.0.0":
-  version: 5.2.0
-  resolution: "require-in-the-middle@npm:5.2.0"
-  dependencies:
-    debug: "npm:^4.1.1"
-    module-details-from-path: "npm:^1.0.3"
-    resolve: "npm:^1.22.1"
-  checksum: 10/e9ff348975d2d0c338f1d42b84775b4122e42becbf2c62b7fffc88712151e7e717a783d324eba08ed5c258f154a68a0193191edee593586efe0a95e85ceabc98
-  languageName: node
-  linkType: hard
-
 "require-main-filename@npm:^2.0.0":
   version: 2.0.0
   resolution: "require-main-filename@npm:2.0.0"
@@ -12311,7 +11715,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@npm:^1.1.7, resolve@npm:^1.20.0, resolve@npm:^1.22.1, resolve@npm:^1.22.8":
+"resolve@npm:^1.1.7, resolve@npm:^1.20.0, resolve@npm:^1.22.8":
   version: 1.22.11
   resolution: "resolve@npm:1.22.11"
   dependencies:
@@ -12324,7 +11728,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@patch:resolve@npm%3A^1.1.7#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.20.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.1#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.8#optional!builtin<compat/resolve>":
+"resolve@patch:resolve@npm%3A^1.1.7#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.20.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.8#optional!builtin<compat/resolve>":
   version: 1.22.11
   resolution: "resolve@patch:resolve@npm%3A1.22.11#optional!builtin<compat/resolve>::version=1.22.11&hash=c3c19d"
   dependencies:
@@ -12526,13 +11930,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"run-series@npm:^1.1.8":
-  version: 1.1.9
-  resolution: "run-series@npm:1.1.9"
-  checksum: 10/375a2c8141715f6e10d5de47b140217f0d1b123bbf16f7d5d96bf12eafd7aed47c23dccc4ffd1c0b9d854f5076ef285628a4d21f4c58780ed77012efcfcd9b8c
-  languageName: node
-  linkType: hard
-
 "rxjs@npm:7.8.2":
   version: 7.8.2
   resolution: "rxjs@npm:7.8.2"
@@ -12542,7 +11939,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"safe-buffer@npm:5.2.1, safe-buffer@npm:^5.0.1, safe-buffer@npm:^5.2.1, safe-buffer@npm:~5.2.0":
+"safe-buffer@npm:5.2.1, safe-buffer@npm:^5.0.1, safe-buffer@npm:~5.2.0":
   version: 5.2.1
   resolution: "safe-buffer@npm:5.2.1"
   checksum: 10/32872cd0ff68a3ddade7a7617b8f4c2ae8764d8b7d884c651b74457967a9e0e886267d3ecc781220629c44a865167b61c375d2da6c720c840ecd73f45d5d9451
@@ -12579,13 +11976,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sax@npm:^1.2.4":
-  version: 1.4.4
-  resolution: "sax@npm:1.4.4"
-  checksum: 10/00ff7b258baa37d98f8abfa0b5c8b3ee739ca37e9b6ecb83405be9e6e5b0b2856394a5eff142db1d987d589b54b139d4236f25830c1e17a2b640efa53c8fda72
-  languageName: node
-  linkType: hard
-
 "scheduler@npm:^0.26.0":
   version: 0.26.0
   resolution: "scheduler@npm:0.26.0"
@@ -12597,15 +11987,6 @@ __metadata:
   version: 0.27.0
   resolution: "scheduler@npm:0.27.0"
   checksum: 10/eab3c3a8373195173e59c147224fc30dabe6dd453f248f5e610e8458512a5a2ee3a06465dc400ebfe6d35c9f5b7f3bb6b2e41c88c86fd177c25a73e7286a1e06
-  languageName: node
-  linkType: hard
-
-"semver@npm:7.7.2":
-  version: 7.7.2
-  resolution: "semver@npm:7.7.2"
-  bin:
-    semver: bin/semver.js
-  checksum: 10/7a24cffcaa13f53c09ce55e05efe25cd41328730b2308678624f8b9f5fc3093fc4d189f47950f0b811ff8f3c3039c24a2c36717ba7961615c682045bf03e1dda
   languageName: node
   linkType: hard
 
@@ -12624,17 +12005,6 @@ __metadata:
   bin:
     semver: bin/semver.js
   checksum: 10/8dbc3168e057a38fc322af909c7f5617483c50caddba135439ff09a754b20bdd6482a5123ff543dad4affa488ecf46ec5fb56d61312ad20bb140199b88dfaea9
-  languageName: node
-  linkType: hard
-
-"semver@npm:~7.5.0, semver@npm:~7.5.4":
-  version: 7.5.4
-  resolution: "semver@npm:7.5.4"
-  dependencies:
-    lru-cache: "npm:^6.0.0"
-  bin:
-    semver: bin/semver.js
-  checksum: 10/985dec0d372370229a262c737063860fabd4a1c730662c1ea3200a2f649117761a42184c96df62a0e885e76fbd5dace41087d6c1ac0351b13c0df5d6bcb1b5ac
   languageName: node
   linkType: hard
 
@@ -12823,13 +12193,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shimmer@npm:^1.2.0":
-  version: 1.2.1
-  resolution: "shimmer@npm:1.2.1"
-  checksum: 10/aa0d6252ad1c682a4fdfda69e541be987f7a265ac7b00b1208e5e48cc68dc55f293955346ea4c71a169b7324b82c70f8400b3d3d2d60b2a7519f0a3522423250
-  languageName: node
-  linkType: hard
-
 "side-channel-list@npm:^1.0.0":
   version: 1.0.0
   resolution: "side-channel-list@npm:1.0.0"
@@ -12940,7 +12303,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"socks-proxy-agent@npm:^8.0.2, socks-proxy-agent@npm:^8.0.3, socks-proxy-agent@npm:^8.0.5":
+"socks-proxy-agent@npm:^8.0.3":
   version: 8.0.5
   resolution: "socks-proxy-agent@npm:8.0.5"
   dependencies:
@@ -12987,17 +12350,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map-support@npm:0.5.21":
-  version: 0.5.21
-  resolution: "source-map-support@npm:0.5.21"
-  dependencies:
-    buffer-from: "npm:^1.0.0"
-    source-map: "npm:^0.6.0"
-  checksum: 10/8317e12d84019b31e34b86d483dd41d6f832f389f7417faf8fc5c75a66a12d9686e47f589a0554a868b8482f037e23df9d040d29387eb16fa14cb85f091ba207
-  languageName: node
-  linkType: hard
-
-"source-map@npm:^0.6.0, source-map@npm:^0.6.1, source-map@npm:~0.6.1":
+"source-map@npm:^0.6.0, source-map@npm:^0.6.1":
   version: 0.6.1
   resolution: "source-map@npm:0.6.1"
   checksum: 10/59ef7462f1c29d502b3057e822cdbdae0b0e565302c4dd1a95e11e793d8d9d62006cdc10e0fd99163ca33ff2071360cf50ee13f90440806e7ed57d81cba2f7ff
@@ -13015,13 +12368,6 @@ __metadata:
   version: 4.2.0
   resolution: "split2@npm:4.2.0"
   checksum: 10/09bbefc11bcf03f044584c9764cd31a252d8e52cea29130950b26161287c11f519807c5e54bd9e5804c713b79c02cefe6a98f4688630993386be353e03f534ab
-  languageName: node
-  linkType: hard
-
-"sprintf-js@npm:1.1.2":
-  version: 1.1.2
-  resolution: "sprintf-js@npm:1.1.2"
-  checksum: 10/0044322a252b36bffc3d8a462a4882de57830e18d37d1cc000104ff4744b512d6a9b1ca6240e7ad141a987a1eaad071668fe12d11c496c11d3641c4797a6cf3f
   languageName: node
   linkType: hard
 
@@ -13296,15 +12642,6 @@ __metadata:
   version: 1.0.0
   resolution: "supports-preserve-symlinks-flag@npm:1.0.0"
   checksum: 10/a9dc19ae2220c952bd2231d08ddeecb1b0328b61e72071ff4000c8384e145cc07c1c0bdb3b5a1cb06e186a7b2790f1dee793418b332f6ddf320de25d9125be7e
-  languageName: node
-  linkType: hard
-
-"systeminformation@npm:^5.7":
-  version: 5.31.1
-  resolution: "systeminformation@npm:5.31.1"
-  bin:
-    systeminformation: lib/cli.js
-  conditions: (os=darwin | os=linux | os=win32 | os=freebsd | os=openbsd | os=netbsd | os=sunos | os=android)
   languageName: node
   linkType: hard
 
@@ -13662,14 +12999,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:1.9.3":
-  version: 1.9.3
-  resolution: "tslib@npm:1.9.3"
-  checksum: 10/cda3e70d2a6802556ac1e307fa9e6c1b47fe2452540d1497c33435a6e0c99fb88ddcd355e8ad7535c3cfdc7d309fc67197548e16b75b3d3e3812ca138e39dc99
-  languageName: node
-  linkType: hard
-
-"tslib@npm:2.8.1, tslib@npm:^2.0.0, tslib@npm:^2.0.1, tslib@npm:^2.1.0, tslib@npm:^2.4.0, tslib@npm:^2.6.2, tslib@npm:^2.6.3, tslib@npm:^2.8.0":
+"tslib@npm:2.8.1, tslib@npm:^2.0.0, tslib@npm:^2.1.0, tslib@npm:^2.4.0, tslib@npm:^2.6.2, tslib@npm:^2.6.3, tslib@npm:^2.8.0":
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
   checksum: 10/3e2e043d5c2316461cb54e5c7fe02c30ef6dccb3384717ca22ae5c6b5bc95232a6241df19c622d9c73b809bea33b187f6dbc73030963e29950c2141bc32a79f7
@@ -13696,22 +13026,6 @@ __metadata:
   bin:
     tsx: dist/cli.mjs
   checksum: 10/7afedeff855ba98c47dc28b33d7e8e253c4dc1f791938db402d79c174bdf806b897c1a5f91e5b1259c112520c816f826b4c5d98f0bad7e95b02dec66fedb64d2
-  languageName: node
-  linkType: hard
-
-"tv4@npm:^1.3.0":
-  version: 1.3.0
-  resolution: "tv4@npm:1.3.0"
-  checksum: 10/2b11f89805ad1a34ab1aab27117ab97de4c67c49f6b02e88d35c38c713df15eaeff69e3a30f9696a0ea1b678df625925a3114ed9e7c32429a9061062f3568762
-  languageName: node
-  linkType: hard
-
-"tx2@npm:~1.0.4":
-  version: 1.0.5
-  resolution: "tx2@npm:1.0.5"
-  dependencies:
-    json-stringify-safe: "npm:^5.0.1"
-  checksum: 10/9fd50d642e6668426f3e5894af0bef4864d8a6a0b5f0fa6a64e9189d8844613e4ad1385f60d28879df4e99a6dc3bdb2731d888c1b7de658c404fe8b125a40af0
   languageName: node
   linkType: hard
 
@@ -14298,18 +13612,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vizion@npm:~2.2.1":
-  version: 2.2.1
-  resolution: "vizion@npm:2.2.1"
-  dependencies:
-    async: "npm:^2.6.3"
-    git-node-fs: "npm:^1.0.0"
-    ini: "npm:^1.3.5"
-    js-git: "npm:^0.7.8"
-  checksum: 10/ab45f496521d4dd2fc22f9f435317a37d25fc60dbccb426bdb2a26aec69ae9d5d2759c18082d8b6bc429b0fd5ff12d0319c355cb9a8492e4cd61445a2245915f
-  languageName: node
-  linkType: hard
-
 "w3c-keyname@npm:^2.2.0":
   version: 2.2.8
   resolution: "w3c-keyname@npm:2.2.8"
@@ -14509,21 +13811,6 @@ __metadata:
     imurmurhash: "npm:^0.1.4"
     signal-exit: "npm:^3.0.7"
   checksum: 10/3be1f5508a46c190619d5386b1ac8f3af3dbe951ed0f7b0b4a0961eed6fc626bd84b50cf4be768dabc0a05b672f5d0c5ee7f42daa557b14415d18c3a13c7d246
-  languageName: node
-  linkType: hard
-
-"ws@npm:^7.0.0, ws@npm:~7.5.10":
-  version: 7.5.10
-  resolution: "ws@npm:7.5.10"
-  peerDependencies:
-    bufferutil: ^4.0.1
-    utf-8-validate: ^5.0.2
-  peerDependenciesMeta:
-    bufferutil:
-      optional: true
-    utf-8-validate:
-      optional: true
-  checksum: 10/9c796b84ba80ffc2c2adcdfc9c8e9a219ba99caa435c9a8d45f9ac593bba325563b3f83edc5eb067cc6d21b9a6bf2c930adf76dd40af5f58a5ca6859e81858f0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- replace the custom skill frontmatter serializer with `yaml.stringify` so synced skills like `playwright-mcp` produce valid `SKILL.md` files
- add `sb memory install --all` so semantic memory can be enabled across the main repo and active git worktrees
- switch memory embeddings to chunked storage for long memories, with chunk-based semantic recall and chunk-aware backfill tooling
- document and wire the memory backfill flow around the new chunked embedding strategy

## Testing
- `npx vitest run packages/api/src/data/repositories/memory-repository.test.ts packages/api/src/services/embeddings/router.test.ts --reporter=dot`
- `yarn workspace @personal-context/api type-check` *(only pre-existing failures remain in `src/channels/gateway.ts` and `src/mcp/server.ts`)*

## Notes
- I previously ran `sb memory install --all --skip-pull` to update `.env.local` in the main repo and active worktrees.
- While investigating Ollama 400s, I confirmed the issue was long inputs exceeding model context; the router now clamps oversized local inputs before embedding.
- I could not rerun the live chunk backfill to completion in this session because Supabase connectivity was flaky (`fetch failed`), but the script and retrieval path are in place.