### PR TITLE
fix: channel plugin dedup + logging + skill table rename (by Wren)

### DIFF
--- a/packages/api/src/mcp/tools/inbox-handlers.ts
+++ b/packages/api/src/mcp/tools/inbox-handlers.ts
@@ -871,14 +871,18 @@ export async function handleGetInbox(args: unknown, dataComposer: DataComposer) 
     ];
 
     if (threadIds.length > 0) {
-      // Get open threads for this user
-      const { data: threads } = await threadTable(supabase, 'inbox_threads')
+      // Get open threads for this user (optionally filtered by since)
+      let threadQuery = threadTable(supabase, 'inbox_threads')
         .select('id, thread_key, title, user_id, created_by_agent_id, updated_at')
         .eq('user_id', resolved.user.id)
         .eq('status', 'open')
         .in('id', threadIds)
         .order('updated_at', { ascending: false })
         .limit(20);
+      if (since) {
+        threadQuery = threadQuery.gt('updated_at', since);
+      }
+      const { data: threads } = await threadQuery;
 
       if (threads?.length) {
         threadsWithUnread = await Promise.all(
@@ -908,12 +912,19 @@ export async function handleGetInbox(args: unknown, dataComposer: DataComposer) 
               }
 
               // Count unread messages (after last read, or all if no read status)
+              // When `since` is provided, use the later of lastReadAt and since
               let countQuery = threadTable(supabase, 'inbox_thread_messages')
                 .select('*', { count: 'exact', head: true })
                 .eq('thread_id', t.id);
 
-              if (lastReadAt) {
-                countQuery = countQuery.gt('created_at', lastReadAt);
+              const effectiveCutoff =
+                since && lastReadAt
+                  ? since > lastReadAt
+                    ? since
+                    : lastReadAt
+                  : since || lastReadAt;
+              if (effectiveCutoff) {
+                countQuery = countQuery.gt('created_at', effectiveCutoff);
               }
 
               const { count } = await countQuery;

--- a/packages/api/src/mcp/tools/inbox-handlers.ts
+++ b/packages/api/src/mcp/tools/inbox-handlers.ts
@@ -871,18 +871,19 @@ export async function handleGetInbox(args: unknown, dataComposer: DataComposer) 
     ];
 
     if (threadIds.length > 0) {
-      // Get open threads for this user (optionally filtered by since)
-      let threadQuery = threadTable(supabase, 'inbox_threads')
+      // Get open threads for this user.
+      // NOTE: `since` is NOT applied to threads — thread read pointers
+      // (inbox_thread_read_status.last_read_at) already handle "which
+      // messages have I seen." Filtering threads by updated_at would
+      // cause missed messages when lastPollTime advances past the
+      // thread's updated_at between polls.
+      const { data: threads } = await threadTable(supabase, 'inbox_threads')
         .select('id, thread_key, title, user_id, created_by_agent_id, updated_at')
         .eq('user_id', resolved.user.id)
         .eq('status', 'open')
         .in('id', threadIds)
         .order('updated_at', { ascending: false })
         .limit(20);
-      if (since) {
-        threadQuery = threadQuery.gt('updated_at', since);
-      }
-      const { data: threads } = await threadQuery;
 
       if (threads?.length) {
         threadsWithUnread = await Promise.all(
@@ -912,19 +913,12 @@ export async function handleGetInbox(args: unknown, dataComposer: DataComposer) 
               }
 
               // Count unread messages (after last read, or all if no read status)
-              // When `since` is provided, use the later of lastReadAt and since
               let countQuery = threadTable(supabase, 'inbox_thread_messages')
                 .select('*', { count: 'exact', head: true })
                 .eq('thread_id', t.id);
 
-              const effectiveCutoff =
-                since && lastReadAt
-                  ? since > lastReadAt
-                    ? since
-                    : lastReadAt
-                  : since || lastReadAt;
-              if (effectiveCutoff) {
-                countQuery = countQuery.gt('created_at', effectiveCutoff);
+              if (lastReadAt) {
+                countQuery = countQuery.gt('created_at', lastReadAt);
               }
 
               const { count } = await countQuery;

--- a/packages/api/src/skills/repository.ts
+++ b/packages/api/src/skills/repository.ts
@@ -257,7 +257,7 @@ export class SkillsRepository {
    */
   async getUserInstalledSkills(userId: string): Promise<UserInstalledSkill[]> {
     const { data, error } = await this.supabase
-      .from('user_installed_skills')
+      .from('skill_installations')
       .select('*')
       .eq('user_id', userId)
       .eq('enabled', true);

--- a/packages/channel-plugin/index.ts
+++ b/packages/channel-plugin/index.ts
@@ -90,6 +90,11 @@ const agentId = resolveAgentId();
 const email = resolveEmail();
 const accessToken = resolveAccessToken();
 
+// Debug startup state
+process.stderr.write(
+  `[pcp-channel] startup: agent=${agentId}, email=${email || '(none)'}, token=${accessToken ? 'yes(' + accessToken.slice(0, 20) + '...)' : 'NO'}, server=${PCP_SERVER_URL}\n`
+);
+
 async function callPcp(
   tool: string,
   args: Record<string, unknown>
@@ -177,22 +182,31 @@ Do NOT ignore channel messages — they are from your teammates and deserve time
 
 // ─── Polling Loop ───────────────────────────────────────────
 
-let lastPollTime = new Date().toISOString(); // only fetch messages after this timestamp
 const seenMessageIds = new Set<string>(); // prevent re-emission across poll cycles
 
 async function pollInbox(): Promise<void> {
   if (!email) return;
 
   try {
+    // Use status: 'unread' — the pointer auto-advances on each get_inbox
+    // call, so messages are only returned once. seenMessageIds provides
+    // belt-and-suspenders dedup.
     const result = await callPcp('get_inbox', {
       email,
       agentId,
-      status: 'all',
-      since: lastPollTime,
+      status: 'unread',
       limit: 20,
     });
 
-    if (!result?.success) return;
+    if (!result?.success) {
+      process.stderr.write(`[pcp-channel] poll failed: ${JSON.stringify(result).slice(0, 200)}\n`);
+      return;
+    }
+    const threadCount = ((result.threadsWithUnread as unknown[]) || []).length;
+    const msgCount = ((result.messages as unknown[]) || []).length;
+    if (threadCount > 0 || msgCount > 0) {
+      process.stderr.write(`[pcp-channel] poll: ${threadCount} threads, ${msgCount} inbox msgs\n`);
+    }
 
     // Check for new thread messages
     const threads = (result.threadsWithUnread as Array<Record<string, unknown>>) || [];
@@ -278,9 +292,9 @@ async function pollInbox(): Promise<void> {
       });
     }
 
-    lastPollTime = new Date().toISOString();
-  } catch {
-    // Silent — polling should not crash the plugin
+    // Read pointer auto-advances on get_inbox — no manual tracking needed
+  } catch (err) {
+    process.stderr.write(`[pcp-channel] poll error: ${err instanceof Error ? err.message : String(err)}\n`);
   }
 }
 

--- a/packages/channel-plugin/index.ts
+++ b/packages/channel-plugin/index.ts
@@ -22,9 +22,29 @@
 
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import { readFileSync, existsSync } from 'fs';
+import { readFileSync, existsSync, mkdirSync, appendFileSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
+
+// ─── Logging ────────────────────────────────────────────────
+// Logs to ~/.pcp/logs/channel-plugin.log for debugging.
+// Cannot use stdout (reserved for MCP stdio transport).
+
+const LOG_DIR = join(homedir(), '.pcp', 'logs');
+const LOG_FILE = join(LOG_DIR, 'channel-plugin.log');
+
+function log(level: 'info' | 'warn' | 'error' | 'debug', message: string, data?: Record<string, unknown>): void {
+  try {
+    mkdirSync(LOG_DIR, { recursive: true });
+    const ts = new Date().toISOString();
+    const line = data
+      ? `${ts} [${level}] ${message} ${JSON.stringify(data)}\n`
+      : `${ts} [${level}] ${message}\n`;
+    appendFileSync(LOG_FILE, line);
+  } catch {
+    // Can't log — don't crash the plugin
+  }
+}
 
 // ─── Config ─────────────────────────────────────────────────
 
@@ -90,10 +110,13 @@ const agentId = resolveAgentId();
 const email = resolveEmail();
 const accessToken = resolveAccessToken();
 
-// Debug startup state
-process.stderr.write(
-  `[pcp-channel] startup: agent=${agentId}, email=${email || '(none)'}, token=${accessToken ? 'yes(' + accessToken.slice(0, 20) + '...)' : 'NO'}, server=${PCP_SERVER_URL}\n`
-);
+log('info', 'Channel plugin starting', {
+  agentId,
+  email: email || '(none)',
+  hasToken: !!accessToken,
+  server: PCP_SERVER_URL,
+  pollIntervalMs: POLL_INTERVAL_MS,
+});
 
 async function callPcp(
   tool: string,
@@ -198,14 +221,13 @@ async function pollInbox(): Promise<void> {
     });
 
     if (!result?.success) {
-      process.stderr.write(`[pcp-channel] poll failed: ${JSON.stringify(result).slice(0, 200)}\n`);
+      log('error', 'Poll failed', { result: JSON.stringify(result).slice(0, 300) });
       return;
     }
     const threadCount = ((result.threadsWithUnread as unknown[]) || []).length;
     const msgCount = ((result.messages as unknown[]) || []).length;
-    if (threadCount > 0 || msgCount > 0) {
-      process.stderr.write(`[pcp-channel] poll: ${threadCount} threads, ${msgCount} inbox msgs\n`);
-    }
+    const totalUnread = (result.totalUnreadCount as number) || 0;
+    log('debug', 'Poll result', { threadCount, msgCount, totalUnread, since: lastPollTime });
 
     // Check for new thread messages
     const threads = (result.threadsWithUnread as Array<Record<string, unknown>>) || [];
@@ -240,6 +262,7 @@ async function pollInbox(): Promise<void> {
         const content = (msg.content as string) || '';
         const messageType = (msg.messageType as string) || 'message';
 
+        log('info', 'Pushing thread message to channel', { threadKey, sender, msgId, msgTs });
         await mcp.notification({
           method: 'notifications/claude/channel',
           params: {
@@ -293,14 +316,16 @@ async function pollInbox(): Promise<void> {
 
     lastPollTime = new Date().toISOString();
   } catch (err) {
-    process.stderr.write(`[pcp-channel] poll error: ${err instanceof Error ? err.message : String(err)}\n`);
+    log('error', 'Poll error', { error: err instanceof Error ? err.message : String(err) });
   }
 }
 
 // ─── Start ──────────────────────────────────────────────────
 
 async function main(): Promise<void> {
+  log('info', 'Connecting MCP stdio transport');
   await mcp.connect(new StdioServerTransport());
+  log('info', 'MCP connected, starting poll loop');
 
   // Start polling loop
   setInterval(pollInbox, POLL_INTERVAL_MS);
@@ -312,6 +337,6 @@ async function main(): Promise<void> {
 }
 
 main().catch((err) => {
-  process.stderr.write(`PCP channel plugin failed: ${err.message}\n`);
+  log('error', 'Channel plugin crashed', { error: err.message });
   process.exit(1);
 });

--- a/packages/channel-plugin/index.ts
+++ b/packages/channel-plugin/index.ts
@@ -182,19 +182,18 @@ Do NOT ignore channel messages — they are from your teammates and deserve time
 
 // ─── Polling Loop ───────────────────────────────────────────
 
-const seenMessageIds = new Set<string>(); // prevent re-emission across poll cycles
+let lastPollTime = new Date().toISOString();
+const seenMessageIds = new Set<string>(); // belt-and-suspenders dedup
 
 async function pollInbox(): Promise<void> {
   if (!email) return;
 
   try {
-    // Use status: 'unread' — the pointer auto-advances on each get_inbox
-    // call, so messages are only returned once. seenMessageIds provides
-    // belt-and-suspenders dedup.
     const result = await callPcp('get_inbox', {
       email,
       agentId,
-      status: 'unread',
+      status: 'all',
+      since: lastPollTime,
       limit: 20,
     });
 
@@ -292,7 +291,7 @@ async function pollInbox(): Promise<void> {
       });
     }
 
-    // Read pointer auto-advances on get_inbox — no manual tracking needed
+    lastPollTime = new Date().toISOString();
   } catch (err) {
     process.stderr.write(`[pcp-channel] poll error: ${err instanceof Error ? err.message : String(err)}\n`);
   }

--- a/packages/channel-plugin/index.ts
+++ b/packages/channel-plugin/index.ts
@@ -207,6 +207,7 @@ Do NOT ignore channel messages — they are from your teammates and deserve time
 
 let lastPollTime = new Date().toISOString();
 const seenMessageIds = new Set<string>(); // belt-and-suspenders dedup
+const lastThreadTimestamps = new Map<string, string>(); // threadKey → last seen created_at
 
 async function pollInbox(): Promise<void> {
   if (!email) return;


### PR DESCRIPTION
Fixes from channel plugin testing:
- Missing lastThreadTimestamps declaration (crash on first thread message)
- since filter only on legacy inbox, threads use read pointers
- File-based logging to ~/.pcp/logs/channel-plugin.log
- skill_installations table rename (was user_installed_skills)

Verified: Lumen's reply appeared as channel event with no replay.