### PR TITLE
refactor: rename pcp-channel to pcp-inbox + review policy (by Wren)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -645,6 +645,7 @@ Defined in [CONTRIBUTING.md](./CONTRIBUTING.md). Key SB-specific reminders:
 - **Sign reviews**: end PR comments with `— Wren`, `— Lumen`, etc.
 - **Do not wait for permission to open a PR** once implementation is ready. Create the PR proactively unless the user explicitly asked you not to.
 - **Never push directly to main** from a feature branch. Always use PRs. This includes releases, changelog updates, and docs changes.
+- **ALL PRs require a sibling review before merge.** No exceptions unless Conor explicitly says otherwise. Do not merge your own PR without at least one other SB's LGTM. This is a hard rule — merging without review has caused bugs that could have been caught. Use `sb wait --thread pr:<number>` to hold for the review.
 - **Verify CI passes before merging.** Check `gh run list --branch <branch>` for the CI status. If tests fail, fix them before merging — don't merge red. When fixing CI, run the full test suite locally (`npx vitest run`) to catch issues before pushing.
 - **Simple PR wait helper**: for short review loops, use `yarn pr:wait-reply <prNumber> --timeout 120 --interval 10` instead of manual `sleep`, then re-check review status via MCP GitHub tools.
 - **Commit messages**: pass multi-line messages directly to `-m "..."` — bash handles literal newlines in double-quoted strings. Do not use `$(cat <<'EOF' ... EOF)` or other command substitution patterns; they add complexity for no benefit.

--- a/packages/channel-plugin/README.md
+++ b/packages/channel-plugin/README.md
@@ -5,7 +5,7 @@ Pushes PCP inbox messages and thread replies into a running Claude Code session 
 ## What it does
 
 - Polls PCP inbox every 10 seconds for new messages
-- Pushes thread replies and inbox messages as `<channel source="pcp-channel">` events
+- Pushes thread replies and inbox messages as `<channel source="pcp-inbox">` events
 - Filters out own messages (no echo)
 - Replies go through the existing `send_to_inbox` tool on the `pcp` MCP server
 
@@ -13,9 +13,9 @@ Pushes PCP inbox messages and thread replies into a running Claude Code session 
 
 ```bash
 # Development mode (research preview)
-claude --dangerously-load-development-channels server:pcp-channel
+claude --dangerously-load-development-channels server:pcp-inbox
 
-# Or via sb (auto-detected when pcp-channel is in .mcp.json)
+# Or via sb (auto-detected when pcp-inbox is in .mcp.json)
 sb -a wren
 ```
 
@@ -31,7 +31,7 @@ sb -a wren
 ## How messages appear
 
 ```xml
-<channel source="pcp-channel" thread_key="pr:231" sender="lumen" message_type="task_request">
+<channel source="pcp-inbox" thread_key="pr:231" sender="lumen" message_type="task_request">
 From lumen: I reviewed PR #231 and I'm requesting changes...
 </channel>
 ```

--- a/packages/channel-plugin/index.ts
+++ b/packages/channel-plugin/index.ts
@@ -12,7 +12,7 @@
  * - Exposes reply tool for two-way communication
  *
  * Usage:
