### PR TITLE
feat: add sandbox defaults to studios and agent settings (by Lumen)

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,20 @@ Useful options:
 
 - `--studio-access none|ro|rw` — disable studio mounts, or make them read-only
 - `--network default|none` — default outbound networking, or no network
+- `--sandbox-profile pcp-auth` / `--pcp-auth` — mount narrow PCP auth continuity files (`~/.pcp/auth.json`, `~/.pcp/config.json`) for direct CLI access inside the container
+
+Persist default sandbox settings for a studio:
+
+```bash
+sb studio sandbox config
+sb studio sandbox config --sandbox-profile pcp-auth --studio-access rw --network default --siblings on
+```
+
+Notes:
+
+- `/studio` is an **internal container path**, not a slash command
+- sandbox defaults live in the studio’s local `.pcp/identity.json`
+- `sb studio list` shows the current sandbox default summary and whether the studio’s sandbox container is running
 - `--backend-auth claude,codex,gemini` — explicitly mount backend auth/config dirs into the container (read-only by default)
 - `--mount hostPath:containerPath[:ro|rw]` — add a narrow explicit extra mount
 

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -89,6 +89,13 @@ type ChannelRouteRow = {
   agent_identities: ChannelRouteIdentityRow | ChannelRouteIdentityRow[] | null;
 };
 
+type SandboxSettings = {
+  profile?: 'default' | 'pcp-auth';
+  studioAccess?: 'none' | 'ro' | 'rw';
+  network?: 'default' | 'none';
+  includeSiblingStudios?: boolean;
+};
+
 const ADMIN_ACCESS_TOKEN_LIFETIME_SECONDS = 3600; // 1 hour
 const ADMIN_REFRESH_TOKEN_LIFETIME_DAYS = 90;
 const ADMIN_CLIENT_ID = 'dashboard';
@@ -191,6 +198,56 @@ function parseRouteMetadata(input: unknown): Record<string, unknown> {
   }
 
   return input as Record<string, unknown>;
+}
+
+function normalizeSandboxSettings(input: unknown): SandboxSettings | null {
+  if (input == null) return null;
+  if (typeof input !== 'object' || Array.isArray(input)) {
+    throw new Error('sandboxDefaults must be an object or null');
+  }
+
+  const raw = input as Record<string, unknown>;
+  const next: SandboxSettings = {};
+
+  if ('profile' in raw) {
+    if (raw.profile !== 'default' && raw.profile !== 'pcp-auth') {
+      throw new Error('sandboxDefaults.profile must be "default" or "pcp-auth"');
+    }
+    next.profile = raw.profile;
+  }
+
+  if ('studioAccess' in raw) {
+    if (raw.studioAccess !== 'none' && raw.studioAccess !== 'ro' && raw.studioAccess !== 'rw') {
+      throw new Error('sandboxDefaults.studioAccess must be "none", "ro", or "rw"');
+    }
+    next.studioAccess = raw.studioAccess;
+  }
+
+  if ('network' in raw) {
+    if (raw.network !== 'default' && raw.network !== 'none') {
+      throw new Error('sandboxDefaults.network must be "default" or "none"');
+    }
+    next.network = raw.network;
+  }
+
+  if ('includeSiblingStudios' in raw) {
+    if (typeof raw.includeSiblingStudios !== 'boolean') {
+      throw new Error('sandboxDefaults.includeSiblingStudios must be a boolean');
+    }
+    next.includeSiblingStudios = raw.includeSiblingStudios;
+  }
+
+  return next;
+}
+
+function extractIdentitySandboxDefaults(metadata: unknown): SandboxSettings | null {
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) return null;
+  const raw = (metadata as Record<string, unknown>).sandboxDefaults;
+  try {
+    return normalizeSandboxSettings(raw);
+  } catch {
+    return null;
+  }
 }
 
 function extractRouteIdentity(route: ChannelRouteRow): ChannelRouteIdentityRow | null {
@@ -881,7 +938,7 @@ async function resolveWorkspaceIdentityScope(
       id: string;
       agent_id: string;
       name: string;
-      role: string | null;
+      role: string;
     } => Boolean(row.id) && Boolean(row.agent_id) && Boolean(row.name)
   );
 
