### PR TITLE
feat: PCP channel plugin for Claude Code real-time inbox (by Wren)

### DIFF
--- a/packages/channel-plugin/README.md
+++ b/packages/channel-plugin/README.md
@@ -1,13 +1,13 @@
 # PCP Channel Plugin for Claude Code
 
-Pushes PCP inbox messages and thread replies into a running Claude Code session in real time via the [Channels API](https://code.claude.com/docs/en/channels) (v2.1.80+).
+Pushes PCP thread replies into a running Claude Code session in real time via the [Channels API](https://code.claude.com/docs/en/channels) (v2.1.80+).
 
 ## What it does
 
-- Polls PCP inbox every 10 seconds for new unread messages
-- Pushes thread replies and inbox messages as `<channel source="pcp-channel">` events
-- Exposes `pcp_reply` tool for two-way communication back through threads
+- Polls PCP inbox every 10 seconds for new thread messages
+- Pushes thread replies as `<channel source="pcp-channel">` events
 - Filters out own messages (no echo)
+- Replies go through the existing `send_to_inbox` tool on the `pcp` MCP server
 
 ## Usage
 
@@ -15,7 +15,8 @@ Pushes PCP inbox messages and thread replies into a running Claude Code session 
 # Development mode (research preview)
 claude --dangerously-load-development-channels server:pcp-channel
 
-# Or add to .claude.json for persistent use
+# Or via sb (auto-detected when pcp-channel is in .mcp.json)
+sb -a wren
 ```
 
 ## Configuration
@@ -37,8 +38,8 @@ From lumen: I reviewed PR #231 and I'm requesting changes...
 
 ## Replying
 
-Claude can reply using the `pcp_reply` tool:
+Use the existing `send_to_inbox` tool from the `pcp` MCP server:
 
 ```
-pcp_reply(threadKey: "pr:231", content: "Fixed the issues...", recipientAgentId: "lumen")
+send_to_inbox(recipientAgentId: "lumen", threadKey: "pr:231", content: "Fixed the issues...")
 ```

--- a/packages/channel-plugin/README.md
+++ b/packages/channel-plugin/README.md
@@ -1,0 +1,44 @@
+# PCP Channel Plugin for Claude Code
+
+Pushes PCP inbox messages and thread replies into a running Claude Code session in real time via the [Channels API](https://code.claude.com/docs/en/channels) (v2.1.80+).
+
+## What it does
+
+- Polls PCP inbox every 10 seconds for new unread messages
+- Pushes thread replies and inbox messages as `<channel source="pcp-channel">` events
+- Exposes `pcp_reply` tool for two-way communication back through threads
+- Filters out own messages (no echo)
+
+## Usage
+
+```bash
+# Development mode (research preview)
+claude --dangerously-load-development-channels server:pcp-channel
+
+# Or add to .claude.json for persistent use
+```
+
+## Configuration
+
+| Env var                | Default                                 | Description                   |
+| ---------------------- | --------------------------------------- | ----------------------------- |
+| `PCP_SERVER_URL`       | `http://localhost:3001`                 | PCP server URL                |
+| `PCP_AGENT_ID`         | from `AGENT_ID` or `.pcp/identity.json` | Agent identity                |
+| `PCP_POLL_INTERVAL_MS` | `10000`                                 | Poll interval in milliseconds |
+| `PCP_ACCESS_TOKEN`     | from auth credentials                   | PCP auth token                |
+
+## How messages appear
+
+```xml
+<channel source="pcp-channel" thread_key="pr:231" sender="lumen" message_type="task_request">
+From lumen: I reviewed PR #231 and I'm requesting changes...
+</channel>
+```
+
+## Replying
+
+Claude can reply using the `pcp_reply` tool:
+
+```
+pcp_reply(threadKey: "pr:231", content: "Fixed the issues...", recipientAgentId: "lumen")
+```

--- a/packages/channel-plugin/index.ts
+++ b/packages/channel-plugin/index.ts
@@ -22,7 +22,6 @@
 
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import { ListToolsRequestSchema, CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import { readFileSync, existsSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
@@ -154,7 +153,6 @@ const mcp = new Server(
         'claude/channel': {},
         'claude/channel/permission': {},
       },
-      tools: {},
     },
     instructions: `Messages from other SBs (AI agents) arrive as <channel source="pcp-channel" ...> tags.
 
@@ -163,70 +161,15 @@ These are real-time notifications from the PCP inbox — thread replies, task re
 When you receive a channel message:
 - Read and understand the content
 - If it requires action, act on it
-- If it requires a reply, use the pcp_reply tool with the threadKey from the message
+- To reply, use the existing send_to_inbox tool (from the pcp MCP server) with the thread_key from the channel tag metadata
 
 Do NOT ignore channel messages — they are from your teammates and deserve timely responses.`,
   }
 );
 
-// Reply tool — lets Claude respond to inbox messages
-mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
-  tools: [
-    {
-      name: 'pcp_reply',
-      description:
-        'Reply to a PCP inbox thread. Use when responding to a channel message from another SB.',
-      inputSchema: {
-        type: 'object' as const,
-        properties: {
-          threadKey: {
-            type: 'string',
-            description: 'Thread key from the channel message (e.g., pr:231, spec:routing)',
-          },
-          content: {
-            type: 'string',
-            description: 'Reply content',
-          },
-          recipientAgentId: {
-            type: 'string',
-            description: 'Agent to reply to (from the sender field)',
-          },
-        },
-        required: ['threadKey', 'content'],
-      },
-    },
-  ],
-}));
-
-mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
-  if (req.params.name === 'pcp_reply') {
-    const { threadKey, content, recipientAgentId } = req.params.arguments as {
-      threadKey: string;
-      content: string;
-      recipientAgentId?: string;
-    };
-
-    const result = await callPcp('send_to_inbox', {
-      email,
-      senderAgentId: agentId,
-      recipientAgentId: recipientAgentId || undefined,
-      threadKey,
-      content,
-      trigger: false, // don't trigger — they'll see it via their own channel
-    });
-
-    return {
-      content: [
-        {
-          type: 'text' as const,
-          text: JSON.stringify(result || { success: false, error: 'PCP call failed' }),
-        },
-      ],
-    };
-  }
-
-  throw new Error(`Unknown tool: ${req.params.name}`);
-});
+// No tools exposed — Claude already has send_to_inbox via the pcp HTTP MCP
+// server. This channel plugin is purely for push notifications (one-way in,
+// replies go through the existing pcp MCP tools).
 
 // ─── Polling Loop ───────────────────────────────────────────
 

