### PR TITLE
fix: Codex triggered sessions need full sandbox bypass (by Wren)

### DIFF
--- a/packages/api/src/mcp/tools/studio-handlers.ts
+++ b/packages/api/src/mcp/tools/studio-handlers.ts
@@ -113,6 +113,9 @@ const updateStudioSchema = userIdentifierBaseSchema.extend({
     .describe(
       'ThreadKey glob patterns this studio handles for trigger routing. Examples: "pr:*", "spec:*", "branch:wren/feat/auth". Use "*" for catch-all (one per agent). Replaces existing patterns.'
     ),
+  // NOTE: sandbox_bypass is intentionally NOT exposed via MCP tools — it's a
+  // security-sensitive setting that should only be changed via admin API
+  // endpoints or the web dashboard (future: /individuals/<id> settings page).
 });
 
 const closeStudioSchema = userIdentifierBaseSchema.extend({

--- a/packages/api/src/routes/admin-endpoints.test.ts
+++ b/packages/api/src/routes/admin-endpoints.test.ts
@@ -1148,4 +1148,151 @@ describe('admin endpoint handlers (no-500 regression)', () => {
       expect((res._json as any).users).toEqual([]);
     });
   });
+
+  describe('PATCH /studios/:studioId', () => {
+    it('should update sandbox_bypass on a valid studio', async () => {
+      mockSupabaseFrom.mockImplementation((table: string) => {
+        if (table === 'studios') {
+          return {
+            select: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                eq: vi.fn().mockReturnValue({
+                  maybeSingle: vi.fn().mockResolvedValue({
+                    data: { id: 'studio-123', user_id: 'user-123' },
+                    error: null,
+                  }),
+                }),
+              }),
+            }),
+            update: vi.fn().mockReturnValue({
+              eq: vi.fn().mockResolvedValue({ data: null, error: null }),
+            }),
+          };
+        }
+        return createQueryChain(null);
+      });
+
+      const handler = findRouteHandler('patch', '/studios/:studioId');
+      const req = createAuthenticatedReq({
+        params: { studioId: 'studio-123' },
+        body: { sandboxBypass: true },
+      });
+      const res = createMockRes();
+      await handler!(req, res);
+
+      expect(res._status).toBe(200);
+      expect((res._json as any).success).toBe(true);
+      expect((res._json as any).sandbox_bypass).toBe(true);
+    });
+
+    it('should return 404 for non-existent studio', async () => {
+      mockSupabaseFrom.mockImplementation(() => ({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+            }),
+          }),
+        }),
+      }));
+
+      const handler = findRouteHandler('patch', '/studios/:studioId');
+      const req = createAuthenticatedReq({
+        params: { studioId: 'nonexistent' },
+        body: { sandboxBypass: true },
+      });
+      const res = createMockRes();
+      await handler!(req, res);
+
+      expect(res._status).toBe(404);
+    });
+
+    it('should return 400 when no valid fields provided', async () => {
+      mockSupabaseFrom.mockImplementation(() => ({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              maybeSingle: vi.fn().mockResolvedValue({
+                data: { id: 'studio-123', user_id: 'user-123' },
+                error: null,
+              }),
+            }),
+          }),
+        }),
+      }));
+
+      const handler = findRouteHandler('patch', '/studios/:studioId');
+      const req = createAuthenticatedReq({
+        params: { studioId: 'studio-123' },
+        body: {},
+      });
+      const res = createMockRes();
+      await handler!(req, res);
+
+      expect(res._status).toBe(400);
+    });
+  });
+
+  describe('PATCH /identities/:agentId/settings', () => {
+    it('should update sandbox_bypass on a valid identity', async () => {
+      mockSupabaseFrom.mockImplementation((table: string) => {
+        if (table === 'agent_identities') {
+          return {
+            select: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                eq: vi.fn().mockReturnValue({
+                  eq: vi.fn().mockReturnValue({
+                    maybeSingle: vi.fn().mockResolvedValue({
+                      data: { id: 'identity-abc' },
+                      error: null,
+                    }),
+                  }),
+                }),
+              }),
+            }),
+            update: vi.fn().mockReturnValue({
+              eq: vi.fn().mockResolvedValue({ data: null, error: null }),
+            }),
+          };
+        }
+        return createQueryChain(null);
+      });
+
+      const handler = findRouteHandler('patch', '/identities/:agentId/settings');
+      const req = createAuthenticatedReq({
+        params: { agentId: 'lumen' },
+        body: { sandboxBypass: true },
+      });
+      const res = createMockRes();
+      await handler!(req, res);
+
+      expect(res._status).toBe(200);
+      expect((res._json as any).success).toBe(true);
+      expect((res._json as any).sandbox_bypass).toBe(true);
+    });
+
+    it('should return 404 for unknown agent', async () => {
+      mockSupabaseFrom.mockImplementation(() => ({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+              }),
+            }),
+          }),
+        }),
+      }));
+
+      const handler = findRouteHandler('patch', '/identities/:agentId/settings');
+      const req = createAuthenticatedReq({
+        params: { agentId: 'nonexistent' },
+        body: { sandboxBypass: true },
+      });
+      const res = createMockRes();
+      await handler!(req, res);
+
+      expect(res._status).toBe(404);
+    });
+  });
 });

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -2062,7 +2062,7 @@ router.get('/routing/agents/:agentId', async (req: Request, res: Response) => {
     const { data: identity, error: identityError } = await supabase
       .from('agent_identities')
       .select(
-        'id, agent_id, name, role, description, backend, studio_hint, workspace_id, updated_at'
+        'id, agent_id, name, role, description, backend, studio_hint, workspace_id, updated_at, sandbox_bypass'
       )
       .eq('user_id', authReq.pcpUserId)
       .eq('workspace_id', authReq.pcpWorkspaceId)
@@ -2158,7 +2158,7 @@ router.get('/routing/agents/:agentId', async (req: Request, res: Response) => {
     // Fetch studios owned by this agent
     const { data: studiosData } = await supabase
       .from('studios')
-      .select('id, slug, branch, status, route_patterns')
+      .select('id, slug, branch, status, route_patterns, sandbox_bypass')
       .eq('user_id', authReq.pcpUserId)
       .eq('agent_id', identity.agent_id)
       .in('status', ['active', 'idle'])
@@ -2175,6 +2175,7 @@ router.get('/routing/agents/:agentId', async (req: Request, res: Response) => {
         description: identity.description,
         backend: identity.backend,
         studioHint: identity.studio_hint || null,
+        sandboxBypass: identity.sandbox_bypass ?? false,
         updatedAt: identity.updated_at,
       },
       studios: (studiosData || []).map((s: Record<string, unknown>) => ({
@@ -2183,6 +2184,7 @@ router.get('/routing/agents/:agentId', async (req: Request, res: Response) => {
         branch: s.branch,
         status: s.status,
         routePatterns: (s.route_patterns as string[] | null) || [],
+        sandboxBypass: s.sandbox_bypass ?? null,
       })),
       routes,
       reminders: (remindersData || []).map((reminder) => ({
@@ -2204,6 +2206,123 @@ router.get('/routing/agents/:agentId', async (req: Request, res: Response) => {
   } catch (error) {
     logger.error('Failed to load routing agent detail:', error);
     res.status(500).json(errorJson('Failed to load routing agent detail', error));
+  }
+});
+
+/**
+ * PATCH /api/admin/identities/:agentId/settings
+ * Update SB-level settings (sandbox_bypass, etc.). Admin-only — not exposed via MCP.
+ */
+router.patch('/identities/:agentId/settings', async (req: Request, res: Response) => {
+  try {
+    const authReq = req as AdminAuthRequest;
+    const { agentId } = req.params;
+    const supabase = createClient(env.SUPABASE_URL, env.SUPABASE_SECRET_KEY, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+
+    // Find the identity for this agent + workspace
+    const { data: identity, error: fetchErr } = await supabase
+      .from('agent_identities')
+      .select('id')
+      .eq('user_id', authReq.pcpUserId)
+      .eq('workspace_id', authReq.pcpWorkspaceId)
+      .eq('agent_id', agentId)
+      .maybeSingle();
+
+    if (fetchErr || !identity) {
+      res.status(404).json({ error: 'Agent identity not found' });
+      return;
+    }
+
+    const body = (req.body || {}) as Record<string, unknown>;
+    const updates: Record<string, unknown> = {};
+
+    if (typeof body.sandboxBypass === 'boolean') {
+      updates.sandbox_bypass = body.sandboxBypass;
+    }
+
+    if (Object.keys(updates).length === 0) {
+      res.status(400).json({ error: 'No valid fields to update' });
+      return;
+    }
+
+    updates.updated_at = new Date().toISOString();
+
+    const { error: updateErr } = await supabase
+      .from('agent_identities')
+      .update(updates)
+      .eq('id', identity.id);
+
+    if (updateErr) {
+      logger.error('Failed to update identity settings:', updateErr);
+      res.status(500).json(errorJson('Failed to update identity settings', updateErr));
+      return;
+    }
+
+    logger.info('Identity settings updated', { agentId, updates });
+    res.json({ success: true, agentId, ...updates });
+  } catch (error) {
+    logger.error('Failed to update identity settings:', error);
+    res.status(500).json(errorJson('Failed to update identity settings', error));
+  }
+});
+
+/**
+ * PATCH /api/admin/studios/:studioId
+ * Update studio settings (sandbox_bypass, etc.). Admin-only — not exposed via MCP.
+ */
+router.patch('/studios/:studioId', async (req: Request, res: Response) => {
+  try {
+    const authReq = req as AdminAuthRequest;
+    const { studioId } = req.params;
+    const supabase = createClient(env.SUPABASE_URL, env.SUPABASE_SECRET_KEY, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+
+    // Verify studio belongs to this user
+    const { data: studio, error: fetchErr } = await supabase
+      .from('studios')
+      .select('id, user_id')
+      .eq('id', studioId)
+      .eq('user_id', authReq.pcpUserId)
+      .maybeSingle();
+
+    if (fetchErr || !studio) {
+      res.status(404).json({ error: 'Studio not found' });
+      return;
+    }
+
+    const body = (req.body || {}) as Record<string, unknown>;
+    const updates: Record<string, unknown> = {};
+
+    if (typeof body.sandboxBypass === 'boolean') {
+      updates.sandbox_bypass = body.sandboxBypass;
+    }
+
+    if (Object.keys(updates).length === 0) {
+      res.status(400).json({ error: 'No valid fields to update' });
+      return;
+    }
+
+    updates.updated_at = new Date().toISOString();
+
+    const { error: updateErr } = await supabase
+      .from('studios')
+      .update(updates)
+      .eq('id', studioId);
+
+    if (updateErr) {
+      logger.error('Failed to update studio settings:', updateErr);
+      res.status(500).json(errorJson('Failed to update studio', updateErr));
+      return;
+    }
+
+    logger.info('Studio settings updated', { studioId, updates });
+    res.json({ success: true, studioId, ...updates });
+  } catch (error) {
+    logger.error('Failed to update studio:', error);
+    res.status(500).json(errorJson('Failed to update studio', error));
   }
 });
 

--- a/packages/api/src/services/sessions/codex-runner.ts
+++ b/packages/api/src/services/sessions/codex-runner.ts
@@ -110,14 +110,14 @@ export class CodexRunner implements IRunner {
     promptPath: string
   ): string[] {
     // Triggered sessions are non-interactive (no human present).
-    // -a never: suppress all approval prompts (no human to approve)
-    // sandbox_workspace_write.network_access=true: allow HTTP MCP calls to PCP server
-    //   (default workspace-write sandbox blocks network, causing "user cancelled MCP tool call")
-    const args: string[] = [
-      '-a', 'never',
-      '-c', 'sandbox_workspace_write.network_access=true',
-      'exec',
-    ];
+    // sandbox_bypass (opt-in per studio): bypasses sandbox + approvals so
+    // HTTP MCP tools work in exec mode. Without it, Codex's sandbox blocks
+    // network access and MCP calls return "user cancelled".
+    // -a never: fallback when sandbox_bypass is off — suppresses shell
+    // approval prompts but MCP tools remain blocked.
+    const args: string[] = config.sandboxBypass
+      ? ['--dangerously-bypass-approvals-and-sandbox', 'exec']
+      : ['-a', 'never', 'exec'];
     if (isResume) {
       args.push('resume');
     }

--- a/packages/api/src/services/sessions/codex-runner.ts
+++ b/packages/api/src/services/sessions/codex-runner.ts
@@ -109,10 +109,15 @@ export class CodexRunner implements IRunner {
     config: ClaudeRunnerConfig,
     promptPath: string
   ): string[] {
-    // -a never must come BEFORE the exec subcommand — it's a root-level flag.
-    // Non-interactive: never prompt for approvals (no human present).
-    // Keeps sandbox protections — recommended by Codex docs for exec mode.
-    const args: string[] = ['-a', 'never', 'exec'];
+    // Triggered sessions are non-interactive (no human present).
+    // -a never: suppress all approval prompts (no human to approve)
+    // sandbox_workspace_write.network_access=true: allow HTTP MCP calls to PCP server
+    //   (default workspace-write sandbox blocks network, causing "user cancelled MCP tool call")
+    const args: string[] = [
+      '-a', 'never',
+      '-c', 'sandbox_workspace_write.network_access=true',
+      'exec',
+    ];
     if (isResume) {
       args.push('resume');
     }

--- a/packages/api/src/services/sessions/session-service.ts
+++ b/packages/api/src/services/sessions/session-service.ts
@@ -377,6 +377,33 @@ export class SessionService implements ISessionService {
           ? this.config.defaultGeminiModel
           : this.config.defaultModel;
 
+    // Resolve sandbox_bypass: studio override > SB default > false
+    let sandboxBypass = false;
+    if (this.supabase) {
+      // SB-level default from agent_identities
+      const { data: identity } = await this.supabase
+        .from('agent_identities')
+        .select('sandbox_bypass')
+        .eq('user_id', userId)
+        .eq('agent_id', agentId)
+        .order('updated_at', { ascending: false })
+        .limit(1)
+        .maybeSingle();
+      sandboxBypass = identity?.sandbox_bypass ?? false;
+
+      // Studio-level override (null = inherit from SB)
+      if (session.studioId) {
+        const { data: studio } = await this.supabase
+          .from('studios')
+          .select('sandbox_bypass')
+          .eq('id', session.studioId)
+          .maybeSingle();
+        if (studio?.sandbox_bypass !== null && studio?.sandbox_bypass !== undefined) {
+          sandboxBypass = studio.sandbox_bypass;
+        }
+      }
+    }
+
     const runnerConfig: ClaudeRunnerConfig = {
       workingDirectory: resolvedWorkingDirectory,
       mcpConfigPath: this.config.mcpConfigPath,
@@ -397,6 +424,7 @@ export class SessionService implements ISessionService {
       pcpSessionId: session.id,
       agentId,
       ...(session.studioId ? { studioId: session.studioId } : {}),
+      ...(sandboxBypass ? { sandboxBypass: true } : {}),
     };
 
     // 5. Run with selected backend

--- a/packages/api/src/services/sessions/types.ts
+++ b/packages/api/src/services/sessions/types.ts
@@ -403,6 +403,8 @@ export interface ClaudeRunnerConfig {
   agentId?: string;
   /** Studio/worktree scope — written to runtime hint so findRuntimeSessionByLinkId matches */
   studioId?: string;
+  /** When true, bypass sandbox restrictions (e.g., Codex --dangerously-bypass-approvals-and-sandbox). Opt-in per studio. */
+  sandboxBypass?: boolean;
 }
 
 export interface RunnerResult {

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -165,6 +165,11 @@ function toCodexToml(servers: Record<string, McpServerConfig>): string {
       lines.push(`url = ${tomlString(config.url)}`);
     }
 
+    // PCP server: mark as required so Codex fails loudly if it can't connect
+    if (name === 'pcp') {
+      lines.push('required = true');
+    }
+
     if (config.command) {
       lines.push(`command = ${tomlString(config.command)}`);
     }

--- a/packages/web/src/app/(dashboard)/page.tsx
+++ b/packages/web/src/app/(dashboard)/page.tsx
@@ -2,7 +2,7 @@
 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { MessageSquare, GitBranch, ArrowRight, Monitor, FolderGit2 } from 'lucide-react';
+import { MessageSquare, GitBranch, ArrowRight, Monitor, FolderGit2, Settings } from 'lucide-react';
 import Link from 'next/link';
 import { useApiQuery } from '@/lib/api';
 import clsx from 'clsx';
@@ -229,8 +229,9 @@ export default function DashboardPage() {
                       )}
                       <Link
                         href={`/routing/${agent.agentId}`}
-                        className="text-sm font-medium text-gray-500 hover:text-gray-900 transition-colors"
+                        className="inline-flex items-center gap-1 px-2.5 py-1 text-xs font-medium text-gray-600 bg-white border border-gray-200 rounded-md hover:bg-gray-50 hover:text-gray-900 transition-colors"
                       >
+                        <Settings className="h-3 w-3" />
                         Manage
                       </Link>
                     </div>

--- a/packages/web/src/app/(dashboard)/routing/[agentId]/page.tsx
+++ b/packages/web/src/app/(dashboard)/routing/[agentId]/page.tsx
@@ -64,6 +64,7 @@ interface AgentStudio {
   branch: string | null;
   status: string;
   routePatterns: string[];
+  sandboxBypass: boolean | null; // null = inherit from SB default
 }
 
 interface AgentRoutingResponse {
@@ -76,6 +77,7 @@ interface AgentRoutingResponse {
     description: string | null;
     backend: string | null;
     studioHint: string;
+    sandboxBypass: boolean;
     updatedAt: string;
   };
   studios: AgentStudio[];
@@ -275,6 +277,52 @@ export default function AgentRoutingPage() {
           </Badge>
         )}
       </div>
+
+      {/* SB-level settings */}
+      {data?.agent && (
+        <Card className="mt-6">
+          <CardHeader className="pb-3">
+            <div className="flex items-center gap-2">
+              <Info className="h-4 w-4 text-gray-400" />
+              <CardTitle className="text-base font-semibold">Security & Permissions</CardTitle>
+            </div>
+            <CardDescription>
+              Default settings for all of {data.agent.name || agentId}&apos;s studios. Individual studios can override below.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="flex items-center justify-between rounded-lg border p-3 bg-gray-50/50">
+              <div>
+                <p className="text-sm font-medium text-gray-700">MCP sandbox bypass</p>
+                <p className="text-xs text-gray-400 mt-0.5">
+                  Allow MCP tools in triggered sessions (required for Codex HTTP MCP)
+                </p>
+              </div>
+              <button
+                onClick={async () => {
+                  try {
+                    await apiPatch(`/api/admin/identities/${agentId}/settings`, {
+                      sandboxBypass: !data.agent.sandboxBypass,
+                    });
+                    queryClient.invalidateQueries({ queryKey: ['routing-agent', agentId] });
+                  } catch (e) {
+                    console.error('Failed to update SB settings:', e);
+                  }
+                }}
+                className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
+                  data.agent.sandboxBypass ? 'bg-blue-600' : 'bg-gray-200'
+                }`}
+              >
+                <span
+                  className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform shadow-sm ${
+                    data.agent.sandboxBypass ? 'translate-x-6' : 'translate-x-1'
+                  }`}
+                />
+              </button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
 
       {data && !data.heartbeatProcessingEnabled && (
         <div className="mt-4 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900">
@@ -614,16 +662,49 @@ export default function AgentRoutingPage() {
                       </p>
                     )}
                   </div>
-                  <Badge
-                    variant="outline"
-                    className={
-                      studio.status === 'active'
-                        ? 'bg-green-50 text-green-700 border-green-200'
-                        : 'bg-gray-50 text-gray-500 border-gray-200'
-                    }
-                  >
-                    {studio.status}
-                  </Badge>
+                  <div className="flex items-center gap-2 shrink-0">
+                    <label
+                      className="flex items-center gap-1.5 cursor-pointer"
+                      title={studio.sandboxBypass === null
+                        ? `MCP bypass: inheriting ${data?.agent?.sandboxBypass ? 'ON' : 'OFF'} from SB default (click to override)`
+                        : 'MCP bypass: studio override (click to toggle, shift+click to reset to inherit)'}
+                    >
+                      <input
+                        type="checkbox"
+                        checked={studio.sandboxBypass ?? data?.agent?.sandboxBypass ?? false}
+                        onChange={async (e) => {
+                          try {
+                            // Shift+click resets to null (inherit from SB)
+                            const newValue = e.nativeEvent instanceof MouseEvent && e.nativeEvent.shiftKey
+                              ? null
+                              : !(studio.sandboxBypass ?? data?.agent?.sandboxBypass ?? false);
+                            await apiPatch(`/api/admin/studios/${studio.id}`, {
+                              sandboxBypass: newValue,
+                            });
+                            queryClient.invalidateQueries({ queryKey: ['routing-agent', agentId] });
+                          } catch (err) {
+                            console.error('Failed to update sandbox bypass:', err);
+                          }
+                        }}
+                        className={`h-3.5 w-3.5 rounded border-gray-300 focus:ring-blue-500 ${
+                          studio.sandboxBypass === null ? 'text-gray-400' : 'text-blue-600'
+                        }`}
+                      />
+                      <span className="text-xs text-gray-500">
+                        MCP bypass{studio.sandboxBypass === null ? ' (inherited)' : ''}
+                      </span>
+                    </label>
+                    <Badge
+                      variant="outline"
+                      className={
+                        studio.status === 'active'
+                          ? 'bg-green-50 text-green-700 border-green-200'
+                          : 'bg-gray-50 text-gray-500 border-gray-200'
+                      }
+                    >
+                      {studio.status}
+                    </Badge>
+                  </div>
                 </div>
               ))}
             </div>

--- a/supabase/migrations/20260401050812_add_studio_and_identity_sandbox_bypass.sql
+++ b/supabase/migrations/20260401050812_add_studio_and_identity_sandbox_bypass.sql
@@ -1,0 +1,16 @@
+-- Add sandbox_bypass flag to studios and agent_identities.
+-- Precedence: studio override > SB default.
+
+-- Per-studio override
+ALTER TABLE public.studios
+  ADD COLUMN IF NOT EXISTS sandbox_bypass boolean DEFAULT null;
+
+COMMENT ON COLUMN public.studios.sandbox_bypass IS
+  'Per-studio sandbox bypass override. null = inherit from agent identity. true/false = explicit override.';
+
+-- Per-SB default
+ALTER TABLE public.agent_identities
+  ADD COLUMN IF NOT EXISTS sandbox_bypass boolean NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN public.agent_identities.sandbox_bypass IS
+  'SB-level default for sandbox bypass. When true, all studios for this agent default to bypassing sandbox restrictions unless overridden per-studio.';


### PR DESCRIPTION
## Summary
`-a never` alone doesn't unblock MCP tools in Codex triggered sessions. Transcript analysis shows:
- `approval_policy: "never"` is set correctly
- But `network_access: false` in sandbox policy blocks HTTP MCP calls to localhost:3001
- Every PCP tool call returns `"user cancelled MCP tool call"`

`--dangerously-bypass-approvals-and-sandbox` is the only flag that bypasses both approval and network sandbox. Triggered sessions are server-controlled (not user-facing), so this is acceptable.

## Evidence
Codex session transcript `019d312a`: bootstrap, get_thread_messages, and send_to_inbox all returned "user cancelled MCP tool call" despite `-a never` being set.

## Test plan
- [ ] Trigger Lumen and verify MCP tools (send_to_inbox, get_thread_messages) actually work

🤖 Generated with [Claude Code](https://claude.com/claude-code)