### PR TITLE
feat: add PCP skill for OpenClaw/ClawHub (by Wren)

### DIFF
--- a/packages/api/src/skills/builtin/pcp/SKILL.md
+++ b/packages/api/src/skills/builtin/pcp/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: pcp
+version: '0.1.0'
+displayName: Personal Context Protocol
+description: Identity, memory, sessions, and cross-agent messaging via PCP. Gives agents persistent context that survives across sessions and works across AI backends.
+type: guide
+emoji: '🧠'
+category: productivity
+tags:
+  - pcp
+  - memory
+  - context
+  - identity
+  - sessions
+  - inbox
+  - cross-agent
+author: PCP Team
+homepage: https://github.com/conoremclaughlin/personal-context-protocol
+triggers:
+  keywords:
+    - pcp
+    - memory
+    - remember
+    - recall
+    - context
+    - bootstrap
+    - session
+    - inbox
+    - identity
+    - cross-agent
+capabilities:
+  memory: true
+  network: true
+requirements:
+  config:
+    - ~/.pcp/config.json
+metadata:
+  openclaw:
+    emoji: '🧠'
+    requires:
+      config:
+        - openclaw.json.plugins.entries.pcp
+---
+
+# Personal Context Protocol (PCP)
+
+PCP gives you persistent identity, long-term memory, session tracking, and cross-agent messaging. Your context survives across sessions and works across AI backends (Claude Code, Codex, Gemini, OpenClaw).
+
+## Setup
+
+PCP tools are available via MCP. If the PCP MCP server is not already configured, add it to your MCP config:
+
+**Option A — Stdio (spawns a process):**
+
+```json
+{
+  "mcpServers": {
+    "pcp": {
+      "command": "node",
+      "args": ["/path/to/pcp/packages/api/dist/index.js"],
+      "env": { "MCP_TRANSPORT": "stdio" }
+    }
+  }
+}
+```
+
+**Option B — HTTP (connect to running server):**
+
+```json
+{
+  "mcpServers": {
+    "pcp": {
+      "url": "http://localhost:3001/mcp",
+      "headers": {
+        "Authorization": "Bearer ${PCP_ACCESS_TOKEN}"
+      }
+    }
+  }
+}
+```
+
+## Quick Start
+
+At the start of every session, call `bootstrap` to load your identity and context:
+
+```
+bootstrap(agentId: "your-agent-id")
+```
+
+This returns your identity documents, recent memories, active sessions, and team context. Everything you need to know who you are and what you've been working on.
+
+## Core Tools
+
+### Memory — What You Know
+
+```
+remember(content: "Decided to use X because...", agentId: "wren", topicKey: "decision:auth")
+```
+
+Saves to long-term memory with topic tagging. Memories persist across sessions and are filtered by your agentId.
+
+```
+recall(query: "auth approach", agentId: "wren")
+```
+
+Searches your memories. Returns matches sorted by relevance and salience.
+
+**TopicKey convention:** `type:identifier` — e.g., `project:pcp/memory`, `decision:jwt-auth`, `lesson:cross-agent-review`.
+
+### Sessions — Where You Are
+
+Sessions track what you're working on and in what phase:
+
+```
+update_session_phase(phase: "implementing")
+```
+
+Phases: `investigating`, `implementing`, `reviewing`, `blocked:<reason>`, `waiting:<reason>`.
+
+Sessions end automatically, but you can save a summary:
+
+```
+end_session(summary: "Built memory layer with versioning")
+```
+
+### Inbox — Cross-Agent Messaging
+
+Send messages to other agents:
+
+```
+send_to_inbox(
+  recipientAgentId: "lumen",
+  messageType: "task_request",
+  threadKey: "pr:42",
+  subject: "Review PR #42",
+  content: "Please review the auth middleware changes."
+)
+```
+
+Check your inbox:
+
+```
+get_inbox(agentId: "wren")
+```
+
+Read thread messages:
+
+```
+get_thread_messages(threadKey: "pr:42", agentId: "wren")
+```
+
+**threadKey convention:** `pr:42`, `spec:cli-hooks`, `issue:15`, `thread:perf-audit`.
+
+### Identity — Who You Are
+
+Your identity is stored in the database and served via bootstrap. Six documents form your constitution:
+
+| Document  | Scope     | Purpose                   |
+| --------- | --------- | ------------------------- |
+| identity  | Per-agent | Name, role, relationships |
+| soul      | Per-agent | Philosophical core        |
+| heartbeat | Per-agent | Operational checklist     |
+| values    | Shared    | Team principles           |
+| process   | Shared    | How we work               |
+| user      | Shared    | About the human           |
+
+Read: `get_identity(agentId, file: "identity")`. Write: `save_identity(description: "...")`.
+
+## Tool Reference
+
+| Tool                   | Purpose                                           |
+| ---------------------- | ------------------------------------------------- |
+| `bootstrap`            | Load identity, context, memories at session start |
+| `remember`             | Save to long-term memory                          |
+| `recall`               | Search memories                                   |
+| `forget`               | Delete a memory                                   |
+| `update_memory`        | Update salience/topics                            |
+| `send_to_inbox`        | Message another agent                             |
+| `get_inbox`            | Check your inbox                                  |
+| `get_thread_messages`  | Read a conversation thread                        |
+| `mark_thread_read`     | Mark thread as read                               |
+| `update_session_phase` | Set work phase                                    |
+| `end_session`          | End session with summary                          |
+| `get_identity`         | Read identity documents                           |
+| `save_identity`        | Update identity documents                         |
+| `create_task`          | Create a tracked task                             |
+| `list_tasks`           | List tasks                                        |
+| `save_context`         | Save context summaries                            |
+| `get_context`          | Retrieve context                                  |
+| `log_activity`         | Log structured activity events                    |
+
+## Conventions
+
+- **Always bootstrap first.** It loads your identity, context, and recent memories.
+- **Attribute memories.** Include `agentId` and `topicKey` on every `remember()` call.
+- **Use threadKey.** Every `send_to_inbox` should include a threadKey for conversation continuity.
+- **All messages trigger by default.** Only set `trigger: false` if the message can wait 5+ hours.
+- **Phases are semantic.** Use `blocked:awaiting-review` not just `blocked`.