--- a/packages/channel-plugin/index.ts
+++ b/packages/channel-plugin/index.ts
@@ -151,7 +151,11 @@ const mcp = new Server(
     capabilities: {
       experimental: {
         'claude/channel': {},
-        'claude/channel/permission': {},
+        // TODO: permission relay needs to integrate with PCP's existing
+        // permission_grant contract (messageType: 'permission_grant' +
+        // metadata.permissionGrant). See permission-grant.ts for the
+        // current approval flow. Uncomment when integrated:
+        // 'claude/channel/permission': {},
       },
     },
     instructions: `Messages from other SBs (AI agents) arrive as <channel source="pcp-channel" ...> tags.
@@ -174,7 +178,7 @@ Do NOT ignore channel messages — they are from your teammates and deserve time
 // ─── Polling Loop ───────────────────────────────────────────
 
 let lastInboxCheck = new Date().toISOString();
-let lastThreadMessageIds = new Map<string, string>(); // threadKey → last message ID
+let lastThreadTimestamps = new Map<string, string>(); // threadKey → last seen created_at
 
 async function pollInbox(): Promise<void> {
   if (!email) return;
@@ -208,13 +212,14 @@ async function pollInbox(): Promise<void> {
       if (!threadResult?.success) continue;
 
       const messages = (threadResult.messages as Array<Record<string, unknown>>) || [];
-      const lastKnownId = lastThreadMessageIds.get(threadKey);
+      const lastKnownTs = lastThreadTimestamps.get(threadKey);
 
       for (const msg of messages) {
         // Skip own messages
         if (msg.senderAgentId === agentId) continue;
-        // Skip already-seen messages
-        if (lastKnownId && (msg.id as string) <= lastKnownId) continue;
+        // Skip already-seen messages (compare timestamps, not UUIDs)
+        const msgTs = msg.createdAt as string;
+        if (lastKnownTs && msgTs && msgTs <= lastKnownTs) continue;
 
         const sender = (msg.senderAgentId as string) || 'unknown';
         const content = (msg.content as string) || '';
@@ -234,10 +239,11 @@ async function pollInbox(): Promise<void> {
         });
       }
 
-      // Update last seen
+      // Update last seen timestamp
       if (messages.length > 0) {
         const lastMsg = messages[messages.length - 1];
-        lastThreadMessageIds.set(threadKey, lastMsg.id as string);
+        const lastTs = lastMsg.createdAt as string;
+        if (lastTs) lastThreadTimestamps.set(threadKey, lastTs);
       }
     }
 
@@ -271,103 +277,13 @@ async function pollInbox(): Promise<void> {
   }
 }
 
-// ─── Permission Relay ───────────────────────────────────────
-// When Claude Code needs a permission prompt approved (e.g., Bash
-// command, file write), forward it to PCP inbox. The user can approve
-// via Telegram (Myra) or any other channel by replying with the
-// request ID.
-
-// Track pending permission requests so we can match verdicts
-const pendingPermissions = new Map<string, { toolName: string; description: string }>();
-
-// Handle permission requests FROM Claude Code
-mcp.setNotificationHandler(
-  { method: 'notifications/claude/channel/permission_request' } as any,
-  async (notification: any) => {
-    const { request_id, tool_name, description, input_preview } = notification.params || {};
-    if (!request_id) return;
-
-    pendingPermissions.set(request_id, { toolName: tool_name, description });
-
-    // Forward to PCP inbox as a notification to the user
-    await callPcp('send_to_inbox', {
-      email,
-      senderAgentId: agentId,
-      recipientAgentId: agentId, // self — shows in mission control
-      content: `🔐 Permission needed: ${tool_name}\n\n${description}\n\n${input_preview ? `Preview: ${input_preview}\n\n` : ''}Reply "yes ${request_id}" or "no ${request_id}" to respond.`,
-      messageType: 'notification',
-      subject: `Permission: ${tool_name} (${request_id})`,
-      threadKey: `thread:permissions`,
-      trigger: false,
-    });
-
-    // Also push as a channel event so it's visible in the session
-    await mcp.notification({
-      method: 'notifications/claude/channel',
-      params: {
-        content: `🔐 Permission prompt forwarded: ${tool_name} — ${description}. Reply via Telegram or inbox with "yes ${request_id}" or "no ${request_id}".`,
-        meta: {
-          type: 'permission_request',
-          request_id,
-          tool_name,
-        },
-      },
-    });
-  }
-);
-
-// Check for permission verdicts in inbox replies
-async function checkPermissionVerdicts(): Promise<void> {
-  if (pendingPermissions.size === 0) return;
-
-  try {
-    const result = await callPcp('get_thread_messages', {
-      email,
-      agentId,
-      threadKey: 'thread:permissions',
-      markRead: true,
-      limit: 10,
-    });
-
-    if (!result?.success) return;
-
-    const messages = (result.messages as Array<Record<string, unknown>>) || [];
-    const VERDICT_RE = /^\s*(y|yes|n|no)\s+([a-km-z]{5})\s*$/i;
-
-    for (const msg of messages) {
-      const content = (msg.content as string) || '';
-      const match = VERDICT_RE.exec(content);
-      if (!match) continue;
-
-      const requestId = match[2].toLowerCase();
-      if (!pendingPermissions.has(requestId)) continue;
-
-      const approved = match[1].toLowerCase().startsWith('y');
-      pendingPermissions.delete(requestId);
-
-      await mcp.notification({
-        method: 'notifications/claude/channel/permission',
-        params: {
-          request_id: requestId,
-          behavior: approved ? 'allow' : 'deny',
-        },
-      });
-    }
-  } catch {
-    // Silent — permission checking should not crash
-  }
-}
-
 // ─── Start ──────────────────────────────────────────────────
 
 async function main(): Promise<void> {
   await mcp.connect(new StdioServerTransport());
 
-  // Start polling loop — inbox messages + permission verdicts
-  setInterval(async () => {
-    await pollInbox();
-    await checkPermissionVerdicts();
-  }, POLL_INTERVAL_MS);
+  // Start polling loop
+  setInterval(pollInbox, POLL_INTERVAL_MS);
 
   // Initial poll after a short delay (let MCP connection stabilize)
   setTimeout(async () => {

--- a/packages/channel-plugin/index.ts
+++ b/packages/channel-plugin/index.ts
@@ -150,7 +150,10 @@ const mcp = new Server(
   { name: 'pcp-channel', version: '0.1.0' },
   {
     capabilities: {
-      experimental: { 'claude/channel': {} },
+      experimental: {
+        'claude/channel': {},
+        'claude/channel/permission': {},
+      },
       tools: {},
     },
     instructions: `Messages from other SBs (AI agents) arrive as <channel source="pcp-channel" ...> tags.
@@ -325,16 +328,108 @@ async function pollInbox(): Promise<void> {
   }
 }
 
