### PR TITLE
feat: server-side studio filtering via channelPoll (by Wren)

### DIFF
--- a/packages/api/src/mcp/tools/inbox-handlers.test.ts
+++ b/packages/api/src/mcp/tools/inbox-handlers.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { handleSendToInbox, handleGetInbox } from './inbox-handlers';
+import { handleSendToInbox, handleGetInbox, isThreadOwnedByStudio } from './inbox-handlers';
 
 // Mock user-resolver
 vi.mock('../../services/user-resolver', async (importOriginal) => {
@@ -984,5 +984,57 @@ describe('handleGetInbox - recipient session naming', () => {
 
     const parsed = JSON.parse(result.content[0].text);
     expect(parsed.messages[0].recipientSessionId).toBe('b85490f5-0836-4bdd-8193-f6cfa2562a41');
+  });
+});
+
+// =====================================================
+// channelPoll — server-side studio filtering
+// =====================================================
+
+describe('isThreadOwnedByStudio', () => {
+  const MY_STUDIO = 'studio-omega';
+  const OTHER_STUDIO = 'studio-review';
+
+  it('accepts when agent has no messages (new/broadcast thread)', () => {
+    expect(isThreadOwnedByStudio([], MY_STUDIO)).toBe(true);
+  });
+
+  it('accepts when agent has a message from this studio', () => {
+    const messages = [
+      { metadata: { pcp: { sender: { agentId: 'wren', studioId: MY_STUDIO } } } },
+    ];
+    expect(isThreadOwnedByStudio(messages, MY_STUDIO)).toBe(true);
+  });
+
+  it('rejects when agent has messages only from a different studio', () => {
+    const messages = [
+      { metadata: { pcp: { sender: { agentId: 'wren', studioId: OTHER_STUDIO } } } },
+    ];
+    expect(isThreadOwnedByStudio(messages, MY_STUDIO)).toBe(false);
+  });
+
+  it('accepts when at least one message matches (mixed studios)', () => {
+    const messages = [
+      { metadata: { pcp: { sender: { agentId: 'wren', studioId: OTHER_STUDIO } } } },
+      { metadata: { pcp: { sender: { agentId: 'wren', studioId: MY_STUDIO } } } },
+    ];
+    expect(isThreadOwnedByStudio(messages, MY_STUDIO)).toBe(true);
+  });
+
+  it('rejects when messages have no pcp metadata', () => {
+    const messages = [{ metadata: {} }];
+    expect(isThreadOwnedByStudio(messages, MY_STUDIO)).toBe(false);
+  });
+
+  it('rejects when messages have pcp.sender but no studioId', () => {
+    const messages = [
+      { metadata: { pcp: { sender: { agentId: 'wren' } } } },
+    ];
+    expect(isThreadOwnedByStudio(messages, MY_STUDIO)).toBe(false);
+  });
+
+  it('rejects when metadata is null', () => {
+    const messages = [{ metadata: null }];
+    expect(isThreadOwnedByStudio(messages, MY_STUDIO)).toBe(false);
   });
 });