@@ -2062,7 +2119,7 @@ router.get('/routing/agents/:agentId', async (req: Request, res: Response) => {
     const { data: identity, error: identityError } = await supabase
       .from('agent_identities')
       .select(
-        'id, agent_id, name, role, description, backend, studio_hint, workspace_id, updated_at'
+        'id, agent_id, name, role, description, backend, metadata, studio_hint, workspace_id, updated_at'
       )
       .eq('user_id', authReq.pcpUserId)
       .eq('workspace_id', authReq.pcpWorkspaceId)
@@ -2175,6 +2232,7 @@ router.get('/routing/agents/:agentId', async (req: Request, res: Response) => {
         description: identity.description,
         backend: identity.backend,
         studioHint: identity.studio_hint || null,
+        sandboxDefaults: extractIdentitySandboxDefaults(identity.metadata),
         updatedAt: identity.updated_at,
       },
       studios: (studiosData || []).map((s: Record<string, unknown>) => ({
@@ -2514,10 +2572,28 @@ router.patch('/routing/identities/:identityId', async (req: Request, res: Respon
   try {
     const authReq = req as AdminAuthRequest;
     const { identityId } = req.params;
-    const { studioHint } = req.body;
+    const body = (req.body || {}) as Record<string, unknown>;
+    const studioHint = 'studioHint' in body ? normalizeNullableText(body.studioHint) : undefined;
+    let sandboxDefaults: SandboxSettings | null | undefined = undefined;
 
-    if (typeof studioHint !== 'string' || !studioHint.trim()) {
-      res.status(400).json({ error: 'studioHint is required (non-empty string)' });
+    if ('sandboxDefaults' in body) {
+      try {
+        sandboxDefaults = normalizeSandboxSettings(body.sandboxDefaults);
+      } catch (error) {
+        res.status(400).json({
+          error: error instanceof Error ? error.message : 'Invalid sandboxDefaults payload',
+        });
+        return;
+      }
+    }
+
+    if (studioHint === undefined && sandboxDefaults === undefined) {
+      res.status(400).json({ error: 'Provide studioHint and/or sandboxDefaults' });
+      return;
+    }
+
+    if ('studioHint' in body && !studioHint) {
+      res.status(400).json({ error: 'studioHint must be a non-empty string when provided' });
       return;
     }
 
@@ -2528,7 +2604,7 @@ router.patch('/routing/identities/:identityId', async (req: Request, res: Respon
     // Verify identity belongs to user + workspace
     const { data: identity, error: fetchError } = await supabase
       .from('agent_identities')
-      .select('id, agent_id')
+      .select('id, agent_id, metadata')
       .eq('id', identityId)
       .eq('user_id', authReq.pcpUserId)
       .eq('workspace_id', authReq.pcpWorkspaceId)
@@ -2539,9 +2615,28 @@ router.patch('/routing/identities/:identityId', async (req: Request, res: Respon
       return;
     }
 
+    const updates: Record<string, unknown> = {};
+    if (typeof studioHint === 'string') {
+      updates.studio_hint = studioHint;
+    }
+    if (sandboxDefaults !== undefined) {
+      const metadata =
+        identity.metadata &&
+        typeof identity.metadata === 'object' &&
+        !Array.isArray(identity.metadata)
+          ? { ...(identity.metadata as Record<string, unknown>) }
+          : {};
+      if (sandboxDefaults === null) {
+        delete metadata.sandboxDefaults;
+      } else {
+        metadata.sandboxDefaults = sandboxDefaults;
+      }
+      updates.metadata = metadata;
+    }
+
     const { error: updateError } = await supabase
       .from('agent_identities')
-      .update({ studio_hint: studioHint.trim() })
+      .update(updates)
       .eq('id', identityId);
 
     if (updateError) {
@@ -2550,7 +2645,12 @@ router.patch('/routing/identities/:identityId', async (req: Request, res: Respon
       return;
     }
 
-    res.json({ success: true, identityId, studioHint: studioHint.trim() });
+    res.json({
+      success: true,
+      identityId,
+      studioHint: studioHint?.trim(),
+      sandboxDefaults: sandboxDefaults ?? extractIdentitySandboxDefaults(identity.metadata),
+    });
   } catch (error) {
     logger.error('Failed to update identity studio_hint:', error);
     res.status(500).json(errorJson('Failed to update identity', error));

--- a/packages/cli/src/backends/identity.ts
+++ b/packages/cli/src/backends/identity.ts
@@ -22,6 +22,17 @@ export interface RuntimePreferences {
   approvalMode?: 'interactive' | 'jsonl' | 'auto-approve';
 }
 
+export type StudioSandboxProfile = 'default' | 'pcp-auth';
+export type StudioSandboxAccessMode = 'none' | 'ro' | 'rw';
+export type StudioSandboxNetworkMode = 'default' | 'none';
+
+export interface StudioSandboxPreferences {
+  profile?: StudioSandboxProfile;
+  studioAccess?: StudioSandboxAccessMode;
+  network?: StudioSandboxNetworkMode;
+  includeSiblingStudios?: boolean;
+}
+
 export interface IdentityJson {
   agentId: string;
   identityId?: string;
@@ -32,6 +43,8 @@ export interface IdentityJson {
   studio?: string;
   /** Persisted runtime preferences for sb chat */
   runtime?: RuntimePreferences;
+  /** Persisted studio sandbox preferences for sb studio sandbox */
+  sandbox?: StudioSandboxPreferences;
 }
 
 /**
@@ -56,6 +69,42 @@ export function saveRuntimePreferences(cwd: string, prefs: RuntimePreferences): 
   try {
     const existing = readIdentityJson(cwd) || ({} as Record<string, unknown>);
     const merged = { ...existing, runtime: { ...(existing.runtime || {}), ...prefs } };
+    writeFileSync(identityPath, JSON.stringify(merged, null, 2) + '\n', 'utf-8');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Save studio sandbox preferences to .pcp/identity.json.
+ * Merges with existing content — only updates the `sandbox` field.
+ */
+export function saveStudioSandboxPreferences(
+  cwd: string,
+  prefs: StudioSandboxPreferences
+): boolean {
+  const identityPath = join(cwd, '.pcp', 'identity.json');
+  try {
+    const existing = readIdentityJson(cwd) || ({} as Record<string, unknown>);
+    const merged = { ...existing, sandbox: { ...(existing.sandbox || {}), ...prefs } };
+    writeFileSync(identityPath, JSON.stringify(merged, null, 2) + '\n', 'utf-8');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Remove persisted studio sandbox preferences from .pcp/identity.json.
+ */
+export function clearStudioSandboxPreferences(cwd: string): boolean {
+  const identityPath = join(cwd, '.pcp', 'identity.json');
+  try {
+    const existing = readIdentityJson(cwd);
+    if (!existing) return false;
+    const merged = { ...existing } as Record<string, unknown>;
+    delete merged.sandbox;
     writeFileSync(identityPath, JSON.stringify(merged, null, 2) + '\n', 'utf-8');
     return true;
   } catch {

--- a/packages/cli/src/commands/studio-sandbox.test.ts
+++ b/packages/cli/src/commands/studio-sandbox.test.ts
@@ -125,6 +125,40 @@ describe('studio sandbox planning', () => {
     expect(plan.mounts).toEqual([]);
     expect(plan.studioAccess).toBe('none');
   });
+
+  it('uses persisted sandbox defaults from .pcp/identity.json when CLI flags are absent', () => {
+    const repoRoot = initRepo(join(tmpRoot, 'repo-defaults'));
+    const studioPath = join(tmpRoot, 'repo-defaults--alpha');
+    git(`worktree add -b lumen/studio/alpha "${studioPath}"`, repoRoot);
+
+    mkdirSync(join(studioPath, '.pcp'), { recursive: true });
+    writeFileSync(
+      join(studioPath, '.pcp', 'identity.json'),
+      JSON.stringify(
+        {
+          agentId: 'lumen',
+          studio: 'alpha',
+          sandbox: {
+            profile: 'default',
+            studioAccess: 'ro',
+            network: 'none',
+            includeSiblingStudios: false,
+          },
+        },
+        null,
+        2
+      ),
+      'utf-8'
+    );
+
+    const plan = buildStudioSandboxPlan(studioPath);
+
+    expect(plan.profile).toBe('default');
+    expect(plan.studioAccess).toBe('ro');
+    expect(plan.network).toBe('none');
+    expect(plan.mounts.some((mount) => mount.target.startsWith('/studios/'))).toBe(false);
+    expect(plan.mounts.find((mount) => mount.target === '/studio')?.readOnly).toBe(true);
+  });
 });
 
 describe('extra mount parsing', () => {

--- a/packages/cli/src/commands/studio-sandbox.ts
+++ b/packages/cli/src/commands/studio-sandbox.ts
@@ -5,11 +5,18 @@ import { homedir } from 'os';
 import { basename, dirname, join, resolve as resolvePath } from 'path';
 import { Command } from 'commander';
 import chalk from 'chalk';
-import { readIdentityJson } from '../backends/identity.js';
+import {
+  clearStudioSandboxPreferences,
+  readIdentityJson,
+  saveStudioSandboxPreferences,
+  type IdentityJson,
+  type StudioSandboxPreferences,
+} from '../backends/identity.js';
 
 export type StudioAccessMode = 'none' | 'ro' | 'rw';
 export type StudioNetworkMode = 'default' | 'none';
 export type BackendAuthName = 'claude' | 'codex' | 'gemini';
+export type StudioSandboxProfile = 'default' | 'pcp-auth';
 
 export interface StudioSandboxMount {
   source: string;
@@ -23,6 +30,7 @@ export interface StudioSandboxContext {
   studioName: string;
   studioId?: string;
   agentId?: string;
+  identity?: IdentityJson | null;
   canonicalRepoRoot: string;
   canonicalGitDir?: string;
   worktreePaths: string[];
@@ -30,6 +38,7 @@ export interface StudioSandboxContext {
 
 export interface StudioSandboxPlanOptions {
   image?: string;
+  profile?: StudioSandboxProfile;
   studioAccess?: StudioAccessMode;
   network?: StudioNetworkMode;
   includeSiblingStudios?: boolean;
@@ -43,6 +52,7 @@ export interface StudioSandboxPlan {
   workdir: '/studio';
   uid?: number;
   gid?: number;
+  profile: StudioSandboxProfile;
   network: StudioNetworkMode;
   studioAccess: StudioAccessMode;
   context: StudioSandboxContext;
@@ -64,6 +74,18 @@ const BACKEND_AUTH_DIRS: Record<BackendAuthName, string> = {
   codex: join(homedir(), '.codex'),
   gemini: join(homedir(), '.gemini'),
 };
+const PCP_AUTH_FILES = [
+  {
+    source: join(homedir(), '.pcp', 'auth.json'),
+    target: `${CONTAINER_HOME}/.pcp/auth.json`,
+    reason: 'pcp auth token',
+  },
+  {
+    source: join(homedir(), '.pcp', 'config.json'),
+    target: `${CONTAINER_HOME}/.pcp/config.json`,
+    reason: 'pcp config',
+  },
+] as const;
 
 function git(args: string[], cwd: string): string {
   return execFileSync('git', args, {
@@ -225,9 +247,7 @@ function isDangerousSourcePath(source: string): boolean {
 export function parseExtraMount(spec: string): ParsedExtraMount {
   const parts = spec.split(':');
   if (parts.length < 2 || parts.length > 3) {
-    throw new Error(
-      `Invalid mount "${spec}". Expected hostPath:containerPath[:ro|rw] format.`
-    );
+    throw new Error(`Invalid mount "${spec}". Expected hostPath:containerPath[:ro|rw] format.`);
   }
 
   const [source, target, mode = 'rw'] = parts;
@@ -290,6 +310,7 @@ export function getStudioSandboxContext(cwd: string): StudioSandboxContext {
     studioName: identity?.studio || basename(studioPath),
     studioId: identity?.studioId,
     agentId: identity?.agentId,
+    identity,
     canonicalRepoRoot,
     canonicalGitDir: resolveCanonicalGitDir(canonicalRepoRoot),
     worktreePaths: getWorktreePaths(canonicalRepoRoot),
@@ -310,13 +331,39 @@ function makeMount(
   };
 }
 
+function normalizeSandboxProfile(
+  value: unknown,
+  fallback: StudioSandboxProfile = 'default'
+): StudioSandboxProfile {
+  return value === 'pcp-auth' ? 'pcp-auth' : fallback;
+}
+
+function getIdentitySandboxPreferences(
+  context: StudioSandboxContext
+): StudioSandboxPreferences | undefined {
+  return context.identity?.sandbox;
+}
+
+function addPcpAuthMounts(mounts: StudioSandboxMount[]): void {
+  for (const mount of PCP_AUTH_FILES) {
+    if (!existsSync(mount.source)) continue;
+    mounts.push(makeMount(mount.source, mount.target, true, mount.reason));
+  }
+}
+
 export function buildStudioSandboxPlan(
   cwd: string,
   options: StudioSandboxPlanOptions = {}
 ): StudioSandboxPlan {
   const context = getStudioSandboxContext(cwd);
-  const studioAccess = options.studioAccess || 'rw';
-  const includeSiblingStudios = options.includeSiblingStudios ?? true;
+  const sandboxPrefs = getIdentitySandboxPreferences(context);
+  const profile = normalizeSandboxProfile(options.profile ?? sandboxPrefs?.profile);
+  const studioAccess =
+    options.studioAccess ?? sandboxPrefs?.studioAccess ?? ('rw' satisfies StudioAccessMode);
+  const includeSiblingStudios =
+    options.includeSiblingStudios ?? sandboxPrefs?.includeSiblingStudios ?? true;
+  const network =
+    options.network ?? sandboxPrefs?.network ?? ('default' satisfies StudioNetworkMode);
   const readOnly = studioAccess === 'ro';
   const mounts: StudioSandboxMount[] = [];
 
@@ -365,6 +412,10 @@ export function buildStudioSandboxPlan(
     }
   }
 
+  if (profile === 'pcp-auth') {
+    addPcpAuthMounts(mounts);
+  }
+
   for (const spec of options.extraMountSpecs || []) {
     const parsed = parseExtraMount(spec);
     mounts.push(makeMount(parsed.source, parsed.target, parsed.readOnly, 'explicit extra mount'));
@@ -381,7 +432,8 @@ export function buildStudioSandboxPlan(
     workdir: '/studio',
     uid,
     gid,
-    network: options.network || 'default',
+    profile,
+    network,
     studioAccess,
     context,
     mounts,
@@ -456,11 +508,34 @@ function runDocker(args: string[], inherit = true): void {
   }
 }
 
-function inspectContainerName(containerName: string): boolean {
+export function inspectContainerName(containerName: string): boolean {
   const result = spawnSync('docker', ['container', 'inspect', containerName], {
     stdio: 'ignore',
   });
   return result.status === 0;
+}
+
+export function getStudioSandboxRuntimeStatus(cwd: string): {
+  containerName: string;
+  running: boolean;
+  preferences?: StudioSandboxPreferences;
+} {
+  const context = getStudioSandboxContext(cwd);
+  const containerName = buildContainerName(context);
+  return {
+    containerName,
+    running: inspectContainerName(containerName),
+    preferences: getIdentitySandboxPreferences(context),
+  };
+}
+
+export function formatSandboxPreferenceSummary(prefs?: StudioSandboxPreferences): string {
+  if (!prefs) return 'manual';
+  const profile = normalizeSandboxProfile(prefs.profile);
+  const studioAccess = prefs.studioAccess || 'rw';
+  const network = prefs.network || 'default';
+  const siblings = prefs.includeSiblingStudios === false ? 'siblings:off' : 'siblings:on';
+  return `${profile}, ${studioAccess}, ${network}, ${siblings}`;
 }
 
 function printPlan(plan: StudioSandboxPlan, json = false): void {
@@ -475,6 +550,7 @@ function printPlan(plan: StudioSandboxPlan, json = false): void {
   console.log(chalk.dim(`  Studio:    ${plan.context.studioPath}`));
   console.log(chalk.dim(`  Access:    ${plan.studioAccess}`));
   console.log(chalk.dim(`  Network:   ${plan.network}`));
+  console.log(chalk.dim(`  Profile:   ${plan.profile}`));
   if (plan.patchedMcpConfigPath) {
     console.log(chalk.dim(`  MCP file:  ${plan.patchedMcpConfigPath}`));
   }
@@ -490,29 +566,43 @@ function printPlan(plan: StudioSandboxPlan, json = false): void {
 
 function addCommonSandboxOptions(command: Command): Command {
   return command
-    .option('--image <image>', 'Sandbox image', DEFAULT_IMAGE)
-    .option('--studio-access <mode>', 'Studio access: none|ro|rw', 'rw')
-    .option('--network <mode>', 'Network mode: default|none', 'default')
+    .option('--image <image>', 'Sandbox image')
+    .option('--sandbox-profile <profile>', 'Sandbox profile: default|pcp-auth')
+    .option('--pcp-auth', 'Mount narrow PCP auth/config files for direct CLI continuity')
+    .option('--studio-access <mode>', 'Studio access: none|ro|rw')
+    .option('--network <mode>', 'Network mode: default|none')
     .option('--backend-auth <list>', 'Mount backend auth dirs: claude,codex,gemini,all')
     .option('--mount <spec...>', 'Extra mount(s): hostPath:containerPath[:ro|rw]')
     .option('--no-sibling-studios', 'Do not mount sibling studios under /studios');
 }
 
 function buildPlanFromCommand(cwd: string, options: Record<string, unknown>): StudioSandboxPlan {
-  const studioAccess = String(options.studioAccess || 'rw') as StudioAccessMode;
-  if (!['none', 'ro', 'rw'].includes(studioAccess)) {
+  const studioAccess =
+    options.studioAccess === undefined ? undefined : String(options.studioAccess);
+  if (studioAccess !== undefined && !['none', 'ro', 'rw'].includes(studioAccess)) {
     throw new Error(`Invalid --studio-access value: ${studioAccess}`);
   }
 
-  const network = String(options.network || 'default') as StudioNetworkMode;
-  if (!['default', 'none'].includes(network)) {
+  const network = options.network === undefined ? undefined : String(options.network);
+  if (network !== undefined && !['default', 'none'].includes(network)) {
     throw new Error(`Invalid --network value: ${network}`);
   }
 
+  const rawProfile =
+    options.pcpAuth === true
+      ? 'pcp-auth'
+      : typeof options.sandboxProfile === 'string'
+        ? options.sandboxProfile
+        : undefined;
+  if (rawProfile !== undefined && rawProfile !== 'default' && rawProfile !== 'pcp-auth') {
+    throw new Error(`Invalid --sandbox-profile value: ${rawProfile}`);
+  }
+
   return buildStudioSandboxPlan(cwd, {
-    image: typeof options.image === 'string' ? options.image : DEFAULT_IMAGE,
-    studioAccess,
-    network,
+    image: typeof options.image === 'string' ? options.image : undefined,
+    profile: rawProfile,
+    studioAccess: studioAccess as StudioAccessMode | undefined,
+    network: network as StudioNetworkMode | undefined,
     includeSiblingStudios: options.siblingStudios !== false,
     backendAuth: resolveBackendAuthNames(
       typeof options.backendAuth === 'string' ? options.backendAuth : undefined
@@ -523,6 +613,71 @@ function buildPlanFromCommand(cwd: string, options: Record<string, unknown>): St
         ? [options.mount]
         : [],
   });
+}
+
+function configCommand(options: Record<string, unknown>): void {
+  const cwd = process.cwd();
+
+  if (options.clear) {
+    if (!clearStudioSandboxPreferences(cwd)) {
+      throw new Error('No studio sandbox preferences found to clear');
+    }
+    console.log(chalk.green('✓ Cleared studio sandbox defaults from .pcp/identity.json'));
+    return;
+  }
+
+  const prefs: StudioSandboxPreferences = {};
+  let changed = false;
+
+  if (typeof options.sandboxProfile === 'string') {
+    if (options.sandboxProfile !== 'default' && options.sandboxProfile !== 'pcp-auth') {
+      throw new Error(`Invalid --sandbox-profile value: ${options.sandboxProfile}`);
+    }
+    prefs.profile = options.sandboxProfile;
+    changed = true;
+  }
+
+  if (typeof options.studioAccess === 'string') {
+    if (!['none', 'ro', 'rw'].includes(options.studioAccess)) {
+      throw new Error(`Invalid --studio-access value: ${options.studioAccess}`);
+    }
+    prefs.studioAccess = options.studioAccess as StudioAccessMode;
+    changed = true;
+  }
+
+  if (typeof options.network === 'string') {
+    if (!['default', 'none'].includes(options.network)) {
+      throw new Error(`Invalid --network value: ${options.network}`);
+    }
+    prefs.network = options.network as StudioNetworkMode;
+    changed = true;
+  }
+
+  if (typeof options.siblings === 'string') {
+    if (options.siblings !== 'on' && options.siblings !== 'off') {
+      throw new Error(`Invalid --siblings value: ${options.siblings}. Use on or off.`);
+    }
+    prefs.includeSiblingStudios = options.siblings === 'on';
+    changed = true;
+  }
+
+  if (!changed) {
+    const current = readIdentityJson(cwd)?.sandbox;
+    if (options.json) {
+      console.log(JSON.stringify(current || {}, null, 2));
+      return;
+    }
+    console.log(chalk.bold('Studio sandbox defaults'));
+    console.log(chalk.dim(`  ${formatSandboxPreferenceSummary(current)}`));
+    return;
+  }
+
+  if (!saveStudioSandboxPreferences(cwd, prefs)) {
+    throw new Error('Failed to save studio sandbox defaults to .pcp/identity.json');
+  }
+
+  console.log(chalk.green('✓ Updated studio sandbox defaults'));
+  console.log(chalk.dim(`  ${formatSandboxPreferenceSummary(readIdentityJson(cwd)?.sandbox)}`));
 }
 
 function buildSandboxImage(options: { image?: string; noCache?: boolean }, cwd: string): void {
@@ -585,7 +740,9 @@ function shellCommand(options: Record<string, unknown>): void {
 function execCommand(command: string[], options: Record<string, unknown>): void {
   const plan = buildPlanFromCommand(process.cwd(), options);
   if (!inspectContainerName(plan.containerName)) {
-    throw new Error(`Sandbox is not running: ${plan.containerName}. Start it with sb studio sandbox up`);
+    throw new Error(
+      `Sandbox is not running: ${plan.containerName}. Start it with sb studio sandbox up`
+    );
   }
   if (command.length === 0) {
     throw new Error('No command provided for sandbox exec');
@@ -604,6 +761,8 @@ function statusCommand(options: Record<string, unknown>): void {
           running,
           image: plan.image,
           studioPath: plan.context.studioPath,
+          profile: plan.profile,
+          preferences: plan.context.identity?.sandbox || null,
         },
         null,
         2
@@ -617,6 +776,10 @@ function statusCommand(options: Record<string, unknown>): void {
   console.log(chalk.dim(`  Running:   ${running ? 'yes' : 'no'}`));
   console.log(chalk.dim(`  Image:     ${plan.image}`));
   console.log(chalk.dim(`  Studio:    ${plan.context.studioPath}`));
+  console.log(chalk.dim(`  Profile:   ${plan.profile}`));
+  console.log(
+    chalk.dim(`  Defaults:   ${formatSandboxPreferenceSummary(plan.context.identity?.sandbox)}`)
+  );
 }
 
 function downCommand(options: Record<string, unknown>): void {
@@ -655,10 +818,14 @@ export function registerStudioSandboxCommands(studio: Command): void {
       .command('run [command...]')
       .allowExcessArguments(true)
       .description('Run a one-shot command in a new studio sandbox container')
-  ).action((command: string[], options: Record<string, unknown>) => runCommand(command || [], options));
+  ).action((command: string[], options: Record<string, unknown>) =>
+    runCommand(command || [], options)
+  );
 
   addCommonSandboxOptions(
-    sandbox.command('shell').description('Open a shell in the running sandbox, or start an ephemeral one')
+    sandbox
+      .command('shell')
+      .description('Open a shell in the running sandbox, or start an ephemeral one')
   ).action(shellCommand);
 
   addCommonSandboxOptions(
@@ -666,13 +833,26 @@ export function registerStudioSandboxCommands(studio: Command): void {
       .command('exec <command...>')
       .allowExcessArguments(true)
       .description('Run a command inside the running studio sandbox')
-  ).action((command: string[], options: Record<string, unknown>) => execCommand(command || [], options));
+  ).action((command: string[], options: Record<string, unknown>) =>
+    execCommand(command || [], options)
+  );
 
   addCommonSandboxOptions(
     sandbox.command('status').description('Show status for the current studio sandbox')
   )
     .option('--json', 'Output JSON')
     .action(statusCommand);
+
+  sandbox
+    .command('config')
+    .description('Show or persist default studio sandbox settings in .pcp/identity.json')
+    .option('--sandbox-profile <profile>', 'Default profile: default|pcp-auth')
+    .option('--studio-access <mode>', 'Default studio access: none|ro|rw')
+    .option('--network <mode>', 'Default network mode: default|none')
+    .option('--siblings <mode>', 'Default sibling studio mounts: on|off')
+    .option('--clear', 'Clear stored sandbox defaults')
+    .option('--json', 'Output JSON when showing current config')
+    .action(configCommand);
 
   addCommonSandboxOptions(
     sandbox.command('down').description('Stop the running studio sandbox for this studio')

--- a/packages/cli/src/commands/studio.ts
+++ b/packages/cli/src/commands/studio.ts
@@ -42,8 +42,12 @@ import { fileURLToPath } from 'url';
 import { homedir } from 'os';
 import { installHooks, callPcpTool } from './hooks.js';
 import { loadAuth, decodeJwtPayload, isTokenExpired } from '../auth/tokens.js';
-import { resolveAgentId } from '../backends/identity.js';
-import { registerStudioSandboxCommands } from './studio-sandbox.js';
+import { resolveAgentId, type StudioSandboxPreferences } from '../backends/identity.js';
+import {
+  formatSandboxPreferenceSummary,
+  getStudioSandboxRuntimeStatus,
+  registerStudioSandboxCommands,
+} from './studio-sandbox.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -60,6 +64,7 @@ interface StudioIdentity {
   branch: string;
   createdAt: string;
   createdBy?: string;
+  sandbox?: StudioSandboxPreferences;
 }
 
 interface StudioInfo {
@@ -1128,6 +1133,17 @@ function listCommand(): void {
       if (ws.identity.createdBy) {
         console.log(chalk.dim(`    Owner:  ${ws.identity.createdBy}`));
       }
+    }
+    try {
+      const sandbox = getStudioSandboxRuntimeStatus(ws.path);
+      console.log(
+        chalk.dim(`    Sandbox:`) +
+          ' ' +
+          formatSandboxPreferenceSummary(ws.identity?.sandbox) +
+          chalk.dim(` (${sandbox.running ? 'running' : 'stopped'})`)
+      );
+    } catch {
+      // Non-fatal: stale or broken worktrees can fail git-based sandbox introspection.
     }
     console.log('');
   }

--- a/packages/web/src/app/(dashboard)/routing/[agentId]/page.tsx
+++ b/packages/web/src/app/(dashboard)/routing/[agentId]/page.tsx
@@ -66,6 +66,13 @@ interface AgentStudio {
   routePatterns: string[];
 }
 
+interface AgentSandboxDefaults {
+  profile?: 'default' | 'pcp-auth';
+  studioAccess?: 'none' | 'ro' | 'rw';
+  network?: 'default' | 'none';
+  includeSiblingStudios?: boolean;
+}
+
 interface AgentRoutingResponse {
   heartbeatProcessingEnabled: boolean;
   agent: {
@@ -76,6 +83,7 @@ interface AgentRoutingResponse {
     description: string | null;
     backend: string | null;
     studioHint: string;
+    sandboxDefaults: AgentSandboxDefaults | null;
     updatedAt: string;
   };
   studios: AgentStudio[];
@@ -89,6 +97,13 @@ interface RouteFormState {
   chatId: string;
   studioHint: string;
   isActive: boolean;
+}
+
+interface SandboxDefaultsFormState {
+  profile: '' | 'default' | 'pcp-auth';
+  studioAccess: '' | 'none' | 'ro' | 'rw';
+  network: '' | 'default' | 'none';
+  includeSiblingStudios: boolean;
 }
 
 const PLATFORM_OPTIONS = ['telegram', 'whatsapp', 'discord', 'slack', 'email'];
@@ -128,6 +143,26 @@ function initialFormFromRoute(route: AgentRoute): RouteFormState {
     studioHint: route.studioHint || '',
     isActive: route.isActive,
   };
+}
+
+function initialSandboxForm(
+  sandboxDefaults: AgentSandboxDefaults | null | undefined
+): SandboxDefaultsFormState {
+  return {
+    profile: sandboxDefaults?.profile || '',
+    studioAccess: sandboxDefaults?.studioAccess || '',
+    network: sandboxDefaults?.network || '',
+    includeSiblingStudios: sandboxDefaults?.includeSiblingStudios ?? true,
+  };
+}
+
+function sandboxSummary(sandboxDefaults: AgentSandboxDefaults | null | undefined): string {
+  if (!sandboxDefaults) return 'Inherit / manual';
+  const profile = sandboxDefaults.profile || 'default';
+  const studioAccess = sandboxDefaults.studioAccess || 'rw';
+  const network = sandboxDefaults.network || 'default';
+  const siblings = sandboxDefaults.includeSiblingStudios === false ? 'siblings off' : 'siblings on';
+  return `${profile} · ${studioAccess} · ${network} · ${siblings}`;
 }
 
 const STATUS_COLORS: Record<string, string> = {
@@ -170,6 +205,28 @@ export default function AgentRoutingPage() {
     },
   });
 
+  const [editingSandboxDefaults, setEditingSandboxDefaults] = useState(false);
+  const [sandboxDefaultsForm, setSandboxDefaultsForm] = useState<SandboxDefaultsFormState>({
+    profile: '',
+    studioAccess: '',
+    network: '',
+    includeSiblingStudios: true,
+  });
+
+  const updateSandboxDefaultsMutation = useMutation({
+    mutationFn: ({
+      identityId,
+      sandboxDefaults,
+    }: {
+      identityId: string;
+      sandboxDefaults: AgentSandboxDefaults | null;
+    }) => apiPatch(`/api/admin/routing/identities/${identityId}`, { sandboxDefaults }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['routing-agent', agentId] });
+      setEditingSandboxDefaults(false);
+    },
+  });
+
   // Reminder studio editing
   const [editingReminderId, setEditingReminderId] = useState<string | null>(null);
   const [reminderStudioValue, setReminderStudioValue] = useState('');
@@ -205,6 +262,11 @@ export default function AgentRoutingPage() {
     if (!selectedRoute) return;
     setEditForm(initialFormFromRoute(selectedRoute));
   }, [editingRouteId, data?.routes]);
+
+  useEffect(() => {
+    if (!data?.agent || editingSandboxDefaults) return;
+    setSandboxDefaultsForm(initialSandboxForm(data.agent.sandboxDefaults));
+  }, [data?.agent, editingSandboxDefaults]);
 
   const createRouteMutation = useApiPost<{ route: AgentRoute }, Record<string, unknown>>(
     '/api/admin/routing/routes',
@@ -246,6 +308,7 @@ export default function AgentRoutingPage() {
     updateRouteMutation.error?.message ||
     deleteRouteMutation.error?.message ||
     updateHomeStudioMutation.error?.message ||
+    updateSandboxDefaultsMutation.error?.message ||
     updateReminderStudioMutation.error?.message;
 
   const selectClassName =
@@ -356,6 +419,152 @@ export default function AgentRoutingPage() {
                     }}
                   >
                     {studioHintLabel(data.agent.studioHint, studios)}
+                    <Pencil className="h-3 w-3 text-gray-400" />
+                  </button>
+                )}
+              </div>
+            </div>
+          )}
+
+          {data?.agent && (
+            <div className="mb-6 flex items-start justify-between gap-4 border-b border-gray-100 pb-4">
+              <div className="flex items-start gap-2.5 text-sm text-gray-500">
+                <Info className="mt-0.5 h-4 w-4 text-gray-400" />
+                <div>
+                  <div className="text-gray-700 font-medium">Sandbox defaults</div>
+                  <div className="mt-1">
+                    Advisory defaults for studio sandboxes. These shape local studio runtime
+                    behavior; the internal container mount path remains <code>/studio</code>.
+                  </div>
+                </div>
+              </div>
+              <div className="min-w-[280px] shrink-0">
+                {editingSandboxDefaults ? (
+                  <div className="space-y-2 rounded-md border border-gray-200 p-3">
+                    <div className="grid gap-2 sm:grid-cols-3">
+                      <label className="text-xs text-gray-500">
+                        Profile
+                        <select
+                          className={`${selectClassName} mt-1`}
+                          value={sandboxDefaultsForm.profile}
+                          onChange={(event) =>
+                            setSandboxDefaultsForm((current) => ({
+                              ...current,
+                              profile: event.target.value as SandboxDefaultsFormState['profile'],
+                            }))
+                          }
+                        >
+                          <option value="">Inherit / manual</option>
+                          <option value="default">default</option>
+                          <option value="pcp-auth">pcp-auth</option>
+                        </select>
+                      </label>
+                      <label className="text-xs text-gray-500">
+                        Studio access
+                        <select
+                          className={`${selectClassName} mt-1`}
+                          value={sandboxDefaultsForm.studioAccess}
+                          onChange={(event) =>
+                            setSandboxDefaultsForm((current) => ({
+                              ...current,
+                              studioAccess: event.target
+                                .value as SandboxDefaultsFormState['studioAccess'],
+                            }))
+                          }
+                        >
+                          <option value="">Default</option>
+                          <option value="none">none</option>
+                          <option value="ro">ro</option>
+                          <option value="rw">rw</option>
+                        </select>
+                      </label>
+                      <label className="text-xs text-gray-500">
+                        Network
+                        <select
+                          className={`${selectClassName} mt-1`}
+                          value={sandboxDefaultsForm.network}
+                          onChange={(event) =>
+                            setSandboxDefaultsForm((current) => ({
+                              ...current,
+                              network: event.target.value as SandboxDefaultsFormState['network'],
+                            }))
+                          }
+                        >
+                          <option value="">Default</option>
+                          <option value="default">default</option>
+                          <option value="none">none</option>
+                        </select>
+                      </label>
+                    </div>
+                    <label className="flex items-center gap-2 text-sm text-gray-600">
+                      <input
+                        type="checkbox"
+                        checked={sandboxDefaultsForm.includeSiblingStudios}
+                        onChange={(event) =>
+                          setSandboxDefaultsForm((current) => ({
+                            ...current,
+                            includeSiblingStudios: event.target.checked,
+                          }))
+                        }
+                      />
+                      Mount sibling studios under the shared studios area
+                    </label>
+                    <div className="flex items-center justify-end gap-2">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => {
+                          setSandboxDefaultsForm(initialSandboxForm(data.agent.sandboxDefaults));
+                          setEditingSandboxDefaults(false);
+                        }}
+                      >
+                        Cancel
+                      </Button>
+                      <Button
+                        size="sm"
+                        disabled={updateSandboxDefaultsMutation.isPending}
+                        onClick={() => {
+                          const hasAnySandboxOverride =
+                            sandboxDefaultsForm.profile ||
+                            sandboxDefaultsForm.studioAccess ||
+                            sandboxDefaultsForm.network ||
+                            sandboxDefaultsForm.includeSiblingStudios === false;
+
+                          updateSandboxDefaultsMutation.mutate({
+                            identityId: data.agent.id,
+                            sandboxDefaults: hasAnySandboxOverride
+                              ? {
+                                  ...(sandboxDefaultsForm.profile
+                                    ? { profile: sandboxDefaultsForm.profile }
+                                    : {}),
+                                  ...(sandboxDefaultsForm.studioAccess
+                                    ? { studioAccess: sandboxDefaultsForm.studioAccess }
+                                    : {}),
+                                  ...(sandboxDefaultsForm.network
+                                    ? { network: sandboxDefaultsForm.network }
+                                    : {}),
+                                  ...(sandboxDefaultsForm.includeSiblingStudios === false
+                                    ? { includeSiblingStudios: false }
+                                    : {}),
+                                }
+                              : null,
+                          });
+                        }}
+                      >
+                        <Save className="mr-2 h-4 w-4" />
+                        Save
+                      </Button>
+                    </div>
+                  </div>
+                ) : (
+                  <button
+                    className="inline-flex min-h-[40px] items-center gap-2 rounded-md border border-gray-200 px-3 py-2 text-left text-sm font-medium text-gray-700 hover:bg-gray-50 hover:border-gray-300 transition-colors cursor-pointer"
+                    onClick={() => {
+                      setSandboxDefaultsForm(initialSandboxForm(data.agent.sandboxDefaults));
+                      setEditingSandboxDefaults(true);
+                    }}
+                  >
+                    <span>{sandboxSummary(data.agent.sandboxDefaults)}</span>
                     <Pencil className="h-3 w-3 text-gray-400" />
                   </button>
                 )}

--- a/scripts/studio-sandbox-entrypoint.sh
+++ b/scripts/studio-sandbox-entrypoint.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 HOME_DIR="${HOME:-/home/sb}"
 mkdir -p \
   "${HOME_DIR}" \
+  "${HOME_DIR}/.pcp" \
   "${HOME_DIR}/.claude" \
   "${HOME_DIR}/.codex" \
   "${HOME_DIR}/.gemini"


### PR DESCRIPTION
## Summary
- add first-class studio sandbox defaults in `.pcp/identity.json`, including a `pcp-auth` preset for narrow PCP continuity mounts
- surface sandbox default summaries and running/stopped status in `sb studio list`, plus add `sb studio sandbox config`
- expose agent-level sandbox defaults in the routing settings UI via `agent_identities.metadata.sandboxDefaults`

## Why
This productizes the successful Docker sandbox patterns from PR #268 so operators don't need to remember raw mount flags. It also starts surfacing sandbox customization where people actually look: studio reporting and agent settings.

## Testing
- `npx vitest run packages/cli/src/commands/studio-sandbox.test.ts packages/cli/src/commands/studio.test.ts packages/cli/src/commands/studio-new.test.ts`
- `yarn workspace @personal-context/cli type-check`
- `yarn workspace @personal-context/cli build`
- `node packages/cli/dist/cli.js studio sandbox config --json`
- `node packages/cli/dist/cli.js studio list`

## Notes
- `/studio` remains an internal container path, not user-facing product language
- these sandbox defaults are advisory/runtime settings; they do **not** replace the existing tool-policy hierarchy
- `yarn workspace @personal-context/web type-check` still hits unrelated generated `.next` validator errors in this checkout; no errors from the touched routing page were emitted
- `yarn workspace @personal-context/api type-check` still has unrelated pre-existing repo-wide errors, but no errors from `packages/api/src/routes/admin.ts` after this change

— Lumen