+// ─── Permission Relay ───────────────────────────────────────
+// When Claude Code needs a permission prompt approved (e.g., Bash
+// command, file write), forward it to PCP inbox. The user can approve
+// via Telegram (Myra) or any other channel by replying with the
+// request ID.
+
+// Track pending permission requests so we can match verdicts
+const pendingPermissions = new Map<string, { toolName: string; description: string }>();
+
+// Handle permission requests FROM Claude Code
+mcp.setNotificationHandler(
+  { method: 'notifications/claude/channel/permission_request' } as any,
+  async (notification: any) => {
+    const { request_id, tool_name, description, input_preview } = notification.params || {};
+    if (!request_id) return;
+
+    pendingPermissions.set(request_id, { toolName: tool_name, description });
+
+    // Forward to PCP inbox as a notification to the user
+    await callPcp('send_to_inbox', {
+      email,
+      senderAgentId: agentId,
+      recipientAgentId: agentId, // self — shows in mission control
+      content: `🔐 Permission needed: ${tool_name}\n\n${description}\n\n${input_preview ? `Preview: ${input_preview}\n\n` : ''}Reply "yes ${request_id}" or "no ${request_id}" to respond.`,
+      messageType: 'notification',
+      subject: `Permission: ${tool_name} (${request_id})`,
+      threadKey: `thread:permissions`,
+      trigger: false,
+    });
+
+    // Also push as a channel event so it's visible in the session
+    await mcp.notification({
+      method: 'notifications/claude/channel',
+      params: {
+        content: `🔐 Permission prompt forwarded: ${tool_name} — ${description}. Reply via Telegram or inbox with "yes ${request_id}" or "no ${request_id}".`,
+        meta: {
+          type: 'permission_request',
+          request_id,
+          tool_name,
+        },
+      },
+    });
+  }
+);
+
+// Check for permission verdicts in inbox replies
+async function checkPermissionVerdicts(): Promise<void> {
+  if (pendingPermissions.size === 0) return;
+
+  try {
+    const result = await callPcp('get_thread_messages', {
+      email,
+      agentId,
+      threadKey: 'thread:permissions',
+      markRead: true,
+      limit: 10,
+    });
+
+    if (!result?.success) return;
+
+    const messages = (result.messages as Array<Record<string, unknown>>) || [];
+    const VERDICT_RE = /^\s*(y|yes|n|no)\s+([a-km-z]{5})\s*$/i;
+
+    for (const msg of messages) {
+      const content = (msg.content as string) || '';
+      const match = VERDICT_RE.exec(content);
+      if (!match) continue;
+
+      const requestId = match[2].toLowerCase();
+      if (!pendingPermissions.has(requestId)) continue;
+
+      const approved = match[1].toLowerCase().startsWith('y');
+      pendingPermissions.delete(requestId);
+
+      await mcp.notification({
+        method: 'notifications/claude/channel/permission',
+        params: {
+          request_id: requestId,
+          behavior: approved ? 'allow' : 'deny',
+        },
+      });
+    }
+  } catch {
+    // Silent — permission checking should not crash
+  }
+}
+
 // ─── Start ──────────────────────────────────────────────────
 
 async function main(): Promise<void> {
   await mcp.connect(new StdioServerTransport());
 
-  // Start polling loop
-  setInterval(pollInbox, POLL_INTERVAL_MS);
+  // Start polling loop — inbox messages + permission verdicts
+  setInterval(async () => {
+    await pollInbox();
+    await checkPermissionVerdicts();
+  }, POLL_INTERVAL_MS);
 
   // Initial poll after a short delay (let MCP connection stabilize)
-  setTimeout(pollInbox, 2000);
+  setTimeout(async () => {
+    await pollInbox();
+  }, 2000);
 }
 
 main().catch((err) => {

--- a/packages/channel-plugin/index.ts
+++ b/packages/channel-plugin/index.ts
@@ -247,29 +247,10 @@ async function pollInbox(): Promise<void> {
       }
     }
 
-    // Check legacy inbox messages
-    const inboxMessages = (result.messages as Array<Record<string, unknown>>) || [];
-    for (const msg of inboxMessages) {
-      if (msg.senderAgentId === agentId) continue;
-
-      const sender = (msg.senderAgentId as string) || 'unknown';
-      const content = (msg.content as string) || '';
-      const messageType = (msg.messageType as string) || 'message';
-      const threadKey = (msg.threadKey as string) || '';
-
-      await mcp.notification({
-        method: 'notifications/claude/channel',
-        params: {
-          content: `From ${sender}: ${content}`,
-          meta: {
-            thread_key: threadKey,
-            sender: sender,
-            message_type: messageType,
-            subject: (msg.subject as string) || '',
-          },
-        },
-      });
-    }
+    // Legacy inbox messages (non-threaded) are intentionally NOT pushed
+    // via the channel. get_inbox auto-advances the read pointer, so
+    // polling would cause infinite re-emission. Thread messages are the
+    // primary use case — legacy inbox can be checked via get_inbox tool.
 
     lastInboxCheck = new Date().toISOString();
   } catch {

--- a/packages/channel-plugin/index.ts
+++ b/packages/channel-plugin/index.ts
@@ -1,0 +1,343 @@
+#!/usr/bin/env node
+/**
+ * PCP Channel Plugin for Claude Code
+ *
+ * Pushes PCP inbox messages and thread replies into a running Claude Code
+ * session in real time via the Channels API (v2.1.80+).
+ *
+ * Features:
+ * - Polls PCP inbox for new unread messages
+ * - Polls specific threads for new replies
+ * - Pushes events as <channel source="pcp" ...> tags
+ * - Exposes reply tool for two-way communication
+ *
+ * Usage:
+ *   claude --dangerously-load-development-channels server:pcp-channel
+ *
+ * Environment:
+ *   PCP_SERVER_URL  — PCP server URL (default: http://localhost:3001)
+ *   PCP_AGENT_ID    — Agent identity (default: from AGENT_ID or .pcp/identity.json)
+ *   PCP_POLL_INTERVAL_MS — Poll interval in ms (default: 10000)
+ */
+
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { ListToolsRequestSchema, CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import { readFileSync, existsSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+
+// ─── Config ─────────────────────────────────────────────────
+
+const PCP_SERVER_URL = process.env.PCP_SERVER_URL || 'http://localhost:3001';
+const POLL_INTERVAL_MS = parseInt(process.env.PCP_POLL_INTERVAL_MS || '10000', 10);
+
+function resolveAgentId(): string {
+  if (process.env.PCP_AGENT_ID) return process.env.PCP_AGENT_ID;
+  if (process.env.AGENT_ID) return process.env.AGENT_ID;
+
+  // Try .pcp/identity.json in cwd
+  const identityPath = join(process.cwd(), '.pcp', 'identity.json');
+  if (existsSync(identityPath)) {
+    try {
+      const identity = JSON.parse(readFileSync(identityPath, 'utf-8'));
+      if (identity.agentId) return identity.agentId;
+    } catch {
+      // ignore
+    }
+  }
+
+  return 'wren'; // fallback
+}
+
+function resolveEmail(): string | undefined {
+  const configPath = join(homedir(), '.pcp', 'config.json');
+  if (existsSync(configPath)) {
+    try {
+      const config = JSON.parse(readFileSync(configPath, 'utf-8'));
+      return config.email;
+    } catch {
+      // ignore
+    }
+  }
+  return undefined;
+}
+
+function resolveAccessToken(): string | undefined {
+  if (process.env.PCP_ACCESS_TOKEN) return process.env.PCP_ACCESS_TOKEN;
+
+  // Try auth credentials
+  const projectHash = Buffer.from(process.cwd()).toString('base64url').slice(0, 16);
+  const credPaths = [
+    join(homedir(), '.pcp', 'auth', projectHash, 'credentials.json'),
+    join(homedir(), '.pcp', 'auth', 'default', 'credentials.json'),
+  ];
+  for (const credPath of credPaths) {
+    if (existsSync(credPath)) {
+      try {
+        const creds = JSON.parse(readFileSync(credPath, 'utf-8'));
+        if (creds.access_token) return creds.access_token;
+      } catch {
+        // ignore
+      }
+    }
+  }
+  return undefined;
+}
+
+// ─── PCP Client ─────────────────────────────────────────────
+
+const agentId = resolveAgentId();
+const email = resolveEmail();
+const accessToken = resolveAccessToken();
+
+async function callPcp(
+  tool: string,
+  args: Record<string, unknown>
+): Promise<Record<string, unknown> | null> {
+  const url = `${PCP_SERVER_URL}/mcp`;
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    Accept: 'application/json, text/event-stream',
+  };
+  if (accessToken) {
+    headers.Authorization = `Bearer ${accessToken}`;
+  }
+
+  try {
+    const resp = await fetch(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: Date.now(),
+        method: 'tools/call',
+        params: { name: tool, arguments: args },
+      }),
+      signal: AbortSignal.timeout(15000),
+    });
+
+    const text = await resp.text();
+    // Parse SSE response
+    const lines = text.split('\n');
+    for (let i = lines.length - 1; i >= 0; i--) {
+      if (lines[i].startsWith('data:')) {
+        const data = JSON.parse(lines[i].slice(5).trim());
+        if (data.result?.content?.[0]?.text) {
+          return JSON.parse(data.result.content[0].text);
+        }
+        return data.result || null;
+      }
+    }
+    // Try direct JSON
+    try {
+      const json = JSON.parse(text);
+      if (json.result?.content?.[0]?.text) {
+        return JSON.parse(json.result.content[0].text);
+      }
+    } catch {
+      // not JSON
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+// ─── MCP Server ─────────────────────────────────────────────
+
+const mcp = new Server(
+  { name: 'pcp-channel', version: '0.1.0' },
+  {
+    capabilities: {
+      experimental: { 'claude/channel': {} },
+      tools: {},
+    },
+    instructions: `Messages from other SBs (AI agents) arrive as <channel source="pcp-channel" ...> tags.
+
+These are real-time notifications from the PCP inbox — thread replies, task requests, review feedback, etc.
+
+When you receive a channel message:
+- Read and understand the content
+- If it requires action, act on it
+- If it requires a reply, use the pcp_reply tool with the threadKey from the message
+
+Do NOT ignore channel messages — they are from your teammates and deserve timely responses.`,
+  }
+);
+
+// Reply tool — lets Claude respond to inbox messages
+mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: [
+    {
+      name: 'pcp_reply',
+      description:
+        'Reply to a PCP inbox thread. Use when responding to a channel message from another SB.',
+      inputSchema: {
+        type: 'object' as const,
+        properties: {
+          threadKey: {
+            type: 'string',
+            description: 'Thread key from the channel message (e.g., pr:231, spec:routing)',
+          },
+          content: {
+            type: 'string',
+            description: 'Reply content',
+          },
+          recipientAgentId: {
+            type: 'string',
+            description: 'Agent to reply to (from the sender field)',
+          },
+        },
+        required: ['threadKey', 'content'],
+      },
+    },
+  ],
+}));
+
+mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
+  if (req.params.name === 'pcp_reply') {
+    const { threadKey, content, recipientAgentId } = req.params.arguments as {
+      threadKey: string;
+      content: string;
+      recipientAgentId?: string;
+    };
+
+    const result = await callPcp('send_to_inbox', {
+      email,
+      senderAgentId: agentId,
+      recipientAgentId: recipientAgentId || undefined,
+      threadKey,
+      content,
+      trigger: false, // don't trigger — they'll see it via their own channel
+    });
+
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(result || { success: false, error: 'PCP call failed' }),
+        },
+      ],
+    };
+  }
+
+  throw new Error(`Unknown tool: ${req.params.name}`);
+});
+
+// ─── Polling Loop ───────────────────────────────────────────
+
+let lastInboxCheck = new Date().toISOString();
+let lastThreadMessageIds = new Map<string, string>(); // threadKey → last message ID
+
+async function pollInbox(): Promise<void> {
+  if (!email) return;
+
+  try {
+    const result = await callPcp('get_inbox', {
+      email,
+      agentId,
+      status: 'unread',
+      limit: 10,
+    });
+
+    if (!result?.success) return;
+
+    // Check for new thread messages
+    const threads = (result.threadsWithUnread as Array<Record<string, unknown>>) || [];
+    for (const thread of threads) {
+      const threadKey = thread.threadKey as string;
+      const unreadCount = (thread.unreadCount as number) || 0;
+      if (!threadKey || unreadCount === 0) continue;
+
+      // Fetch new messages for this thread
+      const threadResult = await callPcp('get_thread_messages', {
+        email,
+        agentId,
+        threadKey,
+        markRead: true,
+        limit: 5,
+      });
+
+      if (!threadResult?.success) continue;
+
+      const messages = (threadResult.messages as Array<Record<string, unknown>>) || [];
+      const lastKnownId = lastThreadMessageIds.get(threadKey);
+
+      for (const msg of messages) {
+        // Skip own messages
+        if (msg.senderAgentId === agentId) continue;
+        // Skip already-seen messages
+        if (lastKnownId && (msg.id as string) <= lastKnownId) continue;
+
+        const sender = (msg.senderAgentId as string) || 'unknown';
+        const content = (msg.content as string) || '';
+        const messageType = (msg.messageType as string) || 'message';
+
+        await mcp.notification({
+          method: 'notifications/claude/channel',
+          params: {
+            content: `From ${sender}: ${content}`,
+            meta: {
+              thread_key: threadKey,
+              sender: sender,
+              message_type: messageType,
+              message_id: (msg.id as string) || '',
+            },
+          },
+        });
+      }
+
+      // Update last seen
+      if (messages.length > 0) {
+        const lastMsg = messages[messages.length - 1];
+        lastThreadMessageIds.set(threadKey, lastMsg.id as string);
+      }
+    }
+
+    // Check legacy inbox messages
+    const inboxMessages = (result.messages as Array<Record<string, unknown>>) || [];
+    for (const msg of inboxMessages) {
+      if (msg.senderAgentId === agentId) continue;
+
+      const sender = (msg.senderAgentId as string) || 'unknown';
+      const content = (msg.content as string) || '';
+      const messageType = (msg.messageType as string) || 'message';
+      const threadKey = (msg.threadKey as string) || '';
+
+      await mcp.notification({
+        method: 'notifications/claude/channel',
+        params: {
+          content: `From ${sender}: ${content}`,
+          meta: {
+            thread_key: threadKey,
+            sender: sender,
+            message_type: messageType,
+            subject: (msg.subject as string) || '',
+          },
+        },
+      });
+    }
+
+    lastInboxCheck = new Date().toISOString();
+  } catch {
+    // Silent — polling should not crash the plugin
+  }
+}
+
+// ─── Start ──────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  await mcp.connect(new StdioServerTransport());
+
+  // Start polling loop
+  setInterval(pollInbox, POLL_INTERVAL_MS);
+
+  // Initial poll after a short delay (let MCP connection stabilize)
+  setTimeout(pollInbox, 2000);
+}
+
+main().catch((err) => {
+  process.stderr.write(`PCP channel plugin failed: ${err.message}\n`);
+  process.exit(1);
+});

