### PR TITLE
fix: restore legacy inbox push in channel plugin (by Wren)

### DIFF
--- a/packages/channel-plugin/README.md
+++ b/packages/channel-plugin/README.md
@@ -1,11 +1,11 @@
 # PCP Channel Plugin for Claude Code
 
-Pushes PCP thread replies into a running Claude Code session in real time via the [Channels API](https://code.claude.com/docs/en/channels) (v2.1.80+).
+Pushes PCP inbox messages and thread replies into a running Claude Code session in real time via the [Channels API](https://code.claude.com/docs/en/channels) (v2.1.80+).
 
 ## What it does
 
-- Polls PCP inbox every 10 seconds for new thread messages
-- Pushes thread replies as `<channel source="pcp-channel">` events
+- Polls PCP inbox every 10 seconds for new messages
+- Pushes thread replies and inbox messages as `<channel source="pcp-channel">` events
 - Filters out own messages (no echo)
 - Replies go through the existing `send_to_inbox` tool on the `pcp` MCP server
 

--- a/packages/channel-plugin/index.ts
+++ b/packages/channel-plugin/index.ts
@@ -247,10 +247,30 @@ async function pollInbox(): Promise<void> {
       }
     }
 
-    // Legacy inbox messages (non-threaded) are intentionally NOT pushed
-    // via the channel. get_inbox auto-advances the read pointer, so
-    // polling would cause infinite re-emission. Thread messages are the
-    // primary use case — legacy inbox can be checked via get_inbox tool.
+    // Legacy inbox messages (non-threaded). The read pointer auto-advances
+    // on get_inbox, so these only appear once per poll cycle.
+    const inboxMessages = (result.messages as Array<Record<string, unknown>>) || [];
+    for (const msg of inboxMessages) {
+      if (msg.senderAgentId === agentId) continue;
+
+      const sender = (msg.senderAgentId as string) || 'unknown';
+      const content = (msg.content as string) || '';
+      const messageType = (msg.messageType as string) || 'message';
+      const msgThreadKey = (msg.threadKey as string) || '';
+
+      await mcp.notification({
+        method: 'notifications/claude/channel',
+        params: {
+          content: `From ${sender}: ${content}`,
+          meta: {
+            thread_key: msgThreadKey,
+            sender,
+            message_type: messageType,
+            subject: (msg.subject as string) || '',
+          },
+        },
+      });
+    }
 
     lastInboxCheck = new Date().toISOString();
   } catch {


### PR DESCRIPTION
Pointer-based read tracking handles dedup. Removing legacy inbox was an overcorrection — messages only appear once per poll cycle.