### PR TITLE
fix: conditional bootstrap self-healing in identity prompt (by Wren)

### DIFF
--- a/packages/cli/src/backends/adapters.test.ts
+++ b/packages/cli/src/backends/adapters.test.ts
@@ -7,15 +7,20 @@ import { buildIdentityPrompt } from './identity.js';
 import { decodeContextToken } from '@inklabs/shared';
 
 describe('buildIdentityPrompt conditional bootstrap', () => {
-  it('includes self-healing instructions when no startup context is provided', () => {
+  it('includes conditional self-healing instructions when no startup context is provided', () => {
     const prompt = buildIdentityPrompt('wren');
 
     expect(prompt).toContain('You are wren');
-    expect(prompt).toContain('Skip directly to loading user config');
-    expect(prompt).toContain('verify that your constitution docs were loaded');
-    expect(prompt).toContain('bootstrap');
+    // Should tell agent to check for existing docs first, not bootstrap unconditionally
+    expect(prompt).toContain('check whether your constitution docs are already present');
+    expect(prompt).toContain('If these are present');
+    expect(prompt).toContain('do NOT call bootstrap again');
+    expect(prompt).toContain('If these are NOT present');
+    expect(prompt).toContain('call the `bootstrap` MCP tool manually');
     expect(prompt).not.toContain('Bootstrap has already been completed');
-    // Should NOT have the actual startup context section (only a reference to it in self-healing text)
+    // Should NOT unconditionally instruct bootstrap
+    expect(prompt).not.toContain('Skip directly to loading user config');
+    // Should NOT have the actual startup context section
     expect(prompt).not.toContain('## Bootstrapped Startup Context (PCP)');
   });
 
@@ -28,7 +33,7 @@ describe('buildIdentityPrompt conditional bootstrap', () => {
     expect(prompt).toContain('## Bootstrapped Startup Context (PCP)');
     expect(prompt).toContain('### Identity');
     expect(prompt).toContain('I am Lumen.');
-    expect(prompt).not.toContain('verify that your constitution docs were loaded');
+    expect(prompt).not.toContain('check whether your constitution docs are already present');
   });
 });
 

--- a/packages/cli/src/backends/adapters.test.ts
+++ b/packages/cli/src/backends/adapters.test.ts
@@ -3,7 +3,34 @@ import { readFileSync } from 'fs';
 import { ClaudeAdapter } from './claude.js';
 import { CodexAdapter } from './codex.js';
 import { GeminiAdapter } from './gemini.js';
+import { buildIdentityPrompt } from './identity.js';
 import { decodeContextToken } from '@inklabs/shared';
+
+describe('buildIdentityPrompt conditional bootstrap', () => {
+  it('includes self-healing instructions when no startup context is provided', () => {
+    const prompt = buildIdentityPrompt('wren');
+
+    expect(prompt).toContain('You are wren');
+    expect(prompt).toContain('Skip directly to loading user config');
+    expect(prompt).toContain('verify that your constitution docs were loaded');
+    expect(prompt).toContain('bootstrap');
+    expect(prompt).not.toContain('Bootstrap has already been completed');
+    // Should NOT have the actual startup context section (only a reference to it in self-healing text)
+    expect(prompt).not.toContain('## Bootstrapped Startup Context (PCP)');
+  });
+
+  it('skips manual bootstrap when startup context is provided', () => {
+    const prompt = buildIdentityPrompt('lumen', '### Identity\nI am Lumen.');
+
+    expect(prompt).toContain('You are lumen');
+    expect(prompt).toContain('Bootstrap has already been completed');
+    expect(prompt).toContain('Do NOT call bootstrap again');
+    expect(prompt).toContain('## Bootstrapped Startup Context (PCP)');
+    expect(prompt).toContain('### Identity');
+    expect(prompt).toContain('I am Lumen.');
+    expect(prompt).not.toContain('verify that your constitution docs were loaded');
+  });
+});
 
 describe('backend adapters session resume wiring', () => {
   it('passes claude backendSessionId through --resume', () => {

--- a/packages/cli/src/backends/identity.ts
+++ b/packages/cli/src/backends/identity.ts
@@ -221,13 +221,11 @@ ${injectedContext}`;
   }
 
   // No startup context provided. For Claude Code, the session-start hook
-  // injects constitution docs separately. But if hooks aren't installed or
+  // normally injects constitution docs. But if hooks aren't installed or
   // the hook fails, the agent needs to self-heal by calling bootstrap manually.
   return `${identityHeader}
 
-Skip directly to loading user config from ~/.ink/config.json and bootstrap as "${agentId}".
-
-**IMPORTANT**: After session initialization, verify that your constitution docs were loaded. Look for a "Session Context (PCP)" or "Bootstrapped Startup Context" section in your context that contains your identity, soul, values, process, and user documents. If these are NOT present, the session-start hook may have failed — you MUST call the \`bootstrap\` MCP tool manually to load your identity context. Do not proceed without your constitution.
+Load user config from ~/.ink/config.json, then check whether your constitution docs are already present. Look for a "Session Context (PCP)" or "Bootstrapped Startup Context" section in your context containing your identity, soul, values, process, and user documents. If these are present, the session-start hook succeeded — do NOT call bootstrap again. If these are NOT present, the hook may have failed — call the \`bootstrap\` MCP tool manually as "${agentId}" to load your identity context. Do not proceed without your constitution.
 
 ${toolPriority}`;
 }

--- a/packages/cli/src/backends/identity.ts
+++ b/packages/cli/src/backends/identity.ts
@@ -186,17 +186,15 @@ export function resolveBackend(cliBackend?: string): string {
  * Build the identity prompt content. Same across all backends.
  */
 export function buildIdentityPrompt(agentId: string, startupContextBlock?: string): string {
-  const basePrompt = `## Identity Override (CRITICAL)
+  const identityHeader = `## Identity Override (CRITICAL)
 
 **You are ${agentId}. Your agent ID is \`${agentId}\`.**
 
 When calling PCP tools (bootstrap, remember, recall, update_session_phase, etc.), use \`agentId: "${agentId}"\`.
 Do NOT read \`.ink/identity.json\` — your identity is set by this system prompt.
-Do NOT run \`echo $AGENT_ID\` — use the agentId provided above.
+Do NOT run \`echo $AGENT_ID\` — use the agentId provided above.`;
 
-Skip directly to loading user config from ~/.ink/config.json and bootstrap as "${agentId}".
-
-## Tool Priority (IMPORTANT)
+  const toolPriority = `## Tool Priority (IMPORTANT)
 
 Always use **PCP cloud tools** (mcp__inkwell__*) over file reads or Claude Code builtins:
 - Identity: use mcp__inkwell__bootstrap, not file reads
@@ -207,13 +205,31 @@ Always use **PCP cloud tools** (mcp__inkwell__*) over file reads or Claude Code 
 PCP tools persist across sessions and are shared with the user and other agents.`;
 
   const injectedContext = startupContextBlock?.trim();
-  if (!injectedContext) return basePrompt;
 
-  return `${basePrompt}
+  if (injectedContext) {
+    // Startup context was pre-loaded (e.g., by sb CLI for Codex/Gemini).
+    // The agent has constitution docs — no need to call bootstrap again.
+    return `${identityHeader}
+
+Bootstrap has already been completed. Your constitution docs are loaded below. Do NOT call bootstrap again unless you need to refresh context.
+
+${toolPriority}
 
 ## Bootstrapped Startup Context (PCP)
 
 ${injectedContext}`;
+  }
+
+  // No startup context provided. For Claude Code, the session-start hook
+  // injects constitution docs separately. But if hooks aren't installed or
+  // the hook fails, the agent needs to self-heal by calling bootstrap manually.
+  return `${identityHeader}
+
+Skip directly to loading user config from ~/.ink/config.json and bootstrap as "${agentId}".
+
+**IMPORTANT**: After session initialization, verify that your constitution docs were loaded. Look for a "Session Context (PCP)" or "Bootstrapped Startup Context" section in your context that contains your identity, soul, values, process, and user documents. If these are NOT present, the session-start hook may have failed — you MUST call the \`bootstrap\` MCP tool manually to load your identity context. Do not proceed without your constitution.
+
+${toolPriority}`;
 }
 
 /**


### PR DESCRIPTION
## Summary

- When `startupContextBlock` is provided (Codex/Gemini via `sb` CLI), the identity prompt now explicitly tells the agent that bootstrap is complete — prevents redundant bootstrap calls
- When no startup context is present (Claude Code relying on hooks), the prompt includes **self-healing instructions**: verify constitution docs are in context, and if not, call `bootstrap` manually
- Adds 2 tests for the conditional behavior

## Problem

The identity override prompt always said "Skip directly to loading user config and bootstrap" regardless of whether the session-start hook succeeded. When hooks failed or weren't installed (e.g., in the Inkah repo), agents interpreted this as "bootstrap already happened" and proceeded without constitution docs — missing conventions like the co-author format.

## Test plan

- [x] New tests pass: `buildIdentityPrompt` with and without `startupContextBlock`
- [x] Existing adapter tests still pass (22/22)
- [x] Pre-existing Gemini test failures confirmed on main (not introduced by this change)
- [ ] Sibling review

— Wren