### PR TITLE
feat: cross-studio self-messaging support (by Wren)

### DIFF
--- a/packages/api/src/mcp/tools/inbox-handlers.test.ts
+++ b/packages/api/src/mcp/tools/inbox-handlers.test.ts
@@ -1037,4 +1037,34 @@ describe('isThreadOwnedByStudio', () => {
     const messages = [{ metadata: null }];
     expect(isThreadOwnedByStudio(messages, MY_STUDIO)).toBe(false);
   });
+
+  it('accepts cross-studio self-message via recipient.studioId', () => {
+    // wren-omega sends to wren-review: message has sender.studioId=omega, recipient.studioId=review
+    // When review's channel plugin polls, it should accept because recipient matches
+    const messages = [
+      {
+        metadata: {
+          pcp: {
+            sender: { agentId: 'wren', studioId: OTHER_STUDIO },
+            recipient: { studioId: MY_STUDIO },
+          },
+        },
+      },
+    ];
+    expect(isThreadOwnedByStudio(messages, MY_STUDIO)).toBe(true);
+  });
+
+  it('rejects when recipient.studioId targets a different studio', () => {
+    const messages = [
+      {
+        metadata: {
+          pcp: {
+            sender: { agentId: 'wren', studioId: OTHER_STUDIO },
+            recipient: { studioId: 'some-third-studio' },
+          },
+        },
+      },
+    ];
+    expect(isThreadOwnedByStudio(messages, MY_STUDIO)).toBe(false);
+  });
 });

--- a/packages/api/src/mcp/tools/inbox-handlers.ts
+++ b/packages/api/src/mcp/tools/inbox-handlers.ts
@@ -414,6 +414,15 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
     // For new threads, trigger all recipients (existing behavior).
     let agentsToTrigger: string[] = [];
 
+    // Cross-studio self-messaging: when the sender targets themselves in a
+    // different studio (via recipientStudioId/recipientStudioHint), don't
+    // exclude self from trigger resolution.
+    const selfStudioTarget = !!(
+      senderAgentId &&
+      (recipientStudioId || recipientStudioHint) &&
+      allRecipients.includes(senderAgentId)
+    );
+
     if (trigger !== false && !missingSenderSession) {
       if (existingThread && senderAgentId) {
         // Reply: fetch current participants from DB for accurate trigger resolution
@@ -426,10 +435,11 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
           triggerAll,
           messageType,
           recipients: allRecipients,
+          selfStudioTarget,
         });
       } else {
-        // New thread: trigger all recipients except sender
-        agentsToTrigger = allRecipients.filter((a) => a !== senderAgentId);
+        // New thread: trigger all recipients (exclude sender unless cross-studio self-message)
+        agentsToTrigger = allRecipients.filter((a) => selfStudioTarget || a !== senderAgentId);
       }
     }
 
@@ -453,9 +463,14 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
         // message on this thread to extract their sender session. This ensures
         // replies route back to the session that originated the conversation,
         // not whatever session happens to be most recently updated.
+        //
+        // Cross-studio self-message: when sender === recipient, skip auto-resolve
+        // from thread history (it would find our own session). The trigger system
+        // will use recipientStudioId to route to the correct studio session.
         let resolvedRecipientSessionId: string | undefined =
           effectiveRecipientSessionId || undefined;