--- a/packages/cli/src/commands/awaken.ts
+++ b/packages/cli/src/commands/awaken.ts
@@ -22,6 +22,7 @@ import { fileURLToPath } from 'url';
 import { homedir, tmpdir } from 'os';
 import { getBackend, BACKEND_NAMES } from '../backends/index.js';
 import { callPcpTool } from '../lib/pcp-mcp.js';
+import { getValidAccessToken } from '../auth/tokens.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -344,11 +345,21 @@ async function awakenCommand(options: { backend: string; verbose: boolean }): Pr
     )
   );
 
-  // 5. Spawn the backend process
+  // 5. Resolve PCP auth token (same as sb chat) so MCP tools work
+  const authEnv: Record<string, string> = {};
+  try {
+    const token = await getValidAccessToken(process.env.PCP_SERVER_URL || 'http://localhost:3001');
+    if (token) authEnv.PCP_ACCESS_TOKEN = token;
+  } catch {
+    // Auth is best-effort — the backend can fall back to MCP OAuth
+  }
+
+  // 6. Spawn the backend process
   const child = spawn(prepared.binary, prepared.args, {
     stdio: 'inherit',
     env: {
       ...process.env,
+      ...authEnv,
       ...prepared.env,
       AGENT_ID: 'nascent',
     },

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -60,9 +60,6 @@ function buildDefaultMcpJson(serverUrl: string, cwd?: string): Record<string, un
     pcp: {
       type: 'http',
       url: `${serverUrl}/mcp`,
-      headers: {
-        Authorization: 'Bearer ${PCP_ACCESS_TOKEN}',
-      },
     },
   };
 
@@ -105,37 +102,19 @@ function ensureMcpJson(cwd: string): InitStepResult {
       const existing = JSON.parse(readFileSync(mcpPath, 'utf-8')) as Record<string, unknown>;
       const servers = existing.mcpServers as Record<string, unknown> | undefined;
       if (servers?.pcp) {
-        let needsWrite = false;
-        const updatedServers = { ...servers };
-
-        // Migrate existing pcp entry to include auth header if missing
-        const pcpEntry = servers.pcp as Record<string, unknown>;
-        const headers = pcpEntry.headers as Record<string, string> | undefined;
-        if (!headers?.Authorization) {
-          updatedServers.pcp = {
-            ...pcpEntry,
-            headers: { ...headers, Authorization: 'Bearer ${PCP_ACCESS_TOKEN}' },
-          };
-          needsWrite = true;
-        }
-
         // Add pcp-inbox if missing and plugin exists locally
         if (!servers['pcp-inbox']) {
           const channelPath = resolveChannelPluginPath(cwd);
           if (channelPath) {
-            updatedServers['pcp-inbox'] = { command: 'npx', args: ['tsx', channelPath] };
-            needsWrite = true;
+            const updatedServers = { ...servers, 'pcp-inbox': { command: 'npx', args: ['tsx', channelPath] } };
+            const updated = { ...existing, mcpServers: updatedServers };
+            writeFileSync(mcpPath, JSON.stringify(updated, null, 2) + '\n');
+            return {
+              label: '.mcp.json',
+              status: 'updated',
+              detail: 'added pcp-inbox channel plugin',
+            };
           }
-        }
-
-        if (needsWrite) {
-          const updated = { ...existing, mcpServers: updatedServers };
-          writeFileSync(mcpPath, JSON.stringify(updated, null, 2) + '\n');
-          return {
-            label: '.mcp.json',
-            status: 'updated',
-            detail: 'updated pcp config',
-          };
         }
         return { label: '.mcp.json', status: 'exists', detail: 'pcp server configured' };
       }
@@ -148,7 +127,6 @@ function ensureMcpJson(cwd: string): InitStepResult {
           pcp: {
             type: 'http',
             url: `${serverUrl}/mcp`,
-            headers: { Authorization: 'Bearer ${PCP_ACCESS_TOKEN}' },
           },
         },
       };

--- a/packages/openclaw-plugin/index.ts
+++ b/packages/openclaw-plugin/index.ts
@@ -41,14 +41,20 @@ interface PcpAuthConfig {
 }
 
 interface BootstrapResponse {
-  identity?: {
-    identity?: string;
+  // Constitution documents (merged: Supabase priority, local fallback)
+  identityFiles?: {
+    self?: string;
     soul?: string;
+    heartbeat?: string;
     values?: string;
     process?: string;
     user?: string;
   };
-  memories?: Array<{ content: string; topicKey?: string }>;
+  // Knowledge summary: budget-constrained, grouped by topic
+  knowledgeSummary?: string | null;
+  // Topic index: all topics with counts + recency
+  topicIndex?: Array<{ topic: string; count: number }> | null;
+  // User info including timezone
   user?: { timezone?: string };
 }
 
@@ -171,24 +177,24 @@ function formatBootstrapContext(bootstrap: BootstrapResponse, agentId: string): 
 
   sections.push(`<pcp-context agentId="${agentId}">`);
 
-  if (bootstrap.identity?.identity) {
-    sections.push(`<identity>\n${truncate(bootstrap.identity.identity, 2000)}\n</identity>`);
+  // Constitution: identity (self), values, soul
+  if (bootstrap.identityFiles?.self) {
+    sections.push(`<identity>\n${truncate(bootstrap.identityFiles.self, 2000)}\n</identity>`);
   }
 
-  if (bootstrap.identity?.values) {
-    sections.push(`<values>\n${truncate(bootstrap.identity.values, 1500)}\n</values>`);
+  if (bootstrap.identityFiles?.values) {
+    sections.push(`<values>\n${truncate(bootstrap.identityFiles.values, 1500)}\n</values>`);
   }
 
-  if (bootstrap.identity?.soul) {
-    sections.push(`<soul>\n${truncate(bootstrap.identity.soul, 1000)}\n</soul>`);
+  if (bootstrap.identityFiles?.soul) {
+    sections.push(`<soul>\n${truncate(bootstrap.identityFiles.soul, 1000)}\n</soul>`);
   }
 
-  if (bootstrap.memories && bootstrap.memories.length > 0) {
-    const memoryLines = bootstrap.memories
-      .slice(0, 10)
-      .map((m) => `- ${m.topicKey ? `[${m.topicKey}] ` : ''}${truncate(m.content, 200)}`)
-      .join('\n');
-    sections.push(`<recent-memories>\n${memoryLines}\n</recent-memories>`);
+  // Knowledge summary (pre-formatted by PCP, grouped by topic)
+  if (bootstrap.knowledgeSummary) {
+    sections.push(
+      `<knowledge-summary>\n${truncate(bootstrap.knowledgeSummary, 3000)}\n</knowledge-summary>`
+    );
   }
 
   if (bootstrap.user?.timezone) {

--- a/packages/openclaw-plugin/index.ts
+++ b/packages/openclaw-plugin/index.ts
@@ -1,0 +1,349 @@
+/**
+ * OpenClaw PCP Plugin
+ *
+ * Integrates Personal Context Protocol with OpenClaw.
+ * Auto-injects PCP identity context on agent start and
+ * ends PCP sessions on agent completion.
+ *
+ * Config:
+ *   serverUrl     - PCP server URL (default: http://localhost:3001)
+ *   accessToken   - PCP access token (or reads from ~/.pcp/auth.json)
+ *   agentId       - Agent identity (or reads from ~/.pcp/config.json)
+ *   autoBootstrap - Inject identity context before each turn (default: true)
+ *   autoSessionEnd - End PCP session on agent_end (default: true)
+ */
+
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+import type { OpenClawPluginApi } from 'openclaw/plugin-sdk';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface PcpConfig {
+  serverUrl: string;
+  accessToken?: string;
+  agentId?: string;
+  autoBootstrap: boolean;
+  autoSessionEnd: boolean;
+}
+
+interface PcpUserConfig {
+  userId?: string;
+  email?: string;
+  agentMapping?: Record<string, string>;
+}
+
+interface PcpAuthConfig {
+  accessToken?: string;
+}
+
+interface BootstrapResponse {
+  identity?: {
+    identity?: string;
+    soul?: string;
+    values?: string;
+    process?: string;
+    user?: string;
+  };
+  memories?: Array<{ content: string; topicKey?: string }>;
+  user?: { timezone?: string };
+}
+
+// ============================================================================
+// Config Resolution
+// ============================================================================
+
+function readJsonFile<T>(path: string): T | null {
+  try {
+    if (!existsSync(path)) return null;
+    return JSON.parse(readFileSync(path, 'utf-8')) as T;
+  } catch {
+    return null;
+  }
+}
+
+function resolveAgentId(pluginAgentId?: string): string | null {
+  if (pluginAgentId) return pluginAgentId;
+
+  // Check ~/.pcp/config.json agentMapping
+  const config = readJsonFile<PcpUserConfig>(join(homedir(), '.pcp', 'config.json'));
+  if (config?.agentMapping?.openclaw) return config.agentMapping.openclaw;
+
+  // Fall back to first mapping
+  if (config?.agentMapping) {
+    const ids = Object.values(config.agentMapping);
+    if (ids.length > 0) return ids[0];
+  }
+
+  return null;
+}
+
+function resolveAccessToken(pluginToken?: string): string | null {
+  if (pluginToken) return pluginToken;
+
+  // Check PCP_ACCESS_TOKEN env var
+  if (process.env.PCP_ACCESS_TOKEN) return process.env.PCP_ACCESS_TOKEN;
+
+  // Check ~/.pcp/auth.json
+  const auth = readJsonFile<PcpAuthConfig>(join(homedir(), '.pcp', 'auth.json'));
+  return auth?.accessToken ?? null;
+}
+
+function resolveUserId(): string | null {
+  const config = readJsonFile<PcpUserConfig>(join(homedir(), '.pcp', 'config.json'));
+  return config?.userId ?? null;
+}
+
+// ============================================================================
+// PCP API Client
+// ============================================================================
+
+class PcpClient {
+  constructor(
+    private serverUrl: string,
+    private accessToken: string
+  ) {}
+
+  /**
+   * Call a PCP MCP tool via the HTTP transport.
+   * Uses the JSON-RPC format expected by the MCP server.
+   */
+  async callTool(name: string, args: Record<string, unknown>): Promise<unknown> {
+    const url = `${this.serverUrl}/mcp`;
+    const body = {
+      jsonrpc: '2.0',
+      id: Date.now(),
+      method: 'tools/call',
+      params: { name, arguments: args },
+    };
+
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream',
+        Authorization: `Bearer ${this.accessToken}`,
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      throw new Error(`PCP API error: ${response.status} ${response.statusText}`);
+    }
+
+    const contentType = response.headers.get('content-type') ?? '';
+
+    // Handle SSE (Streamable HTTP transport)
+    if (contentType.includes('text/event-stream')) {
+      const text = await response.text();
+      // Parse last SSE data line containing the result
+      const lines = text.split('\n');
+      for (let i = lines.length - 1; i >= 0; i--) {
+        if (lines[i].startsWith('data: ')) {
+          const data = JSON.parse(lines[i].slice(6));
+          if (data.result?.content?.[0]?.text) {
+            return JSON.parse(data.result.content[0].text);
+          }
+          return data.result;
+        }
+      }
+      return null;
+    }
+
+    // Handle plain JSON response
+    const data = await response.json();
+    if (data.result?.content?.[0]?.text) {
+      return JSON.parse(data.result.content[0].text);
+    }
+    return data.result;
+  }
+}
+
+// ============================================================================
+// Context Formatting
+// ============================================================================
+
+function formatBootstrapContext(bootstrap: BootstrapResponse, agentId: string): string {
+  const sections: string[] = [];
+
+  sections.push(`<pcp-context agentId="${agentId}">`);
+
+  if (bootstrap.identity?.identity) {
+    sections.push(`<identity>\n${truncate(bootstrap.identity.identity, 2000)}\n</identity>`);
+  }
+
+  if (bootstrap.identity?.values) {
+    sections.push(`<values>\n${truncate(bootstrap.identity.values, 1500)}\n</values>`);
+  }
+
+  if (bootstrap.identity?.soul) {
+    sections.push(`<soul>\n${truncate(bootstrap.identity.soul, 1000)}\n</soul>`);
+  }
+
+  if (bootstrap.memories && bootstrap.memories.length > 0) {
+    const memoryLines = bootstrap.memories
+      .slice(0, 10)
+      .map((m) => `- ${m.topicKey ? `[${m.topicKey}] ` : ''}${truncate(m.content, 200)}`)
+      .join('\n');
+    sections.push(`<recent-memories>\n${memoryLines}\n</recent-memories>`);
+  }
+
+  if (bootstrap.user?.timezone) {
+    sections.push(`<timezone>${bootstrap.user.timezone}</timezone>`);
+  }
+
+  sections.push('</pcp-context>');
+
+  return sections.join('\n\n');
+}
+
+function truncate(text: string, maxLength: number): string {
+  if (text.length <= maxLength) return text;
+  return text.slice(0, maxLength - 1) + '…';
+}
+
+// ============================================================================
+// Plugin Entry
+// ============================================================================
+
+export default function pcpPlugin(api: OpenClawPluginApi) {
+  const pluginConfig = (api.pluginConfig ?? {}) as Partial<PcpConfig>;
+
+  const serverUrl = pluginConfig.serverUrl ?? 'http://localhost:3001';
+  const autoBootstrap = pluginConfig.autoBootstrap ?? true;
+  const autoSessionEnd = pluginConfig.autoSessionEnd ?? true;
+
+  const agentId = resolveAgentId(pluginConfig.agentId);
+  const accessToken = resolveAccessToken(pluginConfig.accessToken);
+
+  if (!accessToken) {
+    api.logger.warn(
+      'pcp: no access token found. Set plugins.entries.pcp.config.accessToken, ' +
+        "PCP_ACCESS_TOKEN env var, or run 'sb login'. PCP hooks disabled."
+    );
+    return;
+  }
+
+  if (!agentId) {
+    api.logger.warn(
+      'pcp: no agent ID resolved. Set plugins.entries.pcp.config.agentId ' +
+        'or add an openclaw entry to ~/.pcp/config.json agentMapping. PCP hooks disabled.'
+    );
+    return;
+  }
+
+  const userId = resolveUserId();
+  const client = new PcpClient(serverUrl, accessToken);
+
+  api.logger.info?.(`pcp: initialized (agent=${agentId}, server=${serverUrl})`);
+
+  // --------------------------------------------------------------------------
+  // Hook: auto-bootstrap — inject PCP identity context before each agent turn
+  // --------------------------------------------------------------------------
+
+  if (autoBootstrap) {
+    api.on('before_prompt_build', async () => {
+      try {
+        const result = (await client.callTool('bootstrap', {
+          ...(userId ? { userId } : {}),
+          agentId,
+        })) as BootstrapResponse | null;
+
+        if (!result) {
+          api.logger.warn('pcp: bootstrap returned no data');
+          return;
+        }
+
+        const context = formatBootstrapContext(result, agentId);
+        api.logger.info?.(`pcp: injected ${context.length} chars of identity context`);
+
+        return { prependContext: context };
+      } catch (err) {
+        api.logger.warn(`pcp: bootstrap failed: ${String(err)}`);
+      }
+    });
+  }
+
+  // --------------------------------------------------------------------------
+  // Hook: auto-session-end — end PCP session when agent turn completes
+  // --------------------------------------------------------------------------
+
+  if (autoSessionEnd) {
+    api.on('agent_end', async (event) => {
+      try {
+        await client.callTool('end_session', {
+          ...(userId ? { userId } : {}),
+          agentId,
+          summary: event.success
+            ? `Agent turn completed (${event.durationMs ? Math.round(event.durationMs / 1000) + 's' : 'unknown duration'})`
+            : `Agent turn failed: ${event.error ?? 'unknown error'}`,
+        });
+        api.logger.info?.('pcp: session ended');
+      } catch (err) {
+        // Fire-and-forget — don't block agent completion
+        api.logger.warn(`pcp: end_session failed: ${String(err)}`);
+      }
+    });
+  }
+
+  // --------------------------------------------------------------------------
+  // Tool: pcp_status — quick check of PCP connectivity and identity
+  // --------------------------------------------------------------------------
+
+  api.registerTool({
+    name: 'pcp_status',
+    label: 'PCP Status',
+    description: 'Check PCP server connectivity and your agent identity',
+    parameters: {
+      type: 'object' as const,
+      properties: {},
+    },
+    async execute() {
+      try {
+        const result = (await client.callTool('get_identity', {
+          agentId,
+          file: 'identity',
+        })) as { content?: string } | null;
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify(
+                {
+                  connected: true,
+                  server: serverUrl,
+                  agentId,
+                  identityLoaded: !!result?.content,
+                },
+                null,
+                2
+              ),
+            },
+          ],
+        };
+      } catch (err) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify(
+                {
+                  connected: false,
+                  server: serverUrl,
+                  agentId,
+                  error: String(err),
+                },
+                null,
+                2
+              ),
+            },
+          ],
+        };
+      }
+    },
+  });
+}

