### PR TITLE
fix: remove dead PreCompress/postCompact hooks for Gemini (by Wren)

### DIFF
--- a/packages/api/src/mcp/tools/activity-stream-handlers.ts
+++ b/packages/api/src/mcp/tools/activity-stream-handlers.ts
@@ -301,7 +301,7 @@ export async function handleGetActivity(args: unknown, dataComposer: DataCompose
     offset: params.offset,
   });
 
-  logger.info(`Retrieved ${activities.length} activities for user ${user.id}`);
+  logger.debug(`Retrieved ${activities.length} activities for user ${user.id}`);
 
   return {
     content: [
@@ -404,7 +404,7 @@ export async function handleGetSessionContext(args: unknown, dataComposer: DataC
     }
   );
 
-  logger.info(`Retrieved ${activities.length} activities for session context`, {
+  logger.debug(`Retrieved ${activities.length} activities for session context`, {
     userId: user.id,
     sessionId: params.sessionId,
   });

--- a/packages/api/src/services/sessions/codex-runner.ts
+++ b/packages/api/src/services/sessions/codex-runner.ts
@@ -109,14 +109,14 @@ export class CodexRunner implements IRunner {
     config: ClaudeRunnerConfig,
     promptPath: string
   ): string[] {
-    const args: string[] = ['exec'];
+    // -a never must come BEFORE the exec subcommand — it's a root-level flag.
+    // Non-interactive: never prompt for approvals (no human present).
+    // Keeps sandbox protections — recommended by Codex docs for exec mode.
+    const args: string[] = ['-a', 'never', 'exec'];
     if (isResume) {
       args.push('resume');
     }
 
-    // Non-interactive: never prompt for approvals (no human present).
-    // Keeps sandbox protections — recommended by Codex docs for exec mode.
-    args.push('-a', 'never');
     args.push('--json');
     args.push('-c', `model_instructions_file=${promptPath}`);
 

--- a/packages/api/src/services/sessions/codex-runner.ts
+++ b/packages/api/src/services/sessions/codex-runner.ts
@@ -114,6 +114,9 @@ export class CodexRunner implements IRunner {
       args.push('resume');
     }
 
+    // Non-interactive: never prompt for approvals (no human present).
+    // Keeps sandbox protections — recommended by Codex docs for exec mode.
+    args.push('-a', 'never');
     args.push('--json');
     args.push('-c', `model_instructions_file=${promptPath}`);
 

--- a/packages/cli/src/commands/hooks.test.ts
+++ b/packages/cli/src/commands/hooks.test.ts
@@ -194,14 +194,14 @@ describe('installHooks: Gemini', () => {
     expect(existsSync(configPath)).toBe(true);
 
     const config = JSON.parse(readFileSync(configPath, 'utf-8'));
-    // SessionStart[0] = compress matcher (post-compact), SessionStart[1] = startup matcher
-    expect(config.hooks.SessionStart[0].matcher).toBe('compress');
-    expect(config.hooks.SessionStart[0].hooks[0].command).toContain('hooks post-compact');
-    expect(config.hooks.SessionStart[1].matcher).toBe('startup');
-    expect(config.hooks.SessionStart[1].hooks[0].command).toContain('hooks on-session-start');
+    // SessionStart: startup matcher only (PreCompress/postCompact disabled —
+    // Gemini has no post-compression SessionStart event)
+    expect(config.hooks.SessionStart).toHaveLength(1);
+    expect(config.hooks.SessionStart[0].matcher).toBe('startup');
+    expect(config.hooks.SessionStart[0].hooks[0].command).toContain('hooks on-session-start');
     expect(config.hooks.BeforeAgent[0].hooks[0].command).toContain('hooks on-prompt');
     expect(config.hooks.AfterAgent[0].hooks[0].command).toContain('hooks on-stop');
-    expect(config.hooks.PreCompress[0].hooks[0].command).toContain('hooks pre-compact');
+    expect(config.hooks.PreCompress).toBeUndefined();
   });
 
   it('should preserve existing Gemini settings', () => {

--- a/packages/cli/src/commands/hooks.ts
+++ b/packages/cli/src/commands/hooks.ts
@@ -122,12 +122,16 @@ const GEMINI: HookCapabilities = {
   configFormat: 'json',
   events: {
     sessionStart: 'SessionStart',
-    preCompact: 'PreCompress',
-    postCompact: 'SessionStart', // uses "compress" matcher on SessionStart (Gemini uses "compress", not Claude's "compact")
+    // PreCompress/postCompact disabled: Gemini fires PreCompress but has no
+    // post-compression SessionStart event (SessionStartSource only has
+    // 'startup'/'resume'/'clear' — no 'compress'). The "compress" matcher
+    // on SessionStart is dead code and lifecycle gets stuck at 'compacting'.
+    preCompact: null,
+    postCompact: null,
     onPrompt: 'BeforeAgent',
     onStop: 'AfterAgent',
   },
-  supportsCompaction: true,
+  supportsCompaction: false,
   supportsPromptHook: true,
 };
 
@@ -1173,18 +1177,9 @@ function installGemini(cwd: string, force: boolean): InstallResult {
 
   const sbPath = resolveSbBinaryPath(cwd);
   const pcpHooks: Record<string, unknown> = {
-    // SessionStart: two matchers — "compress" for post-compression identity re-injection,
-    // "startup" for initial session setup. Gemini uses "compress" (not Claude's "compact").
+    // SessionStart: startup matcher only. PreCompress/postCompact disabled —
+    // Gemini has no post-compression SessionStart event so lifecycle gets stuck.
     [GEMINI.events.sessionStart!]: [
-      {
-        matcher: 'compress',
-        hooks: [
-          {
-            type: 'command',
-            command: buildManagedHookCommand(sbPath, 'post-compact', GEMINI.name),
-          },
-        ],
-      },
       {
         matcher: 'startup',
         hooks: [
@@ -1211,16 +1206,6 @@ function installGemini(cwd: string, force: boolean): InstallResult {
           {
             type: 'command',
             command: buildManagedHookCommand(sbPath, 'on-stop', GEMINI.name),
-          },
-        ],
-      },
-    ],
-    [GEMINI.events.preCompact!]: [
-      {
-        hooks: [
-          {
-            type: 'command',
-            command: buildManagedHookCommand(sbPath, 'pre-compact', GEMINI.name),
           },
         ],
       },


### PR DESCRIPTION
## Summary
Gemini CLI's `SessionStartSource` only has `startup`/`resume`/`clear` — no `compress`. The `compress` matcher on `SessionStart` was dead code that never fired, causing lifecycle to get permanently stuck at `compacting` after `PreCompress`. This likely caused Aster's sessions to hang.

- Set `preCompact`/`postCompact` to `null` in Gemini `HookCapabilities`
- Remove `compress` matcher and `PreCompress` from hook installation
- Update test to verify no PreCompress hooks are installed
- Manually cleaned `.gemini/settings.json` in wren-omega and aster studios

## Test plan
- [x] 56 hooks tests pass
- [ ] Verify Aster sessions no longer get stuck at `compacting`

🤖 Generated with [Claude Code](https://claude.com/claude-code)