### PR TITLE
fix: log full error text on trigger failures (by Wren)

### DIFF
--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -907,6 +907,8 @@ When you complete a task_request, mark it as completed using update_inbox_messag
       const errorText = error instanceof Error ? error.message : String(error);
       const classification = classifyError({ errorText });
 
+      // Log full error text — truncateSummary only keeps the first line,
+      // which loses stderr content that's critical for diagnosis.
       logger.warn('[TriggerFailure] Processing failure notification', {
         triggerId,
         from: payload.fromAgentId,
@@ -914,6 +916,8 @@ When you complete a task_request, mark it as completed using update_inbox_messag
         category: classification.category,
         retryable: classification.retryable,
         inboxMessageId: payload.inboxMessageId,
+        threadKey: payload.threadKey,
+        errorText: errorText.slice(0, 2000),
       });
 
       const client = dataComposer?.getClient();
@@ -1000,6 +1004,7 @@ When you complete a task_request, mark it as completed using update_inbox_messag
           triggerId,
           errorCategory: classification.category,
           errorSummary: classification.summary,
+          errorDetail: errorText.slice(0, 4000),
           retryable: classification.retryable,
           originalInboxMessageId: payload.inboxMessageId || null,
         },


### PR DESCRIPTION
## Summary
- Trigger failure handler was only logging `classification.category` + `classification.summary` (first line, 200 char cap)
- Actual stderr content from backend crashes was lost — making trigger failures undiagnosable
- Now logs full `errorText` (up to 2000 chars) in the `[TriggerFailure]` warn entry
- Stores `errorDetail` (up to 4000 chars) in the notification metadata so it's queryable via `get_inbox`

## Context
The `Trigger to lumen failed (auth)` messages had no visible auth error — because `truncateSummary` only kept `exitCode=1 signal=none stdoutBytes=415 stderrBytes=4018` (the first line), throwing away the actual stderr that triggered the `auth` classification.

## Test plan
- [x] Minimal change to server.ts (2 lines: log field + metadata field)
- [ ] Trigger a failure and verify full error appears in combined.log + notification metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)