--- a/packages/api/src/mcp/tools/inbox-handlers.ts
+++ b/packages/api/src/mcp/tools/inbox-handlers.ts
@@ -128,6 +128,15 @@ const getInboxSchema = userIdentifierBaseSchema.extend({
     .datetime()
     .optional()
     .describe('Only return messages created after this ISO timestamp'),
+  channelPoll: z
+    .boolean()
+    .optional()
+    .default(false)
+    .describe(
+      'When true, filter threads by studio ownership using the studioId from request context. ' +
+        'Used by channel plugins to only receive threads belonging to their studio. ' +
+        'Threads with no studio affinity (new, unrouted) are included as broadcast.'
+    ),
 });
 
 const updateInboxMessageSchema = userIdentifierBaseSchema.extend({
@@ -731,7 +740,7 @@ export async function handleGetInbox(args: unknown, dataComposer: DataComposer) 
   const parsed = getInboxSchema.parse(args);
   const resolved = await resolveUserOrThrow(parsed, dataComposer);
 
-  const { status = 'unread', priority, messageType, limit = 20, since } = parsed;
+  const { status = 'unread', priority, messageType, limit = 20, since, channelPoll } = parsed;
   // Enforce identity: pinned agents can only read their own inbox.
   // When agentId is omitted, return inbox across ALL agents (unified timeline).
   const agentId = parsed.agentId
@@ -961,6 +970,64 @@ export async function handleGetInbox(args: unknown, dataComposer: DataComposer) 
 
         // Only include threads that actually have unread messages
         threadsWithUnread = threadsWithUnread.filter((t) => t.unreadCount > 0);
+
+        // Channel poll studio filtering: when channelPoll=true, filter threads
+        // to only those owned by the requesting studio. Uses the same sender
+        // metadata that the trigger system stamps on thread messages.
+        if (channelPoll && agentId) {
+          const reqCtx = getRequestContext();
+          const sessCtx = getSessionContext();
+          const callerStudioId = reqCtx?.workspaceId || sessCtx?.workspaceId || null;
+
+          if (callerStudioId) {
+            const filteredThreads: typeof threadsWithUnread = [];
+
+            for (const thread of threadsWithUnread) {
+              // Fetch our agent's messages on this thread to check studio ownership
+              const threadRow = threads?.find(
+                (t: { thread_key: string }) => t.thread_key === thread.threadKey
+              );
+              if (!threadRow) {
+                filteredThreads.push(thread); // safety fallback — include if we can't check
+                continue;
+              }
+
+              const { data: ourMessages } = await threadTable(supabase, 'inbox_thread_messages')
+                .select('metadata')
+                .eq('thread_id', (threadRow as { id: string }).id)
+                .eq('sender_agent_id', agentId)
+                .order('created_at', { ascending: false })
+                .limit(5);
+
+              if (!ourMessages?.length) {
+                // We haven't sent any messages on this thread — broadcast (accept in any studio)
+                filteredThreads.push(thread);
+                continue;
+              }
+
+              // Check if any of our messages came from this studio
+              const ownsThread = ourMessages.some((m: { metadata: Json }) => {
+                const pcp = (m.metadata as Record<string, unknown>)?.pcp as
+                  | Record<string, unknown>
+                  | undefined;
+                const sender = pcp?.sender as Record<string, unknown> | undefined;
+                return sender?.studioId === callerStudioId;
+              });
+
+              if (ownsThread) {
+                filteredThreads.push(thread);
+              } else {
+                logger.debug('[ChannelPoll] Filtered thread (owned by different studio)', {
+                  threadKey: thread.threadKey,
+                  callerStudioId,
+                });
+              }
+            }
+
+            threadsWithUnread = filteredThreads;
+          }
+        }
+
         threadUnreadCount = threadsWithUnread.reduce((sum, t) => sum + t.unreadCount, 0);
       }
     }

--- a/packages/api/src/mcp/tools/inbox-handlers.ts
+++ b/packages/api/src/mcp/tools/inbox-handlers.ts
@@ -106,6 +106,32 @@ const sendToInboxSchema = userIdentifierBaseSchema.extend({
     ),
 });
 
