### PR TITLE
feat: session_scope config + UI toggle for per-sender isolation (by Wren)

### DIFF
--- a/packages/api/src/data/supabase/types.ts
+++ b/packages/api/src/data/supabase/types.ts
@@ -133,6 +133,7 @@ export type Database = {
           permissions: Json;
           relationships: Json | null;
           role: string;
+          session_scope: string;
           soul: string | null;
           studio_hint: string | null;
           updated_at: string | null;
@@ -154,6 +155,7 @@ export type Database = {
           permissions?: Json;
           relationships?: Json | null;
           role: string;
+          session_scope?: string;
           soul?: string | null;
           studio_hint?: string | null;
           updated_at?: string | null;
@@ -175,6 +177,7 @@ export type Database = {
           permissions?: Json;
           relationships?: Json | null;
           role?: string;
+          session_scope?: string;
           soul?: string | null;
           studio_hint?: string | null;
           updated_at?: string | null;

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -2176,6 +2176,7 @@ router.get('/routing/agents/:agentId', async (req: Request, res: Response) => {
         backend: identity.backend,
         studioHint: identity.studio_hint || null,
         sandboxBypass: identity.sandbox_bypass ?? false,
+        sessionScope: identity.session_scope || 'global',
         updatedAt: identity.updated_at,
       },
       studios: (studiosData || []).map((s: Record<string, unknown>) => ({
@@ -2211,8 +2212,8 @@ router.get('/routing/agents/:agentId', async (req: Request, res: Response) => {
 
 /**
  * PATCH /api/admin/identities/:agentId/settings
- * Update SB-level settings: sandbox_bypass, backend, runtime config (tool profile,
- * tool routing, max turns, passive recall). Admin-only — not exposed via MCP.
+ * Update SB-level settings: sandbox_bypass, session_scope, backend, runtime config
+ * (tool profile, tool routing, max turns, passive recall). Admin-only — not exposed via MCP.
  */
 router.patch('/identities/:agentId/settings', async (req: Request, res: Response) => {
   try {
@@ -2266,6 +2267,10 @@ router.patch('/identities/:agentId/settings', async (req: Request, res: Response
       if (passiveRecall !== undefined) runtimeConfig.passiveRecall = passiveRecall;
 
       updates.metadata = { ...existingMeta, runtimeConfig };
+    }
+
+    if (body.sessionScope === 'global' || body.sessionScope === 'per_sender') {
+      updates.session_scope = body.sessionScope;
     }
 
     if (Object.keys(updates).length === 0) {
@@ -2342,10 +2347,7 @@ router.patch('/studios/:studioId', async (req: Request, res: Response) => {
 
     updates.updated_at = new Date().toISOString();
 
-    const { error: updateErr } = await supabase
-      .from('studios')
-      .update(updates)
-      .eq('id', studioId);
+    const { error: updateErr } = await supabase.from('studios').update(updates).eq('id', studioId);
 
     if (updateErr) {
       logger.error('Failed to update studio settings:', updateErr);

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -2062,7 +2062,7 @@ router.get('/routing/agents/:agentId', async (req: Request, res: Response) => {
     const { data: identity, error: identityError } = await supabase
       .from('agent_identities')
       .select(
-        'id, agent_id, name, role, description, backend, studio_hint, workspace_id, updated_at, sandbox_bypass'
+        'id, agent_id, name, role, description, backend, studio_hint, workspace_id, updated_at, sandbox_bypass, session_scope'
       )
       .eq('user_id', authReq.pcpUserId)
       .eq('workspace_id', authReq.pcpWorkspaceId)

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -159,6 +159,7 @@ async function startServer(config: ServerConfig = {}): Promise<void> {
 
     // Resolve agent: mention → channel_routes → AGENT_ID env fallback
     let routedAgentId = agentId;
+    let routedIdentityId: string | undefined;
     const isGroupChat = metadata?.chatType === 'group' || metadata?.chatType === 'channel';
 
     // For group chats, try mention-based routing first
@@ -173,6 +174,7 @@ async function startServer(config: ServerConfig = {}): Promise<void> {
       );
       if (mentionMatch) {
         routedAgentId = mentionMatch.agentId;
+        routedIdentityId = mentionMatch.identityId;
         logger.debug(`[Route] Resolved agent from @mention`, {
           platform: channel,
           agentId: mentionMatch.agentId,
@@ -193,6 +195,7 @@ async function startServer(config: ServerConfig = {}): Promise<void> {
       );
       if (route) {
         routedAgentId = route.agentId;
+        routedIdentityId = route.identityId;
         routeStudioHint = route.studioHint;
         logger.debug(`[Route] Resolved agent from channel_routes`, {
           platform: channel,
@@ -219,13 +222,13 @@ async function startServer(config: ServerConfig = {}): Promise<void> {
     let agentSessionScope: string | null = null;
     if (isExternalChannelForContact && dataComposer) {
       try {
-        const { data: identity } = await dataComposer
-          .getClient()
-          .from('agent_identities')
-          .select('session_scope')
-          .eq('user_id', userId)
-          .eq('agent_id', routedAgentId)
-          .single();
+        let scopeQuery = dataComposer.getClient().from('agent_identities').select('session_scope');
+        if (routedIdentityId) {
+          scopeQuery = scopeQuery.eq('id', routedIdentityId);
+        } else {
+          scopeQuery = scopeQuery.eq('user_id', userId).eq('agent_id', routedAgentId);
+        }
+        const { data: identity } = await scopeQuery.single();
         agentSessionScope = identity?.session_scope || 'global';
       } catch {
         // Fall through — default to global (no isolation)

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -209,14 +209,29 @@ async function startServer(config: ServerConfig = {}): Promise<void> {
       }
     }
 
-    // Resolve contact for per-sender session isolation
+    // Resolve contact for per-sender session isolation (only when agent has session_scope: 'per_sender')
     let contactId: string | undefined;
     const isExternalChannelForContact =
       channel === 'telegram' ||
       channel === 'whatsapp' ||
       channel === 'discord' ||
       channel === 'slack';
+    let agentSessionScope: string | null = null;
     if (isExternalChannelForContact && dataComposer) {
+      try {
+        const { data: identity } = await dataComposer
+          .getClient()
+          .from('agent_identities')
+          .select('session_scope')
+          .eq('user_id', userId)
+          .eq('agent_id', routedAgentId)
+          .single();
+        agentSessionScope = identity?.session_scope || 'global';
+      } catch {
+        // Fall through — default to global (no isolation)
+      }
+    }
+    if (isExternalChannelForContact && dataComposer && agentSessionScope === 'per_sender') {
       try {
         const platformMap: Record<string, 'telegram' | 'discord' | 'whatsapp' | 'imessage'> = {
           telegram: 'telegram',

--- a/packages/web/src/app/(dashboard)/routing/[agentId]/page.tsx
+++ b/packages/web/src/app/(dashboard)/routing/[agentId]/page.tsx
@@ -287,7 +287,8 @@ export default function AgentRoutingPage() {
               <CardTitle className="text-base font-semibold">Security & Permissions</CardTitle>
             </div>
             <CardDescription>
-              Default settings for all of {data.agent.name || agentId}&apos;s studios. Individual studios can override below.
+              Default settings for all of {data.agent.name || agentId}&apos;s studios. Individual
+              studios can override below.
             </CardDescription>
           </CardHeader>
           <CardContent>
@@ -316,6 +317,38 @@ export default function AgentRoutingPage() {
                 <span
                   className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform shadow-sm ${
                     data.agent.sandboxBypass ? 'translate-x-6' : 'translate-x-1'
+                  }`}
+                />
+              </button>
+            </div>
+
+            <div className="flex items-center justify-between rounded-lg border p-3 bg-gray-50/50 mt-3">
+              <div>
+                <p className="text-sm font-medium text-gray-700">Per-sender session isolation</p>
+                <p className="text-xs text-gray-400 mt-0.5">
+                  Each external sender gets their own session and memories (for public-facing SBs)
+                </p>
+              </div>
+              <button
+                onClick={async () => {
+                  try {
+                    const newScope =
+                      data.agent.sessionScope === 'per_sender' ? 'global' : 'per_sender';
+                    await apiPatch(`/api/admin/identities/${agentId}/settings`, {
+                      sessionScope: newScope,
+                    });
+                    queryClient.invalidateQueries({ queryKey: ['routing-agent', agentId] });
+                  } catch (e) {
+                    console.error('Failed to update session scope:', e);
+                  }
+                }}
+                className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
+                  data.agent.sessionScope === 'per_sender' ? 'bg-blue-600' : 'bg-gray-200'
+                }`}
+              >
+                <span
+                  className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform shadow-sm ${
+                    data.agent.sessionScope === 'per_sender' ? 'translate-x-6' : 'translate-x-1'
                   }`}
                 />
               </button>
@@ -665,9 +698,11 @@ export default function AgentRoutingPage() {
                   <div className="flex items-center gap-2 shrink-0">
                     <label
                       className="flex items-center gap-1.5 cursor-pointer"
-                      title={studio.sandboxBypass === null
-                        ? `MCP bypass: inheriting ${data?.agent?.sandboxBypass ? 'ON' : 'OFF'} from SB default (click to override)`
-                        : 'MCP bypass: studio override (click to toggle, shift+click to reset to inherit)'}
+                      title={
+                        studio.sandboxBypass === null
+                          ? `MCP bypass: inheriting ${data?.agent?.sandboxBypass ? 'ON' : 'OFF'} from SB default (click to override)`
+                          : 'MCP bypass: studio override (click to toggle, shift+click to reset to inherit)'
+                      }
                     >
                       <input
                         type="checkbox"
@@ -675,9 +710,10 @@ export default function AgentRoutingPage() {
                         onChange={async (e) => {
                           try {
                             // Shift+click resets to null (inherit from SB)
-                            const newValue = e.nativeEvent instanceof MouseEvent && e.nativeEvent.shiftKey
-                              ? null
-                              : !(studio.sandboxBypass ?? data?.agent?.sandboxBypass ?? false);
+                            const newValue =
+                              e.nativeEvent instanceof MouseEvent && e.nativeEvent.shiftKey
+                                ? null
+                                : !(studio.sandboxBypass ?? data?.agent?.sandboxBypass ?? false);
                             await apiPatch(`/api/admin/studios/${studio.id}`, {
                               sandboxBypass: newValue,
                             });

--- a/packages/web/src/app/(dashboard)/routing/[agentId]/page.tsx
+++ b/packages/web/src/app/(dashboard)/routing/[agentId]/page.tsx
@@ -78,6 +78,7 @@ interface AgentRoutingResponse {
     backend: string | null;
     studioHint: string;
     sandboxBypass: boolean;
+    sessionScope: string;
     updatedAt: string;
   };
   studios: AgentStudio[];

--- a/supabase/migrations/20260402055401_agent_session_scope.sql
+++ b/supabase/migrations/20260402055401_agent_session_scope.sql
@@ -1,0 +1,13 @@
+-- Agent session scope configuration
+--
+-- Controls whether an SB uses per-sender session isolation.
+-- Values:
+--   'global'     — default, all senders share one session (today's behavior)
+--   'per_sender'  — each external sender gets an isolated session + memories
+--
+-- Aligns with OpenClaw's session.scope naming convention.
+
+ALTER TABLE agent_identities ADD COLUMN IF NOT EXISTS session_scope text DEFAULT 'global';
+
+COMMENT ON COLUMN agent_identities.session_scope IS
+  'Session isolation mode: global (shared) or per_sender (isolated per external sender)';


### PR DESCRIPTION
## Summary

Adds the configuration layer for per-sender session isolation. The backend plumbing was built in PR #264 and #286 — this adds the switch to turn it on.

- **Migration**: `session_scope` column on `agent_identities` (`'global'` default, `'per_sender'` for isolation). Naming aligns with OpenClaw's `session.scope` convention.
- **Gateway gating**: Contact resolution now only runs when the routed agent has `session_scope = 'per_sender'`. Global-scoped agents skip contact resolution entirely.
- **API**: `PATCH /api/admin/identities/:agentId/settings` accepts `sessionScope`. GET returns it.
- **UI**: Toggle on routing/\<agentId\> settings page alongside sandbox bypass.

## How to enable per-sender isolation

1. Dashboard: Go to Routing → select agent → toggle "Per-sender session isolation"
2. API: `PATCH /api/admin/identities/myra-public/settings { "sessionScope": "per_sender" }`

## Test plan

- [x] Per-sender unit tests pass (103 tests)
- [x] API type-check passes (0 new errors)
- [ ] Manual: toggle on dashboard, verify `session_scope` updated in DB
- [ ] Manual: send message to per_sender agent via Telegram, verify contact created + isolated session
- [ ] Manual: send message to global agent, verify no contact resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)