### PR TITLE
fix: update_inbox_message now handles thread messages (by Wren)

### DIFF
--- a/packages/api/src/mcp/tools/inbox-handlers.test.ts
+++ b/packages/api/src/mcp/tools/inbox-handlers.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { handleSendToInbox, handleGetInbox, isThreadOwnedByStudio } from './inbox-handlers';
+import { handleSendToInbox, handleGetInbox, handleUpdateInboxMessage, isThreadOwnedByStudio } from './inbox-handlers';
 
 // Mock user-resolver
 vi.mock('../../services/user-resolver', async (importOriginal) => {
@@ -1066,5 +1066,124 @@ describe('isThreadOwnedByStudio', () => {
       },
     ];
     expect(isThreadOwnedByStudio(messages, MY_STUDIO)).toBe(false);
+  });
+});
+
+// =====================================================
+// update_inbox_message — thread message fallback
+// =====================================================
+
+describe('handleUpdateInboxMessage — thread message fallback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should update thread read pointer when given a thread message ID', async () => {
+    const threadMsgId = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+    const threadId = 'f1e2d3c4-b5a6-7890-abcd-ef0987654321';
+
+    // Track upsert calls
+    const upsertCalls: unknown[] = [];
+
+    const fromFn = vi.fn().mockImplementation((table: string) => {
+      if (table === 'agent_inbox') {
+        // Legacy inbox: no match
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                eq: vi.fn().mockReturnValue({
+                  maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+                }),
+              }),
+            }),
+          }),
+        };
+      }
+      if (table === 'inbox_thread_messages') {
+        // Thread message found
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              maybeSingle: vi.fn().mockResolvedValue({
+                data: { id: threadMsgId, thread_id: threadId },
+                error: null,
+              }),
+            }),
+          }),
+        };
+      }
+      if (table === 'inbox_threads') {
+        // Thread belongs to user
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                maybeSingle: vi.fn().mockResolvedValue({
+                  data: { id: threadId },
+                  error: null,
+                }),
+              }),
+            }),
+          }),
+        };
+      }
+      if (table === 'inbox_thread_participants') {
+        // Agent is a participant
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                maybeSingle: vi.fn().mockResolvedValue({
+                  data: { agent_id: 'wren' },
+                  error: null,
+                }),
+              }),
+            }),
+          }),
+        };
+      }
+      if (table === 'inbox_thread_read_status') {
+        return {
+          upsert: vi.fn().mockImplementation((data: unknown) => {
+            upsertCalls.push(data);
+            return Promise.resolve({ data: null, error: null });
+          }),
+        };
+      }
+      if (table === 'agent_identities') {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                order: vi.fn().mockResolvedValue({ data: [], error: null }),
+              }),
+            }),
+          }),
+        };
+      }
+      return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis() };
+    });
+
+    const mockDc = {
+      getClient: vi.fn().mockReturnValue({ from: fromFn }),
+      repositories: {},
+    };
+
+    const result = await handleUpdateInboxMessage(
+      {
+        email: 'test@test.com',
+        messageId: threadMsgId,
+        agentId: 'wren',
+        status: 'completed',
+      },
+      mockDc as never
+    );
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.success).toBe(true);
+    expect(parsed.threadId).toBe(threadId);
+    expect(parsed.status).toBe('completed');
+    expect(upsertCalls.length).toBe(1);
   });
 });

--- a/packages/api/src/mcp/tools/inbox-handlers.ts
+++ b/packages/api/src/mcp/tools/inbox-handlers.ts
@@ -1200,13 +1200,24 @@ export async function handleUpdateInboxMessage(args: unknown, dataComposer: Data
     };
   }
 
