### PR TITLE
fix: remaining PCP → Inkstand in constants, MCP server name, Docker image (by Wren)

### DIFF
--- a/packages/api/src/channels/index.ts
+++ b/packages/api/src/channels/index.ts
@@ -2,7 +2,7 @@
  * Channels module
  *
  * This module provides integration with messaging platforms through clawdbot.
- * It allows the personal context protocol to receive and process messages from:
+ * It allows Inkstand to receive and process messages from:
  * - Telegram
  * - WhatsApp
  * - Discord

--- a/packages/api/src/channels/types.ts
+++ b/packages/api/src/channels/types.ts
@@ -1,5 +1,5 @@
 /**
- * Channel integration types for personal-context-protocol
+ * Channel integration types for Inkstand
  * These types are designed to be compatible with clawdbot's message context format
  */
 

--- a/packages/api/src/config/constants.ts
+++ b/packages/api/src/config/constants.ts
@@ -1,14 +1,14 @@
 // Application constants
 
-export const APP_NAME = 'Personal Context Protocol';
+export const APP_NAME = 'Inkstand';
 export const APP_VERSION = '1.0.0';
 export const APP_DESCRIPTION =
-  'MCP server for managing personal context across messaging platforms';
+  'MCP server for persistent memory and context management across AI agents';
 
 // MCP Server metadata
-export const MCP_SERVER_NAME = 'personal-context-protocol';
+export const MCP_SERVER_NAME = 'inkstand';
 export const MCP_SERVER_VERSION = '1.0.0';
-export const MCP_SERVER_DESCRIPTION = `Personal Context Protocol (PCP) - Persistent memory and context management for AI agents.
+export const MCP_SERVER_DESCRIPTION = `Inkstand - Persistent memory and context management for AI agents.
 
 ## User Identification
 Most tools require identifying a user. You can use ANY ONE of these methods:

--- a/packages/api/src/exports.ts
+++ b/packages/api/src/exports.ts
@@ -1,5 +1,5 @@
 /**
- * Public API exports for @personal-context-protocol/api
+ * Public API exports for @inkstand/api
  *
  * This file exports all public APIs that can be used by consumers of this package.
  */

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -5,7 +5,7 @@ import { env } from './config/env';
 
 async function main() {
   try {
-    logger.info('Starting Personal Context Protocol server...');
+    logger.info('Starting Inkstand server...');
     logger.info(`Environment: ${env.NODE_ENV}`);
     logger.info(`MCP Transport: ${env.MCP_TRANSPORT}`);
 
@@ -27,7 +27,7 @@ async function main() {
     logger.info('Starting MCP server...');
     await mcpServer.start();
 
-    logger.info('Personal Context Protocol server is running!');
+    logger.info('Inkstand server is running!');
 
     // Graceful shutdown
     process.on('SIGINT', async () => {

--- a/packages/api/src/mcp/server.test.ts
+++ b/packages/api/src/mcp/server.test.ts
@@ -244,7 +244,7 @@ describe('MCP StreamableHTTP Transport (stateless)', () => {
     expect(sessionId).toBeNull();
 
     const result = parseSSEResult(res.body) as any;
-    expect(result.result.serverInfo.name).toBe('personal-context-protocol');
+    expect(result.result.serverInfo.name).toBe('inkstand');
     expect(result.result.protocolVersion).toBe('2025-03-26');
   });
 

--- a/packages/cli/src/commands/studio-sandbox.ts
+++ b/packages/cli/src/commands/studio-sandbox.ts
@@ -57,7 +57,7 @@ export interface ParsedExtraMount {
   readOnly: boolean;
 }
 
-const DEFAULT_IMAGE = 'personal-context-protocol:studio-sandbox';
+const DEFAULT_IMAGE = 'inkstand:studio-sandbox';
 const CONTAINER_HOME = '/home/sb';
 const BACKEND_AUTH_DIRS: Record<BackendAuthName, string> = {
   claude: join(homedir(), '.claude'),


### PR DESCRIPTION
## Summary

The MCP server name and session metadata still showed "personal-context-protocol" / "PCP". This is what appears in session listings, MCP tool metadata, and server startup logs.

- `APP_NAME` → "Inkstand"
- `MCP_SERVER_NAME` → "inkstand" (this is what shows in `ink session list`)
- `MCP_SERVER_DESCRIPTION` → updated
- Docker sandbox image → `inkstand:studio-sandbox`
- Server startup messages in index.ts
- Comment updates in exports, channels

6 files, 10 lines changed.

— Wren