### PR TITLE
fix: restore codex runner sessions in picker (by Lumen)

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -203,7 +203,7 @@ program
   .option('--session-candidates-json', 'Output session candidates as JSON (testing/debug)')
   .option(
     '--session-candidates-all',
-    'Include all backend-local sessions in picker/json (debug mode; includes non-interactive sources)'
+    'Include all backend-local session sources in picker/json (debug mode)'
   )
   .option('--session-choice <choice>', 'Force session selection (new | pcp:<id> | local:<id>)')
   .option('--sb-debug', 'Enable SB debug logging to ~/.pcp/sb-debug.log')

--- a/packages/cli/src/commands/claude.test.ts
+++ b/packages/cli/src/commands/claude.test.ts
@@ -12,6 +12,7 @@ import {
   filterPcpSessionsForContext,
   filterUntrackedLocalClaudeSessions,
   buildSessionPickerLabel,
+  getBackendLocalSessionsForProject,
   getClaudeLocalSessionsForProject,
   getKnownClaudeSessionIds,
   getCodexLocalSessionsForProject,
@@ -1330,6 +1331,14 @@ describe('getCodexLocalSessionsForProject', () => {
         includeExecSources: false,
       });
       expect(cliOnlySessions.map((session) => session.sessionId)).toEqual([matchingSessionId]);
+
+      const defaultBackendSessions = getBackendLocalSessionsForProject('codex', projectPath, 10, {
+        includeAllSources: false,
+      });
+      expect(defaultBackendSessions.map((session) => session.sessionId)).toEqual([
+        nonCliSessionId,
+        matchingSessionId,
+      ]);
 
       const sessionsIncludingExec = getCodexLocalSessionsForProject(projectPath, 10, {
         includeExecSources: true,

--- a/packages/cli/src/commands/claude.test.ts
+++ b/packages/cli/src/commands/claude.test.ts
@@ -1319,9 +1319,17 @@ describe('getCodexLocalSessionsForProject', () => {
 
     try {
       const sessions = getCodexLocalSessionsForProject(projectPath, 10);
-      expect(sessions.map((session) => session.sessionId)).toEqual([matchingSessionId]);
-      expect(sessions[0]?.latestPrompt).toBe('assistant: Most recent assistant reply');
-      expect(sessions[0]?.transcriptPath).toContain(matchingSessionId);
+      expect(sessions.map((session) => session.sessionId)).toEqual([
+        nonCliSessionId,
+        matchingSessionId,
+      ]);
+      expect(sessions[1]?.latestPrompt).toBe('assistant: Most recent assistant reply');
+      expect(sessions[1]?.transcriptPath).toContain(matchingSessionId);
+
+      const cliOnlySessions = getCodexLocalSessionsForProject(projectPath, 10, {
+        includeExecSources: false,
+      });
+      expect(cliOnlySessions.map((session) => session.sessionId)).toEqual([matchingSessionId]);
 
       const sessionsIncludingExec = getCodexLocalSessionsForProject(projectPath, 10, {
         includeExecSources: true,

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -2049,9 +2049,11 @@ export function getBackendLocalSessionsForProject(
 ): BackendLocalSessionSummary[] {
   if (backend === 'claude') return getClaudeLocalSessionsForProject(cwd, limit);
   if (backend === 'codex') {
-    return getCodexLocalSessionsForProject(cwd, limit, {
-      includeExecSources: options.includeAllSources,
-    });
+    return getCodexLocalSessionsForProject(
+      cwd,
+      limit,
+      options.includeAllSources ? { includeExecSources: true } : {}
+    );
   }
   if (backend === 'gemini') return getGeminiLocalSessionsForProject(cwd, limit);
   return [];

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -1644,7 +1644,10 @@ export function getCodexLocalSessionsForProject(
     includeExecSources?: boolean;
   } = {}
 ): BackendLocalSessionSummary[] {
-  const includeExecSources = options.includeExecSources === true;
+  // Default to including exec/runner-owned Codex sessions. Those automated runs are
+  // still attachable debugging artifacts, and hiding them regressed `sb -b codex`
+  // session visibility compared to prior behavior.
+  const includeExecSources = options.includeExecSources !== false;
   const fallbackToJsonl = (reason: string): BackendLocalSessionSummary[] => {
     const fallback = getCodexLocalSessionsFromJsonl(cwd, limit, { includeExecSources });
     sbDebugLog('backend', 'codex_local_sessions_fallback_jsonl', {
@@ -1763,7 +1766,7 @@ function getCodexLocalSessionsFromJsonl(
     includeExecSources?: boolean;
   } = {}
 ): BackendLocalSessionSummary[] {
-  const includeExecSources = options.includeExecSources === true;
+  const includeExecSources = options.includeExecSources !== false;
   const codexSessionsDir = join(homedir(), '.codex', 'sessions');
   if (!existsSync(codexSessionsDir)) return [];
 


### PR DESCRIPTION
## Summary
- restore Codex exec/runner sessions to the default backend-local session discovery flow
- keep an explicit `includeExecSources: false` path for internal/test-only cli-only filtering
- update the regression test and session-candidates help text

## Why
`sb -a lumen -b codex` used to show attachable Codex sessions created by automated runner flows as well as CLI sessions. A recent filter changed Codex discovery to default to `source = 'cli'`, which hid runner-created sessions from the picker and made debugging automated runs harder.

This change makes Codex local-session discovery include exec sources by default again, so automated runs show up in the normal picker/attach flow.

## Verification
- `yarn workspace @personal-context/cli vitest run src/commands/claude.test.ts src/cli.test.ts`
- `yarn workspace @personal-context/cli type-check`
- `git diff --check`