### PR TITLE
feat: agent runtime settings — dashboard UI + API (by Wren)

### DIFF
--- a/packages/api/src/routes/admin-endpoints.test.ts
+++ b/packages/api/src/routes/admin-endpoints.test.ts
@@ -1278,7 +1278,7 @@ describe('admin endpoint handlers (no-500 regression)', () => {
                 eq: vi.fn().mockReturnValue({
                   eq: vi.fn().mockReturnValue({
                     maybeSingle: vi.fn().mockResolvedValue({
-                      data: { id: 'identity-abc' },
+                      data: { id: 'identity-abc', metadata: {} },
                       error: null,
                     }),
                   }),
@@ -1286,7 +1286,14 @@ describe('admin endpoint handlers (no-500 regression)', () => {
               }),
             }),
             update: vi.fn().mockReturnValue({
-              eq: vi.fn().mockResolvedValue({ data: null, error: null }),
+              eq: vi.fn().mockReturnValue({
+                select: vi.fn().mockReturnValue({
+                  single: vi.fn().mockResolvedValue({
+                    data: { sandbox_bypass: true, backend: null, metadata: {} },
+                    error: null,
+                  }),
+                }),
+              }),
             }),
           };
         }

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -2211,7 +2211,8 @@ router.get('/routing/agents/:agentId', async (req: Request, res: Response) => {
 
 /**
  * PATCH /api/admin/identities/:agentId/settings
- * Update SB-level settings (sandbox_bypass, etc.). Admin-only — not exposed via MCP.
+ * Update SB-level settings: sandbox_bypass, backend, runtime config (tool profile,
+ * tool routing, max turns, passive recall). Admin-only — not exposed via MCP.
  */
 router.patch('/identities/:agentId/settings', async (req: Request, res: Response) => {
   try {
@@ -2224,7 +2225,7 @@ router.patch('/identities/:agentId/settings', async (req: Request, res: Response
     // Find the identity for this agent + workspace
     const { data: identity, error: fetchErr } = await supabase
       .from('agent_identities')
-      .select('id')
+      .select('id, metadata')
       .eq('user_id', authReq.pcpUserId)
       .eq('workspace_id', authReq.pcpWorkspaceId)
       .eq('agent_id', agentId)
@@ -2238,8 +2239,33 @@ router.patch('/identities/:agentId/settings', async (req: Request, res: Response
     const body = (req.body || {}) as Record<string, unknown>;
     const updates: Record<string, unknown> = {};
 
+    // Top-level columns
     if (typeof body.sandboxBypass === 'boolean' || body.sandboxBypass === null) {
       updates.sandbox_bypass = body.sandboxBypass;
+    }
+    if (body.backend !== undefined) {
+      updates.backend = body.backend;
+    }
+
+    // Runtime config fields → stored in metadata.runtimeConfig
+    const { toolProfile, toolRouting, maxTurns, passiveRecall } = body;
+    if (
+      toolProfile !== undefined ||
+      toolRouting !== undefined ||
+      maxTurns !== undefined ||
+      passiveRecall !== undefined
+    ) {
+      const existingMeta = (identity.metadata || {}) as Record<string, unknown>;
+      const runtimeConfig: Record<string, unknown> = {
+        ...((existingMeta.runtimeConfig as Record<string, unknown>) || {}),
+      };
+
+      if (toolProfile !== undefined) runtimeConfig.toolProfile = toolProfile;
+      if (toolRouting !== undefined) runtimeConfig.toolRouting = toolRouting;
+      if (maxTurns !== undefined) runtimeConfig.maxTurns = maxTurns;
+      if (passiveRecall !== undefined) runtimeConfig.passiveRecall = passiveRecall;
+
+      updates.metadata = { ...existingMeta, runtimeConfig };
     }
 
     if (Object.keys(updates).length === 0) {
@@ -2249,10 +2275,12 @@ router.patch('/identities/:agentId/settings', async (req: Request, res: Response
 
     updates.updated_at = new Date().toISOString();
 
-    const { error: updateErr } = await supabase
+    const { data: updated, error: updateErr } = await supabase
       .from('agent_identities')
       .update(updates)
-      .eq('id', identity.id);
+      .eq('id', identity.id)
+      .select()
+      .single();
 
     if (updateErr) {
       logger.error('Failed to update identity settings:', updateErr);
@@ -2260,8 +2288,15 @@ router.patch('/identities/:agentId/settings', async (req: Request, res: Response
       return;
     }
 
+    const meta = (updated.metadata || {}) as Record<string, unknown>;
     logger.info('Identity settings updated', { agentId, updates });
-    res.json({ success: true, agentId, ...updates });
+    res.json({
+      success: true,
+      agentId,
+      backend: updated.backend || null,
+      sandbox_bypass: updated.sandbox_bypass,
+      runtimeConfig: (meta.runtimeConfig as Record<string, unknown>) || null,
+    });
   } catch (error) {
     logger.error('Failed to update identity settings:', error);
     res.status(500).json(errorJson('Failed to update identity settings', error));
@@ -2959,81 +2994,6 @@ router.get('/individuals', async (req: Request, res: Response) => {
   } catch (error) {
     logger.error('Failed to list individuals:', error);
     res.status(500).json(errorJson('Failed to list individuals', error));
-  }
-});
-
-/**
- * PUT /api/admin/individuals/:agentId/settings
- * Update runtime settings for an AI being
- */
-router.put('/individuals/:agentId/settings', async (req: Request, res: Response) => {
-  try {
-    const { agentId } = req.params;
-    const { backend, toolProfile, toolRouting, maxTurns, passiveRecall } = req.body;
-    const supabase = createClient(env.SUPABASE_URL, env.SUPABASE_SECRET_KEY, {
-      auth: { autoRefreshToken: false, persistSession: false },
-    });
-    const authReq = req as AdminAuthRequest;
-
-    // Find the identity
-    const { data: identity, error: findError } = await supabase
-      .from('agent_identities')
-      .select('id, metadata, backend')
-      .eq('agent_id', agentId)
-      .eq('user_id', authReq.pcpUserId)
-      .eq('workspace_id', authReq.pcpWorkspaceId)
-      .single();
-
-    if (findError || !identity) {
-      res.status(404).json({ error: 'Agent not found' });
-      return;
-    }
-
-    // Build updates
-    const existingMeta = (identity.metadata || {}) as Record<string, unknown>;
-    const runtimeConfig: Record<string, unknown> = {
-      ...(existingMeta.runtimeConfig as Record<string, unknown> || {}),
-    };
-
-    if (toolProfile !== undefined) runtimeConfig.toolProfile = toolProfile;
-    if (toolRouting !== undefined) runtimeConfig.toolRouting = toolRouting;
-    if (maxTurns !== undefined) runtimeConfig.maxTurns = maxTurns;
-    if (passiveRecall !== undefined) runtimeConfig.passiveRecall = passiveRecall;
-
-    const updates: Record<string, unknown> = {
-      metadata: { ...existingMeta, runtimeConfig },
-    };
-
-    // backend is a top-level column, not metadata
-    if (backend !== undefined) {
-      updates.backend = backend;
-    }
-
-    const { data: updated, error: updateError } = await supabase
-      .from('agent_identities')
-      .update(updates as never)
-      .eq('id', identity.id)
-      .select()
-      .single();
-
-    if (updateError) {
-      logger.error('Failed to update agent settings:', updateError);
-      res.status(500).json(errorJson('Failed to update settings', updateError));
-      return;
-    }
-
-    const meta = (updated.metadata || {}) as Record<string, unknown>;
-    res.json({
-      success: true,
-      settings: {
-        agentId,
-        backend: updated.backend || null,
-        runtimeConfig: (meta.runtimeConfig as Record<string, unknown>) || null,
-      },
-    });
-  } catch (error) {
-    logger.error('Failed to update agent settings:', error);
-    res.status(500).json(errorJson('Failed to update agent settings', error));
   }
 });
 

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -2932,28 +2932,108 @@ router.get('/individuals', async (req: Request, res: Response) => {
     }
 
     res.json({
-      individuals: (data || []).map((identity) => ({
-        id: identity.id,
-        agentId: identity.agent_id,
-        name: identity.name,
-        role: identity.role,
-        description: identity.description,
-        values: identity.values,
-        relationships: identity.relationships,
-        capabilities: identity.capabilities,
-        metadata: identity.metadata,
-        heartbeat: identity.heartbeat,
-        soul: identity.soul,
-        hasSoul: !!identity.soul,
-        hasHeartbeat: !!identity.heartbeat,
-        version: identity.version,
-        createdAt: identity.created_at,
-        updatedAt: identity.updated_at,
-      })),
+      individuals: (data || []).map((identity) => {
+        const meta = (identity.metadata || {}) as Record<string, unknown>;
+        return {
+          id: identity.id,
+          agentId: identity.agent_id,
+          name: identity.name,
+          role: identity.role,
+          backend: identity.backend || null,
+          description: identity.description,
+          values: identity.values,
+          relationships: identity.relationships,
+          capabilities: identity.capabilities,
+          metadata: identity.metadata,
+          runtimeConfig: (meta.runtimeConfig as Record<string, unknown>) || null,
+          heartbeat: identity.heartbeat,
+          soul: identity.soul,
+          hasSoul: !!identity.soul,
+          hasHeartbeat: !!identity.heartbeat,
+          version: identity.version,
+          createdAt: identity.created_at,
+          updatedAt: identity.updated_at,
+        };
+      }),
     });
   } catch (error) {
     logger.error('Failed to list individuals:', error);
     res.status(500).json(errorJson('Failed to list individuals', error));
+  }
+});
+
+/**
+ * PUT /api/admin/individuals/:agentId/settings
+ * Update runtime settings for an AI being
+ */
+router.put('/individuals/:agentId/settings', async (req: Request, res: Response) => {
+  try {
+    const { agentId } = req.params;
+    const { backend, toolProfile, toolRouting, maxTurns, passiveRecall } = req.body;
+    const supabase = createClient(env.SUPABASE_URL, env.SUPABASE_SECRET_KEY, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+    const authReq = req as AdminAuthRequest;
+
+    // Find the identity
+    const { data: identity, error: findError } = await supabase
+      .from('agent_identities')
+      .select('id, metadata, backend')
+      .eq('agent_id', agentId)
+      .eq('user_id', authReq.pcpUserId)
+      .eq('workspace_id', authReq.pcpWorkspaceId)
+      .single();
+
+    if (findError || !identity) {
+      res.status(404).json({ error: 'Agent not found' });
+      return;
+    }
+
+    // Build updates
+    const existingMeta = (identity.metadata || {}) as Record<string, unknown>;
+    const runtimeConfig: Record<string, unknown> = {
+      ...(existingMeta.runtimeConfig as Record<string, unknown> || {}),
+    };
+
+    if (toolProfile !== undefined) runtimeConfig.toolProfile = toolProfile;
+    if (toolRouting !== undefined) runtimeConfig.toolRouting = toolRouting;
+    if (maxTurns !== undefined) runtimeConfig.maxTurns = maxTurns;
+    if (passiveRecall !== undefined) runtimeConfig.passiveRecall = passiveRecall;
+
+    const updates: Record<string, unknown> = {
+      metadata: { ...existingMeta, runtimeConfig },
+    };
+
+    // backend is a top-level column, not metadata
+    if (backend !== undefined) {
+      updates.backend = backend;
+    }
+
+    const { data: updated, error: updateError } = await supabase
+      .from('agent_identities')
+      .update(updates as never)
+      .eq('id', identity.id)
+      .select()
+      .single();
+
+    if (updateError) {
+      logger.error('Failed to update agent settings:', updateError);
+      res.status(500).json(errorJson('Failed to update settings', updateError));
+      return;
+    }
+
+    const meta = (updated.metadata || {}) as Record<string, unknown>;
+    res.json({
+      success: true,
+      settings: {
+        agentId,
+        backend: updated.backend || null,
+        runtimeConfig: (meta.runtimeConfig as Record<string, unknown>) || null,
+      },
+    });
+  } catch (error) {
+    logger.error('Failed to update agent settings:', error);
+    res.status(500).json(errorJson('Failed to update agent settings', error));
   }
 });
 

--- a/packages/web/src/app/(dashboard)/individuals/[agentId]/page.tsx
+++ b/packages/web/src/app/(dashboard)/individuals/[agentId]/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState } from 'react';
 import Link from 'next/link';
 import { useRouter, useParams } from 'next/navigation';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -12,26 +13,44 @@ import {
   FileText,
   History,
   Inbox,
+  Settings,
   Share2,
   Sparkles,
   User,
   Zap,
+  Save,
+  Loader2,
 } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import { useApiQuery } from '@/lib/api';
+import { useApiQuery, useApiPut, useQueryClient } from '@/lib/api';
 import { normalizeDocMarkdown } from '@/lib/markdown/normalize-doc';
+import clsx from 'clsx';
+
+interface RuntimeConfig {
+  toolProfile?: string;
+  toolRouting?: string;
+  maxTurns?: number;
+  passiveRecall?: {
+    enabled?: boolean;
+    cooldownTurns?: number;
+    budgetCeiling?: number;
+    maxInjectPerTurn?: number;
+  };
+}
 
 interface Identity {
   id: string;
   agentId: string;
   name: string;
   role: string;
+  backend?: string | null;
   description?: string;
   values?: string[];
   relationships?: Record<string, string>;
   capabilities?: string[];
   metadata?: Record<string, unknown>;
+  runtimeConfig?: RuntimeConfig | null;
   heartbeat?: string;
   soul?: string;
   hasSoul: boolean;
@@ -43,6 +62,235 @@ interface Identity {
 
 interface IndividualsResponse {
   individuals: Identity[];
+}
+
+// ─── Runtime Settings Panel ─────────────────────────────────────
+
+const BACKENDS = [
+  { value: '', label: 'Not set' },
+  { value: 'claude', label: 'Claude (Anthropic)' },
+  { value: 'claude-code', label: 'Claude Code' },
+  { value: 'codex', label: 'Codex (OpenAI)' },
+  { value: 'gemini', label: 'Gemini (Google)' },
+];
+
+const TOOL_PROFILES = [
+  { value: '', label: 'Not set (use CLI default)' },
+  { value: 'minimal', label: 'Minimal — Read-only, no writes or comms' },
+  { value: 'safe', label: 'Safe — Memory + session allowed, comms prompted' },
+  { value: 'collaborative', label: 'Collaborative — Full collaboration, no prompts' },
+  { value: 'full', label: 'Full — Privileged, all tools, no restrictions' },
+];
+
+const TOOL_ROUTING = [
+  { value: '', label: 'Not set (use CLI default)' },
+  { value: 'local', label: 'Local — PCP tools via pcp-tool blocks' },
+  { value: 'backend', label: 'Backend — Native MCP tool calling' },
+];
+
+function RuntimeSettingsPanel({ agentId, identity }: { agentId: string; identity: Identity }) {
+  const queryClient = useQueryClient();
+  const rc = identity.runtimeConfig || {};
+
+  const [backend, setBackend] = useState(identity.backend || '');
+  const [toolProfile, setToolProfile] = useState(rc.toolProfile || '');
+  const [toolRouting, setToolRouting] = useState(rc.toolRouting || '');
+  const [maxTurns, setMaxTurns] = useState(String(rc.maxTurns || ''));
+  const [recallEnabled, setRecallEnabled] = useState(rc.passiveRecall?.enabled !== false);
+  const [recallCooldown, setRecallCooldown] = useState(String(rc.passiveRecall?.cooldownTurns ?? '3'));
+  const [recallCeiling, setRecallCeiling] = useState(String(rc.passiveRecall?.budgetCeiling ?? '0.8'));
+  const [recallMaxInject, setRecallMaxInject] = useState(String(rc.passiveRecall?.maxInjectPerTurn ?? '2'));
+
+  const saveSettings = useApiPut<
+    { success: boolean },
+    { id: string; body: Record<string, unknown> }
+  >(
+    ({ id }) => `/api/admin/individuals/${id}/settings`,
+    ({ body }) => body,
+    { onSuccess: () => queryClient.invalidateQueries({ queryKey: ['individuals'] }) }
+  );
+
+  const handleSave = () => {
+    saveSettings.mutate({
+      id: agentId,
+      body: {
+        backend: backend || null,
+        toolProfile: toolProfile || null,
+        toolRouting: toolRouting || null,
+        maxTurns: maxTurns ? parseInt(maxTurns, 10) : null,
+        passiveRecall: {
+          enabled: recallEnabled,
+          cooldownTurns: parseInt(recallCooldown, 10) || 3,
+          budgetCeiling: parseFloat(recallCeiling) || 0.8,
+          maxInjectPerTurn: parseInt(recallMaxInject, 10) || 2,
+        },
+      },
+    });
+  };
+
+  const selectClass =
+    'w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-gray-300 bg-white';
+  const inputClass =
+    'w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-gray-300';
+  const labelClass = 'block text-sm font-medium text-gray-700 mb-1';
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Settings className="h-5 w-5 text-gray-500" />
+            Runtime Settings
+          </CardTitle>
+          <CardDescription>
+            Configure default backend, tool permissions, and passive recall for{' '}
+            <span className="font-semibold">{identity.name}</span>. These settings apply when
+            launching via <code className="bg-gray-100 px-1.5 py-0.5 rounded text-xs">sb chat --agent {agentId}</code>.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          {/* Backend */}
+          <div>
+            <label className={labelClass}>Default Backend</label>
+            <select value={backend} onChange={(e) => setBackend(e.target.value)} className={selectClass}>
+              {BACKENDS.map((b) => (
+                <option key={b.value} value={b.value}>{b.label}</option>
+              ))}
+            </select>
+            <p className="mt-1 text-xs text-gray-400">Which AI provider runs this agent by default.</p>
+          </div>
+
+          <div className="grid gap-6 md:grid-cols-2">
+            {/* Tool Profile */}
+            <div>
+              <label className={labelClass}>Tool Profile</label>
+              <select value={toolProfile} onChange={(e) => setToolProfile(e.target.value)} className={selectClass}>
+                {TOOL_PROFILES.map((p) => (
+                  <option key={p.value} value={p.value}>{p.label}</option>
+                ))}
+              </select>
+              <p className="mt-1 text-xs text-gray-400">Which PCP tools are allowed without prompting.</p>
+            </div>
+
+            {/* Tool Routing */}
+            <div>
+              <label className={labelClass}>Tool Routing</label>
+              <select value={toolRouting} onChange={(e) => setToolRouting(e.target.value)} className={selectClass}>
+                {TOOL_ROUTING.map((r) => (
+                  <option key={r.value} value={r.value}>{r.label}</option>
+                ))}
+              </select>
+              <p className="mt-1 text-xs text-gray-400">How PCP tool calls are routed.</p>
+            </div>
+          </div>
+
+          {/* Max Turns */}
+          <div className="max-w-xs">
+            <label className={labelClass}>Max Turns (automated sessions)</label>
+            <input
+              type="number"
+              min="1"
+              max="20"
+              placeholder="3"
+              value={maxTurns}
+              onChange={(e) => setMaxTurns(e.target.value)}
+              className={inputClass}
+            />
+            <p className="mt-1 text-xs text-gray-400">How many conversational turns in --message mode.</p>
+          </div>
+
+          {/* Passive Recall */}
+          <div>
+            <label className={labelClass}>Passive Recall</label>
+            <div className="mt-2 space-y-3 rounded-lg border border-gray-100 p-4 bg-gray-50/50">
+              <label className="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={recallEnabled}
+                  onChange={(e) => setRecallEnabled(e.target.checked)}
+                  className="rounded border-gray-300"
+                />
+                <span className="text-sm text-gray-700">Enable passive memory recall</span>
+              </label>
+
+              {recallEnabled && (
+                <div className="grid gap-4 md:grid-cols-3 pt-2">
+                  <div>
+                    <label className="block text-xs text-gray-500 mb-1">Cooldown (turns)</label>
+                    <input
+                      type="number"
+                      min="0"
+                      max="20"
+                      value={recallCooldown}
+                      onChange={(e) => setRecallCooldown(e.target.value)}
+                      className={inputClass}
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-xs text-gray-500 mb-1">Budget ceiling</label>
+                    <input
+                      type="number"
+                      min="0"
+                      max="1"
+                      step="0.05"
+                      value={recallCeiling}
+                      onChange={(e) => setRecallCeiling(e.target.value)}
+                      className={inputClass}
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-xs text-gray-500 mb-1">Max inject/turn</label>
+                    <input
+                      type="number"
+                      min="1"
+                      max="10"
+                      value={recallMaxInject}
+                      onChange={(e) => setRecallMaxInject(e.target.value)}
+                      className={inputClass}
+                    />
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Save */}
+          <div className="flex items-center gap-3 pt-2">
+            <Button onClick={handleSave} disabled={saveSettings.isPending}>
+              {saveSettings.isPending ? (
+                <Loader2 className="h-4 w-4 animate-spin mr-2" />
+              ) : (
+                <Save className="h-4 w-4 mr-2" />
+              )}
+              Save Settings
+            </Button>
+            {saveSettings.isSuccess && (
+              <span className="text-sm text-green-600">Settings saved.</span>
+            )}
+            {saveSettings.isError && (
+              <span className="text-sm text-red-600">Failed to save: {saveSettings.error?.message}</span>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* CLI Quick Reference */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm text-gray-500">CLI Quick Reference</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <pre className="bg-gray-900 text-gray-100 p-3 rounded-md text-xs font-mono overflow-x-auto">
+{`# Run ${identity.name} with saved settings
+sb chat --agent ${agentId}${backend ? ` --backend ${backend}` : ''}${toolProfile ? ` --profile ${toolProfile}` : ''}${toolRouting ? ` --tool-routing ${toolRouting}` : ''}${maxTurns ? ` --max-turns ${maxTurns}` : ''}
+
+# Heartbeat mode
+sb chat --agent ${agentId}${backend ? ` --backend ${backend}` : ''} --profile ${toolProfile || 'collaborative'} --max-turns ${maxTurns || '3'} --message "Heartbeat check"`}
+          </pre>
+        </CardContent>
+      </Card>
+    </div>
+  );
 }
 
 export default function AgentDetailPage() {
@@ -129,13 +377,17 @@ export default function AgentDetailPage() {
 
       {/* Main Content Tabs */}
       <Tabs defaultValue="overview" className="w-full">
-        <TabsList className="grid w-full grid-cols-4 lg:w-[600px]">
+        <TabsList className="grid w-full grid-cols-5 lg:w-[750px]">
           <TabsTrigger value="overview">Overview</TabsTrigger>
           <TabsTrigger value="soul" disabled={!identity.hasSoul}>
             Constitution
           </TabsTrigger>
           <TabsTrigger value="heartbeat" disabled={!identity.hasHeartbeat}>
             Operating guide
+          </TabsTrigger>
+          <TabsTrigger value="runtime">
+            <Settings className="h-3.5 w-3.5 mr-1" />
+            Runtime
           </TabsTrigger>
           <TabsTrigger value="raw">Identity JSON</TabsTrigger>
         </TabsList>
@@ -271,6 +523,11 @@ export default function AgentDetailPage() {
               </div>
             </CardContent>
           </Card>
+        </TabsContent>
+
+        {/* Runtime Settings Tab */}
+        <TabsContent value="runtime" className="mt-6">
+          <RuntimeSettingsPanel agentId={agentId} identity={identity} />
         </TabsContent>
 
         {/* Raw Identity Tab */}

--- a/packages/web/src/app/(dashboard)/individuals/[agentId]/page.tsx
+++ b/packages/web/src/app/(dashboard)/individuals/[agentId]/page.tsx
@@ -389,7 +389,7 @@ export default function AgentDetailPage() {
             <Settings className="h-3.5 w-3.5 mr-1" />
             Runtime
           </TabsTrigger>
-          <TabsTrigger value="raw">Identity JSON</TabsTrigger>
+          <TabsTrigger value="raw">Advanced</TabsTrigger>
         </TabsList>
 
         {/* Overview Tab */}
@@ -536,9 +536,9 @@ export default function AgentDetailPage() {
             <CardHeader>
               <CardTitle className="flex items-center gap-2">
                 <FileText className="h-5 w-5 text-gray-500" />
-                Identity JSON
+                Advanced
               </CardTitle>
-              <CardDescription>Structured identity payload used by API/UI.</CardDescription>
+              <CardDescription>Raw identity data used by the system.</CardDescription>
             </CardHeader>
             <CardContent>
               <pre className="bg-gray-900 text-gray-100 p-4 rounded-md overflow-x-auto text-sm font-mono">

--- a/packages/web/src/app/(dashboard)/individuals/[agentId]/page.tsx
+++ b/packages/web/src/app/(dashboard)/individuals/[agentId]/page.tsx
@@ -23,7 +23,7 @@ import {
 } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import { useApiQuery, useApiPut, useQueryClient } from '@/lib/api';
+import { useApiQuery, useApiPatch, useQueryClient } from '@/lib/api';
 import { normalizeDocMarkdown } from '@/lib/markdown/normalize-doc';
 import clsx from 'clsx';
 
@@ -84,7 +84,7 @@ const TOOL_PROFILES = [
 
 const TOOL_ROUTING = [
   { value: '', label: 'Not set (use CLI default)' },
-  { value: 'local', label: 'Local — PCP tools via pcp-tool blocks' },
+  { value: 'local', label: 'Local — Ink tools via ink-tool blocks' },
   { value: 'backend', label: 'Backend — Native MCP tool calling' },
 ];
 
@@ -101,11 +101,11 @@ function RuntimeSettingsPanel({ agentId, identity }: { agentId: string; identity
   const [recallCeiling, setRecallCeiling] = useState(String(rc.passiveRecall?.budgetCeiling ?? '0.8'));
   const [recallMaxInject, setRecallMaxInject] = useState(String(rc.passiveRecall?.maxInjectPerTurn ?? '2'));
 
-  const saveSettings = useApiPut<
+  const saveSettings = useApiPatch<
     { success: boolean },
     { id: string; body: Record<string, unknown> }
   >(
-    ({ id }) => `/api/admin/individuals/${id}/settings`,
+    ({ id }) => `/api/admin/identities/${id}/settings`,
     ({ body }) => body,
     { onSuccess: () => queryClient.invalidateQueries({ queryKey: ['individuals'] }) }
   );
@@ -145,7 +145,7 @@ function RuntimeSettingsPanel({ agentId, identity }: { agentId: string; identity
           <CardDescription>
             Configure default backend, tool permissions, and passive recall for{' '}
             <span className="font-semibold">{identity.name}</span>. These settings apply when
-            launching via <code className="bg-gray-100 px-1.5 py-0.5 rounded text-xs">sb chat --agent {agentId}</code>.
+            launching via <code className="bg-gray-100 px-1.5 py-0.5 rounded text-xs">ink chat --agent {agentId}</code>.
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-6">
@@ -169,7 +169,7 @@ function RuntimeSettingsPanel({ agentId, identity }: { agentId: string; identity
                   <option key={p.value} value={p.value}>{p.label}</option>
                 ))}
               </select>
-              <p className="mt-1 text-xs text-gray-400">Which PCP tools are allowed without prompting.</p>
+              <p className="mt-1 text-xs text-gray-400">Which Ink tools are allowed without prompting.</p>
             </div>
 
             {/* Tool Routing */}
@@ -180,7 +180,7 @@ function RuntimeSettingsPanel({ agentId, identity }: { agentId: string; identity
                   <option key={r.value} value={r.value}>{r.label}</option>
                 ))}
               </select>
-              <p className="mt-1 text-xs text-gray-400">How PCP tool calls are routed.</p>
+              <p className="mt-1 text-xs text-gray-400">How Ink tool calls are routed.</p>
             </div>
           </div>
 
@@ -282,10 +282,10 @@ function RuntimeSettingsPanel({ agentId, identity }: { agentId: string; identity
         <CardContent>
           <pre className="bg-gray-900 text-gray-100 p-3 rounded-md text-xs font-mono overflow-x-auto">
 {`# Run ${identity.name} with saved settings
-sb chat --agent ${agentId}${backend ? ` --backend ${backend}` : ''}${toolProfile ? ` --profile ${toolProfile}` : ''}${toolRouting ? ` --tool-routing ${toolRouting}` : ''}${maxTurns ? ` --max-turns ${maxTurns}` : ''}
+ink chat --agent ${agentId}${backend ? ` --backend ${backend}` : ''}${toolProfile ? ` --profile ${toolProfile}` : ''}${toolRouting ? ` --tool-routing ${toolRouting}` : ''}${maxTurns ? ` --max-turns ${maxTurns}` : ''}
 
 # Heartbeat mode
-sb chat --agent ${agentId}${backend ? ` --backend ${backend}` : ''} --profile ${toolProfile || 'collaborative'} --max-turns ${maxTurns || '3'} --message "Heartbeat check"`}
+ink chat --agent ${agentId}${backend ? ` --backend ${backend}` : ''} --profile ${toolProfile || 'collaborative'} --max-turns ${maxTurns || '3'} --message "Heartbeat check"`}
           </pre>
         </CardContent>
       </Card>

--- a/packages/web/src/app/(dashboard)/individuals/[agentId]/page.tsx
+++ b/packages/web/src/app/(dashboard)/individuals/[agentId]/page.tsx
@@ -25,8 +25,6 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { useApiQuery, useApiPatch, useQueryClient } from '@/lib/api';
 import { normalizeDocMarkdown } from '@/lib/markdown/normalize-doc';
-import clsx from 'clsx';
-
 interface RuntimeConfig {
   toolProfile?: string;
   toolRouting?: string;

--- a/packages/web/src/app/(dashboard)/individuals/[agentId]/page.tsx
+++ b/packages/web/src/app/(dashboard)/individuals/[agentId]/page.tsx
@@ -142,8 +142,8 @@ function RuntimeSettingsPanel({ agentId, identity }: { agentId: string; identity
           </CardTitle>
           <CardDescription>
             Configure default backend, tool permissions, and passive recall for{' '}
-            <span className="font-semibold">{identity.name}</span>. These settings apply when
-            launching via <code className="bg-gray-100 px-1.5 py-0.5 rounded text-xs">ink chat --agent {agentId}</code>.
+            <span className="font-semibold">{identity.name}</span>. These are stored defaults
+            used by triggers and heartbeats. Use the CLI reference below to apply them manually.
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-6">
@@ -279,7 +279,7 @@ function RuntimeSettingsPanel({ agentId, identity }: { agentId: string; identity
         </CardHeader>
         <CardContent>
           <pre className="bg-gray-900 text-gray-100 p-3 rounded-md text-xs font-mono overflow-x-auto">
-{`# Run ${identity.name} with saved settings
+{`# Run ${identity.name} with these settings
 ink chat --agent ${agentId}${backend ? ` --backend ${backend}` : ''}${toolProfile ? ` --profile ${toolProfile}` : ''}${toolRouting ? ` --tool-routing ${toolRouting}` : ''}${maxTurns ? ` --max-turns ${maxTurns}` : ''}
 
 # Heartbeat mode

--- a/packages/web/src/lib/api/hooks.ts
+++ b/packages/web/src/lib/api/hooks.ts
@@ -5,7 +5,7 @@ import {
   type UseQueryOptions,
   type UseMutationOptions,
 } from '@tanstack/react-query';
-import { apiGet, apiPost, apiPut, apiDelete, type ApiError } from './client';
+import { apiGet, apiPost, apiPut, apiPatch, apiDelete, type ApiError } from './client';
 
 /**
  * Hook for authenticated GET requests with React Query caching.
@@ -84,6 +84,20 @@ export function useApiPut<TResponse, TInput>(
 ) {
   return useMutation<TResponse, ApiError, TInput>({
     mutationFn: (input) => apiPut<TResponse>(pathFn(input), bodyFn(input)),
+    ...options,
+  });
+}
+
+/**
+ * Hook for authenticated PATCH mutations with dynamic path.
+ */
+export function useApiPatch<TResponse, TInput>(
+  pathFn: (input: TInput) => string,
+  bodyFn: (input: TInput) => unknown,
+  options?: Omit<UseMutationOptions<TResponse, ApiError, TInput>, 'mutationFn'>
+) {
+  return useMutation<TResponse, ApiError, TInput>({
+    mutationFn: (input) => apiPatch<TResponse>(pathFn(input), bodyFn(input)),
     ...options,
   });
 }


### PR DESCRIPTION
## Summary

New **Runtime** tab on the agent detail page (`/individuals/:agentId`) for configuring per-agent defaults:

- **Default backend** — claude, claude-code, codex, gemini
- **Tool profile** — minimal, safe, collaborative, full
- **Tool routing** — local (ink-tool blocks), backend (native MCP)
- **Max turns** — for automated `--message` sessions
- **Passive recall** — enabled, cooldown turns, budget ceiling, max inject per turn

Settings stored in `agent_identities.metadata.runtimeConfig` (JSONB) — no migration needed. Backend is a top-level column.

API: consolidated into existing `PATCH /api/admin/identities/:agentId/settings` (handles both `sandboxBypass` and runtime config in one endpoint).

Also includes a CLI quick reference card showing the `ink chat` command with the saved settings applied.

### Changes since original PR

- Rebased onto current main (post-Inkwell rename)
- Consolidated `PUT /individuals/:agentId/settings` → existing `PATCH /identities/:agentId/settings`
- Added `useApiPatch` hook to web lib
- Updated all naming: `sb chat` → `ink chat`, `PCP tools` → `Ink tools`
- Updated admin endpoint test mock chain

## Test plan

- [ ] Navigate to `/individuals/myra` → Runtime tab visible
- [ ] Set backend to "Claude", profile to "Collaborative", max turns to 3
- [ ] Save → settings persisted, page reloads with saved values
- [ ] Verify `PATCH /api/admin/identities/:agentId/settings` accepts both `sandboxBypass` and runtime config fields
- [ ] Routing page sandbox bypass toggle still works (shared endpoint)
- [ ] Full test suite passes locally (59 files, 755+ tests)

— Wren