### PR TITLE
fix(hooks): skip compacting lifecycle for backends without postCompact (by Wren)

### DIFF
--- a/packages/cli/src/commands/hooks.ts
+++ b/packages/cli/src/commands/hooks.ts
@@ -1613,14 +1613,20 @@ async function statusCommand(options: { backend?: string }): Promise<void> {
 // Hook Handlers
 // ============================================================================
 
-async function preCompactHandler(): Promise<void> {
+async function preCompactHandler(options?: { backend?: string }): Promise<void> {
   await readStdin(); // consume stdin but we don't need it
 
-  // Mark session as compacting so mission control can see it
   const cwd = process.cwd();
   const config = getPcpConfig();
   const agentId = resolveAgentId() || 'unknown';
-  await updateRuntimeGenerationState(cwd, config, agentId, 'compacting');
+  const backend = resolveLifecycleBackend(cwd, options?.backend);
+
+  // Only set 'compacting' lifecycle if this backend has a postCompact event
+  // that will reset it to 'idle'. Without postCompact (e.g., Gemini/PreCompress),
+  // the lifecycle gets stuck at 'compacting' permanently.
+  if (backend.events.postCompact) {
+    await updateRuntimeGenerationState(cwd, config, agentId, 'compacting');
+  }
 
   process.stdout.write(loadTemplate('hook-pre-compact'));
 }
@@ -2075,7 +2081,7 @@ export function registerHooksCommands(program: Command): void {
     .command('pre-compact')
     .description('Hook: output pre-compaction reminder')
     .option('--backend <name>', 'Backend context for this hook invocation')
-    .action(preCompactHandler);
+    .action((opts) => preCompactHandler(opts));
 
   hooks
     .command('post-compact')


### PR DESCRIPTION
## Summary

- **Fix stuck 'compacting' lifecycle for Gemini sessions.** The `preCompactHandler` was setting `lifecycle: 'compacting'` via the `POST /api/hooks/lifecycle` REST endpoint, but Gemini has `postCompact: null` (no PostCompress event), so nothing ever reset it to `'idle'`. Sessions got permanently stuck in `sb mission` as "compacting".
- **Guard the compacting lifecycle behind `backend.events.postCompact`.** Now only backends with a post-compact hook (Claude Code) set the transient compacting state. Gemini skips it entirely.
- **Fix Commander options passthrough** — `preCompactHandler` was registered directly as `.action(preCompactHandler)` instead of `.action((opts) => preCompactHandler(opts))`, so the `--backend` flag was never reaching the handler.

## Root Cause

```
PreCompress (Gemini) → sb hooks pre-compact → sets lifecycle: 'compacting'
                       ↓
              No PostCompress event → postCompactHandler never fires
                       ↓
              lifecycle stuck at 'compacting' forever
```

Also manually reset Aster's stuck session `4a8e7e34` in the DB.

## Test plan

- [ ] Verify `sb hooks pre-compact --backend gemini` does NOT call the lifecycle endpoint
- [ ] Verify `sb hooks pre-compact --backend claude-code` still sets 'compacting' lifecycle
- [ ] Confirm `sb mission` no longer shows Aster as "compacting"
- [ ] Type-check passes (`tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Wren