--- a/packages/openclaw-plugin/openclaw.plugin.json
+++ b/packages/openclaw-plugin/openclaw.plugin.json
@@ -1,0 +1,54 @@
+{
+  "id": "pcp",
+  "skills": ["skills"],
+  "uiHints": {
+    "serverUrl": {
+      "label": "PCP Server URL",
+      "placeholder": "http://localhost:3001",
+      "help": "URL of the running PCP server"
+    },
+    "accessToken": {
+      "label": "Access Token",
+      "sensitive": true,
+      "placeholder": "eyJhbGciOi...",
+      "help": "PCP access token (from ~/.pcp/auth.json or 'sb login')"
+    },
+    "agentId": {
+      "label": "Agent ID",
+      "placeholder": "wren",
+      "help": "Your PCP agent identity. If omitted, reads from ~/.pcp/config.json agentMapping."
+    },
+    "autoBootstrap": {
+      "label": "Auto-Bootstrap",
+      "help": "Inject PCP identity context at the start of each agent turn"
+    },
+    "autoSessionEnd": {
+      "label": "Auto Session End",
+      "help": "Automatically end the PCP session when the agent turn completes"
+    }
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "serverUrl": {
+        "type": "string",
+        "default": "http://localhost:3001"
+      },
+      "accessToken": {
+        "type": "string"
+      },
+      "agentId": {
+        "type": "string"
+      },
+      "autoBootstrap": {
+        "type": "boolean",
+        "default": true
+      },
+      "autoSessionEnd": {
+        "type": "boolean",
+        "default": true
+      }
+    }
+  }
+}

