### PR TITLE
fix: mission control missing studio labels on completed sessions (by Wren)

### DIFF
--- a/packages/api/src/services/sessions/session-service.ts
+++ b/packages/api/src/services/sessions/session-service.ts
@@ -437,6 +437,11 @@ export class SessionService implements ISessionService {
 
     // 5a. Log backend spawn to activity stream (fire-and-forget)
     const triggerSource = metadata?.triggerType as string | undefined;
+    // Derive studio hint (worktree folder name) for mission display so it
+    // doesn't depend on the session still being active when the feed renders.
+    const worktreeFolder = resolvedWorkingDirectory
+      ? resolvedWorkingDirectory.replace(/\/+$/, '').split('/').pop()
+      : undefined;
     this.activityStream
       .logActivity({
         userId,
@@ -448,6 +453,7 @@ export class SessionService implements ISessionService {
         payload: {
           backend: resolvedBackend,
           studioId: session.studioId,
+          ...(worktreeFolder ? { studioHint: worktreeFolder } : {}),
           ...(triggerSource ? { triggerSource } : {}),
           ...(request.sender?.id ? { triggeredBy: request.sender.id } : {}),
           ...(metadata?.threadKey ? { threadKey: metadata.threadKey } : {}),
@@ -501,6 +507,7 @@ export class SessionService implements ISessionService {
           backend: resolvedBackend,
           durationMs: turnDurationMs,
           studioId: session.studioId,
+          ...(worktreeFolder ? { studioHint: worktreeFolder } : {}),
           ...(triggerSource ? { triggerSource } : {}),
           ...(request.sender?.id ? { triggeredBy: request.sender.id } : {}),
           ...(metadata?.threadKey ? { threadKey: metadata.threadKey } : {}),


### PR DESCRIPTION
## Summary
Mission control was missing studio labels for spawn/complete events when the session had already completed by the time the display refreshed.

**Root cause:** `list_sessions` only fetches `status: 'active'`, so completed sessions weren't in `sessionsById`. The studio label resolution fell through to `'-'`.

**Fix:** Stamp `studioHint` (worktree folder name) directly on `agent_spawn` and `agent_complete` activity payloads. The display's resolution chain already checks `payload.studioHint` first, so this works regardless of session lifecycle.

## Test plan
- [ ] Trigger an agent, wait for completion, verify studio label shows in mission feed

🤖 Generated with [Claude Code](https://claude.com/claude-code)