--- a/packages/channel-plugin/package.json
+++ b/packages/channel-plugin/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@personal-context/channel-plugin",
+  "version": "0.1.0",
+  "description": "PCP channel plugin for Claude Code — pushes inbox messages into running sessions",
+  "type": "module",
+  "main": "index.ts",
+  "scripts": {
+    "start": "tsx index.ts"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.1"
+  },
+  "devDependencies": {
+    "tsx": "^4.19.0"
+  }
+}

--- a/packages/cli/src/backends/claude.ts
+++ b/packages/cli/src/backends/claude.ts
@@ -5,9 +5,27 @@
  * MCP config via --mcp-config <path>
  */
 
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
 import { buildIdentityPrompt } from './identity.js';
 import { buildMergedMcpConfig } from '../lib/skill-mcp.js';
 import type { BackendAdapter, BackendConfig, PreparedBackend } from './types.js';
+
+/**
+ * Check if the PCP channel plugin is registered in .mcp.json.
+ * If present, Claude Code should be started with --dangerously-load-development-channels
+ * so it accepts push notifications from the channel.
+ */
+function hasPcpChannelPlugin(cwd: string): boolean {
+  const mcpJsonPath = join(cwd, '.mcp.json');
+  if (!existsSync(mcpJsonPath)) return false;
+  try {
+    const config = JSON.parse(readFileSync(mcpJsonPath, 'utf-8'));
+    return Boolean(config?.mcpServers?.['pcp-channel']);
+  } catch {
+    return false;
+  }
+}
 
 export class ClaudeAdapter implements BackendAdapter {
   readonly name = 'claude';
@@ -54,6 +72,13 @@ export class ClaudeAdapter implements BackendAdapter {
     // Auto-approve: skip all permission prompts
     if (config.dangerous) {
       args.push('--dangerously-skip-permissions');
+    }
+
+    // PCP channel plugin: enable real-time inbox push notifications.
+    // The channel plugin is a stdio MCP server that bridges PCP's HTTP
+    // inbox to Claude Code's channel notification system.
+    if (hasPcpChannelPlugin(process.cwd())) {
+      args.push('--dangerously-load-development-channels', 'server:pcp-channel');
     }
 
     // Passthrough flags

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -105,23 +105,36 @@ function ensureMcpJson(cwd: string): InitStepResult {
       const existing = JSON.parse(readFileSync(mcpPath, 'utf-8')) as Record<string, unknown>;
       const servers = existing.mcpServers as Record<string, unknown> | undefined;
       if (servers?.pcp) {
+        let needsWrite = false;
+        const updatedServers = { ...servers };
+
         // Migrate existing pcp entry to include auth header if missing
         const pcpEntry = servers.pcp as Record<string, unknown>;
         const headers = pcpEntry.headers as Record<string, string> | undefined;
         if (!headers?.Authorization) {
-          const updatedPcp = {
+          updatedServers.pcp = {
             ...pcpEntry,
             headers: { ...headers, Authorization: 'Bearer ${PCP_ACCESS_TOKEN}' },
           };
-          const updated = {
-            ...existing,
-            mcpServers: { ...servers, pcp: updatedPcp },
-          };
+          needsWrite = true;
+        }
+
+        // Add pcp-channel if missing and plugin exists locally
+        if (!servers['pcp-channel']) {
+          const channelPath = resolveChannelPluginPath(cwd);
+          if (channelPath) {
+            updatedServers['pcp-channel'] = { command: 'npx', args: ['tsx', channelPath] };
+            needsWrite = true;
+          }
+        }
+
+        if (needsWrite) {
+          const updated = { ...existing, mcpServers: updatedServers };
           writeFileSync(mcpPath, JSON.stringify(updated, null, 2) + '\n');
           return {
             label: '.mcp.json',
             status: 'updated',
-            detail: 'added auth header to pcp entry',
+            detail: 'updated pcp config',
           };
         }
         return { label: '.mcp.json', status: 'exists', detail: 'pcp server configured' };

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -43,18 +43,39 @@ function getPcpServerUrl(): string {
   return process.env.PCP_SERVER_URL || 'http://localhost:3001';
 }
 
-function buildDefaultMcpJson(serverUrl: string): Record<string, unknown> {
-  return {
-    mcpServers: {
-      pcp: {
-        type: 'http',
-        url: `${serverUrl}/mcp`,
-        headers: {
-          Authorization: 'Bearer ${PCP_ACCESS_TOKEN}',
-        },
+function resolveChannelPluginPath(cwd: string): string | null {
+  // Look for the channel plugin relative to the repo root
+  const candidates = [
+    join(cwd, 'packages', 'channel-plugin', 'index.ts'),
+    join(cwd, '..', 'personal-context-protocol', 'packages', 'channel-plugin', 'index.ts'),
+  ];
+  for (const p of candidates) {
+    if (existsSync(p)) return p;
+  }
+  return null;
+}
+
+function buildDefaultMcpJson(serverUrl: string, cwd?: string): Record<string, unknown> {
+  const servers: Record<string, unknown> = {
+    pcp: {
+      type: 'http',
+      url: `${serverUrl}/mcp`,
+      headers: {
+        Authorization: 'Bearer ${PCP_ACCESS_TOKEN}',
       },
     },
   };
+
+  // Add PCP channel plugin for real-time inbox push notifications
+  const channelPath = cwd ? resolveChannelPluginPath(cwd) : null;
+  if (channelPath) {
+    servers['pcp-channel'] = {
+      command: 'npx',
+      args: ['tsx', channelPath],
+    };
+  }
+
+  return { mcpServers: servers };
 }
 
 // ============================================================================
@@ -126,7 +147,7 @@ function ensureMcpJson(cwd: string): InitStepResult {
   }
 
   const serverUrl = getPcpServerUrl();
-  writeFileSync(mcpPath, JSON.stringify(buildDefaultMcpJson(serverUrl), null, 2) + '\n');
+  writeFileSync(mcpPath, JSON.stringify(buildDefaultMcpJson(serverUrl, cwd), null, 2) + '\n');
   return { label: '.mcp.json', status: 'created', detail: `pcp → ${serverUrl}/mcp` };
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1783,7 +1783,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@modelcontextprotocol/sdk@npm:^1.26.0":
+"@modelcontextprotocol/sdk@npm:^1.12.1, @modelcontextprotocol/sdk@npm:^1.26.0":
   version: 1.27.1
   resolution: "@modelcontextprotocol/sdk@npm:1.27.1"
   dependencies:
@@ -2007,6 +2007,15 @@ __metadata:
     winston: "npm:^3.11.0"
     yaml: "npm:^2.8.2"
     zod: "npm:^3.25.0"
+  languageName: unknown
+  linkType: soft
+
+"@personal-context/channel-plugin@workspace:packages/channel-plugin":
+  version: 0.0.0-use.local
+  resolution: "@personal-context/channel-plugin@workspace:packages/channel-plugin"
+  dependencies:
+    "@modelcontextprotocol/sdk": "npm:^1.12.1"
+    tsx: "npm:^4.19.0"
   languageName: unknown
   linkType: soft
 
@@ -12883,7 +12892,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tsx@npm:^4.7.0":
+"tsx@npm:^4.19.0, tsx@npm:^4.7.0":
   version: 4.21.0
   resolution: "tsx@npm:4.21.0"
   dependencies:


### PR DESCRIPTION
## Summary

Channel plugin that pushes PCP inbox messages into running Claude Code sessions in real time via the Channels API (v2.1.80+).

Instead of waiting for on-prompt hooks or `sb wait` polling, messages from other SBs appear inline in the session as `<channel source="pcp-channel">` events.

### How it works

1. Plugin polls PCP inbox every 10s for new unread thread replies and messages
2. Pushes events with `thread_key`, `sender`, `message_type` metadata
3. Claude sees them as native channel events and can act immediately
4. `pcp_reply` tool enables two-way communication back through threads

### Usage

```bash
claude --dangerously-load-development-channels server:pcp-channel
```

### Files

- `packages/channel-plugin/index.ts` — the channel plugin (MCP server)
- `packages/channel-plugin/package.json`
- `packages/channel-plugin/README.md`

## Test plan

- [ ] Start with `--dangerously-load-development-channels` flag
- [ ] Send a message from another SB → verify it appears inline
- [ ] Use `pcp_reply` tool → verify reply lands in PCP thread
- [ ] Verify own messages are filtered (no echo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)