### PR TITLE
fix: Gemini adapter auth via settings.json override (by Wren)

### DIFF
--- a/packages/cli/src/backends/adapters.test.ts
+++ b/packages/cli/src/backends/adapters.test.ts
@@ -399,6 +399,54 @@ describe('backend adapters session resume wiring', () => {
     }
   });
 
-  // TODO: Gemini adapter auth regression test — needs settings.json override
-  // wiring first. See packages/cli/src/backends/gemini.ts TODO comment.
+  it('gemini adapter produces PCP_CONTEXT_TOKEN with session/studio/agent', () => {
+    const adapter = new GeminiAdapter();
+    const prepared = adapter.prepare({
+      agentId: 'aster',
+      model: undefined,
+      promptParts: [],
+      passthroughArgs: [],
+      pcpSessionId: 'sess-gemini-789',
+      studioId: 'studio-aster-012',
+    });
+
+    try {
+      expect(prepared.env.PCP_CONTEXT_TOKEN).toBeDefined();
+      const token = decodeContextToken(prepared.env.PCP_CONTEXT_TOKEN);
+      expect(token).not.toBeNull();
+      expect(token!.sessionId).toBe('sess-gemini-789');
+      expect(token!.studioId).toBe('studio-aster-012');
+      expect(token!.agentId).toBe('aster');
+      expect(token!.runtime).toBe('gemini');
+      expect(token!.cliAttached).toBe(true);
+    } finally {
+      prepared.cleanup();
+    }
+  });
+
+  it('gemini adapter generates settings.json with auth + context headers', () => {
+    const adapter = new GeminiAdapter();
+    const prepared = adapter.prepare({
+      agentId: 'aster',
+      model: undefined,
+      promptParts: [],
+      passthroughArgs: [],
+      pcpSessionId: 'sess-gemini-789',
+    });
+
+    try {
+      // Should have GEMINI_CLI_SYSTEM_SETTINGS_PATH pointing to temp file
+      expect(prepared.env.GEMINI_CLI_SYSTEM_SETTINGS_PATH).toBeDefined();
+      const settingsContent = readFileSync(prepared.env.GEMINI_CLI_SYSTEM_SETTINGS_PATH, 'utf-8');
+      const settings = JSON.parse(settingsContent);
+
+      // PCP server should have auth + context headers
+      expect(settings.mcpServers.pcp).toBeDefined();
+      expect(settings.mcpServers.pcp.headers.Authorization).toBe('Bearer ${PCP_ACCESS_TOKEN}');
+      expect(settings.mcpServers.pcp.headers['x-pcp-context']).toBe('${PCP_CONTEXT_TOKEN}');
+      expect(settings.mcpServers.pcp.headers['x-pcp-session-id']).toBe('${PCP_SESSION_ID}');
+    } finally {
+      prepared.cleanup();
+    }
+  });
 });

--- a/packages/cli/src/backends/gemini.ts
+++ b/packages/cli/src/backends/gemini.ts
@@ -2,25 +2,88 @@
  * Gemini CLI Backend Adapter
  *
  * Identity injection via GEMINI_SYSTEM_MD=<tmpfile> env var
- * MCP config via .gemini/settings.json (not yet implemented)
+ * MCP config via GEMINI_CLI_SYSTEM_SETTINGS_PATH → temp settings.json
+ *   with auth + session headers merged into PCP server config.
  *
  * Docs: https://geminicli.com/docs/
  */
 
