### PR TITLE
fix: set cliAttached via REST lifecycle endpoint, not MCP (by Wren)

### DIFF
--- a/packages/api/src/routes/hook-lifecycle.ts
+++ b/packages/api/src/routes/hook-lifecycle.ts
@@ -42,11 +42,12 @@ export function createHookLifecycleRouter(dataComposer: DataComposer): Router {
         return;
       }
 
-      const { sessionId, lifecycle, agentId, workingDir } = req.body as {
+      const { sessionId, lifecycle, agentId, workingDir, cliAttached } = req.body as {
         sessionId?: string;
         lifecycle?: string;
         agentId?: string;
         workingDir?: string;
+        cliAttached?: boolean;
       };
 
       if (!sessionId) {
@@ -54,7 +55,11 @@ export function createHookLifecycleRouter(dataComposer: DataComposer): Router {
         return;
       }
 
-      if (!lifecycle || !VALID_LIFECYCLES.includes(lifecycle as Lifecycle)) {
+      // lifecycle is required unless cliAttached is the only update
+      if (
+        (!lifecycle || !VALID_LIFECYCLES.includes(lifecycle as Lifecycle)) &&
+        cliAttached === undefined
+      ) {
         res.status(400).json({
           success: false,
           error: `lifecycle must be one of: ${VALID_LIFECYCLES.join(', ')}`,
@@ -73,8 +78,10 @@ export function createHookLifecycleRouter(dataComposer: DataComposer): Router {
         return;
       }
 
-      const updates: { lifecycle: string; workingDir?: string } = { lifecycle };
+      const updates: { lifecycle?: string; workingDir?: string; cliAttached?: boolean } = {};
+      if (lifecycle) updates.lifecycle = lifecycle;
       if (workingDir) updates.workingDir = workingDir;
+      if (cliAttached !== undefined) updates.cliAttached = cliAttached;
 
       const updated = await dataComposer.repositories.memory.updateSession(sessionId, updates);
 

--- a/packages/cli/src/commands/hooks.ts
+++ b/packages/cli/src/commands/hooks.ts
@@ -1949,15 +1949,23 @@ async function onPromptHandler(options?: { backend?: string }): Promise<void> {
   await updateRuntimeGenerationState(cwd, config, agentId, 'running');
 
   // Mark session as CLI-attached (human present at REPL).
-  // This tells the trigger handler to route messages to the pending queue
-  // instead of spawning a new process.
+  // Uses the REST lifecycle endpoint, NOT MCP — cliAttached is a runtime
+  // signal that must bypass MCP schema validation (additionalProperties: false
+  // strips it). The REST endpoint is purpose-built for hook-managed state.
   if (reconciled.pcpSessionId) {
     try {
-      await callPcpTool('update_session_phase', {
-        email: config?.email,
-        agentId,
-        sessionId: reconciled.pcpSessionId,
-        cliAttached: true,
+      const serverUrl = getPcpServerUrl();
+      const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+      const token = await getValidAccessToken(serverUrl);
+      if (token) headers.Authorization = `Bearer ${token}`;
+      await fetch(`${serverUrl}/api/hooks/lifecycle`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          sessionId: reconciled.pcpSessionId,
+          cliAttached: true,
+        }),
+        signal: AbortSignal.timeout(5000),
       });
     } catch {
       // Silent — don't fail the prompt for this


### PR DESCRIPTION
## Summary

The `cliAttached` flag was never actually being set on sessions because MCP's `additionalProperties: false` silently stripped it from `update_session_phase` calls.

**Fix**: Use the REST `POST /api/hooks/lifecycle` endpoint instead of MCP. This endpoint is purpose-built for hook-managed state and bypasses MCP schema validation.

Changes:
- `hook-lifecycle.ts`: Accept `cliAttached` field, allow lifecycle-less updates when only cliAttached is being set
- `hooks.ts`: on-prompt handler calls REST endpoint directly instead of `callPcpTool('update_session_phase', { cliAttached: true })`

This fixes the CLI-attached routing: triggers will now route to the pending queue instead of spawning a new session when a human is at the keyboard.

## Test plan

- [ ] Run `sb -a wren` interactively, verify `cli_attached = true` on the session in DB
- [ ] Trigger while CLI-attached, verify message goes to pending queue (not spawn)
- [x] Type-checks clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)