### PR TITLE
fix: dedup legacy inbox in channel plugin (by Wren)

### DIFF
--- a/packages/api/src/mcp/tools/inbox-handlers.ts
+++ b/packages/api/src/mcp/tools/inbox-handlers.ts
@@ -123,6 +123,11 @@ const getInboxSchema = userIdentifierBaseSchema.extend({
     .enum(['message', 'task_request', 'session_resume', 'notification', 'permission_grant'])
     .optional(),
   limit: z.number().min(1).max(200).optional().default(20).describe('Max messages'),
+  since: z
+    .string()
+    .datetime()
+    .optional()
+    .describe('Only return messages created after this ISO timestamp'),
 });
 
 const updateInboxMessageSchema = userIdentifierBaseSchema.extend({
@@ -726,7 +731,7 @@ export async function handleGetInbox(args: unknown, dataComposer: DataComposer) 
   const parsed = getInboxSchema.parse(args);
   const resolved = await resolveUserOrThrow(parsed, dataComposer);
 
-  const { status = 'unread', priority, messageType, limit = 20 } = parsed;
+  const { status = 'unread', priority, messageType, limit = 20, since } = parsed;
   // Enforce identity: pinned agents can only read their own inbox.
   // When agentId is omitted, return inbox across ALL agents (unified timeline).
   const agentId = parsed.agentId
@@ -745,6 +750,9 @@ export async function handleGetInbox(args: unknown, dataComposer: DataComposer) 
   }
   if (status !== 'all') {
     query = query.eq('status', status);
+  }
+  if (since) {
+    query = query.gt('created_at', since);
   }
   if (priority) {
     query = query.eq('priority', priority);

--- a/packages/channel-plugin/index.ts
+++ b/packages/channel-plugin/index.ts
@@ -177,8 +177,8 @@ Do NOT ignore channel messages — they are from your teammates and deserve time
 
 // ─── Polling Loop ───────────────────────────────────────────
 
-let lastInboxCheck = new Date().toISOString();
-let lastThreadTimestamps = new Map<string, string>(); // threadKey → last seen created_at
+let lastPollTime = new Date().toISOString(); // only fetch messages after this timestamp
+const seenMessageIds = new Set<string>(); // prevent re-emission across poll cycles
 
 async function pollInbox(): Promise<void> {
   if (!email) return;
@@ -187,8 +187,9 @@ async function pollInbox(): Promise<void> {
     const result = await callPcp('get_inbox', {
       email,
       agentId,
-      status: 'unread',
-      limit: 10,
+      status: 'all',
+      since: lastPollTime,
+      limit: 20,
     });
 
     if (!result?.success) return;
@@ -215,11 +216,12 @@ async function pollInbox(): Promise<void> {
       const lastKnownTs = lastThreadTimestamps.get(threadKey);
 
       for (const msg of messages) {
-        // Skip own messages
-        if (msg.senderAgentId === agentId) continue;
-        // Skip already-seen messages (compare timestamps, not UUIDs)
+        const msgId = msg.id as string;
         const msgTs = msg.createdAt as string;
+        if (msg.senderAgentId === agentId) continue;
+        if (msgId && seenMessageIds.has(msgId)) continue;
         if (lastKnownTs && msgTs && msgTs <= lastKnownTs) continue;
+        if (msgId) seenMessageIds.add(msgId);
 
         const sender = (msg.senderAgentId as string) || 'unknown';
         const content = (msg.content as string) || '';
@@ -247,11 +249,15 @@ async function pollInbox(): Promise<void> {
       }
     }
 
-    // Legacy inbox messages (non-threaded). The read pointer auto-advances
-    // on get_inbox, so these only appear once per poll cycle.
+    // Legacy inbox messages (non-threaded). Since we pass `since: lastPollTime`
+    // to get_inbox, only new messages are returned. seenMessageIds prevents
+    // any edge-case re-emission.
     const inboxMessages = (result.messages as Array<Record<string, unknown>>) || [];
     for (const msg of inboxMessages) {
+      const msgId = msg.id as string;
       if (msg.senderAgentId === agentId) continue;
+      if (msgId && seenMessageIds.has(msgId)) continue;
+      if (msgId) seenMessageIds.add(msgId);
 
       const sender = (msg.senderAgentId as string) || 'unknown';
       const content = (msg.content as string) || '';
@@ -272,7 +278,7 @@ async function pollInbox(): Promise<void> {
       });
     }
 
-    lastInboxCheck = new Date().toISOString();
+    lastPollTime = new Date().toISOString();
   } catch {
     // Silent — polling should not crash the plugin
   }


### PR DESCRIPTION
Legacy inbox replayed every 10s. Now uses same pluginStartedAt + seenMessageIds filters as threads.