### PR TITLE
feat(mission): show full inbox message body in feed (by Wren)

### DIFF
--- a/packages/cli/src/commands/mission.test.ts
+++ b/packages/cli/src/commands/mission.test.ts
@@ -794,6 +794,54 @@ describe('inboxMessageToFeedEvent', () => {
     const event = inboxMessageToFeedEvent(msg);
     expect(event.content).toContain('from user');
   });
+
+  it('shows full body in detail when subject is used as preview', () => {
+    const msg: InboxMessage = {
+      id: 'msg-4',
+      subject: 'Review PR #232',
+      content: 'Hey, please review this fix for the stuck compacting lifecycle on Gemini sessions.',
+      messageType: 'task_request',
+      senderAgentId: 'wren',
+      recipientAgentId: 'lumen',
+      createdAt: '2026-03-18T16:36:00Z',
+    };
+    const event = inboxMessageToFeedEvent(msg);
+    expect(event.content).toContain('Review PR #232');
+    expect(event.detail).toContain(
+      'Hey, please review this fix for the stuck compacting lifecycle on Gemini sessions.'
+    );
+  });
+
+  it('shows full body in detail when content is truncated', () => {
+    const longContent = 'A'.repeat(200);
+    const msg: InboxMessage = {
+      id: 'msg-5',
+      content: longContent,
+      messageType: 'message',
+      senderAgentId: 'aster',
+      recipientAgentId: 'wren',
+      createdAt: '2026-03-18T17:00:00Z',
+    };
+    const event = inboxMessageToFeedEvent(msg);
+    // Preview should be truncated
+    expect(event.content.length).toBeLessThan(longContent.length);
+    // Detail should contain the full body
+    expect(event.detail).toContain(longContent);
+  });
+
+  it('does not duplicate short content in detail', () => {
+    const msg: InboxMessage = {
+      id: 'msg-6',
+      content: 'Quick question',
+      messageType: 'message',
+      senderAgentId: 'aster',
+      recipientAgentId: 'wren',
+      createdAt: '2026-03-18T17:00:00Z',
+    };
+    const event = inboxMessageToFeedEvent(msg);
+    // Content fits in preview, no subject — detail should not repeat it
+    expect(event.detail).toBeUndefined();
+  });
 });
 
 // ── backendFromSubtype ──

--- a/packages/cli/src/commands/mission.ts
+++ b/packages/cli/src/commands/mission.ts
@@ -168,14 +168,27 @@ export function inboxMessageToFeedEvent(msg: InboxMessage, timezone?: string): F
     typeof recipientMeta?.studioHint === 'string' ? recipientMeta.studioHint : undefined;
   const studioId = typeof recipientMeta?.studioId === 'string' ? recipientMeta.studioId : undefined;
 
-  const detailParts: string[] = [];
+  const metaParts: string[] = [];
   if (msg.messageType && msg.messageType !== 'message') {
-    detailParts.push(`type: ${msg.messageType}`);
+    metaParts.push(`type: ${msg.messageType}`);
   }
-  if (msg.threadKey) detailParts.push(`thread: ${msg.threadKey}`);
+  if (msg.threadKey) metaParts.push(`thread: ${msg.threadKey}`);
   const studioLabel = studioHint || (studioId ? studioId.slice(0, 8) : undefined);
-  if (studioLabel) detailParts.push(`studio: ${studioLabel}`);
-  if (msg.priority && msg.priority !== 'normal') detailParts.push(`priority: ${msg.priority}`);
+  if (studioLabel) metaParts.push(`studio: ${studioLabel}`);
+  if (msg.priority && msg.priority !== 'normal') metaParts.push(`priority: ${msg.priority}`);
+
+  // Show full message body when it was truncated in the preview line, or when
+  // the preview used the subject (meaning the body wasn't shown at all).
+  const detailLines: string[] = [];
+  if (metaParts.length > 0) detailLines.push(metaParts.join('  ·  '));
+  if (msg.content) {
+    const body = msg.content.trim();
+    const wasSubjectUsed = Boolean(msg.subject);
+    const wasTruncated = body.replace(/\s+/g, ' ').length > maxPreview;
+    if (wasSubjectUsed || wasTruncated) {
+      detailLines.push(body);
+    }
+  }
 
   return {
     id: `inbox-${msg.id}`,
@@ -183,7 +196,7 @@ export function inboxMessageToFeedEvent(msg: InboxMessage, timezone?: string): F
     agent: recipient,
     content,
     time: formatHumanTime(msg.createdAt, timezone),
-    detail: detailParts.length > 0 ? detailParts.join('  ·  ') : undefined,
+    detail: detailLines.length > 0 ? detailLines.join('\n') : undefined,
   };
 }
 


### PR DESCRIPTION
## Summary

- **Show full message content in mission feed.** Previously inbox messages were truncated to ~120 chars. Now the complete body renders in the detail section when it was truncated or when a subject was used as the preview line.
- **No duplication for short messages** — if the content fits in the preview line and there's no subject, the detail field stays clean.

## Before/After

**Before:** `from wren: [task_request] Review PR #232: fix stuck compacting lifecy…`

**After:**
```
from wren: [task_request] Review PR #232: fix stuck compacting lifecycle
  type: task_request  ·  thread: pr:232
  Hey both — requesting review on a small fix...
  The bug: preCompactHandler sets lifecycle: 'compacting' via the REST
  lifecycle endpoint, but Gemini has postCompact: null...
```

## Test plan

- [x] 69/69 mission tests pass (3 new tests added)
- [x] Type-check passes
- [ ] Visual verification with `sb mission --watch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Wren