+/**
+ * Check if a thread is owned by a specific studio based on the agent's
+ * message metadata. Used by channelPoll filtering.
+ *
+ * Returns true (accept) when:
+ * - Agent has no messages on the thread (new/broadcast — accept in any studio)
+ * - Agent's messages include one from this studioId
+ *
+ * Returns false (skip) when:
+ * - Agent has messages but none from this studioId (different studio owns it)
+ */
+export function isThreadOwnedByStudio(
+  agentMessages: Array<{ metadata: unknown }>,
+  callerStudioId: string
+): boolean {
+  if (!agentMessages.length) return true; // no messages from us — broadcast
+
+  return agentMessages.some((m) => {
+    const pcp = (m.metadata as Record<string, unknown>)?.pcp as
+      | Record<string, unknown>
+      | undefined;
+    const sender = pcp?.sender as Record<string, unknown> | undefined;
+    return sender?.studioId === callerStudioId;
+  });
+}
+
 const getInboxSchema = userIdentifierBaseSchema.extend({
   agentId: z
     .string()
@@ -999,22 +1025,7 @@ export async function handleGetInbox(args: unknown, dataComposer: DataComposer) 
                 .order('created_at', { ascending: false })
                 .limit(5);
 
-              if (!ourMessages?.length) {
-                // We haven't sent any messages on this thread — broadcast (accept in any studio)
-                filteredThreads.push(thread);
-                continue;
-              }
-
-              // Check if any of our messages came from this studio
-              const ownsThread = ourMessages.some((m: { metadata: Json }) => {
-                const pcp = (m.metadata as Record<string, unknown>)?.pcp as
-                  | Record<string, unknown>
-                  | undefined;
-                const sender = pcp?.sender as Record<string, unknown> | undefined;
-                return sender?.studioId === callerStudioId;
-              });
-
-              if (ownsThread) {
+              if (isThreadOwnedByStudio(ourMessages || [], callerStudioId)) {
                 filteredThreads.push(thread);
               } else {
                 logger.debug('[ChannelPoll] Filtered thread (owned by different studio)', {

--- a/packages/channel-plugin/index.test.ts
+++ b/packages/channel-plugin/index.test.ts
@@ -2,32 +2,11 @@ import { describe, it, expect } from 'vitest';
 
 /**
  * Unit tests for channel plugin filtering logic.
- * These test the pure functions without needing a running server.
+ *
+ * Thread studio filtering is now handled server-side via channelPoll=true
+ * on get_inbox. These tests cover the remaining client-side logic:
+ * legacy inbox message filtering, dedup, and since behavior.
  */
-
-// ─── Thread ownership check (extracted from plugin) ────────────────
-// Determines if a thread belongs to this studio based on participation history.
-function isThreadOwnedByThisStudio(
-  messages: Array<Record<string, unknown>>,
-  myAgentId: string,
-  myStudioId: string | undefined
-): boolean {
-  if (!myStudioId) return true;
-
-  const ourMessages = messages.filter((m) => m.senderAgentId === myAgentId);
-  if (ourMessages.length === 0) return true; // new thread — accept
-
-  for (const msg of ourMessages) {
-    const metadata = msg.metadata as Record<string, unknown> | undefined;
-    const pcp = metadata?.pcp as Record<string, unknown> | undefined;
-    const sender = pcp?.sender as Record<string, unknown> | undefined;
-    const senderStudioId = sender?.studioId as string | undefined;
-
-    if (senderStudioId && senderStudioId === myStudioId) return true;
-  }
-
-  return false; // our agent participated from a different studio
-}
 
 // ─── Legacy inbox message filter (extracted from plugin) ───────────
 function isLegacyMessageForThisStudio(
@@ -47,107 +26,6 @@ function isLegacyMessageForThisStudio(
 
 const MY_STUDIO = 'ef511db1-a158-4a06-ba40-abb61785dbbc';
 const OTHER_STUDIO = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
-const MY_AGENT = 'wren';
-
-describe('isThreadOwnedByThisStudio', () => {
-  it('accepts threads where our agent participated from this studio', () => {
-    const messages = [
-      {
-        senderAgentId: 'wren',
-        content: 'hello',
-        metadata: { pcp: { sender: { agentId: 'wren', studioId: MY_STUDIO } } },
-      },
-      {
-        senderAgentId: 'lumen',
-        content: 'ack',
-        metadata: { pcp: { sender: { agentId: 'lumen', studioId: 'lumen-studio' } } },
-      },
-    ];
-    expect(isThreadOwnedByThisStudio(messages, MY_AGENT, MY_STUDIO)).toBe(true);
-  });
-
-  it('rejects threads where our agent participated from a different studio', () => {
-    const messages = [
-      {
-        senderAgentId: 'wren',
-        content: 'hello',
-        metadata: { pcp: { sender: { agentId: 'wren', studioId: OTHER_STUDIO } } },
-      },
-      {
-        senderAgentId: 'lumen',
-        content: 'ack',
-        metadata: { pcp: { sender: { agentId: 'lumen' } } },
-      },
-    ];
-    expect(isThreadOwnedByThisStudio(messages, MY_AGENT, MY_STUDIO)).toBe(false);
-  });
-
-  it('accepts new threads where our agent has no messages yet', () => {
-    const messages = [
-      {
-        senderAgentId: 'lumen',
-        content: 'hey wren',
-        metadata: { pcp: { sender: { agentId: 'lumen' } } },
-      },
-    ];
-    expect(isThreadOwnedByThisStudio(messages, MY_AGENT, MY_STUDIO)).toBe(true);
-  });
-
-  it('accepts all threads when studioId is undefined', () => {
-    const messages = [
-      {
-        senderAgentId: 'wren',
-        content: 'hello',
-        metadata: { pcp: { sender: { agentId: 'wren', studioId: OTHER_STUDIO } } },
-      },
-    ];
-    expect(isThreadOwnedByThisStudio(messages, MY_AGENT, undefined)).toBe(true);
-  });
-
-  it('accepts threads where our agent has messages with no studio metadata', () => {
-    // Pre-studio messages (no metadata.pcp.sender.studioId) — treat as unowned
-    const messages = [
-      {
-        senderAgentId: 'wren',
-        content: 'old message',
-        metadata: { pcp: { sender: { agentId: 'wren' } } },
-      },
-    ];
-    // No studioId in sender → never matches → falls through to false
-    // BUT: this is pre-studio data, so we shouldn't reject it.
-    // Actually, the function returns false here — which is incorrect for legacy data.
-    // For now this is acceptable since all active studios stamp studioId.
-    expect(isThreadOwnedByThisStudio(messages, MY_AGENT, MY_STUDIO)).toBe(false);
-  });
-
-  it('accepts threads with mixed studio participation (at least one match)', () => {
-    const messages = [
-      {
-        senderAgentId: 'wren',
-        content: 'from other studio',
-        metadata: { pcp: { sender: { agentId: 'wren', studioId: OTHER_STUDIO } } },
-      },
-      {
-        senderAgentId: 'wren',
-        content: 'from this studio',
-        metadata: { pcp: { sender: { agentId: 'wren', studioId: MY_STUDIO } } },
-      },
-    ];
-    expect(isThreadOwnedByThisStudio(messages, MY_AGENT, MY_STUDIO)).toBe(true);
-  });
-
-  it('ignores other agents studio IDs when checking ownership', () => {
-    const messages = [
-      {
-        senderAgentId: 'lumen',
-        content: 'from lumen',
-        metadata: { pcp: { sender: { agentId: 'lumen', studioId: MY_STUDIO } } },
-      },
-    ];
-    // lumen's messages have our studioId, but we (wren) have no messages — new thread
-    expect(isThreadOwnedByThisStudio(messages, MY_AGENT, MY_STUDIO)).toBe(true);
-  });
-});
 
 describe('isLegacyMessageForThisStudio', () => {
   it('accepts messages addressed to this studio', () => {

--- a/packages/channel-plugin/index.ts
+++ b/packages/channel-plugin/index.ts
@@ -113,46 +113,10 @@ const studioId = process.env.PCP_STUDIO_ID || undefined;
 const sessionId = process.env.PCP_SESSION_ID || undefined;
 
 /**
- * Check if this studio is a participant in a thread by examining message history.
- *
- * Thread messages don't have explicit recipient routing — instead, each message
- * carries `metadata.pcp.sender.studioId` identifying which studio sent it.
- * If our agent has sent messages on this thread from a DIFFERENT studio, this
- * studio should not receive push events (that thread belongs to the other studio).
- *
- * Returns true (accept) when:
- * - No studioId configured (accept all — single-studio setup)
- * - Our agent has no messages on the thread yet (new thread — accept in any studio)
- * - Our agent's messages on the thread came from THIS studioId
- *
- * Returns false (skip) when:
- * - Our agent has messages on the thread from a DIFFERENT studioId
- */
-function isThreadOwnedByThisStudio(
-  messages: Array<Record<string, unknown>>
-): boolean {
-  if (!studioId) return true; // no studio context — accept all
-
-  // Find messages sent by our agent and check which studio they came from
-  const ourMessages = messages.filter((m) => m.senderAgentId === agentId);
-  if (ourMessages.length === 0) return true; // new thread for us — accept
-
-  for (const msg of ourMessages) {
-    const metadata = msg.metadata as Record<string, unknown> | undefined;
-    const pcp = metadata?.pcp as Record<string, unknown> | undefined;
-    const sender = pcp?.sender as Record<string, unknown> | undefined;
-    const senderStudioId = sender?.studioId as string | undefined;
-
-    if (senderStudioId && senderStudioId === studioId) return true; // we participated from this studio
-  }
-
-  // Our agent participated but from a different studio — skip
-  return false;
-}
-
-/**
  * Check if a legacy inbox message is addressed to this studio.
  * Legacy messages (non-threaded) carry explicit recipient routing.
+ *
+ * Thread filtering is handled server-side via channelPoll=true on get_inbox.
  */
 function isLegacyMessageForThisStudio(msg: Record<string, unknown>): boolean {
   if (!studioId) return true;
@@ -277,6 +241,7 @@ async function pollInbox(): Promise<void> {
       status: 'all',
       since: lastPollTime,
       limit: 20,
+      channelPoll: true,
     });
 
     if (!result?.success) {
@@ -295,15 +260,14 @@ async function pollInbox(): Promise<void> {
       const unreadCount = (thread.unreadCount as number) || 0;
       if (!threadKey || unreadCount === 0) continue;
 
-      // Peek at thread messages WITHOUT advancing the read pointer.
-      // We must check studio ownership before marking read — the read pointer
-      // is per-agent (not per-studio), so a non-owning studio marking read
-      // would prevent the owning studio from ever seeing these as unread.
+      // Studio filtering is handled server-side via channelPoll=true.
+      // The server only returns threads owned by this studio (or broadcast
+      // threads with no studio affinity), so we can safely mark read here.
       const threadResult = await callPcp('get_thread_messages', {
         email,
         agentId,
         threadKey,
-        markRead: false,
+        markRead: true,
         limit: 5,
       });
 
@@ -311,17 +275,6 @@ async function pollInbox(): Promise<void> {
 
       const messages = (threadResult.messages as Array<Record<string, unknown>>) || [];
       const lastKnownTs = lastThreadTimestamps.get(threadKey);
-
-      // Studio filter: check if this studio owns the thread (based on our
-      // agent's participation history). Skip entire thread if another studio
-      // of the same agent is the active participant.
-      if (!isThreadOwnedByThisStudio(messages)) {
-        log('debug', 'Skipping thread (owned by different studio)', { threadKey, studioId });
-        continue;
-      }
-
-      // Now mark read — we've confirmed this studio owns the thread.
-      await callPcp('mark_thread_read', { email, agentId, threadKey });
 
       for (const msg of messages) {
         const msgId = msg.id as string;

--- a/packages/channel-plugin/index.ts
+++ b/packages/channel-plugin/index.ts
@@ -152,6 +152,13 @@ async function callPcp(
   if (accessToken) {
     headers.Authorization = `Bearer ${accessToken}`;
   }
+  // Forward studio/session context so the server can apply channelPoll filtering
+  if (studioId) {
+    headers['x-pcp-studio-id'] = studioId;
+  }
+  if (sessionId) {
+    headers['x-pcp-session-id'] = sessionId;
+  }
 
   try {
     const resp = await fetch(url, {


### PR DESCRIPTION
## Summary
- Move thread studio filtering from channel plugin (client-side) to `get_inbox` handler (server-side)
- Add `channelPoll: true` parameter — opt-in studio filtering using studioId from request context headers
- Server checks `metadata.pcp.sender.studioId` on agent's thread messages to determine ownership
- Threads with no agent messages (new/broadcast) pass through to all studios
- Channel plugin simplified: drops `isThreadOwnedByThisStudio`, reverts to `markRead: true`, passes `channelPoll: true`
- Single routing implementation — fix routing on the server, all channel plugins pick it up on next poll without redeployment

## Test plan
- [x] 11 channel plugin unit tests pass
- [x] 18 inbox handler unit tests pass
- [ ] Live test: verify studio filtering works via channel events
- [ ] Verify non-channelPoll get_inbox calls still return all threads

🤖 Generated with [Claude Code](https://claude.com/claude-code)