### PR TITLE
fix: Codex resume must come before config flags (by Wren)

### DIFF
--- a/packages/cli/src/backends/codex.ts
+++ b/packages/cli/src/backends/codex.ts
@@ -34,22 +34,25 @@ export class CodexAdapter implements BackendAdapter {
 
     const args: string[] = [];
 
-    // Identity injection via config override
-    args.push('--config', `model_instructions_file=${promptFile}`);
+    // Resume MUST come before --config flags. Codex treats `resume` as a
+    // subcommand with its own `-c` flag — config flags before `resume`
+    // are root-level and don't apply to the resumed session.
+    if (config.backendSessionId) {
+      args.push('resume', config.backendSessionId);
+    }
+
+    // Identity injection via config override (uses -c which works both
+    // as root --config and as resume's -c flag)
+    args.push('-c', `model_instructions_file=${promptFile}`);
 
     // PCP session headers — Codex resolves env var names to values at runtime
     for (const { header, envVar } of PCP_ENV_HEADERS) {
-      args.push('--config', `mcp_servers.pcp.env_http_headers.${header}="${envVar}"`);
+      args.push('-c', `mcp_servers.pcp.env_http_headers.${header}="${envVar}"`);
     }
 
     // Model (only if explicitly specified by user)
     if (config.model) {
       args.push('--model', config.model);
-    }
-
-    // Resume a specific backend-native Codex session when available.
-    if (config.backendSessionId) {
-      args.push('resume', config.backendSessionId);
     }
     // NOTE:
     // Codex does not currently expose a reliable "set session id on first run"

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -3222,18 +3222,23 @@ async function ensurePcpSessionContext(
         ? runtimeBackendSessionIdByPcpSessionId.get(chosen.id)
         : undefined,
     });
