### PR TITLE
fix: accept null in sandbox_bypass PATCH for inheritance reset (by Wren)

### DIFF
--- a/packages/api/src/routes/admin-endpoints.test.ts
+++ b/packages/api/src/routes/admin-endpoints.test.ts
@@ -1185,6 +1185,41 @@ describe('admin endpoint handlers (no-500 regression)', () => {
       expect((res._json as any).sandbox_bypass).toBe(true);
     });
 
+    it('should accept null to reset sandbox_bypass to inherited', async () => {
+      mockSupabaseFrom.mockImplementation((table: string) => {
+        if (table === 'studios') {
+          return {
+            select: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                eq: vi.fn().mockReturnValue({
+                  maybeSingle: vi.fn().mockResolvedValue({
+                    data: { id: 'studio-123', user_id: 'user-123' },
+                    error: null,
+                  }),
+                }),
+              }),
+            }),
+            update: vi.fn().mockReturnValue({
+              eq: vi.fn().mockResolvedValue({ data: null, error: null }),
+            }),
+          };
+        }
+        return createQueryChain(null);
+      });
+
+      const handler = findRouteHandler('patch', '/studios/:studioId');
+      const req = createAuthenticatedReq({
+        params: { studioId: 'studio-123' },
+        body: { sandboxBypass: null },
+      });
+      const res = createMockRes();
+      await handler!(req, res);
+
+      expect(res._status).toBe(200);
+      expect((res._json as any).success).toBe(true);
+      expect((res._json as any).sandbox_bypass).toBeNull();
+    });
+
     it('should return 404 for non-existent studio', async () => {
       mockSupabaseFrom.mockImplementation(() => ({
         select: vi.fn().mockReturnValue({

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -2238,7 +2238,7 @@ router.patch('/identities/:agentId/settings', async (req: Request, res: Response
     const body = (req.body || {}) as Record<string, unknown>;
     const updates: Record<string, unknown> = {};
 
-    if (typeof body.sandboxBypass === 'boolean') {
+    if (typeof body.sandboxBypass === 'boolean' || body.sandboxBypass === null) {
       updates.sandbox_bypass = body.sandboxBypass;
     }
 
@@ -2296,7 +2296,7 @@ router.patch('/studios/:studioId', async (req: Request, res: Response) => {
     const body = (req.body || {}) as Record<string, unknown>;
     const updates: Record<string, unknown> = {};
 
-    if (typeof body.sandboxBypass === 'boolean') {
+    if (typeof body.sandboxBypass === 'boolean' || body.sandboxBypass === null) {
       updates.sandbox_bypass = body.sandboxBypass;
     }
 


### PR DESCRIPTION
## Summary
Lumen's post-merge review of PR #281: shift+click "reset to inherit" sent `sandboxBypass: null` but the PATCH handler only accepted `boolean`, returning 400.

Fix: accept `null` alongside `boolean`. Regression test added (34 tests pass).

## Test plan
- [x] New test: `should accept null to reset sandbox_bypass to inherited`
- [x] 34 admin endpoint tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)