### PR TITLE
feat: contact identity injection + type column (by Wren)

### DIFF
--- a/packages/api/src/data/repositories/contacts-repository.ts
+++ b/packages/api/src/data/repositories/contacts-repository.ts
@@ -7,11 +7,14 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type { Database } from '../supabase/types.js';
 
+export type ContactType = 'personal' | 'external' | 'group';
+
 export interface Contact {
   id: string;
   userId: string;
   name: string;
   displayName: string | null;
+  type: ContactType;
   aliases: string[];
   email: string | null;
   phone: string | null;
@@ -40,6 +43,7 @@ export interface CreateContactOptions {
   whatsappId?: string;
   notes?: string;
   tags?: string[];
+  type?: ContactType;
 }
 
 export interface ResolveNameResult {
@@ -112,6 +116,7 @@ export class ContactsRepository {
         user_id: options.userId,
         name: options.name,
         display_name: options.displayName,
+        type: options.type || 'personal',
         aliases: options.aliases || [],
         email: options.email,
         phone: options.phone,
@@ -391,9 +396,10 @@ export class ContactsRepository {
         userId,
         name: displayName,
         displayName: info?.name,
+        type: 'external',
         [platformField]: platformId,
         ...(platform === 'telegram' && info?.username ? { telegramUsername: info.username } : {}),
-        tags: ['auto-created', 'external'],
+        tags: ['auto-created'],
       });
     } catch (error: unknown) {
       // Unique constraint race — another request created it first.
@@ -429,10 +435,10 @@ export class ContactsRepository {
     if (platform === 'slack') {
       // Slack uses discord_id column as a generic "chat platform" slot
       const existing = await this.findByPlatformId(userId, 'discord', groupId);
-      if (existing && existing.tags.includes('group')) return existing;
+      if (existing && existing.type === 'group') return existing;
     } else {
       const existing = await this.findByPlatformId(userId, platformForLookup, groupId);
-      if (existing && existing.tags.includes('group')) return existing;
+      if (existing && existing.type === 'group') return existing;
     }
 
     const displayName = info?.groupName || `${platform}-group:${groupId}`;
@@ -450,8 +456,9 @@ export class ContactsRepository {
         userId,
         name: displayName,
         displayName: info?.groupName,
+        type: 'group',
         [platformField]: groupId,
-        tags: ['auto-created', 'group'],
+        tags: ['auto-created'],
       });
     } catch (error: unknown) {
       const err = error as Record<string, unknown>;
@@ -513,6 +520,7 @@ export class ContactsRepository {
       userId: row.user_id,
       name: row.name,
       displayName: row.display_name,
+      type: ((row as Record<string, unknown>).type as ContactType) || 'personal',
       aliases: row.aliases || [],
       email: row.email,
       phone: row.phone,

--- a/packages/api/src/data/supabase/types.ts
+++ b/packages/api/src/data/supabase/types.ts
@@ -980,6 +980,7 @@ export type Database = {
           tags: string[] | null;
           telegram_id: string | null;
           telegram_username: string | null;
+          type: string;
           updated_at: string | null;
           user_id: string;
           whatsapp_id: string | null;
@@ -998,6 +999,7 @@ export type Database = {
           tags?: string[] | null;
           telegram_id?: string | null;
           telegram_username?: string | null;
+          type?: string;
           updated_at?: string | null;
           user_id: string;
           whatsapp_id?: string | null;
@@ -1016,6 +1018,7 @@ export type Database = {
           tags?: string[] | null;
           telegram_id?: string | null;
           telegram_username?: string | null;
+          type?: string;
           updated_at?: string | null;
           user_id?: string;
           whatsapp_id?: string | null;

--- a/packages/api/src/services/sessions/context-builder.ts
+++ b/packages/api/src/services/sessions/context-builder.ts
@@ -12,6 +12,7 @@ import type {
   AgentIdentity,
   UserContext,
   TemporalContext,
+  ContactContext,
   InjectedContext,
   IContextBuilder,
 } from './types.js';
@@ -169,6 +170,30 @@ export class ContextBuilder implements IContextBuilder {
         status: p.status || 'active',
       })),
     };
+
+    // Inject contact identity for per-sender sessions
+    if (session.contactId) {
+      const contactRow = await this.getContact(session.contactId);
+      if (contactRow) {
+        const platform = contactRow.telegram_id
+          ? 'telegram'
+          : contactRow.whatsapp_id
+            ? 'whatsapp'
+            : contactRow.discord_id
+              ? 'discord'
+              : contactRow.imessage_id
+                ? 'imessage'
+                : undefined;
+        context.contact = {
+          id: contactRow.id,
+          name: contactRow.name,
+          displayName: contactRow.display_name || undefined,
+          type:
+            ((contactRow as Record<string, unknown>).type as ContactContext['type']) || 'external',
+          platform,
+        };
+      }
+    }
 
     // Add session history if there's compaction data
     if (session.compactionCount > 0) {
@@ -350,6 +375,22 @@ export class ContextBuilder implements IContextBuilder {
     return data || [];
   }
 
+  private async getContact(contactId: string): Promise<DbContact | null> {
+    const { data, error } = await this.supabase
+      .from('contacts')
+      .select('*')
+      .eq('id', contactId)
+      .single();
+
+    if (error) {
+      if (error.code === 'PGRST116') return null;
+      logger.error('Error fetching contact', { contactId, error });
+      return null;
+    }
+
+    return data;
+  }
+
   private async getActiveProjects(userId: string): Promise<DbProject[]> {
     const { data, error } = await this.supabase
       .from('projects')
@@ -392,6 +433,16 @@ ${context.temporal.greeting}! It is ${context.temporal.currentTime} on ${context
   // User context
   sections.push(`## User Context
 User timezone: ${context.user.timezone}`);
+
+  // Contact identity for per-sender sessions
+  if (context.contact) {
+    const c = context.contact;
+    const platformNote = c.platform ? ` via ${c.platform}` : '';
+    const typeNote = c.type === 'group' ? ' (group chat)' : '';
+    sections.push(`## Current Sender
+You are talking to **${c.displayName || c.name}**${platformNote}${typeNote}.
+This is a contact-scoped session — memories and conversation history are private to this sender.`);
+  }
 
   // Recent memories (if any)
   if (context.recentMemories.length > 0) {

--- a/packages/api/src/services/sessions/types.ts
+++ b/packages/api/src/services/sessions/types.ts
@@ -215,10 +215,21 @@ export interface TemporalContext {
   greeting: string;
 }
 
+/** Contact identity for per-sender session context */
+export interface ContactContext {
+  id: string;
+  name: string;
+  displayName?: string;
+  type: 'personal' | 'external' | 'group';
+  platform?: string;
+}
+
 export interface InjectedContext {
   agent: AgentIdentity;
   user: UserContext;
   temporal: TemporalContext;
+  /** Contact identity when in a per-sender session */
+  contact?: ContactContext;
   recentMemories: Array<{
     id: string;
     content: string;

--- a/supabase/migrations/20260401194832_contact_type_column.sql
+++ b/supabase/migrations/20260401194832_contact_type_column.sql
@@ -1,0 +1,13 @@
+-- Add type column to contacts for categorization
+--
+-- Values:
+--   'personal'  — manually added contacts (address book)
+--   'external'  — auto-created from incoming channel messages
+--   'group'     — synthetic group chat contacts
+--
+-- Default 'personal' for backward compatibility with existing rows.
+
+ALTER TABLE contacts ADD COLUMN IF NOT EXISTS type text DEFAULT 'personal';
+
+-- Index for filtering by type
+CREATE INDEX IF NOT EXISTS idx_contacts_user_type ON contacts(user_id, type);


### PR DESCRIPTION
## Summary

Completes the per-sender session isolation feature (PR #264) with context injection and contact categorization.

- **Contact type column**: `type` on contacts table — `'personal'` (address book), `'external'` (auto-created from channel), `'group'` (synthetic). Replaces tag-based detection with first-class column.
- **Context injection**: When a contact-scoped session is active, the SB's system prompt includes a "Current Sender" section with name, platform, and type so it knows who it's talking to.
- **Auto-creation with type**: `findOrCreateByPlatformId` creates contacts as `type: 'external'`, `findOrCreateGroupContact` creates as `type: 'group'`.

## What the SB sees

In a contact-scoped session, the injected context now includes:

```
## Current Sender
You are talking to **Alice** via telegram.
This is a contact-scoped session — memories and conversation history are private to this sender.
```

## Test plan

- [x] All per-sender unit tests pass (35 tests)
- [x] Type-check passes (0 new errors)
- [ ] Manual: verify contact type is set correctly on auto-creation
- [ ] Manual: verify system prompt includes sender identity in contact-scoped session

🤖 Generated with [Claude Code](https://claude.com/claude-code)