+import { existsSync, readFileSync, writeFileSync, mkdirSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
 import { createIdentityPromptFile } from './identity.js';
+import { encodeContextToken } from '@personal-context/shared';
 import type { BackendAdapter, BackendConfig, PreparedBackend } from './types.js';
 
-// TODO: Gemini reads MCP headers from .gemini/settings.json, not env vars.
-// PCP_CONTEXT_TOKEN + Authorization need to be wired via a generated
-// settings.json override (like gemini-runner.ts does server-side).
-// See: packages/api/src/services/sessions/gemini-runner.ts:88-102
+/**
+ * Build a temp Gemini settings.json that merges PCP auth + session headers
+ * into the MCP server config. Gemini reads MCP headers from settings.json
+ * (not env vars like Codex), so we need a generated override file.
+ *
+ * Uses ${ENV_VAR} syntax — Gemini resolves env vars at runtime.
+ * Authorization uses ${PCP_ACCESS_TOKEN} which is set at the spawn site.
+ * If unset, Gemini sends "Bearer " which the server handles as unauthenticated.
+ *
+ * NOTE: Gemini env var interpolation in MCP headers may be unreliable
+ * (upstream issues #5282, #5828). Aster's existing settings use ${GITHUB_TOKEN}
+ * for GitHub auth which works, but PCP headers haven't been verified end-to-end.
+ * Live validation needed once Aster's quota resets.
+ */
+function buildGeminiSettings(cwd: string): { path: string; cleanup: () => void } | null {
+  // Start from .mcp.json to preserve other MCP servers (supabase, github, etc.)
+  const mcpJsonPath = join(cwd, '.mcp.json');
+  let mcpServers: Record<string, unknown> = {};
+  if (existsSync(mcpJsonPath)) {
+    try {
+      const parsed = JSON.parse(readFileSync(mcpJsonPath, 'utf-8'));
+      mcpServers = parsed.mcpServers || {};
+    } catch {
+      // ignore parse errors
+    }
+  }
+
+  // Merge PCP auth + session headers
+  const pcpConfig = (mcpServers.pcp || {}) as Record<string, unknown>;
+  const existingHeaders = (pcpConfig.headers || {}) as Record<string, string>;
+  mcpServers.pcp = {
+    ...pcpConfig,
+    type: pcpConfig.type || 'http',
+    url: pcpConfig.url || 'http://localhost:3001/mcp',
+    headers: {
+      ...existingHeaders,
+      Authorization: 'Bearer ${PCP_ACCESS_TOKEN}',
+      'x-pcp-context': '${PCP_CONTEXT_TOKEN}',
+      'x-pcp-session-id': '${PCP_SESSION_ID}',
+      'x-pcp-studio-id': '${PCP_STUDIO_ID}',
+    },
+  };
+
+  const settingsDir = join(tmpdir(), 'sb-gemini');
+  mkdirSync(settingsDir, { recursive: true });
+  const settingsFile = join(settingsDir, `settings-${process.pid}-${Date.now()}.json`);
+  try {
+    writeFileSync(settingsFile, JSON.stringify({ mcpServers }, null, 2));
+    return {
+      path: settingsFile,
+      cleanup: () => {
+        try {
+          rmSync(settingsFile, { force: true });
+        } catch {
+          // best-effort
+        }
+      },
+    };
+  } catch {
+    return null;
+  }
+}
 
 export class GeminiAdapter implements BackendAdapter {
   readonly name = 'gemini';
   readonly binary = 'gemini';
 
   prepare(config: BackendConfig): PreparedBackend {
-    const { promptFile, cleanup } = createIdentityPromptFile(config.agentId);
+    const { promptFile, cleanup: identityCleanup } = createIdentityPromptFile(config.agentId);
 
     const args: string[] = [];
 
@@ -50,15 +113,34 @@ export class GeminiAdapter implements BackendAdapter {
     // Passthrough flags
     args.push(...config.passthroughArgs);
 
+    // Build consolidated context token
+    const contextToken = encodeContextToken({
+      sessionId: config.pcpSessionId || '',
+      studioId: config.studioId || '',
+      agentId: config.agentId,
+      cliAttached: true,
+      runtime: 'gemini',
+    });
+
+    // Build temp settings.json with PCP auth + session headers.
+    // PCP_ACCESS_TOKEN is set at the spawn site (after prepare) — the
+    // ${PCP_ACCESS_TOKEN} syntax in settings.json resolves at Gemini runtime.
+    const settings = buildGeminiSettings(process.cwd());
+    const cleanup = () => {
+      identityCleanup();
+      settings?.cleanup();
+    };
+
     return {
       binary: this.binary,
       args,
-      // Identity injection via env var — points to our temp file
       env: {
         AGENT_ID: config.agentId,
         GEMINI_SYSTEM_MD: promptFile,
+        PCP_CONTEXT_TOKEN: contextToken,
         ...(config.pcpSessionId ? { PCP_SESSION_ID: config.pcpSessionId } : {}),
         ...(config.studioId ? { PCP_STUDIO_ID: config.studioId } : {}),
+        ...(settings ? { GEMINI_CLI_SYSTEM_SETTINGS_PATH: settings.path } : {}),
       },
       cleanup,
     };


### PR DESCRIPTION
## Summary
- Gemini reads MCP headers from `.gemini/settings.json`, not env vars — can't use the Codex `env_http_headers` approach
- Generate a temp `settings.json` with auth + session headers via `GEMINI_CLI_SYSTEM_SETTINGS_PATH` (same pattern as server-side `gemini-runner.ts`)
- `buildGeminiSettings()`: reads `.mcp.json`, merges `Authorization`, `x-pcp-context`, individual headers using `${ENV_VAR}` syntax
- Cleans up temp file on exit
- 2 regression tests: context token + settings.json header verification

## Test plan
- [x] 22 adapter tests pass (2 new)
- [ ] Live test: `sb -a aster -b gemini` → verify MCP calls carry auth headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)