### PR TITLE
feat: per-sender session isolation (by Wren)

### DIFF
--- a/packages/api/src/data/composer.ts
+++ b/packages/api/src/data/composer.ts
@@ -14,6 +14,7 @@ import { MemoryRepository } from './repositories/memory-repository';
 import { ActivityStreamRepository } from './repositories/activity-stream.repository';
 import { StudiosRepository } from './repositories/studios.repository';
 import { WorkspacesRepository } from './repositories/workspaces.repository';
+import { ContactsRepository } from './repositories/contacts-repository';
 import { logger } from '../utils/logger';
 
 export class DataComposer {
@@ -33,6 +34,7 @@ export class DataComposer {
     activityStream: ActivityStreamRepository;
     studios: StudiosRepository;
     workspaces: WorkspacesRepository;
+    contacts: ContactsRepository;
   };
 
   private constructor(supabaseClient: SupabaseClient<Database>) {
@@ -53,6 +55,7 @@ export class DataComposer {
       activityStream: new ActivityStreamRepository(supabaseClient),
       studios: new StudiosRepository(supabaseClient),
       workspaces: new WorkspacesRepository(supabaseClient),
+      contacts: new ContactsRepository(supabaseClient),
     };
 
     logger.info('Data composer initialized with all repositories');

--- a/packages/api/src/data/models/memory.ts
+++ b/packages/api/src/data/models/memory.ts
@@ -23,6 +23,7 @@ export interface Memory {
   salience: Salience;
   topics: string[];
   agentId?: string; // Which AI being created this memory (wren, benson, etc). Null = shared memory.
+  contactId?: string; // Per-sender memory scoping. Null = owner/system memory.
   embedding?: number[]; // 1024 dimensions for Voyage AI, nullable for now
   metadata: Record<string, unknown>;
   version: number;
@@ -60,6 +61,7 @@ export interface MemoryCreateInput {
   metadata?: Record<string, unknown>;
   expiresAt?: Date;
   agentId?: string; // Which AI being created this memory
+  contactId?: string; // Per-sender memory scoping
 }
 
 export interface MemorySearchOptions {
@@ -72,6 +74,7 @@ export interface MemorySearchOptions {
   includeExpired?: boolean;
   agentId?: string; // Filter by agent
   includeShared?: boolean; // Include shared memories (agentId=null) when filtering. Default true.
+  contactId?: string; // Filter by contact for per-sender isolation
 }
 
 export type SessionPhase =
@@ -144,6 +147,7 @@ export interface MemoryRow {
   salience: Salience;
   topics: string[];
   agent_id: string | null;
+  contact_id?: string | null; // Optional: RPC functions may not return this column
   embedding_chunks_version?: number | null;
   embedding_chunk_count?: number | null;
   embedding: number[] | null;
@@ -168,6 +172,7 @@ export interface MemoryHistoryRow {
   created_at: string;
   archived_at: string;
   change_type: ChangeType;
+  contact_id: string | null;
 }
 
 export interface SessionRow {

--- a/packages/api/src/data/models/memory.ts
+++ b/packages/api/src/data/models/memory.ts
@@ -117,6 +117,7 @@ export interface SessionCreateInput {
   agentId?: string;
   studioId?: string;
   threadKey?: string;
+  contactId?: string;
   backend?: string;
   model?: string;
   metadata?: Record<string, unknown>;

--- a/packages/api/src/data/repositories/contacts-repository.test.ts
+++ b/packages/api/src/data/repositories/contacts-repository.test.ts
@@ -4,8 +4,14 @@
  * Tests for contact management and name resolution.
  */
 
-import { describe, it, expect } from 'vitest';
-import { calculateSimilarity, levenshteinDistance } from './contacts-repository';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  ContactsRepository,
+  calculateSimilarity,
+  levenshteinDistance,
+} from './contacts-repository';
+import { createMockSupabaseClient, type MockSupabaseClient } from '../../test/mocks/supabase.mock';
+import type { SupabaseClient } from '@supabase/supabase-js';
 
 describe('levenshteinDistance', () => {
   it('should return 0 for identical strings', () => {
@@ -132,5 +138,159 @@ describe('bill-split name scenarios', () => {
     // Partial match but not the same person
     expect(similarity).toBeLessThan(0.8);
     expect(similarity).toBeGreaterThan(0.4);
+  });
+});
+
+// ─── Contact Auto-Resolution Tests ───
+
+describe('ContactsRepository', () => {
+  let mockSupabase: MockSupabaseClient;
+  let repo: ContactsRepository;
+
+  const mockContactRow = {
+    id: 'contact-123',
+    user_id: 'user-456',
+    name: 'Alice',
+    display_name: 'Alice',
+    aliases: [],
+    email: null,
+    phone: null,
+    telegram_id: '99887766',
+    telegram_username: 'alice_tg',
+    imessage_id: null,
+    discord_id: null,
+    whatsapp_id: null,
+    notes: null,
+    tags: ['auto-created', 'external'],
+    created_at: '2026-03-25T12:00:00Z',
+    updated_at: '2026-03-25T12:00:00Z',
+  };
+
+  beforeEach(() => {
+    mockSupabase = createMockSupabaseClient();
+    repo = new ContactsRepository(mockSupabase as unknown as SupabaseClient<any>);
+  });
+
+  describe('findOrCreateByPlatformId', () => {
+    it('should return existing contact when found', async () => {
+      mockSupabase._setReturnData(mockContactRow);
+
+      const result = await repo.findOrCreateByPlatformId('user-456', 'telegram', '99887766', {
+        name: 'Alice',
+        username: 'alice_tg',
+      });
+
+      expect(result.id).toBe('contact-123');
+      expect(result.telegramId).toBe('99887766');
+      // findByPlatformId is called first (select chain)
+      expect(mockSupabase.from).toHaveBeenCalledWith('contacts');
+    });
+
+    it('should create contact when not found', async () => {
+      // First call (findByPlatformId): not found
+      // Second call (createContact): returns new row
+      let callCount = 0;
+      mockSupabase._queryBuilder.single = vi.fn().mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          // findByPlatformId returns not found
+          return Promise.resolve({ data: null, error: { code: 'PGRST116', message: 'not found' } });
+        }
+        // createContact returns new row
+        return Promise.resolve({ data: mockContactRow, error: null });
+      });
+
+      const result = await repo.findOrCreateByPlatformId('user-456', 'telegram', '99887766', {
+        name: 'Alice',
+        username: 'alice_tg',
+      });
+
+      expect(result.id).toBe('contact-123');
+      expect(result.tags).toEqual(['auto-created', 'external']);
+    });
+
+    it('should handle race condition on duplicate create', async () => {
+      let callCount = 0;
+      mockSupabase._queryBuilder.single = vi.fn().mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          // findByPlatformId: not found
+          return Promise.resolve({ data: null, error: { code: 'PGRST116', message: 'not found' } });
+        }
+        if (callCount === 2) {
+          // createContact: duplicate error (Supabase returns plain object, not Error)
+          return Promise.resolve({
+            data: null,
+            error: { code: '23505', message: 'duplicate key value violates unique constraint' },
+          });
+        }
+        // retry findByPlatformId: found
+        return Promise.resolve({ data: mockContactRow, error: null });
+      });
+
+      const result = await repo.findOrCreateByPlatformId('user-456', 'telegram', '99887766', {
+        name: 'Alice',
+      });
+
+      expect(result.id).toBe('contact-123');
+    });
+
+    it('should use platform ID as display name when no name provided', async () => {
+      let callCount = 0;
+      mockSupabase._queryBuilder.single = vi.fn().mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          return Promise.resolve({ data: null, error: { code: 'PGRST116', message: 'not found' } });
+        }
+        return Promise.resolve({
+          data: { ...mockContactRow, name: 'telegram:99887766', display_name: null },
+          error: null,
+        });
+      });
+
+      const result = await repo.findOrCreateByPlatformId('user-456', 'telegram', '99887766');
+
+      expect(result.name).toBe('telegram:99887766');
+    });
+  });
+
+  describe('findOrCreateGroupContact', () => {
+    const mockGroupRow = {
+      ...mockContactRow,
+      id: 'group-789',
+      name: 'Dinner Gang',
+      display_name: 'Dinner Gang',
+      telegram_id: 'group-chat-123',
+      tags: ['auto-created', 'group'],
+    };
+
+    it('should return existing group contact when found', async () => {
+      mockSupabase._setReturnData(mockGroupRow);
+
+      const result = await repo.findOrCreateGroupContact('user-456', 'telegram', 'group-chat-123', {
+        groupName: 'Dinner Gang',
+      });
+
+      expect(result.id).toBe('group-789');
+      expect(result.tags).toContain('group');
+    });
+
+    it('should create group contact when not found', async () => {
+      let callCount = 0;
+      mockSupabase._queryBuilder.single = vi.fn().mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          return Promise.resolve({ data: null, error: { code: 'PGRST116', message: 'not found' } });
+        }
+        return Promise.resolve({ data: mockGroupRow, error: null });
+      });
+
+      const result = await repo.findOrCreateGroupContact('user-456', 'telegram', 'group-chat-123', {
+        groupName: 'Dinner Gang',
+      });
+
+      expect(result.id).toBe('group-789');
+      expect(result.tags).toContain('group');
+    });
   });
 });