--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "pcp-openclaw",
+  "name": "@pcp/openclaw-plugin",
   "version": "0.1.0",
   "description": "Personal Context Protocol plugin for OpenClaw — identity, memory, sessions, and cross-agent messaging",
   "type": "module",

--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "pcp-openclaw",
+  "version": "0.1.0",
+  "description": "Personal Context Protocol plugin for OpenClaw — identity, memory, sessions, and cross-agent messaging",
+  "type": "module",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/conoremclaughlin/personal-context-protocol.git",
+    "directory": "packages/openclaw-plugin"
+  },
+  "keywords": [
+    "openclaw",
+    "pcp",
+    "personal-context-protocol",
+    "mcp",
+    "ai-agent",
+    "memory",
+    "identity"
+  ],
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  },
+  "files": [
+    "index.ts",
+    "openclaw.plugin.json",
+    "skills/"
+  ]
+}

--- a/packages/openclaw-plugin/skills/SKILL.md
+++ b/packages/openclaw-plugin/skills/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: pcp
+version: '0.1.0'
+displayName: Personal Context Protocol
+description: Identity, memory, sessions, and cross-agent messaging via PCP. Gives agents persistent context that survives across sessions and works across AI backends.
+type: guide
+emoji: '🧠'
+category: productivity
+tags:
+  - pcp
+  - memory
+  - context
+  - identity
+  - sessions
+  - inbox
+  - cross-agent
+author: PCP Team
+homepage: https://github.com/conoremclaughlin/personal-context-protocol
+triggers:
+  keywords:
+    - pcp
+    - memory
+    - remember
+    - recall
+    - context
+    - bootstrap
+    - session
+    - inbox
+    - identity
+    - cross-agent
+capabilities:
+  memory: true
+  network: true
+requirements:
+  config:
+    - ~/.pcp/config.json
+metadata:
+  openclaw:
+    emoji: '🧠'
+    requires:
+      config:
+        - openclaw.json.plugins.entries.pcp
+---
+
+# Personal Context Protocol (PCP)
+
+PCP gives you persistent identity, long-term memory, session tracking, and cross-agent messaging. Your context survives across sessions and works across AI backends (Claude Code, Codex, Gemini, OpenClaw).
+
+## Setup
+
+PCP tools are available via MCP. If the PCP MCP server is not already configured, add it to your MCP config:
+
+**Option A — Stdio (spawns a process):**
+
+```json
+{
+  "mcpServers": {
+    "pcp": {
+      "command": "node",
+      "args": ["/path/to/pcp/packages/api/dist/index.js"],
+      "env": { "MCP_TRANSPORT": "stdio" }
+    }
+  }
+}
+```
+
+**Option B — HTTP (connect to running server):**
+
+```json
+{
+  "mcpServers": {
+    "pcp": {
+      "url": "http://localhost:3001/mcp",
+      "headers": {
+        "Authorization": "Bearer ${PCP_ACCESS_TOKEN}"
+      }
+    }
+  }
+}
+```
+
+## Quick Start
+
+At the start of every session, call `bootstrap` to load your identity and context:
+
+```
+bootstrap(agentId: "your-agent-id")
+```
+
+This returns your identity documents, recent memories, active sessions, and team context. Everything you need to know who you are and what you've been working on.
+
+## Core Tools
+
+### Memory — What You Know
+
+```
+remember(content: "Decided to use X because...", agentId: "wren", topicKey: "decision:auth")
+```
+
+Saves to long-term memory with topic tagging. Memories persist across sessions and are filtered by your agentId.
+
+```
+recall(query: "auth approach", agentId: "wren")
+```
+
+Searches your memories. Returns matches sorted by relevance and salience.
+
+**TopicKey convention:** `type:identifier` — e.g., `project:pcp/memory`, `decision:jwt-auth`, `lesson:cross-agent-review`.
+
+### Sessions — Where You Are
+
+Sessions track what you're working on and in what phase:
+
+```
+update_session_phase(phase: "implementing")
+```
+
+Phases: `investigating`, `implementing`, `reviewing`, `blocked:<reason>`, `waiting:<reason>`.
+
+Sessions end automatically, but you can save a summary:
+
+```
+end_session(summary: "Built memory layer with versioning")
+```
+
+### Inbox — Cross-Agent Messaging
+
+Send messages to other agents:
+
+```
+send_to_inbox(
+  recipientAgentId: "lumen",
+  messageType: "task_request",
+  threadKey: "pr:42",
+  subject: "Review PR #42",
+  content: "Please review the auth middleware changes."
+)
+```
+
+Check your inbox:
+
+```
+get_inbox(agentId: "wren")
+```
+
+Read thread messages:
+
+```
+get_thread_messages(threadKey: "pr:42", agentId: "wren")
+```
+
+**threadKey convention:** `pr:42`, `spec:cli-hooks`, `issue:15`, `thread:perf-audit`.
+
+### Identity — Who You Are
+
+Your identity is stored in the database and served via bootstrap. Six documents form your constitution:
+
+| Document  | Scope     | Purpose                   |
+| --------- | --------- | ------------------------- |
+| identity  | Per-agent | Name, role, relationships |
+| soul      | Per-agent | Philosophical core        |
+| heartbeat | Per-agent | Operational checklist     |
+| values    | Shared    | Team principles           |
+| process   | Shared    | How we work               |
+| user      | Shared    | About the human           |
+
+Read: `get_identity(agentId, file: "identity")`. Write: `save_identity(description: "...")`.
+
+## Tool Reference
+
+| Tool                   | Purpose                                           |
+| ---------------------- | ------------------------------------------------- |
+| `bootstrap`            | Load identity, context, memories at session start |
+| `remember`             | Save to long-term memory                          |
+| `recall`               | Search memories                                   |
+| `forget`               | Delete a memory                                   |
+| `update_memory`        | Update salience/topics                            |
+| `send_to_inbox`        | Message another agent                             |
+| `get_inbox`            | Check your inbox                                  |
+| `get_thread_messages`  | Read a conversation thread                        |
+| `mark_thread_read`     | Mark thread as read                               |
+| `update_session_phase` | Set work phase                                    |
+| `end_session`          | End session with summary                          |
+| `get_identity`         | Read identity documents                           |
+| `save_identity`        | Update identity documents                         |
+| `create_task`          | Create a tracked task                             |
+| `list_tasks`           | List tasks                                        |
+| `save_context`         | Save context summaries                            |
+| `get_context`          | Retrieve context                                  |
+| `log_activity`         | Log structured activity events                    |
+
+## Conventions
+
+- **Always bootstrap first.** It loads your identity, context, and recent memories.
+- **Attribute memories.** Include `agentId` and `topicKey` on every `remember()` call.
+- **Use threadKey.** Every `send_to_inbox` should include a threadKey for conversation continuity.
+- **All messages trigger by default.** Only set `trigger: false` if the message can wait 5+ hours.
+- **Phases are semantic.** Use `blocked:awaiting-review` not just `blocked`.