-  // Try thread message — verify agent is a participant on the thread
+  // Try thread message — verify thread belongs to this user AND agent is a participant
   const { data: threadMsg } = await threadTable(supabase, 'inbox_thread_messages')
     .select('id, thread_id')
     .eq('id', messageId)
     .maybeSingle();
 
   if (threadMsg) {
+    // Verify the thread belongs to this user
+    const { data: thread } = await threadTable(supabase, 'inbox_threads')
+      .select('id')
+      .eq('id', threadMsg.thread_id)
+      .eq('user_id', resolved.user.id)
+      .maybeSingle();
+
+    if (!thread) {
+      throw new Error(`Message not found or not accessible: ${messageId}`);
+    }
+
     // Verify this agent is a participant on the thread
     const { data: participant } = await threadTable(supabase, 'inbox_thread_participants')
       .select('agent_id')

--- a/packages/api/src/mcp/tools/inbox-handlers.ts
+++ b/packages/api/src/mcp/tools/inbox-handlers.ts
@@ -1151,56 +1151,110 @@ export async function handleUpdateInboxMessage(args: unknown, dataComposer: Data
 
   const { messageId, agentId, status } = parsed;
 
-  // Verify the message belongs to this agent
-  const { data: existing, error: fetchError } = await supabase
+  // Try legacy agent_inbox first
+  const { data: existing } = await supabase
     .from('agent_inbox')
     .select('*')
     .eq('id', messageId)
     .eq('recipient_user_id', resolved.user.id)
     .eq('recipient_agent_id', agentId)
-    .single();
+    .maybeSingle();
 
-  if (fetchError) {
-    throw new Error(`Message not found or not accessible: ${messageId}`);
+  if (existing) {
+    // Legacy inbox message — update in agent_inbox
+    const updates: Record<string, unknown> = { status };
+    if (status === 'read' && !existing.read_at) {
+      updates.read_at = new Date().toISOString();
+    }
+    if (status === 'acknowledged') {
+      updates.acknowledged_at = new Date().toISOString();
+    }
+
+    const { data: updated, error: updateError } = await supabase
+      .from('agent_inbox')
+      .update(updates)
+      .eq('id', messageId)
+      .select()
+      .single();
+
+    if (updateError) {
+      throw new Error(`Failed to update message: ${updateError.message}`);
+    }
+
+    logger.info('Inbox message updated', { messageId, agentId, newStatus: status });
+
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify({
+            success: true,
+            message: 'Message updated',
+            messageId,
+            status: updated.status,
+            readAt: updated.read_at,
+            acknowledgedAt: updated.acknowledged_at,
+          }),
+        },
+      ],
+    };
   }
 
-  const updates: Record<string, unknown> = { status };
-
-  if (status === 'read' && !existing.read_at) {
-    updates.read_at = new Date().toISOString();
-  }
-  if (status === 'acknowledged') {
-    updates.acknowledged_at = new Date().toISOString();
-  }
-
-  const { data: updated, error: updateError } = await supabase
-    .from('agent_inbox')
-    .update(updates)
+  // Try thread message — verify agent is a participant on the thread
+  const { data: threadMsg } = await threadTable(supabase, 'inbox_thread_messages')
+    .select('id, thread_id')
     .eq('id', messageId)
-    .select()
-    .single();
+    .maybeSingle();
 
-  if (updateError) {
-    throw new Error(`Failed to update message: ${updateError.message}`);
+  if (threadMsg) {
+    // Verify this agent is a participant on the thread
+    const { data: participant } = await threadTable(supabase, 'inbox_thread_participants')
+      .select('agent_id')
+      .eq('thread_id', threadMsg.thread_id)
+      .eq('agent_id', agentId)
+      .maybeSingle();
+
+    if (!participant) {
+      throw new Error(`Message not found or not accessible: ${messageId}`);
+    }
+
+    // Thread messages don't have a status column — mark the thread as read instead
+    if (status === 'read' || status === 'acknowledged' || status === 'completed') {
+      await threadTable(supabase, 'inbox_thread_read_status').upsert(
+        {
+          thread_id: threadMsg.thread_id,
+          agent_id: agentId,
+          last_read_at: new Date().toISOString(),
+        },
+        { onConflict: 'thread_id,agent_id' }
+      );
+    }
+
+    logger.info('Thread message status updated (via read pointer)', {
+      messageId,
+      threadId: threadMsg.thread_id,
+      agentId,
+      newStatus: status,
+    });
+
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify({
+            success: true,
+            message: 'Thread message acknowledged (thread marked as read)',
+            messageId,
+            threadId: threadMsg.thread_id,
+            status,
+          }),
+        },
+      ],
+    };
   }
 
-  logger.info('Inbox message updated', { messageId, agentId, newStatus: status });
-
-  return {
-    content: [
-      {
-        type: 'text' as const,
-        text: JSON.stringify({
-          success: true,
-          message: 'Message updated',
-          messageId,
-          status: updated.status,
-          readAt: updated.read_at,
-          acknowledgedAt: updated.acknowledged_at,
-        }),
-      },
-    ],
-  };
+  // Neither table had this message
+  throw new Error(`Message not found or not accessible: ${messageId}`);
 }
 
 export async function handleMarkInboxRead(args: unknown, dataComposer: DataComposer) {


### PR DESCRIPTION
## Summary
- `update_inbox_message` previously only queried `agent_inbox`, causing "Message not found" errors for thread message IDs (e.g., when Lumen tries to mark a task_request as completed)
- Now tries `agent_inbox` first, falls back to `inbox_thread_messages` with participant verification
- Thread messages don't have a status column — status updates advance the thread read pointer via `inbox_thread_read_status` instead

## Test plan
- [x] 27 existing inbox handler tests pass
- [ ] Verify `update_inbox_message` with a thread message ID no longer throws

🤖 Generated with [Claude Code](https://claude.com/claude-code)