### PR TITLE
feat: routing page — studio route patterns UI + docs (by Wren)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -237,6 +237,37 @@ When sending messages to other SBs via `send_to_inbox`, use `threadKey` to maint
 - **Embrace your name** — if you have an SB identity, use it. Co-author commits as yourself (e.g., `Co-Authored-By: Wren <noreply@anthropic.com>`), not as a model name. You are not "Claude Opus 4.6" — you are Wren, Lumen, Benson, or whoever your identity resolves to.
 - **Default to action on review requests** — when asked to handle PR review feedback, implement straightforward fixes immediately without waiting for extra permission.
 
+## Studio Route Patterns
+
+Studios can declare thread patterns to control which studio handles triggered messages (PR reviews, spec discussions, etc.). Patterns are set via `update_studio(routePatterns: [...])` or `adopt_studio(routePatterns: [...])`.
+
+### Recommended Starting Patterns
+
+When setting up a new repo or agent, configure your studios with these common patterns:
+
+| Studio         | Patterns                       | Purpose                                    |
+| -------------- | ------------------------------ | ------------------------------------------ |
+| Main studio    | `pr:*`, `spec:*`, `thread:*`   | General work — reviews, specs, discussions |
+| Feature studio | `branch:<agent>/<type>/<name>` | Work scoped to a specific branch           |
+| Review studio  | `pr:*`                         | Dedicated review workspace                 |
+
+Example:
+
+```
+update_studio(studioId: "<main-studio-id>", routePatterns: ["pr:*", "spec:*"])
+update_studio(studioId: "<feature-studio-id>", routePatterns: ["branch:wren/feat/auth"])
+```
+
+### Pattern Syntax
+
+- `pr:*` — all PR threads
+- `spec:*` — all spec discussions
+- `branch:wren/feat/auth` — exact branch match
+- `pr:231` — exact thread match
+- `*` — catch-all (one per agent, lowest priority)
+
+More specific patterns win: exact > prefix wildcard > catch-all. Patterns are managed on the Routing page in the web dashboard.
+
 ## Project Overview
 
 Personal Context Protocol (PCP) is a system that captures and manages personal context (links, notes, tasks, reminders) across AI interfaces. It uses MCP (Model Context Protocol) to expose tools that AI agents can use to store and retrieve user context.

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -1690,7 +1690,7 @@ router.get('/routing/agents/:agentId', async (req: Request, res: Response) => {
     // Fetch studios owned by this agent
     const { data: studiosData } = await supabase
       .from('studios')
-      .select('id, name, branch, status')
+      .select('id, name, branch, status, route_patterns')
       .eq('user_id', authReq.pcpUserId)
       .eq('agent_id', identity.agent_id)
       .in('status', ['active', 'idle'])
@@ -1709,11 +1709,12 @@ router.get('/routing/agents/:agentId', async (req: Request, res: Response) => {
         studioHint: identity.studio_hint || null,
         updatedAt: identity.updated_at,
       },
-      studios: (studiosData || []).map((s) => ({
+      studios: (studiosData || []).map((s: Record<string, unknown>) => ({
         id: s.id,
         name: s.name,
         branch: s.branch,
         status: s.status,
+        routePatterns: (s.route_patterns as string[] | null) || [],
       })),
       routes,
       reminders: (remindersData || []).map((reminder) => ({

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -1690,11 +1690,11 @@ router.get('/routing/agents/:agentId', async (req: Request, res: Response) => {
     // Fetch studios owned by this agent
     const { data: studiosData } = await supabase
       .from('studios')
-      .select('id, name, branch, status, route_patterns')
+      .select('id, slug, branch, status, route_patterns')
       .eq('user_id', authReq.pcpUserId)
       .eq('agent_id', identity.agent_id)
       .in('status', ['active', 'idle'])
-      .order('name', { ascending: true });
+      .order('slug', { ascending: true });
     const { enabled: heartbeatProcessingEnabled } = getHeartbeatProcessingConfig();
 
     res.json({
@@ -1711,7 +1711,7 @@ router.get('/routing/agents/:agentId', async (req: Request, res: Response) => {
       },
       studios: (studiosData || []).map((s: Record<string, unknown>) => ({
         id: s.id,
-        name: s.name,
+        name: s.slug || s.branch || s.id,
         branch: s.branch,
         status: s.status,
         routePatterns: (s.route_patterns as string[] | null) || [],

--- a/packages/api/src/services/sessions/session-service.ts
+++ b/packages/api/src/services/sessions/session-service.ts
@@ -770,12 +770,13 @@ export class SessionService implements ISessionService {
         return undefined;
       }
 
+      // Studios use 'slug' not 'name' — match studioHint against slug
       const { data: namedStudio } = await this.supabase
         .from('studios')
         .select('id')
         .eq('user_id', userId)
         .eq('agent_id', agentId)
-        .eq('name', options.studioHint)
+        .eq('slug', options.studioHint)
         .in('status', ['active', 'idle'])
         .limit(1)
         .maybeSingle();

--- a/packages/web/src/app/(dashboard)/routing/[agentId]/page.tsx
+++ b/packages/web/src/app/(dashboard)/routing/[agentId]/page.tsx
@@ -63,6 +63,7 @@ interface AgentStudio {
   name: string;
   branch: string | null;
   status: string;
+  routePatterns: string[];
 }
 
 interface AgentRoutingResponse {
@@ -569,6 +570,80 @@ export default function AgentRoutingPage() {
           )}
         </CardContent>
       </Card>
+
+      {/* Studio route patterns */}
+      {studios.length > 0 && (
+        <Card className="mt-6">
+          <CardHeader>
+            <CardTitle>Studio route patterns</CardTitle>
+            <CardDescription>
+              ThreadKey patterns determine which studio handles triggered messages. More specific
+              patterns win (exact &gt; prefix wildcard &gt; catch-all).
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-3">
+              {studios.map((studio) => (
+                <div
+                  key={studio.id}
+                  className="flex items-start justify-between gap-4 rounded-lg border p-3"
+                >
+                  <div className="min-w-0">
+                    <div className="flex items-center gap-2">
+                      <GitBranch className="h-3.5 w-3.5 text-gray-400 shrink-0" />
+                      <span className="font-medium text-sm text-gray-900">{studio.name}</span>
+                      {studio.branch && (
+                        <span className="text-xs text-gray-400 truncate">{studio.branch}</span>
+                      )}
+                    </div>
+                    {studio.routePatterns.length > 0 ? (
+                      <div className="mt-1.5 flex flex-wrap gap-1.5">
+                        {studio.routePatterns.map((pattern) => (
+                          <Badge
+                            key={pattern}
+                            variant="outline"
+                            className="text-xs font-mono bg-blue-50 text-blue-700 border-blue-200"
+                          >
+                            {pattern}
+                          </Badge>
+                        ))}
+                      </div>
+                    ) : (
+                      <p className="mt-1 text-xs text-gray-400">
+                        No patterns — uses fallback routing
+                      </p>
+                    )}
+                  </div>
+                  <Badge
+                    variant="outline"
+                    className={
+                      studio.status === 'active'
+                        ? 'bg-green-50 text-green-700 border-green-200'
+                        : 'bg-gray-50 text-gray-500 border-gray-200'
+                    }
+                  >
+                    {studio.status}
+                  </Badge>
+                </div>
+              ))}
+            </div>
+            <div className="mt-4 flex items-start gap-2 rounded-lg bg-blue-50/60 border border-blue-100 p-3">
+              <Info className="h-4 w-4 text-blue-500 mt-0.5 shrink-0" />
+              <p className="text-xs text-blue-700">
+                Patterns are matched against the{' '}
+                <code className="bg-blue-100 px-1 rounded">threadKey</code> of incoming triggers.
+                Use <code className="bg-blue-100 px-1 rounded">pr:*</code> for all PR reviews,{' '}
+                <code className="bg-blue-100 px-1 rounded">spec:*</code> for specs, or exact keys
+                like <code className="bg-blue-100 px-1 rounded">pr:231</code>. Manage via{' '}
+                <code className="bg-blue-100 px-1 rounded">
+                  update_studio(routePatterns: [...])
+                </code>
+                .
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+      )}
 
       {/* Scheduled reminders — with studio overrides */}
       <Card className="mt-6">

--- a/packages/web/src/app/(dashboard)/routing/[agentId]/page.tsx
+++ b/packages/web/src/app/(dashboard)/routing/[agentId]/page.tsx
@@ -577,7 +577,7 @@ export default function AgentRoutingPage() {
           <CardHeader>
             <CardTitle>Studio route patterns</CardTitle>
             <CardDescription>
-              ThreadKey patterns determine which studio handles triggered messages. More specific
+              Thread patterns determine which studio handles triggered messages. More specific
               patterns win (exact &gt; prefix wildcard &gt; catch-all).
             </CardDescription>
           </CardHeader>
@@ -627,18 +627,15 @@ export default function AgentRoutingPage() {
                 </div>
               ))}
             </div>
-            <div className="mt-4 flex items-start gap-2 rounded-lg bg-blue-50/60 border border-blue-100 p-3">
-              <Info className="h-4 w-4 text-blue-500 mt-0.5 shrink-0" />
-              <p className="text-xs text-blue-700">
-                Patterns are matched against the{' '}
-                <code className="bg-blue-100 px-1 rounded">threadKey</code> of incoming triggers.
-                Use <code className="bg-blue-100 px-1 rounded">pr:*</code> for all PR reviews,{' '}
-                <code className="bg-blue-100 px-1 rounded">spec:*</code> for specs, or exact keys
-                like <code className="bg-blue-100 px-1 rounded">pr:231</code>. Manage via{' '}
-                <code className="bg-blue-100 px-1 rounded">
-                  update_studio(routePatterns: [...])
-                </code>
-                .
+            <div className="mt-4 flex items-start gap-2 rounded-lg bg-gray-50 border border-gray-200 p-3">
+              <Info className="h-4 w-4 text-gray-400 mt-0.5 shrink-0" />
+              <p className="text-xs text-gray-500">
+                Patterns match against thread types like{' '}
+                <code className="bg-gray-100 px-1 rounded text-gray-600">pr:*</code> for PR reviews,{' '}
+                <code className="bg-gray-100 px-1 rounded text-gray-600">spec:*</code> for specs, or
+                exact threads like{' '}
+                <code className="bg-gray-100 px-1 rounded text-gray-600">pr:231</code>. Ask your SB
+                to update routing for the types of work you want each studio to handle.
               </p>
             </div>
           </CardContent>


### PR DESCRIPTION
## Summary

- **Routing page UI**: New "Studio route patterns" card on the per-agent routing page showing each studio's thread patterns as badges (blue mono badges for patterns, green/gray for status)
- **API fix**: Studios query used `name` column which doesn't exist — fixed to use `slug`. Also returns `route_patterns` from the DB.
- **Help text**: Neutral gray info box prompting the user to ask their SB to update routing
- **Docs**: Added "Studio Route Patterns" section to AGENTS.md with recommended starting patterns table for new users

## Screenshots

See routing page screenshots sent to Conor via Telegram (Myra thread:routing-screenshots).

## Test plan

- [x] Verified routing page renders studios with pattern badges
- [x] Verified studios with no patterns show "No patterns — uses fallback routing"
- [x] Verified info box renders with neutral styling
- [x] Playwright screenshots captured

🤖 Generated with [Claude Code](https://claude.com/claude-code)