--- a/yarn.lock
+++ b/yarn.lock
@@ -1960,6 +1960,12 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@pcp/openclaw-plugin@workspace:packages/openclaw-plugin":
+  version: 0.0.0-use.local
+  resolution: "@pcp/openclaw-plugin@workspace:packages/openclaw-plugin"
+  languageName: unknown
+  linkType: soft
+
 "@personal-context/api@workspace:packages/api":
   version: 0.0.0-use.local
   resolution: "@personal-context/api@workspace:packages/api"
@@ -10595,12 +10601,6 @@ __metadata:
   checksum: 10/01e9a69928f39087d96e1751ce7d6d50da8c39abf9a12e0ac2389c42c83bc76f78c45a475bd9026a02e6a6f79be63acc75667df855862fe567d99a00a540d23d
   languageName: node
   linkType: hard
-
-"pcp-openclaw@workspace:packages/openclaw-plugin":
-  version: 0.0.0-use.local
-  resolution: "pcp-openclaw@workspace:packages/openclaw-plugin"
-  languageName: unknown
-  linkType: soft
 
 "personal-context-protocol@workspace:.":
   version: 0.0.0-use.local

--- a/yarn.lock
+++ b/yarn.lock
@@ -10596,6 +10596,12 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pcp-openclaw@workspace:packages/openclaw-plugin":
+  version: 0.0.0-use.local
+  resolution: "pcp-openclaw@workspace:packages/openclaw-plugin"
+  languageName: unknown
+  linkType: soft
+
 "personal-context-protocol@workspace:.":
   version: 0.0.0-use.local
   resolution: "personal-context-protocol@workspace:."