+  // Claude always preserves backend session links (Claude Code manages its own
+  // session continuity). Codex drops pre-linked sessions on new PCP session
+  // creation to avoid stale links — Codex sessions are independent and the
+  // user explicitly picks which to resume. Gemini is NOT included here because
+  // its session semantics are different and untested for this path.
   const preserveTrackedBackendSessionId = !createdNewPcpSession || backend === 'claude';
   let resolvedTrackedBackendSessionId = preserveTrackedBackendSessionId
     ? backendSessionId
     : undefined;
   if (
     createdNewPcpSession &&
-    backend !== 'claude' &&
+    backend === 'codex' &&
     backendSessionId &&
     !selectedLocalBackendSessionId
   ) {
     // Only ignore pre-linked backend sessions when the user didn't explicitly
-    // select a local session. If they picked a specific Codex/Gemini session
+    // select a local session. If they picked a specific Codex session
     // from the list, they want to resume it.
     sbDebugLog('claude', 'new_session_ignoring_prelinked_backend_session', {
       backend,

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -3223,15 +3223,34 @@ async function ensurePcpSessionContext(
         : undefined,
     });
   const preserveTrackedBackendSessionId = !createdNewPcpSession || backend === 'claude';
-  const resolvedTrackedBackendSessionId = preserveTrackedBackendSessionId
+  let resolvedTrackedBackendSessionId = preserveTrackedBackendSessionId
     ? backendSessionId
     : undefined;
-  if (createdNewPcpSession && backend !== 'claude' && backendSessionId) {
+  if (
+    createdNewPcpSession &&
+    backend !== 'claude' &&
+    backendSessionId &&
+    !selectedLocalBackendSessionId
+  ) {
+    // Only ignore pre-linked backend sessions when the user didn't explicitly
+    // select a local session. If they picked a specific Codex/Gemini session
+    // from the list, they want to resume it.
     sbDebugLog('claude', 'new_session_ignoring_prelinked_backend_session', {
       backend,
       agentId,
       pcpSessionId: chosen.id,
       ignoredBackendSessionId: backendSessionId,
+    });
+  }
+  // When the user explicitly picked a local backend session from the picker,
+  // use it as the resume target even if we created a new PCP session.
+  if (!resolvedTrackedBackendSessionId && selectedLocalBackendSessionId) {
+    resolvedTrackedBackendSessionId = selectedLocalBackendSessionId;
+    sbDebugLog('claude', 'using_selected_local_backend_session', {
+      backend,
+      agentId,
+      selectedLocalBackendSessionId,
+      createdNewPcpSession,
     });
   }
   const adoptedLocalBackendSessionId = resolveAdoptableLocalBackendSessionId({

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -3038,12 +3038,33 @@ async function ensurePcpSessionContext(
     } else if (selection.startsWith('local:') || selection.startsWith('__local__:')) {
       selectedLocalBackendSessionId = localSelection(selection);
       if (selectedLocalBackendSessionId && pcpAvailable) {
+        // Find-or-link: prefer an existing PCP session linked to this backend
+        // session, then try an unlinked PCP session in the same studio, and
+        // only create new as a last resort.
         const linkedPcpSession = pcpSessionByBackendSessionId.get(selectedLocalBackendSessionId);
         if (linkedPcpSession) {
           chosen = linkedPcpSession;
         } else {
-          chosen = await startNewPcpSession();
-          createdNewPcpSession = Boolean(chosen?.id);
+          // Try to find an unlinked PCP session for this agent+studio that
+          // can be adopted instead of creating an orphan.
+          const unlinkable = activeSessions.find(
+            (s) =>
+              !getSessionBackendId(s) &&
+              s.backend === backend &&
+              (!studioId || s.studioId === studioId)
+          );
+          if (unlinkable) {
+            chosen = unlinkable;
+            sbDebugLog('claude', 'adopting_unlinked_pcp_session', {
+              backend,
+              agentId,
+              pcpSessionId: unlinkable.id,
+              selectedLocalBackendSessionId,
+            });
+          } else {
+            chosen = await startNewPcpSession();
+            createdNewPcpSession = Boolean(chosen?.id);
+          }
         }
       }
     } else {
@@ -3180,12 +3201,29 @@ async function ensurePcpSessionContext(
       } else if (selection.startsWith('__local__:')) {
         selectedLocalBackendSessionId = sessionChoiceByValue.get(selection);
         if (selectedLocalBackendSessionId && pcpAvailable) {
+          // Find-or-link: prefer linked PCP session, then adopt unlinked, then create new
           const linkedPcpSession = pcpSessionByBackendSessionId.get(selectedLocalBackendSessionId);
           if (linkedPcpSession) {
             chosen = linkedPcpSession;
           } else {
-            chosen = await startNewPcpSession();
-            createdNewPcpSession = Boolean(chosen?.id);
+            const unlinkable = activeSessions.find(
+              (s) =>
+                !getSessionBackendId(s) &&
+                s.backend === backend &&
+                (!studioId || s.studioId === studioId)
+            );
+            if (unlinkable) {
+              chosen = unlinkable;
+              sbDebugLog('claude', 'adopting_unlinked_pcp_session', {
+                backend,
+                agentId,
+                pcpSessionId: unlinkable.id,
+                selectedLocalBackendSessionId,
+              });
+            } else {
+              chosen = await startNewPcpSession();
+              createdNewPcpSession = Boolean(chosen?.id);
+            }
           }
         }
       }
@@ -3222,11 +3260,22 @@ async function ensurePcpSessionContext(
         ? runtimeBackendSessionIdByPcpSessionId.get(chosen.id)
         : undefined,
     });
-  // Claude always preserves backend session links (Claude Code manages its own
-  // session continuity). Codex drops pre-linked sessions on new PCP session
-  // creation to avoid stale links — Codex sessions are independent and the
-  // user explicitly picks which to resume. Gemini is NOT included here because
-  // its session semantics are different and untested for this path.
+  // ═══════════════════════════════════════════════════════════════════════
+  // BACKEND SESSION LINKING — CRITICAL: Each backend has unique semantics.
+  //
+  // DO NOT modify this section without understanding how each backend
+  // handles session resume, creation, and linking. Careless changes here
+  // cause silent data loss (content not loading, orphaned sessions, wrong
+  // session resumed). Test each backend independently.
+  //
+  // - Claude: Always preserves backend session links. Claude Code manages
+  //   its own session continuity via --resume/--session-id.
+  // - Codex: Sessions are independent local files. PCP links are advisory.
+  //   Drops pre-linked sessions on new PCP session to avoid stale links,
+  //   UNLESS the user explicitly selected a local session from the picker.
+  // - Gemini: Session semantics are different and largely untested for
+  //   this path. Do NOT assume Codex patterns apply to Gemini.
+  // ═══════════════════════════════════════════════════════════════════════
   const preserveTrackedBackendSessionId = !createdNewPcpSession || backend === 'claude';
   let resolvedTrackedBackendSessionId = preserveTrackedBackendSessionId
     ? backendSessionId


### PR DESCRIPTION
## Summary

Three fixes for Codex session resume via `sb` picker:

1. **`resume` before config flags** — Codex treats `resume` as a subcommand with its own `-c` flag. Config flags before `resume` were root-level and didn't apply to the resumed session.

2. **Use selected local backend session** — When the user explicitly picks a local Codex session from the picker, use it as the resume target even if a new PCP session was created. Previously `selectedLocalBackendSessionId` was set but dropped because `createdNewPcpSession` cleared all non-Claude backend links.

3. **Scope session drop to codex only** — The `backend !== 'claude'` guard was too broad. Changed to explicit `backend === 'codex'` since Gemini's session semantics are different and untested.

### Known issue (follow-up)
Picking a local Codex session still creates a new PCP session instead of finding/linking an existing one. This orphans previous PCP sessions.

## Test plan

- [x] `sb -a lumen -b codex --dangerous` → pick Codex session → content loads
- [x] Debug log confirms `selectedLocalBackendSessionId` used as resume target
- [x] Verified Codex receives `resume <id> -c ...` (not `-c ... resume <id>`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)