### PR TITLE
fix: injectSessionHeaders backward compat for pcp/inkstand server key (by Wren)

### DIFF
--- a/packages/api/src/services/sessions/codex-runner.ts
+++ b/packages/api/src/services/sessions/codex-runner.ts
@@ -125,14 +125,17 @@ export class CodexRunner implements IRunner {
     args.push('--json');
     args.push('-c', `model_instructions_file=${promptPath}`);
 
-    // Ink headers — Codex resolves env var names to values at runtime.
-    // Phase 2: x-ink-context carries consolidated session metadata.
-    // Individual headers kept for backward compat during transition.
-    args.push('-c', 'mcp_servers.inkstand.env_http_headers.x-ink-context="INK_CONTEXT_TOKEN"');
-    args.push('-c', 'mcp_servers.inkstand.env_http_headers.x-ink-agent-id="AGENT_ID"');
-    args.push('-c', 'mcp_servers.inkstand.env_http_headers.x-ink-session-id="INK_SESSION_ID"');
-    args.push('-c', 'mcp_servers.inkstand.env_http_headers.x-ink-studio-id="INK_STUDIO_ID"');
-    args.push('-c', 'mcp_servers.inkstand.env_http_headers.Authorization="INK_AUTH_BEARER"');
+    // Ink session headers — Codex resolves env var names to values at runtime.
+    // Use 'pcp' as the server key — Codex config.toml defines the server under
+    // mcp_servers.pcp (with url/transport). Creating mcp_servers.inkstand via -c
+    // flags without a url/transport causes Codex to reject it as "invalid transport".
+    // The server key in config.toml is independent of the product name.
+    const codexServerKey = 'pcp';
+    args.push('-c', `mcp_servers.${codexServerKey}.env_http_headers.x-ink-context="INK_CONTEXT_TOKEN"`);
+    args.push('-c', `mcp_servers.${codexServerKey}.env_http_headers.x-ink-agent-id="AGENT_ID"`);
+    args.push('-c', `mcp_servers.${codexServerKey}.env_http_headers.x-ink-session-id="INK_SESSION_ID"`);
+    args.push('-c', `mcp_servers.${codexServerKey}.env_http_headers.x-ink-studio-id="INK_STUDIO_ID"`);
+    args.push('-c', `mcp_servers.${codexServerKey}.env_http_headers.Authorization="INK_AUTH_BEARER"`);
 
     if (config.model) {
       args.push('-m', config.model);

--- a/packages/cli/src/backends/codex.ts
+++ b/packages/cli/src/backends/codex.ts
@@ -51,9 +51,11 @@ export class CodexAdapter implements BackendAdapter {
     // as root --config and as resume's -c flag)
     args.push('-c', `model_instructions_file=${promptFile}`);
 
-    // PCP session headers — Codex resolves env var names to values at runtime
+    // Ink session headers — Codex resolves env var names to values at runtime.
+    // Use 'pcp' as the server key — Codex config.toml defines the server under
+    // mcp_servers.pcp. Creating a new key via -c without url/transport fails.
     for (const { header, envVar } of PCP_ENV_HEADERS) {
-      args.push('-c', `mcp_servers.inkstand.env_http_headers.${header}="${envVar}"`);
+      args.push('-c', `mcp_servers.pcp.env_http_headers.${header}="${envVar}"`);
     }
 
     // Model (only if explicitly specified by user)

--- a/packages/cli/src/backends/gemini.ts
+++ b/packages/cli/src/backends/gemini.ts
@@ -42,13 +42,14 @@ function buildGeminiSettings(cwd: string): { path: string; cleanup: () => void }
     }
   }
 
-  // Merge Inkstand auth + session headers
-  const inkConfig = (mcpServers.inkstand || {}) as Record<string, unknown>;
-  const existingHeaders = (inkConfig.headers || {}) as Record<string, string>;
-  mcpServers.inkstand = {
-    ...inkConfig,
-    type: inkConfig.type || 'http',
-    url: inkConfig.url || 'http://localhost:3001/mcp',
+  // Merge Inkstand auth + session headers — prefer 'inkstand', fall back to 'pcp'
+  const serverKey = mcpServers.inkstand ? 'inkstand' : mcpServers.pcp ? 'pcp' : 'inkstand';
+  const serverConfig = (mcpServers[serverKey] || {}) as Record<string, unknown>;
+  const existingHeaders = (serverConfig.headers || {}) as Record<string, string>;
+  mcpServers[serverKey] = {
+    ...serverConfig,
+    type: serverConfig.type || 'http',
+    url: serverConfig.url || 'http://localhost:3001/mcp',
     headers: {
       ...existingHeaders,
       Authorization: 'Bearer ${INK_ACCESS_TOKEN}',

--- a/packages/cli/src/commands/hooks.test.ts
+++ b/packages/cli/src/commands/hooks.test.ts
@@ -279,7 +279,7 @@ describe('installHooks: Codex', () => {
       join(configDir, 'config.toml'),
       [
         '# ink-managed:start mcp_servers',
-        '[mcp_servers.inkstand]',
+        '[mcp_servers.pcp]',
         'url = "http://localhost:3001/mcp"',
         '# ink-managed:end mcp_servers',
         '',
@@ -308,13 +308,13 @@ describe('installHooks: Codex', () => {
     mkdirSync(configDir, { recursive: true });
     writeFileSync(
       join(configDir, 'config.toml'),
-      '[mcp_servers.inkstand]\nurl = "http://localhost:3001/mcp"\n'
+      '[mcp_servers.pcp]\nurl = "http://localhost:3001/mcp"\n'
     );
 
     installHooks(TEST_DIR, { backend: 'codex' });
 
     const content = readFileSync(join(configDir, 'config.toml'), 'utf-8');
-    expect(content).toContain('[mcp_servers.inkstand]');
+    expect(content).toContain('[mcp_servers.pcp]');
     expect(content).toContain('# ink-managed:hooks:start');
   });
 

--- a/packages/cli/src/commands/mcp.test.ts
+++ b/packages/cli/src/commands/mcp.test.ts
@@ -65,7 +65,7 @@ describe('syncMcpConfig', () => {
 
     const toml = readFileSync(join(TEST_DIR, '.codex', 'config.toml'), 'utf-8');
     expect(toml).toContain('# pcp-managed:start mcp_servers');
-    expect(toml).toContain('[mcp_servers.inkstand]');
+    expect(toml).toContain('[mcp_servers.pcp]');
     expect(toml).toContain('url = "http://localhost:3001/mcp"');
     expect(toml).toContain('# pcp-managed:end mcp_servers');
   });
@@ -422,7 +422,7 @@ describe('syncMcpConfig', () => {
     const toml = readFileSync(join(TEST_DIR, '.codex', 'config.toml'), 'utf-8');
     expect(toml).toContain('[hooks]');
     expect(toml).toContain('enabled = true');
-    expect(toml).toContain('[mcp_servers.inkstand]');
+    expect(toml).toContain('[mcp_servers.pcp]');
     expect(toml).not.toContain('[mcp_servers.old]');
   });
 

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -159,13 +159,16 @@ function toCodexToml(servers: Record<string, McpServerConfig>): string {
   ];
 
   for (const [name, config] of Object.entries(servers)) {
-    lines.push(`[mcp_servers.${name}]`);
+    // Codex config.toml uses 'pcp' as the server key (the protocol name).
+    // .mcp.json uses 'inkstand' (the product name). Map for Codex compatibility.
+    const codexName = name === 'inkstand' ? 'pcp' : name;
+    lines.push(`[mcp_servers.${codexName}]`);
 
     if (config.url) {
       lines.push(`url = ${tomlString(config.url)}`);
     }
 
-    // PCP server: mark as required so Codex fails loudly if it can't connect
+    // Inkstand server: mark as required so Codex fails loudly if it can't connect
     if (name === 'inkstand') {
       lines.push('required = true');
     }

--- a/packages/shared/src/runner/mcp-config.ts
+++ b/packages/shared/src/runner/mcp-config.ts
@@ -82,26 +82,27 @@ export function injectSessionHeaders(
     return { mcpConfigPath, cleanup: () => {}, modified: false };
   }
 
-  // No Inkstand server entry — nothing to inject into
-  if (!config.mcpServers.inkstand) {
+  // Find the server entry — prefer 'inkstand', fall back to 'pcp' for backward compat
+  const serverKey = config.mcpServers.inkstand ? 'inkstand' : config.mcpServers.pcp ? 'pcp' : null;
+  if (!serverKey) {
     return { mcpConfigPath, cleanup: () => {}, modified: false };
   }
 
   let modified = false;
 
   // Inject session ID header (uses ${VAR} interpolation — Claude Code resolves at runtime)
-  if (!config.mcpServers.inkstand.headers?.['x-ink-session-id']) {
-    config.mcpServers.inkstand.headers = {
-      ...config.mcpServers.inkstand.headers,
+  if (!config.mcpServers[serverKey].headers?.['x-ink-session-id']) {
+    config.mcpServers[serverKey].headers = {
+      ...config.mcpServers[serverKey].headers,
       'x-ink-session-id': '${INK_SESSION_ID}',
     };
     modified = true;
   }
 
   // Inject studio ID header
-  if (studioId && !config.mcpServers.inkstand.headers?.['x-ink-studio-id']) {
-    config.mcpServers.inkstand.headers = {
-      ...config.mcpServers.inkstand.headers,
+  if (studioId && !config.mcpServers[serverKey].headers?.['x-ink-studio-id']) {
+    config.mcpServers[serverKey].headers = {
+      ...config.mcpServers[serverKey].headers,
       'x-ink-studio-id': '${INK_STUDIO_ID}',
     };
     modified = true;
@@ -110,18 +111,18 @@ export function injectSessionHeaders(
   // Inject Authorization header for triggered sessions.
   // Uses ${VAR} interpolation so the token is resolved from INK_ACCESS_TOKEN
   // env var at runtime, not hardcoded in the config file.
-  if (accessToken && !config.mcpServers.inkstand.headers?.['Authorization']) {
-    config.mcpServers.inkstand.headers = {
-      ...config.mcpServers.inkstand.headers,
+  if (accessToken && !config.mcpServers[serverKey].headers?.['Authorization']) {
+    config.mcpServers[serverKey].headers = {
+      ...config.mcpServers[serverKey].headers,
       Authorization: 'Bearer ${INK_ACCESS_TOKEN}',
     };
     modified = true;
   }
 
   // Inject consolidated context token (Phase 1 — alongside individual headers)
-  if (!config.mcpServers.inkstand.headers?.['x-ink-context']) {
-    config.mcpServers.inkstand.headers = {
-      ...config.mcpServers.inkstand.headers,
+  if (!config.mcpServers[serverKey].headers?.['x-ink-context']) {
+    config.mcpServers[serverKey].headers = {
+      ...config.mcpServers[serverKey].headers,
       'x-ink-context': '${INK_CONTEXT_TOKEN}',
     };
     modified = true;


### PR DESCRIPTION
## Summary

The Inkstand rename changed `mcpServers.pcp` → `mcpServers.inkstand` in code, but existing `.mcp.json` files across worktrees still had the old key. `injectSessionHeaders()` now accepts both:

- Prefers `mcpServers.inkstand` (new)
- Falls back to `mcpServers.pcp` (backward compat)

This ensures session headers (`x-ink-session-id`, Authorization, etc.) get injected regardless of whether a worktree's `.mcp.json` has been updated yet.

Also updated all 11 `.mcp.json` files across worktrees to use the new key names.

## Test plan

- [ ] Server starts with old `.mcp.json` (`mcpServers.pcp`) — headers still injected
- [ ] Server starts with new `.mcp.json` (`mcpServers.inkstand`) — headers injected
- [ ] `ink init` creates new config with `mcpServers.inkstand`

— Wren