- *   claude --dangerously-load-development-channels server:pcp-channel
+ *   claude --dangerously-load-development-channels server:pcp-inbox
  *
  * Environment:
  *   PCP_SERVER_URL  — PCP server URL (default: http://localhost:3001)
@@ -195,7 +195,7 @@ async function callPcp(
 // ─── MCP Server ─────────────────────────────────────────────
 
 const mcp = new Server(
-  { name: 'pcp-channel', version: '0.1.0' },
+  { name: 'pcp-inbox', version: '0.1.0' },
   {
     capabilities: {
       experimental: {
@@ -207,7 +207,7 @@ const mcp = new Server(
         // 'claude/channel/permission': {},
       },
     },
-    instructions: `Messages from other SBs (AI agents) arrive as <channel source="pcp-channel" ...> tags.
+    instructions: `Messages from other SBs (AI agents) arrive as <channel source="pcp-inbox" ...> tags.
 
 These are real-time notifications from the PCP inbox — thread replies, task requests, review feedback, etc.
 

--- a/packages/cli/src/backends/claude.ts
+++ b/packages/cli/src/backends/claude.ts
@@ -21,7 +21,7 @@ function hasPcpChannelPlugin(cwd: string): boolean {
   if (!existsSync(mcpJsonPath)) return false;
   try {
     const config = JSON.parse(readFileSync(mcpJsonPath, 'utf-8'));
-    return Boolean(config?.mcpServers?.['pcp-channel']);
+    return Boolean(config?.mcpServers?.['pcp-inbox']);
   } catch {
     return false;
   }
@@ -78,7 +78,7 @@ export class ClaudeAdapter implements BackendAdapter {
     // The channel plugin is a stdio MCP server that bridges PCP's HTTP
     // inbox to Claude Code's channel notification system.
     if (hasPcpChannelPlugin(process.cwd())) {
-      args.push('--dangerously-load-development-channels', 'server:pcp-channel');
+      args.push('--dangerously-load-development-channels', 'server:pcp-inbox');
     }
 
     // Passthrough flags

--- a/packages/cli/src/backends/claude.ts
+++ b/packages/cli/src/backends/claude.ts
@@ -16,7 +16,7 @@ import type { BackendAdapter, BackendConfig, PreparedBackend } from './types.js'
  * If present, Claude Code should be started with --dangerously-load-development-channels
  * so it accepts push notifications from the channel.
  */
-function hasPcpChannelPlugin(cwd: string): boolean {
+function hasPcpInboxPlugin(cwd: string): boolean {
   const mcpJsonPath = join(cwd, '.mcp.json');
   if (!existsSync(mcpJsonPath)) return false;
   try {
@@ -77,7 +77,7 @@ export class ClaudeAdapter implements BackendAdapter {
     // PCP channel plugin: enable real-time inbox push notifications.
     // The channel plugin is a stdio MCP server that bridges PCP's HTTP
     // inbox to Claude Code's channel notification system.
-    if (hasPcpChannelPlugin(process.cwd())) {
+    if (hasPcpInboxPlugin(process.cwd())) {
       args.push('--dangerously-load-development-channels', 'server:pcp-inbox');
     }
 

--- a/packages/cli/src/commands/hooks.ts
+++ b/packages/cli/src/commands/hooks.ts
@@ -854,7 +854,7 @@ function hasActiveChannelPlugin(cwd: string): boolean {
     const mcpJsonPath = join(cwd, '.mcp.json');
     if (!existsSync(mcpJsonPath)) return false;
     const mcpConfig = JSON.parse(readFileSync(mcpJsonPath, 'utf-8'));
-    return Boolean(mcpConfig?.mcpServers?.['pcp-channel']);
+    return Boolean(mcpConfig?.mcpServers?.['pcp-inbox']);
   } catch {
     return false;
   }

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -69,7 +69,7 @@ function buildDefaultMcpJson(serverUrl: string, cwd?: string): Record<string, un
   // Add PCP channel plugin for real-time inbox push notifications
   const channelPath = cwd ? resolveChannelPluginPath(cwd) : null;
   if (channelPath) {
-    servers['pcp-channel'] = {
+    servers['pcp-inbox'] = {
       command: 'npx',
       args: ['tsx', channelPath],
     };
@@ -119,11 +119,11 @@ function ensureMcpJson(cwd: string): InitStepResult {
           needsWrite = true;
         }
 
-        // Add pcp-channel if missing and plugin exists locally
-        if (!servers['pcp-channel']) {
+        // Add pcp-inbox if missing and plugin exists locally
+        if (!servers['pcp-inbox']) {
           const channelPath = resolveChannelPluginPath(cwd);
           if (channelPath) {
-            updatedServers['pcp-channel'] = { command: 'npx', args: ['tsx', channelPath] };
+            updatedServers['pcp-inbox'] = { command: 'npx', args: ['tsx', channelPath] };
             needsWrite = true;
           }
         }


### PR DESCRIPTION
## Summary

- Renamed `pcp-channel` to `pcp-inbox` everywhere (shorter, more descriptive)
- Added hard review policy to AGENTS.md: ALL PRs require sibling review before merge

## Test plan

- [x] Channel plugin logs show correct polling and message delivery
- [x] Lumen's reply delivered via `<channel source="pcp-inbox">` event
- [x] No replay on subsequent polls

🤖 Generated with [Claude Code](https://claude.com/claude-code)