### PR DESCRIPTION
## Summary

Three deliverables for PCP ecosystem improvements:

### 1. PCP Skill (`packages/api/src/skills/builtin/pcp/SKILL.md`)
- Bundled guide skill teaching agents how to use PCP tools
- AgentSkills format — compatible with both PCP and OpenClaw ecosystems
- Covers bootstrap, memory, sessions, cross-agent messaging, identity
- Publishable to ClawHub as a standalone skill

### 2. OpenClaw Plugin (`packages/openclaw-plugin/`)
- Standalone npm-publishable package (`@pcp/openclaw-plugin`)
- **`before_prompt_build` hook**: Auto-calls PCP bootstrap, injects identity/memories/values into system prompt
- **`agent_end` hook**: Auto-ends PCP session with duration summary
- **`pcp_status` tool**: Diagnostic tool for checking PCP connectivity
- Config resolution: reads ~/.pcp/config.json + ~/.pcp/auth.json + env vars
- Bundles the PCP skill (auto-loaded when plugin is enabled)

### 3. Remove auth headers from default `.mcp.json` (`packages/cli/src/commands/init.ts`)
- `sb init` no longer writes `Authorization: Bearer ${PCP_ACCESS_TOKEN}` into `.mcp.json`
- Standalone clients (e.g. Codex) will use the normal MCP OAuth login flow instead of failing with an undefined env var
- Triggered sessions still inject headers via `buildSessionEnv()` + combined MCP config
- Removes the header migration logic that added auth to existing configs

### Installation (OpenClaw plugin)
```bash
# From local path (development)
openclaw plugins install ./packages/openclaw-plugin

# From npm (once published)
openclaw plugins install @pcp/openclaw-plugin
```

## Test plan
- [x] `npx vitest run packages/cli/src/commands/init.test.ts` — 13/13 pass
- [x] Plugin structure matches OpenClaw extension format
- [x] Plugin installed and loaded via `openclaw plugins install` + `openclaw plugins list`
- [x] `create-pcp` published to npm (v0.1.0) and working via `npx create-pcp`
- [ ] Verify skill loads via `list_skills` MCP tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)