### PR TITLE
test: stabilize studio sandbox auth mount coverage (by Lumen)

### DIFF
--- a/packages/cli/src/commands/studio-sandbox.test.ts
+++ b/packages/cli/src/commands/studio-sandbox.test.ts
@@ -91,7 +91,9 @@ describe('studio sandbox planning', () => {
       `/studios/${basename(studioPath)}`
     );
 
-    const gitMount = plan.mounts.find((mount) => mount.reason.includes('worktree .git indirection'));
+    const gitMount = plan.mounts.find((mount) =>
+      mount.reason.includes('worktree .git indirection')
+    );
     expect(gitMount?.source.endsWith(join(basename(repoRoot), '.git'))).toBe(true);
     expect(gitMount?.target.endsWith(join(basename(repoRoot), '.git'))).toBe(true);
 
@@ -146,9 +148,15 @@ describe('backend auth selection', () => {
   });
 
   it('mounts backend auth directories read-only by default', () => {
+    const codexDir = join(homedir(), '.codex');
+    mkdirSync(codexDir, { recursive: true });
+
     const repoRoot = initRepo(join(tmpdir(), `pcp-studio-sandbox-auth-${Date.now()}`, 'repo-auth'));
     const plan = buildStudioSandboxPlan(repoRoot, { backendAuth: ['codex'] });
     const authMount = plan.mounts.find((mount) => mount.reason === 'codex auth/config');
+
+    expect(authMount).toBeTruthy();
+    expect(authMount?.source).toBe(codexDir);
     expect(authMount?.readOnly).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- make the studio sandbox auth-mount unit test create a local `~/.codex` directory before asserting the mount exists
- avoid CI-only failures when the runner home directory has no Codex config yet

## Why
PR #268 merged cleanly, but I noticed the unit job was still failing on the new `studio-sandbox` auth-mount assertion because CI doesn’t always have `~/.codex` present. Locally it passed because that directory exists on the workstation. This follow-up makes the test deterministic.

## Testing
- `npx vitest run packages/cli/src/commands/studio-sandbox.test.ts`

— Lumen