--- a/packages/api/src/data/repositories/contacts-repository.ts
+++ b/packages/api/src/data/repositories/contacts-repository.ts
@@ -361,6 +361,108 @@ export class ContactsRepository {
   }
 
   /**
+   * Find or create a contact by platform identity.
+   * Used by the gateway to auto-resolve contacts from incoming channel messages.
+   * Handles unique constraint races via catch-and-retry.
+   */
+  async findOrCreateByPlatformId(
+    userId: string,
+    platform: 'telegram' | 'discord' | 'whatsapp' | 'imessage',
+    platformId: string,
+    info?: { name?: string; username?: string }
+  ): Promise<Contact> {
+    // Try to find existing contact first
+    const existing = await this.findByPlatformId(userId, platform, platformId);
+    if (existing) return existing;
+
+    // Auto-create with platform ID
+    const platformColumnMap: Record<string, string> = {
+      telegram: 'telegramId',
+      discord: 'discordId',
+      whatsapp: 'whatsappId',
+      imessage: 'imessageId',
+    };
+
+    const platformField = platformColumnMap[platform];
+    const displayName = info?.name || info?.username || `${platform}:${platformId}`;
+
+    try {
+      return await this.createContact({
+        userId,
+        name: displayName,
+        displayName: info?.name,
+        [platformField]: platformId,
+        ...(platform === 'telegram' && info?.username ? { telegramUsername: info.username } : {}),
+        tags: ['auto-created', 'external'],
+      });
+    } catch (error: unknown) {
+      // Unique constraint race — another request created it first
+      const msg = error instanceof Error ? error.message : String(error);
+      if (msg.includes('duplicate') || msg.includes('unique') || msg.includes('23505')) {
+        const retried = await this.findByPlatformId(userId, platform, platformId);
+        if (retried) return retried;
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Find or create a synthetic group contact.
+   * Groups are contacts with type metadata, keyed by platform + groupId.
+   */
+  async findOrCreateGroupContact(
+    userId: string,
+    platform: 'telegram' | 'discord' | 'whatsapp' | 'slack',
+    groupId: string,
+    info?: { groupName?: string }
+  ): Promise<Contact> {
+    // Groups are stored with the groupId in the platform's ID column
+    // and tagged as 'group' for disambiguation
+    const platformForLookup = platform as 'telegram' | 'discord' | 'whatsapp' | 'imessage';
+    if (platform === 'slack') {
+      // Slack uses discord_id column as a generic "chat platform" slot
+      const existing = await this.findByPlatformId(userId, 'discord', groupId);
+      if (existing && existing.tags.includes('group')) return existing;
+    } else {
+      const existing = await this.findByPlatformId(userId, platformForLookup, groupId);
+      if (existing && existing.tags.includes('group')) return existing;
+    }
+
+    const displayName = info?.groupName || `${platform}-group:${groupId}`;
+
+    const platformColumnMap: Record<string, string> = {
+      telegram: 'telegramId',
+      discord: 'discordId',
+      whatsapp: 'whatsappId',
+      slack: 'discordId', // Slack reuses discord column
+    };
+    const platformField = platformColumnMap[platform];
+
+    try {
+      return await this.createContact({
+        userId,
+        name: displayName,
+        displayName: info?.groupName,
+        [platformField]: groupId,
+        tags: ['auto-created', 'group'],
+      });
+    } catch (error: unknown) {
+      const msg = error instanceof Error ? error.message : String(error);
+      if (msg.includes('duplicate') || msg.includes('unique') || msg.includes('23505')) {
+        // Race — try lookup again
+        if (platform === 'slack') {
+          const retried = await this.findByPlatformId(userId, 'discord', groupId);
+          if (retried) return retried;
+        } else {
+          const retried = await this.findByPlatformId(userId, platformForLookup, groupId);
+          if (retried) return retried;
+        }
+      }
+      throw error;
+    }
+  }
+
+  /**
    * Find contact by platform identity
    */
   async findByPlatformId(

--- a/packages/api/src/data/repositories/contacts-repository.ts
+++ b/packages/api/src/data/repositories/contacts-repository.ts
@@ -396,9 +396,16 @@ export class ContactsRepository {
         tags: ['auto-created', 'external'],
       });
     } catch (error: unknown) {
-      // Unique constraint race — another request created it first
-      const msg = error instanceof Error ? error.message : String(error);
-      if (msg.includes('duplicate') || msg.includes('unique') || msg.includes('23505')) {
+      // Unique constraint race — another request created it first.
+      // Supabase errors are plain objects with { code, message }, not Error instances.
+      const err = error as Record<string, unknown>;
+      const msg = err?.message
+        ? String(err.message)
+        : error instanceof Error
+          ? error.message
+          : String(error);
+      const code = err?.code ? String(err.code) : '';
+      if (msg.includes('duplicate') || msg.includes('unique') || code === '23505') {
         const retried = await this.findByPlatformId(userId, platform, platformId);
         if (retried) return retried;
       }
@@ -447,8 +454,14 @@ export class ContactsRepository {
         tags: ['auto-created', 'group'],
       });
     } catch (error: unknown) {
-      const msg = error instanceof Error ? error.message : String(error);
-      if (msg.includes('duplicate') || msg.includes('unique') || msg.includes('23505')) {
+      const err = error as Record<string, unknown>;
+      const msg = err?.message
+        ? String(err.message)
+        : error instanceof Error
+          ? error.message
+          : String(error);
+      const code = err?.code ? String(err.code) : '';
+      if (msg.includes('duplicate') || msg.includes('unique') || code === '23505') {
         // Race — try lookup again
         if (platform === 'slack') {
           const retried = await this.findByPlatformId(userId, 'discord', groupId);

--- a/packages/api/src/data/repositories/memory-repository.test.ts
+++ b/packages/api/src/data/repositories/memory-repository.test.ts
@@ -1011,14 +1011,12 @@ describe('MemoryRepository', () => {
       };
 
       mockSupabase._setReturnData(mockRow);
-      const embedDocument = vi
-        .fn()
-        .mockResolvedValue({
-          vector: new Array(1024).fill(0.1),
-          provider: 'ollama',
-          model: 'mxbai-embed-large',
-          dimensions: 1024,
-        });
+      const embedDocument = vi.fn().mockResolvedValue({
+        vector: new Array(1024).fill(0.1),
+        provider: 'ollama',
+        model: 'mxbai-embed-large',
+        dimensions: 1024,
+      });
       (repo as any).embeddingRouter = {
         isEnabled: vi.fn().mockReturnValue(true),
         embedDocument,
@@ -1490,6 +1488,114 @@ describe('MemoryRepository', () => {
 
       expect(rpc).not.toHaveBeenCalled();
       expect(results).toEqual([]);
+    });
+  });
+
+  // ─── Per-Sender Memory Isolation Tests ───
+
+  describe('contact-scoped remember', () => {
+    it('should write contact_id when provided', async () => {
+      disableEmbeddings();
+      const mockMemoryRow = {
+        id: 'mem-contact-1',
+        user_id: 'user-456',
+        content: 'Alice told me her address',
+        source: 'conversation',
+        salience: 'medium',
+        topics: [],
+        embedding: null,
+        contact_id: 'contact-alice',
+        metadata: {},
+        version: 1,
+        created_at: '2026-03-25T12:00:00Z',
+        expires_at: null,
+      };
+
+      mockSupabase._setReturnData(mockMemoryRow);
+
+      const result = await repo.remember({
+        userId: 'user-456',
+        content: 'Alice told me her address',
+        contactId: 'contact-alice',
+      });
+
+      expect(result.contactId).toBe('contact-alice');
+      expect(mockSupabase.from).toHaveBeenCalledWith('memories');
+    });
+
+    it('should set contact_id to null when not provided', async () => {
+      disableEmbeddings();
+      const mockMemoryRow = {
+        id: 'mem-owner-1',
+        user_id: 'user-456',
+        content: 'General knowledge',
+        source: 'observation',
+        salience: 'high',
+        topics: [],
+        embedding: null,
+        contact_id: null,
+        metadata: {},
+        version: 1,
+        created_at: '2026-03-25T12:00:00Z',
+        expires_at: null,
+      };
+
+      mockSupabase._setReturnData(mockMemoryRow);
+
+      const result = await repo.remember({
+        userId: 'user-456',
+        content: 'General knowledge',
+      });
+
+      expect(result.contactId).toBeUndefined();
+    });
+  });
+
+  describe('contact-scoped recall', () => {
+    it('should filter by contact_id when provided', async () => {
+      disableEmbeddings();
+      const contactMemory = {
+        id: 'mem-1',
+        user_id: 'user-456',
+        content: 'Private to Alice',
+        source: 'conversation',
+        salience: 'medium',
+        topics: [],
+        embedding: null,
+        contact_id: 'contact-alice',
+        metadata: {},
+        version: 1,
+        created_at: '2026-03-25T12:00:00Z',
+        expires_at: null,
+      };
+
+      mockSupabase._setArrayData([contactMemory]);
+
+      const results = await repo.recall('user-456', undefined, {
+        contactId: 'contact-alice',
+        recallMode: 'text',
+      });
+
+      expect(results.length).toBe(1);
+      expect(results[0].contactId).toBe('contact-alice');
+
+      // Verify eq('contact_id', 'contact-alice') was called
+      const eqCalls = (mockSupabase._queryBuilder.eq as ReturnType<typeof vi.fn>).mock.calls;
+      const contactFilter = eqCalls.find(
+        (call: unknown[]) => call[0] === 'contact_id' && call[1] === 'contact-alice'
+      );
+      expect(contactFilter).toBeDefined();
+    });
+
+    it('should not filter by contact_id when not provided (owner session)', async () => {
+      disableEmbeddings();
+      mockSupabase._setArrayData([]);
+
+      await repo.recall('user-456', undefined, { recallMode: 'text' });
+
+      const eqCalls = (mockSupabase._queryBuilder.eq as ReturnType<typeof vi.fn>).mock.calls;
+      const contactFilter = eqCalls.find((call: unknown[]) => call[0] === 'contact_id');
+      expect(contactFilter).toBeUndefined();
     });
   });
 });

--- a/packages/api/src/data/repositories/memory-repository.ts
+++ b/packages/api/src/data/repositories/memory-repository.ts
@@ -220,6 +220,7 @@ export class MemoryRepository {
         metadata: input.metadata || {},
         expires_at: input.expiresAt?.toISOString(),
         agent_id: input.agentId || null,
+        contact_id: input.contactId || null,
         identity_id: identityId,
       })
       .select()
@@ -446,6 +447,12 @@ export class MemoryRepository {
       }
     }
 
+    // Filter by contact for per-sender isolation
+    if (options.contactId) {
+      // In per-contact mode: only show this contact's memories
+      queryBuilder = queryBuilder.eq('contact_id', options.contactId);
+    }
+
     // Exclude expired unless requested
     if (!options.includeExpired) {
       queryBuilder = queryBuilder.or('expires_at.is.null,expires_at.gt.now()');
@@ -546,6 +553,12 @@ export class MemoryRepository {
 
     for (const row of rows) {
       const memory = this.rowToMemory(row);
+
+      // Post-filter for contact-scoped isolation (RPC doesn't support contact_id yet)
+      if (options.contactId && memory.contactId !== options.contactId) {
+        continue;
+      }
+
       const semanticScore = Math.max(0, Math.min(1, row.similarity ?? 0));
       const existing = grouped.get(memory.id);
 
@@ -726,7 +739,8 @@ export class MemoryRepository {
     agentId?: string,
     highLimit: number = 10,
     highWindowDays: number = 7,
-    context: KnowledgeMemoryContext = {}
+    context: KnowledgeMemoryContext = {},
+    contactId?: string
   ): Promise<Memory[]> {
     const buildQuery = (salience: string, limit: number) => {
       let q = this.supabase
@@ -740,6 +754,9 @@ export class MemoryRepository {
 
       if (agentId) {
         q = q.or(`agent_id.eq.${agentId},agent_id.is.null`);
+      }
+      if (contactId) {
+        q = q.eq('contact_id', contactId);
       }
       return q;
     };
@@ -758,6 +775,9 @@ export class MemoryRepository {
 
       if (agentId) {
         q = q.or(`agent_id.eq.${agentId},agent_id.is.null`);
+      }
+      if (contactId) {
+        q = q.eq('contact_id', contactId);
       }
       return q;
     };
@@ -1524,6 +1544,7 @@ export class MemoryRepository {
       salience: row.salience,
       topics: row.topics,
       agentId: row.agent_id || undefined,
+      contactId: (row as MemoryRow).contact_id || undefined,
       embedding: parseEmbeddingValue(row.embedding),
       metadata: row.metadata,
       version: row.version || 1,

--- a/packages/api/src/data/repositories/memory-repository.ts
+++ b/packages/api/src/data/repositories/memory-repository.ts
@@ -1012,6 +1012,9 @@ export class MemoryRepository {
     if (input.threadKey) {
       insertData.thread_key = input.threadKey;
     }
+    if (input.contactId) {
+      insertData.contact_id = input.contactId;
+    }
 
     const { data, error } = await this.supabase
       .from('sessions')
@@ -1135,7 +1138,8 @@ export class MemoryRepository {
   async getActiveSession(
     userId: string,
     agentId?: string,
-    studioId?: string | null
+    studioId?: string | null,
+    contactId?: string
   ): Promise<Session | null> {
     let query = this.supabase
       .from('sessions')
@@ -1156,6 +1160,11 @@ export class MemoryRepository {
       } else {
         query = query.eq('studio_id', studioId);
       }
+    }
+
+    // Per-sender isolation: scope to contact when provided
+    if (contactId) {
+      query = query.eq('contact_id', contactId);
     }
 
     const { data, error } = await query.single();

--- a/packages/api/src/data/repositories/memory-repository.ts
+++ b/packages/api/src/data/repositories/memory-repository.ts
@@ -1186,7 +1186,8 @@ export class MemoryRepository {
     userId: string,
     agentId: string,
     threadKey: string,
-    studioId?: string | null
+    studioId?: string | null,
+    contactId?: string
   ): Promise<Session | null> {
     let query = this.supabase
       .from('sessions')
@@ -1205,6 +1206,11 @@ export class MemoryRepository {
       } else {
         query = query.eq('studio_id', studioId);
       }
+    }
+
+    // Per-sender isolation: scope to contact when provided
+    if (contactId) {
+      query = query.eq('contact_id', contactId);
     }
 
     const { data, error } = await query.single();

--- a/packages/api/src/data/repositories/memory-repository.ts
+++ b/packages/api/src/data/repositories/memory-repository.ts
@@ -1162,9 +1162,12 @@ export class MemoryRepository {
       }
     }
 
-    // Per-sender isolation: scope to contact when provided
+    // Per-sender isolation: always scope by contact to prevent collision.
+    // Contact sessions match their contact; owner sessions match NULL.
     if (contactId) {
       query = query.eq('contact_id', contactId);
+    } else {
+      query = query.is('contact_id', null);
     }
 
     const { data, error } = await query.single();
@@ -1208,9 +1211,12 @@ export class MemoryRepository {
       }
     }
 
-    // Per-sender isolation: scope to contact when provided
+    // Per-sender isolation: always scope by contact to prevent collision.
+    // Contact sessions match their contact; owner sessions match NULL.
     if (contactId) {
       query = query.eq('contact_id', contactId);
+    } else {
+      query = query.is('contact_id', null);
     }
 
     const { data, error } = await query.single();

--- a/packages/api/src/data/supabase/types.ts
+++ b/packages/api/src/data/supabase/types.ts
@@ -1560,6 +1560,7 @@ export type Database = {
       memories: {
         Row: {
           agent_id: string | null;
+          contact_id: string | null;
           content: string;
           created_at: string | null;
           embedding_chunk_count: number | null;
@@ -1579,6 +1580,7 @@ export type Database = {
         };
         Insert: {
           agent_id?: string | null;
+          contact_id?: string | null;
           content: string;
           created_at?: string | null;
           embedding_chunk_count?: number | null;
@@ -1598,6 +1600,7 @@ export type Database = {
         };
         Update: {
           agent_id?: string | null;
+          contact_id?: string | null;
           content?: string;
           created_at?: string | null;
           embedding_chunk_count?: number | null;
@@ -1690,6 +1693,7 @@ export type Database = {
         Row: {
           archived_at: string | null;
           change_type: string;
+          contact_id: string | null;
           content: string;
           created_at: string;
           id: string;
@@ -1706,6 +1710,7 @@ export type Database = {
         Insert: {
           archived_at?: string | null;
           change_type?: string;
+          contact_id?: string | null;
           content: string;
           created_at: string;
           id?: string;
@@ -1722,6 +1727,7 @@ export type Database = {
         Update: {
           archived_at?: string | null;
           change_type?: string;
+          contact_id?: string | null;
           content?: string;
           created_at?: string;
           id?: string;
@@ -2582,6 +2588,7 @@ export type Database = {
           backend_session_id: string | null;
           claude_session_id: string | null;
           compacting_since: string | null;
+          contact_id: string | null;
           context: string | null;
           current_phase: string | null;
           ended_at: string | null;
@@ -2608,6 +2615,7 @@ export type Database = {
           backend_session_id?: string | null;
           claude_session_id?: string | null;
           compacting_since?: string | null;
+          contact_id?: string | null;
           context?: string | null;
           current_phase?: string | null;
           ended_at?: string | null;
@@ -2634,6 +2642,7 @@ export type Database = {
           backend_session_id?: string | null;
           claude_session_id?: string | null;
           compacting_since?: string | null;
+          contact_id?: string | null;
           context?: string | null;
           current_phase?: string | null;
           ended_at?: string | null;

--- a/packages/api/src/data/supabase/types.ts
+++ b/packages/api/src/data/supabase/types.ts
@@ -2416,66 +2416,6 @@ export type Database = {
           },
         ];
       };
-      session_transcript_archives: {
-        Row: {
-          backend: string | null;
-          backend_session_id: string | null;
-          byte_count: number;
-          created_at: string;
-          id: string;
-          line_count: number;
-          payload: Json;
-          session_id: string;
-          source_path: string | null;
-          synced_at: string;
-          updated_at: string;
-          user_id: string;
-        };
-        Insert: {
-          backend?: string | null;
-          backend_session_id?: string | null;
-          byte_count?: number;
-          created_at?: string;
-          id?: string;
-          line_count?: number;
-          payload: Json;
-          session_id: string;
-          source_path?: string | null;
-          synced_at?: string;
-          updated_at?: string;
-          user_id: string;
-        };
-        Update: {
-          backend?: string | null;
-          backend_session_id?: string | null;
-          byte_count?: number;
-          created_at?: string;
-          id?: string;
-          line_count?: number;
-          payload?: Json;
-          session_id?: string;
-          source_path?: string | null;
-          synced_at?: string;
-          updated_at?: string;
-          user_id?: string;
-        };
-        Relationships: [
-          {
-            foreignKeyName: 'session_transcript_archives_session_id_fkey';
-            columns: ['session_id'];
-            isOneToOne: false;
-            referencedRelation: 'sessions';
-            referencedColumns: ['id'];
-          },
-          {
-            foreignKeyName: 'session_transcript_archives_user_id_fkey';
-            columns: ['user_id'];
-            isOneToOne: false;
-            referencedRelation: 'users';
-            referencedColumns: ['id'];
-          },
-        ];
-      };
       session_logs: {
         Row: {
           compacted_at: string | null;

--- a/packages/api/src/mcp/tools/memory-handlers.test.ts
+++ b/packages/api/src/mcp/tools/memory-handlers.test.ts
@@ -1252,7 +1252,8 @@ describe('handleStartSession - threadKey matching', () => {
       'user-123',
       'lumen',
       'pr:32',
-      undefined
+      undefined,
+      undefined // contactId
     );
     // Should NOT have fallen through to studioId lookup
     expect(mockDataComposer.repositories.memory.getActiveSession).not.toHaveBeenCalled();
@@ -1318,7 +1319,8 @@ describe('handleStartSession - threadKey matching', () => {
       'user-123',
       'lumen',
       'pr:32',
-      studioId
+      studioId,
+      undefined // contactId
     );
   });
 

--- a/packages/api/src/mcp/tools/memory-handlers.ts
+++ b/packages/api/src/mcp/tools/memory-handlers.ts
@@ -245,6 +245,13 @@ export const rememberSchema = userIdentifierBaseSchema.extend({
     .string()
     .optional()
     .describe('Which AI being created this memory (e.g., "wren", "benson"). Null = shared memory.'),
+  contactId: z
+    .string()
+    .uuid()
+    .optional()
+    .describe(
+      'Contact ID for per-sender memory scoping. Auto-inherited from session context when available. Null = owner/system memory.'
+    ),
   studioId: z
     .string()
     .uuid()
@@ -275,6 +282,13 @@ export const recallSchema = userIdentifierBaseSchema.extend({
     .boolean()
     .optional()
     .describe('Include shared memories (agentId=null) when filtering by agentId (default: true)'),
+  contactId: z
+    .string()
+    .uuid()
+    .optional()
+    .describe(
+      'Filter by contact ID for per-sender memory isolation. When set, only returns memories scoped to this contact.'
+    ),
 });
 
 export const forgetSchema = userIdentifierBaseSchema.extend({
@@ -561,6 +575,7 @@ export async function handleRemember(args: unknown, dataComposer: DataComposer) 
     metadata,
     expiresAt: params.expiresAt ? new Date(params.expiresAt) : undefined,
     agentId,
+    contactId: params.contactId,
   });
 
   logger.info(`Memory created for user ${user.id}`, {
@@ -612,6 +627,7 @@ export async function handleRecall(args: unknown, dataComposer: DataComposer) {
     includeExpired: params.includeExpired,
     agentId: params.agentId,
     includeShared: params.includeShared,
+    contactId: params.contactId,
   });
 
   logger.info(`Recalled ${memories.length} memories for user ${user.id}`, {

--- a/packages/api/src/mcp/tools/memory-handlers.ts
+++ b/packages/api/src/mcp/tools/memory-handlers.ts
@@ -12,7 +12,12 @@ import type { DataComposer } from '../../data/composer';
 import type { Json } from '../../data/supabase/types';
 import { logger } from '../../utils/logger';
 import { userIdentifierBaseSchema, resolveUserOrThrow } from '../../services/user-resolver';
-import { setSessionContext, pinSessionAgent, getRequestContext } from '../../utils/request-context';
+import {
+  setSessionContext,
+  getSessionContext,
+  pinSessionAgent,
+  getRequestContext,
+} from '../../utils/request-context';
 import { getEffectiveAgentId } from '../../auth/enforce-identity';
 import type { MemorySource, Salience, Session } from '../../data/models/memory';
 import { getCloudSkillsService } from '../../skills/cloud-service';
@@ -50,6 +55,20 @@ const salienceSchema = z.enum(['low', 'medium', 'high', 'critical']);
 
 function resolveStudioId(params: { studioId?: string }): string | undefined {
   return params.studioId;
+}
+
+/**
+ * Resolve contactId from explicit param or session context.
+ * This is the auto-inheritance mechanism: once a contact-scoped session
+ * is started, all memory tools in that session automatically scope to
+ * the same contact without the SB needing to pass contactId explicitly.
+ */
+function resolveContactId(params: { contactId?: string }): string | undefined {
+  if (params.contactId) return params.contactId;
+  const reqCtx = getRequestContext();
+  if (reqCtx?.contactId) return reqCtx.contactId;
+  const sessCtx = getSessionContext();
+  return sessCtx?.contactId;
 }
 
 /** Coerce a comma-separated string into a string array so callers can pass either format. */
@@ -571,6 +590,8 @@ export async function handleRemember(args: unknown, dataComposer: DataComposer) 
     ...(params.topicSummary ? { topicSummary: params.topicSummary } : {}),
   };
 
+  const contactId = resolveContactId(params);
+
   const memory = await dataComposer.repositories.memory.remember({
     userId: user.id,
     content: params.content,
@@ -582,7 +603,7 @@ export async function handleRemember(args: unknown, dataComposer: DataComposer) 
     metadata,
     expiresAt: params.expiresAt ? new Date(params.expiresAt) : undefined,
     agentId,
-    contactId: params.contactId,
+    contactId,
   });
 
   logger.info(`Memory created for user ${user.id}`, {
@@ -625,6 +646,8 @@ export async function handleRecall(args: unknown, dataComposer: DataComposer) {
   const params = recallSchema.parse(args);
   const { user, resolvedBy } = await resolveUserOrThrow(params, dataComposer);
 
+  const contactId = resolveContactId(params);
+
   const memories = await dataComposer.repositories.memory.recall(user.id, params.query, {
     recallMode: params.recallMode,
     source: params.source as MemorySource,
@@ -634,7 +657,7 @@ export async function handleRecall(args: unknown, dataComposer: DataComposer) {
     includeExpired: params.includeExpired,
     agentId: params.agentId,
     includeShared: params.includeShared,
-    contactId: params.contactId,
+    contactId,
   });
 
   logger.info(`Recalled ${memories.length} memories for user ${user.id}`, {
@@ -763,7 +786,8 @@ export async function handleStartSession(args: unknown, dataComposer: DataCompos
       user.id,
       agentId,
       params.threadKey,
-      studioId
+      studioId,
+      params.contactId
     );
   }
 
@@ -830,6 +854,24 @@ export async function handleStartSession(args: unknown, dataComposer: DataCompos
     await dataComposer.repositories.memory.updateSession(session.id, {
       cliAttached: true,
     });
+  }
+
+  // Persist contactId in session context so memory tools auto-inherit it.
+  // This is the key mechanism for per-sender isolation: once a contact-scoped
+  // session is started, all subsequent remember/recall calls in this session
+  // automatically scope to the same contact without the SB needing to pass it.
+  if (params.contactId) {
+    const currentCtx = getRequestContext();
+    if (currentCtx) {
+      // HTTP mode: no-op, per-request context is already set
+    } else {
+      // stdio mode: update the session-scoped context
+      setSessionContext({
+        userId: user.id,
+        agentId,
+        contactId: params.contactId,
+      });
+    }
   }
 
   logger.info(`Session started for user ${user.id}`, {

--- a/packages/api/src/mcp/tools/memory-handlers.ts
+++ b/packages/api/src/mcp/tools/memory-handlers.ts
@@ -334,6 +334,13 @@ export const startSessionSchema = userIdentifierBaseSchema.extend({
     .optional()
     .describe('Backend runtime (e.g., "claude-code", "codex", "gemini")'),
   model: z.string().optional().describe('Model identifier (e.g., "opus-4-6", "sonnet", "o3")'),
+  contactId: z
+    .string()
+    .uuid()
+    .optional()
+    .describe(
+      'Contact ID for per-sender session isolation. When set, the session is scoped to this contact.'
+    ),
   metadata: z.record(z.unknown()).optional().describe('Additional session metadata'),
   forceNew: z
     .boolean()
@@ -764,7 +771,8 @@ export async function handleStartSession(args: unknown, dataComposer: DataCompos
     existingSession = await dataComposer.repositories.memory.getActiveSession(
       user.id,
       agentId,
-      studioId
+      studioId,
+      params.contactId
     );
   }
 
@@ -811,6 +819,7 @@ export async function handleStartSession(args: unknown, dataComposer: DataCompos
     backend: params.backend,
     model: params.model,
     metadata: params.metadata,
+    contactId: params.contactId,
   });
 
   // Persist CLI-attached flag from request context to session record.

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -6404,4 +6404,63 @@ router.delete('/tasks/:taskId/comments/:commentId', async (req: Request, res: Re
   }
 });
 
+// =============================================================================
+// Contacts
+// =============================================================================
+
+/**
+ * POST /api/admin/contacts/resolve
+ * Resolve a platform identity to a contact, optionally auto-creating.
+ * Used by `sb chat --sender telegram:123` for per-sender session isolation.
+ */
+router.post('/contacts/resolve', async (req: Request, res: Response) => {
+  try {
+    const authReq = req as AdminAuthRequest;
+    const { platform, platformId, autoCreate } = req.body as {
+      platform?: string;
+      platformId?: string;
+      autoCreate?: boolean;
+    };
+
+    if (!platform || !platformId) {
+      res.status(400).json({ error: 'platform and platformId are required' });
+      return;
+    }
+
+    const validPlatforms = ['telegram', 'discord', 'whatsapp', 'imessage'] as const;
+    if (!validPlatforms.includes(platform as (typeof validPlatforms)[number])) {
+      res
+        .status(400)
+        .json({ error: `Invalid platform. Must be one of: ${validPlatforms.join(', ')}` });
+      return;
+    }
+
+    const dataComposer = await getDataComposer();
+    const contactsRepo = dataComposer.repositories.contacts;
+
+    if (autoCreate) {
+      const contact = await contactsRepo.findOrCreateByPlatformId(
+        authReq.pcpUserId,
+        platform as 'telegram' | 'discord' | 'whatsapp' | 'imessage',
+        platformId
+      );
+      res.json({ contact });
+    } else {
+      const contact = await contactsRepo.findByPlatformId(
+        authReq.pcpUserId,
+        platform as 'telegram' | 'discord' | 'whatsapp' | 'imessage',
+        platformId
+      );
+      if (!contact) {
+        res.status(404).json({ error: 'Contact not found' });
+        return;
+      }
+      res.json({ contact });
+    }
+  } catch (error) {
+    logger.error('Failed to resolve contact:', error);
+    res.status(500).json(errorJson('Failed to resolve contact', error));
+  }
+});
+
 export default router;

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -209,6 +209,51 @@ async function startServer(config: ServerConfig = {}): Promise<void> {
       }
     }
 
+    // Resolve contact for per-sender session isolation
+    let contactId: string | undefined;
+    const isExternalChannelForContact =
+      channel === 'telegram' ||
+      channel === 'whatsapp' ||
+      channel === 'discord' ||
+      channel === 'slack';
+    if (isExternalChannelForContact && dataComposer) {
+      try {
+        const platformMap: Record<string, 'telegram' | 'discord' | 'whatsapp' | 'imessage'> = {
+          telegram: 'telegram',
+          discord: 'discord',
+          whatsapp: 'whatsapp',
+          slack: 'discord', // Slack uses discord slot
+        };
+        const contactPlatform = platformMap[channel];
+        if (contactPlatform) {
+          if (isGroupChat) {
+            const groupContact = await dataComposer.repositories.contacts.findOrCreateGroupContact(
+              userId,
+              channel as 'telegram' | 'discord' | 'whatsapp' | 'slack',
+              conversationId,
+              { groupName: (metadata as Record<string, unknown>)?.groupName as string | undefined }
+            );
+            contactId = groupContact.id;
+          } else {
+            const senderContact = await dataComposer.repositories.contacts.findOrCreateByPlatformId(
+              userId,
+              contactPlatform,
+              sender.id,
+              { name: sender.name, username: sender.name }
+            );
+            contactId = senderContact.id;
+          }
+        }
+      } catch (contactError) {
+        // Don't fail message processing if contact resolution fails
+        logger.warn('Failed to resolve contact for sender', {
+          channel,
+          senderId: sender.id,
+          error: contactError instanceof Error ? contactError.message : String(contactError),
+        });
+      }
+    }
+
     // Build SessionRequest
     const request: SessionRequest = {
       userId,
@@ -227,6 +272,7 @@ async function startServer(config: ServerConfig = {}): Promise<void> {
         media: metadata?.media,
         triggerType: 'message',
         ...(routeStudioHint ? { studioHint: routeStudioHint } : {}),
+        ...(contactId ? { contactId } : {}),
       },
     };
 

--- a/packages/api/src/services/sessions/context-builder.ts
+++ b/packages/api/src/services/sessions/context-builder.ts
@@ -135,7 +135,7 @@ export class ContextBuilder implements IContextBuilder {
       this.getAgentIdentity(userId, agentId, session.identityId),
       this.getUser(userId),
       this.getContacts(userId),
-      this.getRecentMemories(userId, agentId),
+      this.getRecentMemories(userId, agentId, 10, session.contactId),
       this.getActiveProjects(userId),
     ]);
 
@@ -323,16 +323,24 @@ export class ContextBuilder implements IContextBuilder {
   private async getRecentMemories(
     userId: string,
     agentId: string,
-    limit: number = 10
+    limit: number = 10,
+    contactId?: string
   ): Promise<DbMemory[]> {
     // Get memories for this agent + shared memories (agentId = null)
-    const { data, error } = await this.supabase
+    let query = this.supabase
       .from('memories')
       .select('*')
       .eq('user_id', userId)
       .or(`agent_id.eq.${agentId},agent_id.is.null`)
       .order('created_at', { ascending: false })
       .limit(limit);
+
+    // Per-sender isolation: only show contact-scoped memories
+    if (contactId) {
+      query = query.eq('contact_id', contactId);
+    }
+
+    const { data, error } = await query;
 
     if (error) {
       logger.error('Error fetching recent memories', { userId, agentId, error });

--- a/packages/api/src/services/sessions/per-sender-isolation.test.ts
+++ b/packages/api/src/services/sessions/per-sender-isolation.test.ts
@@ -164,15 +164,35 @@ describe('Per-Sender Session Isolation', () => {
       expect(session).toBeNull();
     });
 
-    it('should not filter by contact_id when not provided (owner session)', async () => {
+    it('should not filter by contact_id when options not provided (backward compat)', async () => {
       const { supabase, filters } = createMockSupabase();
       const repo = new SessionRepository(supabase as never);
 
+      // No options at all — backward compatible, no contact filtering
       await repo.findByUserAndAgent('user-1', 'myra');
 
-      // Verify contact_id filter was NOT applied
-      const contactFilters = filters.filter((f) => f.method === 'eq' && f.args[0] === 'contact_id');
-      expect(contactFilters).toHaveLength(0);
+      const contactEqFilters = filters.filter(
+        (f) => f.method === 'eq' && f.args[0] === 'contact_id'
+      );
+      const contactIsFilters = filters.filter(
+        (f) => f.method === 'is' && f.args[0] === 'contact_id'
+      );
+      expect(contactEqFilters).toHaveLength(0);
+      expect(contactIsFilters).toHaveLength(0);
+    });
+
+    it('should filter for contact_id IS NULL when contactId explicitly undefined (owner session)', async () => {
+      const { supabase, filters } = createMockSupabase();
+      const repo = new SessionRepository(supabase as never);
+
+      // Owner session: contactId key is present but undefined → filter IS NULL
+      // This is how session-service calls it for owner requests
+      await repo.findByUserAndAgent('user-1', 'myra', { contactId: undefined });
+
+      const contactIsNull = filters.find(
+        (f) => f.method === 'is' && f.args[0] === 'contact_id' && f.args[1] === null
+      );
+      expect(contactIsNull).toBeDefined();
     });
   });
 

--- a/packages/api/src/services/sessions/per-sender-isolation.test.ts
+++ b/packages/api/src/services/sessions/per-sender-isolation.test.ts
@@ -1,0 +1,331 @@
+/**
+ * Per-Sender Session Isolation Tests
+ *
+ * Tests that contact_id properly scopes sessions and memories
+ * so external senders get isolated conversation context.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SessionRepository } from './session-repository.js';
+
+vi.mock('../../utils/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+/**
+ * Builds a mock Supabase client that tracks query filters
+ * so we can verify contact_id is passed through.
+ */
+function createMockSupabase(rows: Record<string, unknown>[] = []) {
+  const filters: Array<{ method: string; args: unknown[] }> = [];
+
+  const fakeRow = {
+    id: 'sess-1',
+    user_id: 'user-1',
+    identity_id: null,
+    agent_id: 'myra',
+    studio_id: null,
+    contact_id: null,
+    workspace_id: null,
+    thread_key: null,
+    lifecycle: 'idle',
+    status: 'active',
+    current_phase: null,
+    backend: 'claude-code',
+    model: null,
+    backend_session_id: null,
+    claude_session_id: null,
+    working_dir: null,
+    context: null,
+    started_at: '2026-03-25T08:00:00.000Z',
+    ended_at: null,
+    summary: null,
+    updated_at: '2026-03-25T08:00:00.000Z',
+    message_count: 0,
+    token_count: 0,
+    metadata: {},
+    compacting_since: null,
+  };
+
+  const builder: Record<string, unknown> = {};
+
+  for (const method of [
+    'select',
+    'insert',
+    'update',
+    'eq',
+    'neq',
+    'is',
+    'or',
+    'order',
+    'limit',
+    'gte',
+  ]) {
+    builder[method] = vi.fn().mockImplementation((...args: unknown[]) => {
+      filters.push({ method, args });
+      return builder;
+    });
+  }
+
+  // Single returns the first row or the configured rows
+  builder.single = vi.fn().mockImplementation(() => {
+    if (rows.length > 0) {
+      return Promise.resolve({ data: rows[0], error: null });
+    }
+    return Promise.resolve({ data: { ...fakeRow }, error: null });
+  });
+
+  // Direct await returns array
+  builder.then = (resolve: (value: unknown) => void) => {
+    const result = { data: rows.length > 0 ? rows : [fakeRow], error: null };
+    resolve(result);
+    return Promise.resolve(result);
+  };
+
+  const supabase = {
+    from: vi.fn().mockReturnValue(builder),
+  };
+
+  return { supabase, builder, filters, fakeRow };
+}
+
+describe('Per-Sender Session Isolation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('SessionRepository.findByUserAndAgent with contactId', () => {
+    it('should filter by contact_id when provided', async () => {
+      const contactRow = {
+        id: 'sess-contact-1',
+        user_id: 'user-1',
+        agent_id: 'myra',
+        contact_id: 'contact-alice',
+        identity_id: null,
+        studio_id: null,
+        workspace_id: null,
+        thread_key: null,
+        lifecycle: 'idle',
+        status: 'active',
+        current_phase: null,
+        backend: 'claude-code',
+        model: null,
+        backend_session_id: null,
+        claude_session_id: null,
+        working_dir: null,
+        context: null,
+        started_at: '2026-03-25T08:00:00.000Z',
+        ended_at: null,
+        summary: null,
+        updated_at: '2026-03-25T08:00:00.000Z',
+        message_count: 5,
+        token_count: 1000,
+        metadata: {},
+        compacting_since: null,
+      };
+
+      const { supabase, filters } = createMockSupabase([contactRow]);
+      const repo = new SessionRepository(supabase as never);
+
+      const session = await repo.findByUserAndAgent('user-1', 'myra', {
+        contactId: 'contact-alice',
+      });
+
+      expect(session).not.toBeNull();
+      expect(session!.contactId).toBe('contact-alice');
+
+      // Verify contact_id filter was applied
+      const eqCalls = filters.filter((f) => f.method === 'eq');
+      const contactFilter = eqCalls.find(
+        (f) => f.args[0] === 'contact_id' && f.args[1] === 'contact-alice'
+      );
+      expect(contactFilter).toBeDefined();
+    });
+
+    it('should return null when no session matches the contact_id', async () => {
+      const { supabase } = createMockSupabase([]);
+      // Override single to return not found
+      const builder = supabase.from();
+      builder.then = (resolve: (value: unknown) => void) => {
+        resolve({ data: [], error: null });
+        return Promise.resolve({ data: [], error: null });
+      };
+
+      const repo = new SessionRepository(supabase as never);
+      const session = await repo.findByUserAndAgent('user-1', 'myra', {
+        contactId: 'contact-unknown',
+      });
+
+      expect(session).toBeNull();
+    });
+
+    it('should not filter by contact_id when not provided (owner session)', async () => {
+      const { supabase, filters } = createMockSupabase();
+      const repo = new SessionRepository(supabase as never);
+
+      await repo.findByUserAndAgent('user-1', 'myra');
+
+      // Verify contact_id filter was NOT applied
+      const contactFilters = filters.filter((f) => f.method === 'eq' && f.args[0] === 'contact_id');
+      expect(contactFilters).toHaveLength(0);
+    });
+  });
+
+  describe('SessionRepository.findByThreadKey with contactId', () => {
+    it('should include contact_id filter in thread key lookup', async () => {
+      const { supabase, filters } = createMockSupabase();
+      const repo = new SessionRepository(supabase as never);
+
+      await repo.findByThreadKey('user-1', 'myra', 'thread:billsplit', undefined, 'contact-alice');
+
+      const contactFilter = filters.find(
+        (f) => f.method === 'eq' && f.args[0] === 'contact_id' && f.args[1] === 'contact-alice'
+      );
+      expect(contactFilter).toBeDefined();
+    });
+  });
+
+  describe('Session contactId mapping', () => {
+    it('should map contact_id from DB row to Session.contactId', async () => {
+      const rowWithContact = {
+        id: 'sess-1',
+        user_id: 'user-1',
+        agent_id: 'myra',
+        contact_id: 'contact-bob',
+        identity_id: null,
+        studio_id: null,
+        workspace_id: null,
+        thread_key: null,
+        lifecycle: 'idle',
+        status: 'active',
+        current_phase: null,
+        backend: 'claude-code',
+        model: null,
+        backend_session_id: null,
+        claude_session_id: null,
+        working_dir: null,
+        context: null,
+        started_at: '2026-03-25T08:00:00.000Z',
+        ended_at: null,
+        summary: null,
+        updated_at: '2026-03-25T08:00:00.000Z',
+        message_count: 0,
+        token_count: 0,
+        metadata: {},
+        compacting_since: null,
+      };
+
+      const { supabase } = createMockSupabase([rowWithContact]);
+      const repo = new SessionRepository(supabase as never);
+
+      const session = await repo.findById('sess-1');
+      expect(session).not.toBeNull();
+      expect(session!.contactId).toBe('contact-bob');
+    });
+
+    it('should map null contact_id to undefined (owner session)', async () => {
+      const rowWithoutContact = {
+        id: 'sess-1',
+        user_id: 'user-1',
+        agent_id: 'wren',
+        contact_id: null,
+        identity_id: null,
+        studio_id: null,
+        workspace_id: null,
+        thread_key: null,
+        lifecycle: 'running',
+        status: 'active',
+        current_phase: null,
+        backend: 'claude-code',
+        model: null,
+        backend_session_id: 'abc123',
+        claude_session_id: null,
+        working_dir: null,
+        context: null,
+        started_at: '2026-03-25T08:00:00.000Z',
+        ended_at: null,
+        summary: null,
+        updated_at: '2026-03-25T08:00:00.000Z',
+        message_count: 10,
+        token_count: 5000,
+        metadata: {},
+        compacting_since: null,
+      };
+
+      const { supabase } = createMockSupabase([rowWithoutContact]);
+      const repo = new SessionRepository(supabase as never);
+
+      const session = await repo.findById('sess-1');
+      expect(session).not.toBeNull();
+      expect(session!.contactId).toBeUndefined();
+    });
+  });
+
+  describe('Session creation with contactId', () => {
+    it('should include contact_id in insert payload', async () => {
+      const { supabase, filters } = createMockSupabase();
+      const repo = new SessionRepository(supabase as never);
+
+      await repo.create({
+        userId: 'user-1',
+        agentId: 'myra',
+        contactId: 'contact-alice',
+        backendSessionId: null,
+        type: 'primary',
+        lifecycle: 'idle',
+        status: 'active',
+        contextTokens: 0,
+        totalInputTokens: 0,
+        totalOutputTokens: 0,
+        messageCount: 0,
+        tokenCount: 0,
+        backend: 'claude-code',
+        model: null,
+        lastCompactionAt: null,
+        compactionCount: 0,
+        endedAt: null,
+        metadata: {},
+      });
+
+      // Verify insert was called with contact_id
+      const insertCalls = filters.filter((f) => f.method === 'insert');
+      expect(insertCalls.length).toBeGreaterThan(0);
+      const insertPayload = insertCalls[0].args[0] as Record<string, unknown>;
+      expect(insertPayload.contact_id).toBe('contact-alice');
+    });
+
+    it('should set contact_id to null for owner sessions', async () => {
+      const { supabase, filters } = createMockSupabase();
+      const repo = new SessionRepository(supabase as never);
+
+      await repo.create({
+        userId: 'user-1',
+        agentId: 'wren',
+        backendSessionId: null,
+        type: 'primary',
+        lifecycle: 'idle',
+        status: 'active',
+        contextTokens: 0,
+        totalInputTokens: 0,
+        totalOutputTokens: 0,
+        messageCount: 0,
+        tokenCount: 0,
+        backend: 'claude-code',
+        model: null,
+        lastCompactionAt: null,
+        compactionCount: 0,
+        endedAt: null,
+        metadata: {},
+      });
+
+      const insertCalls = filters.filter((f) => f.method === 'insert');
+      const insertPayload = insertCalls[0].args[0] as Record<string, unknown>;
+      expect(insertPayload.contact_id).toBeNull();
+    });
+  });
+});

--- a/packages/api/src/services/sessions/session-repository.ts
+++ b/packages/api/src/services/sessions/session-repository.ts
@@ -37,6 +37,7 @@ function mapDbToSession(row: DbSession): Session {
     agentId: row.agent_id || '',
     identityId: row.identity_id || undefined,
     studioId: row.studio_id || undefined,
+    contactId: row.contact_id || undefined,
     backendSessionId: row.backend_session_id || row.claude_session_id,
 
     type: (metadata.type as SessionType) || 'primary',
@@ -97,6 +98,7 @@ function mapSessionToDb(
     backend: session.backend,
     model: session.model,
     studio_id: session.studioId || null,
+    contact_id: session.contactId || null,
     thread_key: session.threadKey || null,
     metadata: {
       type: session.type,
@@ -132,7 +134,7 @@ export class SessionRepository implements ISessionRepository {
   async findByUserAndAgent(
     userId: string,
     agentId: string,
-    options?: { status?: SessionStatus; type?: SessionType; studioId?: string }
+    options?: { status?: SessionStatus; type?: SessionType; studioId?: string; contactId?: string }
   ): Promise<Session | null> {
     let query = this.supabase
       .from('sessions')
@@ -146,6 +148,15 @@ export class SessionRepository implements ISessionRepository {
 
     if (options?.studioId) {
       query = query.eq('studio_id', options.studioId);
+    }
+
+    // Contact-scoped session isolation: match by contact_id when provided,
+    // or filter to NULL contact_id for owner/system sessions
+    if (options?.contactId) {
+      query = query.eq('contact_id', options.contactId);
+    } else if (options && 'contactId' in options) {
+      // Explicitly passed contactId: undefined → match NULL (owner session)
+      query = query.is('contact_id', null);
     }
 
     if (options?.status) {
@@ -181,7 +192,8 @@ export class SessionRepository implements ISessionRepository {
     userId: string,
     agentId: string,
     threadKey: string,
-    studioId?: string
+    studioId?: string,
+    contactId?: string
   ): Promise<Session | null> {
     let query = this.supabase
       .from('sessions')
@@ -196,6 +208,10 @@ export class SessionRepository implements ISessionRepository {
 
     if (studioId) {
       query = query.eq('studio_id', studioId);
+    }
+
+    if (contactId) {
+      query = query.eq('contact_id', contactId);
     }
 
     const { data, error } = await query;

--- a/packages/api/src/services/sessions/session-service.test.ts
+++ b/packages/api/src/services/sessions/session-service.test.ts
@@ -1132,7 +1132,9 @@ describe('SessionService', () => {
       expect(mockRepoWithThreadKey.findByThreadKey).toHaveBeenCalledWith(
         'user-456',
         'myra',
-        'pr:43'
+        'pr:43',
+        undefined, // studioId
+        undefined // contactId
       );
       // Should NOT have created a new session
       expect(mockRepoWithThreadKey.create).not.toHaveBeenCalled();
@@ -1178,7 +1180,9 @@ describe('SessionService', () => {
       expect(mockRepoWithThreadKey.findByThreadKey).toHaveBeenCalledWith(
         'user-456',
         'myra',
-        'pr:999'
+        'pr:999',
+        undefined, // studioId
+        undefined // contactId
       );
       expect(mockRepoWithThreadKey.findByUserAndAgent).not.toHaveBeenCalled();
       expect(mockRepoWithThreadKey.create).toHaveBeenCalledWith(

--- a/packages/api/src/services/sessions/session-service.ts
+++ b/packages/api/src/services/sessions/session-service.ts
@@ -229,6 +229,7 @@ export class SessionService implements ISessionService {
         studioId: metadata?.studioId,
         studioHint: metadata?.studioHint,
         recipientSessionId: metadata?.recipientSessionId,
+        contactId: metadata?.contactId,
       });
 
       // 2. Build lock key - must be per agent + session to support sub-agents
@@ -609,6 +610,7 @@ export class SessionService implements ISessionService {
       studioId?: string;
       studioHint?: string;
       recipientSessionId?: string;
+      contactId?: string;
     }
   ): Promise<Session> {
     const type = options?.type || 'primary';
@@ -680,6 +682,7 @@ export class SessionService implements ISessionService {
         const existing = await this.repository.findByUserAndAgent(userId, agentId, {
           type: 'primary',
           ...(resolvedStudioId ? { studioId: resolvedStudioId } : {}),
+          ...(options?.contactId ? { contactId: options.contactId } : {}),
         });
 
         if (existing) {
@@ -712,6 +715,7 @@ export class SessionService implements ISessionService {
       parentSessionId: options?.parentSessionId,
       threadKey: options?.threadKey,
       studioId: resolvedStudioId,
+      contactId: options?.contactId,
       contextTokens: 0,
       totalInputTokens: 0,
       totalOutputTokens: 0,

--- a/packages/api/src/services/sessions/session-service.ts
+++ b/packages/api/src/services/sessions/session-service.ts
@@ -646,11 +646,21 @@ export class SessionService implements ISessionService {
       // ThreadKey match takes priority — find session scoped to this topic
       if (options?.threadKey && 'findByThreadKey' in this.repository) {
         const threadRepo = this.repository as {
-          findByThreadKey: (u: string, a: string, t: string, s?: string) => Promise<Session | null>;
+          findByThreadKey: (
+            u: string,
+            a: string,
+            t: string,
+            s?: string,
+            c?: string
+          ) => Promise<Session | null>;
         };
-        const threadMatch = resolvedStudioId
-          ? await threadRepo.findByThreadKey(userId, agentId, options.threadKey, resolvedStudioId)
-          : await threadRepo.findByThreadKey(userId, agentId, options.threadKey);
+        const threadMatch = await threadRepo.findByThreadKey(
+          userId,
+          agentId,
+          options.threadKey,
+          resolvedStudioId,
+          options?.contactId
+        );
         if (threadMatch) {
           logger.debug('Found existing session by threadKey', {
             sessionId: threadMatch.id,

--- a/packages/api/src/services/sessions/session-service.ts
+++ b/packages/api/src/services/sessions/session-service.ts
@@ -689,10 +689,12 @@ export class SessionService implements ISessionService {
 
       if (!options?.threadKey) {
         // Fall back to general active session match only for non-threaded requests.
+        // Always pass contactId to enforce isolation: contact sessions match their
+        // contact, owner sessions (contactId=undefined) match only NULL rows.
         const existing = await this.repository.findByUserAndAgent(userId, agentId, {
           type: 'primary',
           ...(resolvedStudioId ? { studioId: resolvedStudioId } : {}),
-          ...(options?.contactId ? { contactId: options.contactId } : {}),
+          contactId: options?.contactId,
         });
 
         if (existing) {

--- a/packages/api/src/services/sessions/types.ts
+++ b/packages/api/src/services/sessions/types.ts
@@ -52,6 +52,8 @@ export interface Session {
   identityId?: string;
   /** Studio/worktree scope for this session */
   studioId?: string;
+  /** Contact scope for per-sender session isolation */
+  contactId?: string;
   /** Backend-specific session ID for resume (Claude Code, Codex thread UUID, Gemini session) */
   backendSessionId: string | null;
 
@@ -123,6 +125,8 @@ export interface SessionRequest {
     studioId?: string;
     // Convenience routing hint (e.g., force main studio without UUID lookup)
     studioHint?: string;
+    // Contact scope for per-sender session isolation
+    contactId?: string;
     // Recipient session to inherit studio scope from
     recipientSessionId?: string;
     // For task sessions
@@ -258,6 +262,7 @@ export interface ISessionService {
       studioId?: string;
       studioHint?: string;
       recipientSessionId?: string;
+      contactId?: string;
     }
   ): Promise<Session>;
 
@@ -312,7 +317,7 @@ export interface ISessionRepository {
   findByUserAndAgent(
     userId: string,
     agentId: string,
-    options?: { status?: SessionStatus; type?: SessionType; studioId?: string }
+    options?: { status?: SessionStatus; type?: SessionType; studioId?: string; contactId?: string }
   ): Promise<Session | null>;
 
   findByThreadKey?(

--- a/packages/api/src/utils/request-context.ts
+++ b/packages/api/src/utils/request-context.ts
@@ -41,6 +41,8 @@ export interface RequestContextData {
   workspaceSource?: 'header' | 'default' | 'derived' | 'session';
   /** Conversation ID for channel routing */
   conversationId?: string;
+  /** Contact ID for per-sender session isolation */
+  contactId?: string;
   /** Request timestamp */
   timestamp: Date;
   /** Caller profile for MCP access control */

--- a/packages/cli/src/commands/chat.integration.test.ts
+++ b/packages/cli/src/commands/chat.integration.test.ts
@@ -1941,4 +1941,165 @@ describe('runChat integration', () => {
     const logText = stripAnsi(logSpy.mock.calls.flat().join('\n'));
     expect(logText).toContain('[delegation:wren->lumen:send_to_inbox]');
   });
+
+  // ─── Per-Sender Session Isolation Tests ───
+
+  describe('per-sender session isolation', () => {
+    it('passes contactId to start_session when --contact-id is provided', async () => {
+      testState.inputs = ['/quit'];
+
+      await runChat({
+        agent: 'myra',
+        backend: 'claude',
+        contactId: 'contact-alice-uuid',
+        pollSeconds: '999',
+      });
+
+      const startCall = testState.pcpCalls.find((call) => call.tool === 'start_session');
+      expect(startCall).toBeDefined();
+      expect(startCall!.args.contactId).toBe('contact-alice-uuid');
+    });
+
+    it('creates separate sessions for different contacts', async () => {
+      // Sender A
+      testState.callToolImpl.mockImplementation(async (tool: string) => {
+        switch (tool) {
+          case 'bootstrap':
+            return { user: { timezone: 'America/Los_Angeles' } };
+          case 'start_session':
+            return { session: { id: 'sess-alice' } };
+          case 'get_inbox':
+            return { messages: [] };
+          default:
+            return { success: true };
+        }
+      });
+      testState.inputs = ['/quit'];
+
+      await runChat({
+        agent: 'myra',
+        backend: 'claude',
+        contactId: 'contact-alice',
+        pollSeconds: '999',
+      });
+
+      const aliceStart = testState.pcpCalls.find((c) => c.tool === 'start_session');
+      expect(aliceStart!.args.contactId).toBe('contact-alice');
+
+      // Reset for Sender B
+      testState.pcpCalls = [];
+      testState.callToolImpl.mockImplementation(async (tool: string) => {
+        switch (tool) {
+          case 'bootstrap':
+            return { user: { timezone: 'America/Los_Angeles' } };
+          case 'start_session':
+            return { session: { id: 'sess-bob' } };
+          case 'get_inbox':
+            return { messages: [] };
+          default:
+            return { success: true };
+        }
+      });
+      testState.inputs = ['/quit'];
+
+      await runChat({
+        agent: 'myra',
+        backend: 'claude',
+        contactId: 'contact-bob',
+        pollSeconds: '999',
+      });
+
+      const bobStart = testState.pcpCalls.find((c) => c.tool === 'start_session');
+      expect(bobStart!.args.contactId).toBe('contact-bob');
+
+      // Different contacts → different session IDs requested
+      expect(aliceStart!.args.contactId).not.toBe(bobStart!.args.contactId);
+    });
+
+    it('does not pass contactId for normal owner sessions', async () => {
+      testState.inputs = ['/quit'];
+
+      await runChat({
+        agent: 'wren',
+        backend: 'claude',
+        pollSeconds: '999',
+      });
+
+      const startCall = testState.pcpCalls.find((call) => call.tool === 'start_session');
+      expect(startCall).toBeDefined();
+      expect(startCall!.args.contactId).toBeUndefined();
+    });
+
+    it('resolves --sender via API and passes contactId', async () => {
+      // Mock the fetch call to /api/admin/contacts/resolve
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = vi.fn().mockImplementation(async (url: string | URL) => {
+        const urlStr = typeof url === 'string' ? url : url.toString();
+        if (urlStr.includes('/api/admin/contacts/resolve')) {
+          return {
+            ok: true,
+            json: async () => ({
+              contact: { id: 'resolved-contact-123', name: 'telegram:55512345' },
+            }),
+          } as Response;
+        }
+        return originalFetch(url);
+      }) as typeof fetch;
+
+      // Mock auth token resolution
+      vi.doMock('../auth/tokens.js', () => ({
+        getValidAccessToken: async () => 'test-token-123',
+      }));
+
+      testState.inputs = ['/quit'];
+
+      await runChat({
+        agent: 'myra',
+        backend: 'claude',
+        sender: 'telegram:55512345',
+        pollSeconds: '999',
+      });
+
+      const startCall = testState.pcpCalls.find((call) => call.tool === 'start_session');
+      expect(startCall).toBeDefined();
+      expect(startCall!.args.contactId).toBe('resolved-contact-123');
+
+      // Restore
+      globalThis.fetch = originalFetch;
+      vi.doUnmock('../auth/tokens.js');
+    });
+
+    it('sends user message through backend with contact-scoped session', async () => {
+      testState.callToolImpl.mockImplementation(async (tool: string) => {
+        switch (tool) {
+          case 'bootstrap':
+            return { user: { timezone: 'America/Los_Angeles' } };
+          case 'start_session':
+            return { session: { id: 'sess-contact-1' } };
+          case 'get_inbox':
+            return { messages: [] };
+          default:
+            return { success: true };
+        }
+      });
+
+      testState.inputs = ['what is my balance?', '/quit'];
+
+      await runChat({
+        agent: 'myra',
+        backend: 'claude',
+        contactId: 'contact-alice',
+        pollSeconds: '999',
+      });
+
+      // Backend should have been called with the user's message
+      expect(testState.runBackendImpl).toHaveBeenCalledTimes(1);
+      const backendRequest = testState.runBackendImpl.mock.calls[0][0] as { prompt: string };
+      expect(backendRequest.prompt).toContain('what is my balance?');
+
+      // Session should have been started with contactId
+      const startCall = testState.pcpCalls.find((call) => call.tool === 'start_session');
+      expect(startCall!.args.contactId).toBe('contact-alice');
+    });
+  });
 });

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -1884,34 +1884,52 @@ export async function runChat(options: ChatOptions): Promise<void> {
   if (options.contactId) {
     runtime.contactId = options.contactId;
   } else if (options.sender) {
-    // --sender resolves platform:id to a contact via the resolve_contact MCP tool
+    // --sender resolves platform:id to a contact via the admin API
     const colonIdx = options.sender.indexOf(':');
     if (colonIdx === -1) {
       console.error(chalk.red('--sender must be in format platform:id (e.g., telegram:99887766)'));
       process.exit(1);
     }
-    const platform = options.sender.slice(0, colonIdx);
+    const platform = options.sender.split(':')[0];
     const platformId = options.sender.slice(colonIdx + 1);
     try {
-      const result = (await pcp
-        .callTool('resolve_contact', { platform, platformId, autoCreate: true })
-        .catch(() => null)) as Record<string, unknown> | null;
-      const contact = (result as any)?.contact;
-      if (contact?.id) {
-        runtime.contactId = contact.id;
-        console.log(chalk.dim(`Resolved sender ${platform}:${platformId} → contact ${contact.id}`));
+      const { getPcpServerUrl } = await import('../lib/pcp-mcp.js');
+      const { getValidAccessToken } = await import('../auth/tokens.js');
+      const serverUrl = getPcpServerUrl().replace(/\/+$/, '');
+      const token = await getValidAccessToken(serverUrl);
+      if (!token) throw new Error('Not authenticated');
+
+      const resp = await fetch(`${serverUrl}/api/admin/contacts/resolve`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ platform, platformId, autoCreate: true }),
+      });
+      if (resp.ok) {
+        const data = (await resp.json()) as { contact?: { id?: string; name?: string } };
+        if (data.contact?.id) {
+          runtime.contactId = data.contact.id;
+          console.log(
+            chalk.dim(
+              `Resolved sender ${platform}:${platformId} → contact ${data.contact.name || data.contact.id}`
+            )
+          );
+        }
       } else {
+        const errText = await resp.text().catch(() => '');
         console.log(
           chalk.yellow(
-            `Could not resolve sender ${platform}:${platformId}. ` +
-              'The resolve_contact tool may not be available yet. Use --contact-id <uuid> instead.'
+            `Could not resolve sender: ${errText || resp.statusText}. Continuing without contact scope.`
           )
         );
       }
-    } catch {
+    } catch (error) {
       console.log(
         chalk.yellow(
-          `Failed to resolve sender. Use --contact-id <uuid> for direct contact scoping.`
+          `Failed to resolve sender: ${error instanceof Error ? error.message : String(error)}. ` +
+            `Use --contact-id <uuid> for direct contact scoping.`
         )
       );
     }

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -86,6 +86,8 @@ type ChatOptions = {
   toolRouting?: string;
   ui?: string;
   threadKey?: string;
+  sender?: string;
+  contactId?: string;
   autoRun?: boolean;
   new?: boolean;
   attach?: string | boolean;
@@ -130,6 +132,7 @@ interface ChatRuntime {
   uiMode: 'scroll' | 'live';
   threadKey?: string;
   studioId?: string;
+  contactId?: string;
   userTimezone?: string;
   backendTokenWindow: number;
   sessionId?: string;
@@ -1877,6 +1880,43 @@ export async function runChat(options: ChatOptions): Promise<void> {
               : 'auto-deny'
             : 'interactive',
   };
+  // Resolve --sender or --contact-id for per-sender session isolation
+  if (options.contactId) {
+    runtime.contactId = options.contactId;
+  } else if (options.sender) {
+    // --sender resolves platform:id to a contact via the resolve_contact MCP tool
+    const colonIdx = options.sender.indexOf(':');
+    if (colonIdx === -1) {
+      console.error(chalk.red('--sender must be in format platform:id (e.g., telegram:99887766)'));
+      process.exit(1);
+    }
+    const platform = options.sender.slice(0, colonIdx);
+    const platformId = options.sender.slice(colonIdx + 1);
+    try {
+      const result = (await pcp
+        .callTool('resolve_contact', { platform, platformId, autoCreate: true })
+        .catch(() => null)) as Record<string, unknown> | null;
+      const contact = (result as any)?.contact;
+      if (contact?.id) {
+        runtime.contactId = contact.id;
+        console.log(chalk.dim(`Resolved sender ${platform}:${platformId} → contact ${contact.id}`));
+      } else {
+        console.log(
+          chalk.yellow(
+            `Could not resolve sender ${platform}:${platformId}. ` +
+              'The resolve_contact tool may not be available yet. Use --contact-id <uuid> instead.'
+          )
+        );
+      }
+    } catch {
+      console.log(
+        chalk.yellow(
+          `Failed to resolve sender. Use --contact-id <uuid> for direct contact scoping.`
+        )
+      );
+    }
+  }
+
   await ensureBackendAuthReady(runtime.backend, {
     nonInteractive: Boolean(options.nonInteractive),
     hasMessage: Boolean(options.message?.trim()),
@@ -2144,6 +2184,7 @@ export async function runChat(options: ChatOptions): Promise<void> {
     if (identity?.studioId) {
       startArgs.studioId = identity.studioId;
     }
+    if (runtime.contactId) startArgs.contactId = runtime.contactId;
 
     const sessionStartResult = (await pcp
       .callTool('start_session', startArgs)
@@ -2692,7 +2733,9 @@ export async function runChat(options: ChatOptions): Promise<void> {
       for (const entry of recallEntries) {
         const preview = entry.content.replace(/^\[passive-recall\]\s*/, '').slice(0, 120);
         printLine(
-          chalk.dim(`  💡 memory surfaced: "${preview}${entry.content.length > 120 ? '...' : ''}" (${entry.approxTokens} tok)`)
+          chalk.dim(
+            `  💡 memory surfaced: "${preview}${entry.content.length > 120 ? '...' : ''}" (${entry.approxTokens} tok)`
+          )
         );
       }
 
@@ -2975,16 +3018,26 @@ export async function runChat(options: ChatOptions): Promise<void> {
               const content = (r?.content as Array<{ text: string }> | undefined)?.[0]?.text;
               if (content) {
                 const parsed = JSON.parse(content);
-                printLine(chalk.dim(`  🗑 evicted ${parsed.evicted} entries (${parsed.tokensFreed} tok freed, ${parsed.totalAfter} tok remaining)`));
+                printLine(
+                  chalk.dim(
+                    `  🗑 evicted ${parsed.evicted} entries (${parsed.tokensFreed} tok freed, ${parsed.totalAfter} tok remaining)`
+                  )
+                );
               }
             } else if (result.tool === 'list_context') {
               const r = result.result as Record<string, unknown> | undefined;
               const content = (r?.content as Array<{ text: string }> | undefined)?.[0]?.text;
               if (content) {
                 const parsed = JSON.parse(content);
-                printLine(chalk.dim(`  📋 context: ${parsed.totalEntries} entries, ~${parsed.totalTokens} tok`));
+                printLine(
+                  chalk.dim(
+                    `  📋 context: ${parsed.totalEntries} entries, ~${parsed.totalTokens} tok`
+                  )
+                );
                 if (parsed.bySource) {
-                  const sources = Object.entries(parsed.bySource as Record<string, { count: number; tokens: number }>)
+                  const sources = Object.entries(
+                    parsed.bySource as Record<string, { count: number; tokens: number }>
+                  )
                     .map(([src, { count, tokens }]) => `${src}(${count}/${tokens}t)`)
                     .join(' ');
                   printLine(chalk.dim(`     ${sources}`));
@@ -2997,8 +3050,17 @@ export async function runChat(options: ChatOptions): Promise<void> {
                 const parsed = JSON.parse(content);
                 const signal = parsed.signal as { status: string; reason?: string } | undefined;
                 if (signal) {
-                  const icon = signal.status === 'completed' ? '✅' : signal.status === 'blocked' ? '🚫' : '➡️';
-                  printLine(chalk.dim(`  ${icon} signal: ${signal.status}${signal.reason ? ` — ${signal.reason}` : ''}`));
+                  const icon =
+                    signal.status === 'completed'
+                      ? '✅'
+                      : signal.status === 'blocked'
+                        ? '🚫'
+                        : '➡️';
+                  printLine(
+                    chalk.dim(
+                      `  ${icon} signal: ${signal.status}${signal.reason ? ` — ${signal.reason}` : ''}`
+                    )
+                  );
                 }
               }
             } else {
@@ -3162,12 +3224,12 @@ export async function runChat(options: ChatOptions): Promise<void> {
             .slice(-hookResult.injected);
 
           for (const entry of recallEntries) {
-            const preview = entry.content
-              .replace(/^\[passive-recall\]\s*/, '')
-              .slice(0, 120);
+            const preview = entry.content.replace(/^\[passive-recall\]\s*/, '').slice(0, 120);
             const tokens = entry.approxTokens;
             printLine(
-              chalk.dim(`  💡 memory surfaced: "${preview}${entry.content.length > 120 ? '...' : ''}" (${tokens} tok)`)
+              chalk.dim(
+                `  💡 memory surfaced: "${preview}${entry.content.length > 120 ? '...' : ''}" (${tokens} tok)`
+              )
             );
           }
         }
@@ -4806,6 +4868,11 @@ export function registerChatCommand(program: Command): void {
       )
       .option('--ui <mode>', 'UI mode: live (default) or scroll status rendering', 'live')
       .option('--thread-key <key>', 'Thread key for PCP session routing')
+      .option(
+        '--sender <platform:id>',
+        'Simulate sender identity for per-contact isolation (e.g., telegram:99887766)'
+      )
+      .option('--contact-id <uuid>', 'Use existing contact ID for per-contact session isolation')
       .option('--new', 'Always start a new session (disable auto-attach to latest)')
       .option('--attach [query]', 'Attach to an active session for this SB (optional query filter)')
       .option(

--- a/supabase/migrations/20260325201844_per_sender_session_isolation.sql
+++ b/supabase/migrations/20260325201844_per_sender_session_isolation.sql
@@ -1,0 +1,78 @@
+-- Per-Sender Session Isolation
+--
+-- Adds contact_id to sessions and memories so that external contacts
+-- (Telegram/WhatsApp senders) get isolated conversation history and
+-- memories when talking to a shared SB.
+--
+-- All columns nullable — existing rows stay NULL (backward compatible).
+-- NULL contact_id = owner/system/inter-agent context.
+
+-- ============================================================================
+-- 1. Sessions: per-contact isolation
+-- ============================================================================
+
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS contact_id uuid REFERENCES contacts(id);
+
+-- Composite index for contact-scoped active session lookups
+CREATE INDEX IF NOT EXISTS idx_sessions_contact_lookup
+  ON sessions(user_id, agent_id, contact_id)
+  WHERE status = 'active';
+
+-- ============================================================================
+-- 2. Memories: per-contact scoping
+-- ============================================================================
+
+ALTER TABLE memories ADD COLUMN IF NOT EXISTS contact_id uuid REFERENCES contacts(id);
+
+-- Composite index for contact-scoped memory queries
+CREATE INDEX IF NOT EXISTS idx_memories_contact_lookup
+  ON memories(user_id, agent_id, contact_id);
+
+-- ============================================================================
+-- 3. Memory history: include contact_id for audit trail
+-- ============================================================================
+
+ALTER TABLE memory_history ADD COLUMN IF NOT EXISTS contact_id uuid;
+
+-- ============================================================================
+-- 4. Update archive triggers to include contact_id
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.archive_memory_on_delete()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+BEGIN
+  INSERT INTO memory_history (
+    memory_id, user_id, content, source, salience, topics, metadata,
+    version, created_at, change_type, summary, topic_key, contact_id
+  ) VALUES (
+    OLD.id, OLD.user_id, OLD.content, OLD.source, OLD.salience, OLD.topics,
+    OLD.metadata, OLD.version, OLD.created_at, 'delete', OLD.summary, OLD.topic_key, OLD.contact_id
+  );
+  RETURN OLD;
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.archive_memory_on_update()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+BEGIN
+  IF OLD.content IS DISTINCT FROM NEW.content
+     OR OLD.salience IS DISTINCT FROM NEW.salience
+     OR OLD.topics IS DISTINCT FROM NEW.topics
+     OR OLD.summary IS DISTINCT FROM NEW.summary
+     OR OLD.topic_key IS DISTINCT FROM NEW.topic_key THEN
+    INSERT INTO memory_history (
+      memory_id, user_id, content, source, salience, topics, metadata,
+      version, created_at, change_type, summary, topic_key, contact_id
+    ) VALUES (
+      OLD.id, OLD.user_id, OLD.content, OLD.source, OLD.salience, OLD.topics,
+      OLD.metadata, OLD.version, OLD.created_at, 'update', OLD.summary, OLD.topic_key, OLD.contact_id
+    );
+    NEW.version := OLD.version + 1;
+  END IF;
+  RETURN NEW;
+END;
+$function$;


### PR DESCRIPTION
## Summary

Adds `contact_id` as a first-class dimension on sessions and memories so external senders (Telegram/WhatsApp/Discord) get isolated conversation history and memory per contact. This is the foundation for shared SBs — agents that serve multiple external people independently.

- **Migration**: Nullable `contact_id` FK on sessions, memories, memory_history with composite indexes and updated archive triggers
- **Contact auto-resolution**: `findOrCreateByPlatformId` and `findOrCreateGroupContact` — auto-creates contacts from incoming channel messages
- **Session isolation**: Contact-scoped session lookups and creation — each sender gets their own session
- **Memory scoping**: `remember()` writes `contact_id`, `recall()` and `getKnowledgeMemories()` filter by it
- **Gateway integration**: Message handler resolves contact from sender identity before building SessionRequest
- **Context injection**: Context builder passes `contactId` to memory loading, `RequestContextData` includes it

All changes backward compatible — `NULL contact_id` = owner/system/inter-agent (existing behavior unchanged).

## Spec

`pcp://specs/per-sender-session-isolation` (v2) — reviewed by Myra and Lumen.

Key design decisions:
- Per-contact scoping is an **SB-level mode** (`memory_model` on agent_identities), not a per-memory attribute
- In per-contact mode: contact sessions see ONLY their memories, owner sessions see everything
- Groups are synthetic contacts (`type: 'group'`), DMs are individual contacts (`type: 'external'`)
- Activity stream already has contact-scoped indexes for conversation replay (follow-up work)

## Test plan

- [x] Type-check passes (0 new errors)
- [x] Full test suite passes (1716 tests, 0 failures)
- [ ] Manual: send Telegram message → verify contact auto-created
- [ ] Manual: two different senders → verify separate sessions
- [ ] Manual: `remember()` in sender session → verify `recall()` from other sender doesn't see it
- [ ] Manual: CLI sessions still work with `contact_id = NULL`

🤖 Generated with [Claude Code](https://claude.com/claude-code)