### PR TITLE
fix: inject Authorization header in Codex runner (by Wren)

### DIFF
--- a/packages/api/src/services/sessions/codex-runner.ts
+++ b/packages/api/src/services/sessions/codex-runner.ts
@@ -122,6 +122,13 @@ export class CodexRunner implements IRunner {
     args.push('-c', 'mcp_servers.pcp.env_http_headers.x-pcp-session-id="PCP_SESSION_ID"');
     args.push('-c', 'mcp_servers.pcp.env_http_headers.x-pcp-studio-id="PCP_STUDIO_ID"');
 
+    // Authorization header for triggered sessions — env_http_headers reads the env var
+    // name and sends its value as the header. We set PCP_AUTH_HEADER="Bearer <token>"
+    // in the spawn env so the full header value is sent.
+    if (config.pcpAccessToken) {
+      args.push('-c', 'mcp_servers.pcp.env_http_headers.Authorization="PCP_AUTH_HEADER"');
+    }
+
     if (config.model) {
       args.push('-m', config.model);
     }
@@ -176,6 +183,8 @@ export class CodexRunner implements IRunner {
             studioId: config.studioId,
             accessToken: config.pcpAccessToken,
           }),
+          // PCP_AUTH_HEADER is the full "Bearer <token>" value for env_http_headers
+          ...(config.pcpAccessToken ? { PCP_AUTH_HEADER: `Bearer ${config.pcpAccessToken}` } : {}),
         },
         stdio: ['ignore', 'pipe', 'pipe'],
       });


### PR DESCRIPTION
## Summary

- The Codex runner sets `PCP_ACCESS_TOKEN` in the spawn env but never tells Codex to send it as an `Authorization` header on MCP calls to the PCP server
- The Claude runner handles this via `injectSessionHeaders()`, but the Codex runner uses `-c` flags for `env_http_headers` and was missing the auth header
- This causes Lumen's triggered sessions to fail with exit code 1 (PCP server rejects unauthenticated MCP requests)

**Fix**: Add `env_http_headers.Authorization="PCP_AUTH_HEADER"` to the Codex `-c` flags, with `PCP_AUTH_HEADER="Bearer <token>"` pre-built in the spawn env.

## Test plan

- [ ] Trigger Lumen via `send_to_inbox` — should no longer fail with auth error
- [ ] Verify Codex spawn args include the Authorization env_http_header when `pcpAccessToken` is set
- [ ] Verify no Authorization header is added when `pcpAccessToken` is absent (non-triggered sessions)

— Wren