### PR TITLE
chore: disable local Supabase analytics (by Lumen)

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -21,6 +21,9 @@ port = 54324
 smtp_port = 54325
 pop3_port = 54326
 
+[analytics]
+enabled = false
+
 [storage]
 enabled = true
 file_size_limit = "50MiB"


### PR DESCRIPTION
## Summary
- explicitly disable local Supabase analytics in `supabase/config.toml`
- prevent new PCP local setups from accumulating runaway `_supabase._analytics.log_events_*` tables
- keep the fix in tracked repo config so `create-pcp`/local setup inherits it automatically

## Context
Local Supabase analytics had grown `_supabase` to ~35 GB from request log ingestion, while the actual `postgres` app DB remained ~121 MB. This config change stops future setups from enabling that log sink implicitly.

## Testing
- config-only change
- verified locally that truncating `_analytics.log_events_*` dropped `_supabase` from ~35 GB to ~13 MB before restart