-        if (!resolvedRecipientSessionId) {
+        const isSelfStudioMessage = selfStudioTarget && toAgentId === senderAgentId;
+        if (!resolvedRecipientSessionId && !isSelfStudioMessage) {
           try {
             const { data: recipientMsg } = await threadTable(supabase, 'inbox_thread_messages')
               .select('metadata')
@@ -497,6 +512,9 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
           priority,
           threadKey,
           recipientSessionId: resolvedRecipientSessionId,
+          // Cross-studio self-message: route to the target studio explicitly
+          ...(isSelfStudioMessage && recipientStudioId ? { studioId: recipientStudioId } : {}),
+          ...(isSelfStudioMessage && recipientStudioHint ? { studioHint: recipientStudioHint } : {}),
         };
         const result = gateway.dispatchTrigger(payload);
         if (result.accepted) {

--- a/packages/api/src/mcp/tools/inbox-handlers.ts
+++ b/packages/api/src/mcp/tools/inbox-handlers.ts
@@ -19,6 +19,7 @@ import {
   getParticipants,
   resolveTriggeredAgents,
 } from './thread-handlers.js';
+import { resolveStudioHint } from '../../services/sessions/index.js';
 
 // The thread tables are new and not yet in generated Supabase types.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -373,33 +374,11 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
     let resolvedRecipientStudioId: string | undefined = recipientStudioId || undefined;
     if (!resolvedRecipientStudioId && recipientStudioHint && senderAgentId) {
       try {
-        if (recipientStudioHint === 'main') {
-          // Resolve 'main' hint using the same semantics as
-          // SessionService.resolveMainStudioId(): branch='main' match,
-          // not "most recently updated studio" (which could be a
-          // review/feature studio that happens to be newer).
-          const { data: mainStudio } = await supabase
-            .from('studios')
-            .select('id')
-            .eq('user_id', resolved.user.id)
-            .eq('branch', 'main')
-            .in('status', ['active', 'idle', 'archived'])
-            .order('updated_at', { ascending: false })
-            .limit(1)
-            .maybeSingle();
-          if (mainStudio?.id) resolvedRecipientStudioId = mainStudio.id;
-        } else {
-          // Resolve named hint — match by slug
-          const { data: namedStudio } = await supabase
-            .from('studios')
-            .select('id')
-            .eq('user_id', resolved.user.id)
-            .eq('slug', recipientStudioHint)
-            .in('status', ['active', 'idle'])
-            .limit(1)
-            .maybeSingle();
-          if (namedStudio?.id) resolvedRecipientStudioId = namedStudio.id;
-        }
+        // Reuse the shared resolution function (worktree path → branch fallback
+        // for 'main', slug match for named hints).
+        resolvedRecipientStudioId = await resolveStudioHint(
+          supabase, resolved.user.id, recipientStudioHint, senderAgentId
+        );
       } catch {
         // Best-effort resolution — proceed without stamping
       }

--- a/packages/api/src/mcp/tools/inbox-handlers.ts
+++ b/packages/api/src/mcp/tools/inbox-handlers.ts
@@ -369,9 +369,41 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
         : {};
     // Cross-studio self-messaging: stamp recipient studio on the message
     // so the channelPoll filter can recognize the target studio as an owner.
+    // Resolve recipientStudioHint to a studioId if needed.
+    let resolvedRecipientStudioId: string | undefined = recipientStudioId || undefined;
+    if (!resolvedRecipientStudioId && recipientStudioHint && senderAgentId) {
+      try {
+        if (recipientStudioHint === 'main') {
+          // Resolve 'main' hint — find the main studio for this user
+          const { data: mainStudio } = await supabase
+            .from('studios')
+            .select('id')
+            .eq('user_id', resolved.user.id)
+            .in('status', ['active', 'idle'])
+            .order('updated_at', { ascending: false })
+            .limit(1)
+            .maybeSingle();
+          if (mainStudio?.id) resolvedRecipientStudioId = mainStudio.id;
+        } else {
+          // Resolve named hint — match by slug
+          const { data: namedStudio } = await supabase
+            .from('studios')
+            .select('id')
+            .eq('user_id', resolved.user.id)
+            .eq('slug', recipientStudioHint)
+            .in('status', ['active', 'idle'])
+            .limit(1)
+            .maybeSingle();
+          if (namedStudio?.id) resolvedRecipientStudioId = namedStudio.id;
+        }
+      } catch {
+        // Best-effort resolution — proceed without stamping
+      }
+    }
+
     const selfStudioRecipient = !!(
       senderAgentId &&
-      (recipientStudioId || recipientStudioHint) &&
+      resolvedRecipientStudioId &&
       allRecipients.includes(senderAgentId)
     );
     const threadMessageMetadata = {
@@ -383,8 +415,8 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
           sessionId: senderSessionId,
           studioId: senderStudioId,
         },
-        ...(selfStudioRecipient && recipientStudioId
-          ? { recipient: { studioId: recipientStudioId } }
+        ...(selfStudioRecipient
+          ? { recipient: { studioId: resolvedRecipientStudioId } }
           : {}),
       },
     };
@@ -530,8 +562,12 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
           threadKey,
           recipientSessionId: resolvedRecipientSessionId,
           // Cross-studio self-message: route to the target studio explicitly
-          ...(isSelfStudioMessage && recipientStudioId ? { studioId: recipientStudioId } : {}),
-          ...(isSelfStudioMessage && recipientStudioHint ? { studioHint: recipientStudioHint } : {}),
+          ...(isSelfStudioMessage && resolvedRecipientStudioId
+            ? { studioId: resolvedRecipientStudioId }
+            : {}),
+          ...(isSelfStudioMessage && !resolvedRecipientStudioId && recipientStudioHint
+            ? { studioHint: recipientStudioHint }
+            : {}),
         };
         const result = gateway.dispatchTrigger(payload);
         if (result.accepted) {

--- a/packages/api/src/mcp/tools/inbox-handlers.ts
+++ b/packages/api/src/mcp/tools/inbox-handlers.ts
@@ -374,12 +374,16 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
     if (!resolvedRecipientStudioId && recipientStudioHint && senderAgentId) {
       try {
         if (recipientStudioHint === 'main') {
-          // Resolve 'main' hint — find the main studio for this user
+          // Resolve 'main' hint using the same semantics as
+          // SessionService.resolveMainStudioId(): branch='main' match,
+          // not "most recently updated studio" (which could be a
+          // review/feature studio that happens to be newer).
           const { data: mainStudio } = await supabase
             .from('studios')
             .select('id')
             .eq('user_id', resolved.user.id)
-            .in('status', ['active', 'idle'])
+            .eq('branch', 'main')
+            .in('status', ['active', 'idle', 'archived'])
             .order('updated_at', { ascending: false })
             .limit(1)
             .maybeSingle();

--- a/packages/api/src/mcp/tools/inbox-handlers.ts
+++ b/packages/api/src/mcp/tools/inbox-handlers.ts
@@ -112,10 +112,12 @@ const sendToInboxSchema = userIdentifierBaseSchema.extend({
  *
  * Returns true (accept) when:
  * - Agent has no messages on the thread (new/broadcast — accept in any studio)
- * - Agent's messages include one from this studioId
+ * - Agent's messages include one sent FROM this studioId
+ * - Agent's messages include one with recipient.studioId matching this studio
+ *   (cross-studio self-message targeting this studio)
  *
  * Returns false (skip) when:
- * - Agent has messages but none from this studioId (different studio owns it)
+ * - Agent has messages but none match this studioId as sender or recipient
  */
 export function isThreadOwnedByStudio(
   agentMessages: Array<{ metadata: unknown }>,
@@ -127,8 +129,13 @@ export function isThreadOwnedByStudio(
     const pcp = (m.metadata as Record<string, unknown>)?.pcp as
       | Record<string, unknown>
       | undefined;
+    // Check sender studioId (standard ownership)
     const sender = pcp?.sender as Record<string, unknown> | undefined;
-    return sender?.studioId === callerStudioId;
+    if (sender?.studioId === callerStudioId) return true;
+    // Check recipient studioId (cross-studio self-message targeting this studio)
+    const recipient = pcp?.recipient as Record<string, unknown> | undefined;
+    if (recipient?.studioId === callerStudioId) return true;
+    return false;
   });
 }
 
@@ -360,6 +367,13 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
       rawMeta.pcp && typeof rawMeta.pcp === 'object'
         ? (rawMeta.pcp as Record<string, unknown>)
         : {};
+    // Cross-studio self-messaging: stamp recipient studio on the message
+    // so the channelPoll filter can recognize the target studio as an owner.
+    const selfStudioRecipient = !!(
+      senderAgentId &&
+      (recipientStudioId || recipientStudioHint) &&
+      allRecipients.includes(senderAgentId)
+    );
     const threadMessageMetadata = {
       ...rawMeta,
       pcp: {
@@ -369,6 +383,9 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
           sessionId: senderSessionId,
           studioId: senderStudioId,
         },
+        ...(selfStudioRecipient && recipientStudioId
+          ? { recipient: { studioId: recipientStudioId } }
+          : {}),
       },
     };
 

--- a/packages/api/src/mcp/tools/thread-handlers.test.ts
+++ b/packages/api/src/mcp/tools/thread-handlers.test.ts
@@ -6,58 +6,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-
-// =====================================================
-// UNIT TESTS: resolveTriggeredAgents (pure logic)
-// =====================================================
-
-// Import the function indirectly by testing through the handler,
-// but since it's not exported, we test the logic via reply_to_thread behavior.
-// For now, we replicate the logic here for direct unit testing.
-
-function resolveTriggeredAgents(opts: {
-  senderAgentId: string;
-  participants: string[];
-  creatorAgentId: string;
-  triggerAgents?: string[];
-  triggerAll?: boolean;
-  messageType?: string;
-  recipients?: string[];
-}): string[] {
-  const { senderAgentId, participants, creatorAgentId, triggerAgents, triggerAll, messageType } =
-    opts;
-
-  if (triggerAgents && triggerAgents.length > 0) {
-    const participantSet = new Set(participants);
-    return triggerAgents.filter((a) => a !== senderAgentId && participantSet.has(a));
-  }
-
-  if (triggerAll) {
-    return participants.filter((a) => a !== senderAgentId);
-  }
-
-  const otherParticipants = participants.filter((a) => a !== senderAgentId);
-
-  if (otherParticipants.length === 0) {
-    return [];
-  }
-
-  if (participants.length === 2) {
-    return otherParticipants;
-  }
-
-  const actionableTypes = new Set(['task_request', 'session_resume']);
-  if (messageType && actionableTypes.has(messageType)) {
-    const targets = opts.recipients?.filter((a) => a !== senderAgentId) ?? otherParticipants;
-    return targets.filter((a) => participants.includes(a));
-  }
-
-  if (senderAgentId !== creatorAgentId) {
-    return [creatorAgentId];
-  }
-
-  return [];
-}
+import { resolveTriggeredAgents } from './thread-handlers';
 
 describe('resolveTriggeredAgents', () => {
   describe('1:1 threads (2 participants)', () => {
@@ -233,6 +182,60 @@ describe('resolveTriggeredAgents', () => {
       });
       // triggerAgents takes precedence (spec: triggerAgents > triggerAll > default)
       expect(result).toEqual(['aster']);
+    });
+  });
+
+  describe('cross-studio self-messaging (selfStudioTarget)', () => {
+    it('should trigger sender on self-thread when selfStudioTarget is true', () => {
+      const result = resolveTriggeredAgents({
+        senderAgentId: 'wren',
+        participants: ['wren'],
+        creatorAgentId: 'wren',
+        selfStudioTarget: true,
+      });
+      expect(result).toEqual(['wren']);
+    });
+
+    it('should NOT trigger sender on self-thread when selfStudioTarget is false', () => {
+      const result = resolveTriggeredAgents({
+        senderAgentId: 'wren',
+        participants: ['wren'],
+        creatorAgentId: 'wren',
+        selfStudioTarget: false,
+      });
+      expect(result).toEqual([]);
+    });
+
+    it('should include sender in triggerAll when selfStudioTarget is true', () => {
+      const result = resolveTriggeredAgents({
+        senderAgentId: 'wren',
+        participants: ['wren', 'lumen'],
+        creatorAgentId: 'wren',
+        triggerAll: true,
+        selfStudioTarget: true,
+      });
+      expect(result).toEqual(['wren', 'lumen']);
+    });
+
+    it('should include sender in explicit triggerAgents when selfStudioTarget is true', () => {
+      const result = resolveTriggeredAgents({
+        senderAgentId: 'wren',
+        participants: ['wren', 'lumen'],
+        creatorAgentId: 'wren',
+        triggerAgents: ['wren'],
+        selfStudioTarget: true,
+      });
+      expect(result).toEqual(['wren']);
+    });
+
+    it('should still exclude sender from explicit triggerAgents without selfStudioTarget', () => {
+      const result = resolveTriggeredAgents({
+        senderAgentId: 'wren',
+        participants: ['wren', 'lumen'],
+        creatorAgentId: 'wren',
+        triggerAgents: ['wren'],
+      });
+      expect(result).toEqual([]);
     });
   });
 });

--- a/packages/api/src/mcp/tools/thread-handlers.ts
+++ b/packages/api/src/mcp/tools/thread-handlers.ts
@@ -148,6 +148,10 @@ export async function isParticipant(
  * 2. triggerAll: true → wake all participants except sender
  * 3. Actionable messages (task_request, session_resume) → trigger all recipients
  * 4. Default: 1:1 → other participant; group non-creator → creator; group creator → no one
+ *
+ * Cross-studio self-messaging: when selfStudioTarget is true, the sender is NOT
+ * excluded from trigger lists. This allows an agent to message themselves in a
+ * different studio (e.g., wren-omega sends a review request to wren-review).
  */
 export function resolveTriggeredAgents(opts: {
   senderAgentId: string;
@@ -157,27 +161,31 @@ export function resolveTriggeredAgents(opts: {
   triggerAll?: boolean;
   messageType?: string;
   recipients?: string[];
+  selfStudioTarget?: boolean;
 }): string[] {
-  const { senderAgentId, participants, creatorAgentId, triggerAgents, triggerAll, messageType } =
-    opts;
+  const { senderAgentId, participants, creatorAgentId, triggerAgents, triggerAll, messageType,
+    selfStudioTarget } = opts;
 
-  // Precedence 1: explicit triggerAgents (filter to actual participants, exclude sender)
+  // When targeting self in a different studio, don't exclude sender from triggers
+  const excludeSelf = (a: string) => selfStudioTarget ? true : a !== senderAgentId;
+
+  // Precedence 1: explicit triggerAgents (filter to actual participants)
   if (triggerAgents && triggerAgents.length > 0) {
     const participantSet = new Set(participants);
-    return triggerAgents.filter((a) => a !== senderAgentId && participantSet.has(a));
+    return triggerAgents.filter((a) => excludeSelf(a) && participantSet.has(a));
   }
 
-  // Precedence 2: triggerAll — everyone except sender
+  // Precedence 2: triggerAll — everyone (except sender unless selfStudioTarget)
   if (triggerAll) {
-    return participants.filter((a) => a !== senderAgentId);
+    return participants.filter(excludeSelf);
   }
 
   // Precedence 3: default rules by thread size
   const otherParticipants = participants.filter((a) => a !== senderAgentId);
 
-  // Self-thread (1 participant): no trigger
+  // Self-thread (1 participant): trigger only if cross-studio self-message
   if (otherParticipants.length === 0) {
-    return [];
+    return selfStudioTarget ? [senderAgentId] : [];
   }
 
   // 1:1 thread (2 participants): trigger the other one
@@ -191,7 +199,7 @@ export function resolveTriggeredAgents(opts: {
   const actionableTypes = new Set(['task_request', 'session_resume']);
   if (messageType && actionableTypes.has(messageType)) {
     // Trigger explicit recipients if provided, otherwise all other participants
-    const targets = opts.recipients?.filter((a) => a !== senderAgentId) ?? otherParticipants;
+    const targets = opts.recipients?.filter(excludeSelf) ?? otherParticipants;
     return targets.filter((a) => participants.includes(a));
   }
 

--- a/packages/api/src/services/sessions/index.ts
+++ b/packages/api/src/services/sessions/index.ts
@@ -8,6 +8,7 @@
 export {
   SessionService,
   createSessionService,
+  resolveStudioHint,
   type SessionServiceConfig,
   type IActivityStream,
 } from './session-service.js';

--- a/packages/api/src/services/sessions/session-service.ts
+++ b/packages/api/src/services/sessions/session-service.ts
@@ -1376,6 +1376,57 @@ This session will continue with a fresh context after compaction. Your identity,
 }
 
 /**
+ * Resolve a studio hint to a studioId. Shared by SessionService (private
+ * resolveStudioId) and inbox-handlers (cross-studio self-messaging metadata).
+ *
+ * For 'main': worktree path match → branch='main' fallback.
+ * For named hints: slug match.
+ */
+export async function resolveStudioHint(
+  supabase: SupabaseClient<Database>,
+  userId: string,
+  hint: string,
+  agentId?: string
+): Promise<string | undefined> {
+  if (hint === 'main') {
+    // 1. Worktree path match (canonical main resolution)
+    const { data: mainByPath } = await supabase
+      .from('studios')
+      .select('id')
+      .eq('user_id', userId)
+      .eq('worktree_path', process.cwd())
+      .neq('status', 'cleaned')
+      .limit(1)
+      .maybeSingle();
+    if (mainByPath?.id) return mainByPath.id;
+
+    // 2. Branch match fallback
+    const { data: mainByBranch } = await supabase
+      .from('studios')
+      .select('id')
+      .eq('user_id', userId)
+      .eq('branch', 'main')
+      .in('status', ['active', 'idle', 'archived'])
+      .order('updated_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    return mainByBranch?.id || undefined;
+  }
+
+  // Named hint: match by slug
+  let query = supabase
+    .from('studios')
+    .select('id')
+    .eq('user_id', userId)
+    .eq('slug', hint)
+    .in('status', ['active', 'idle'])
+    .limit(1);
+  if (agentId) query = query.eq('agent_id', agentId);
+  const { data: namedStudio } = await query.maybeSingle();
+  return namedStudio?.id || undefined;
+}
+
+/**
  * Factory function to create a SessionService with real dependencies.
  * Use this in production code. For testing, construct SessionService directly with mocks.
  */

--- a/packages/channel-plugin/index.ts
+++ b/packages/channel-plugin/index.ts
@@ -286,7 +286,15 @@ async function pollInbox(): Promise<void> {
       for (const msg of messages) {
         const msgId = msg.id as string;
         const msgTs = msg.createdAt as string;
-        if (msg.senderAgentId === agentId) continue;
+        // Skip own messages UNLESS they came from a different studio (cross-studio self-message)
+        if (msg.senderAgentId === agentId) {
+          if (!studioId) continue; // no studio context — always skip self
+          const msgPcp = (msg.metadata as Record<string, unknown>)?.pcp as Record<string, unknown> | undefined;
+          const msgSender = msgPcp?.sender as Record<string, unknown> | undefined;
+          const msgStudioId = msgSender?.studioId as string | undefined;
+          if (!msgStudioId || msgStudioId === studioId) continue; // same studio or unknown — skip
+          // Different studio — accept (cross-studio self-message)
+        }
         if (msgId && seenMessageIds.has(msgId)) continue;
         if (lastKnownTs && msgTs && msgTs <= lastKnownTs) continue;
         if (msgId) seenMessageIds.add(msgId);
@@ -324,7 +332,14 @@ async function pollInbox(): Promise<void> {
     const inboxMessages = (result.messages as Array<Record<string, unknown>>) || [];
     for (const msg of inboxMessages) {
       const msgId = msg.id as string;
-      if (msg.senderAgentId === agentId) continue;
+      // Skip own messages unless cross-studio (same logic as thread path above)
+      if (msg.senderAgentId === agentId) {
+        if (!studioId) continue;
+        const msgPcp = (msg.metadata as Record<string, unknown>)?.pcp as Record<string, unknown> | undefined;
+        const msgSender = msgPcp?.sender as Record<string, unknown> | undefined;
+        const msgStudioId = msgSender?.studioId as string | undefined;
+        if (!msgStudioId || msgStudioId === studioId) continue;
+      }
       if (msgId && seenMessageIds.has(msgId)) continue;
       if (!isLegacyMessageForThisStudio(msg)) continue;
       if (msgId) seenMessageIds.add(msgId);


### PR DESCRIPTION
## Summary
- Allow agents to message themselves in a different studio (e.g., wren-omega → wren-review for review requests)
- `resolveTriggeredAgents` gains `selfStudioTarget` flag — keeps sender in trigger lists when targeting a different studio
- `handleSendToInbox` detects cross-studio self-messages when sender is in recipients AND `recipientStudioId`/`recipientStudioHint` is set
- Trigger payload passes `studioId`/`studioHint` for routing; skips thread history auto-resolve for self (would find own session)
- Channel plugin self-filter now checks studioId — accepts messages from self when sent from a different studio
- Replaced duplicated `resolveTriggeredAgents` in test file with direct import

## Test plan
- [x] 65 tests pass across 3 files (thread-handlers, inbox-handlers, channel-plugin)
- [x] 5 new selfStudioTarget unit tests
- [ ] Live test: send_to_inbox from wren-omega to wren with recipientStudioHint targeting wren-review

🤖 Generated with [Claude Code](https://claude.com/claude-code)