### PR TITLE
fix: update stale .pcp paths and assertions in CLI integration tests (by Wren)

### DIFF
--- a/packages/cli/src/commands/chat.integration.test.ts
+++ b/packages/cli/src/commands/chat.integration.test.ts
@@ -191,8 +191,8 @@ describe('runChat integration', () => {
     };
     expect(backendRequest.backend).toBe('gemini');
     expect(backendRequest.prompt).toContain('Latest user message:\nheartbeat pulse');
-    // Newly created session in non-interactive mode should be ended.
-    expect(testState.pcpCalls.some((call) => call.tool === 'end_session')).toBe(true);
+    // Non-interactive sessions are left resumable (update_session_phase, not end_session).
+    expect(testState.pcpCalls.some((call) => call.tool === 'update_session_phase')).toBe(true);
   });
 
   it('attaches to provided session id and does not end attached session', async () => {
@@ -1088,7 +1088,7 @@ describe('runChat integration', () => {
     const logText = stripAnsi(logSpy.mock.calls.flat().join('\n'));
     expect(logText).toContain('Capabilities snapshot');
     expect(logText).toContain('MCP servers (2)');
-    expect(logText).toContain('pcp [http] http://localhost:3001/mcp');
+    expect(logText).toContain('inkwell [http] http://localhost:3001/mcp');
     expect(logText).toContain('github [stdio] github-mcp-server');
     expect(logText).toContain('Tool policy');
   });
@@ -1116,7 +1116,7 @@ describe('runChat integration', () => {
 
     const logText = stripAnsi(logSpy.mock.calls.flat().join('\n'));
     expect(logText).toContain('MCP servers (1)');
-    expect(logText).toContain('pcp [http] http://localhost:3001/mcp');
+    expect(logText).toContain('inkwell [http] http://localhost:3001/mcp');
   });
 
   it('toggles inbox auto-run via slash command', async () => {

--- a/packages/cli/src/commands/claude.integration.test.ts
+++ b/packages/cli/src/commands/claude.integration.test.ts
@@ -70,15 +70,15 @@ describe('claude command integration', () => {
     mkdirSync(homeDir, { recursive: true });
     mkdirSync(repoDir, { recursive: true });
     mkdirSync(binDir, { recursive: true });
-    mkdirSync(join(homeDir, '.pcp'), { recursive: true });
-    mkdirSync(join(repoDir, '.pcp'), { recursive: true });
+    mkdirSync(join(homeDir, '.ink'), { recursive: true });
+    mkdirSync(join(repoDir, '.ink'), { recursive: true });
 
     writeFileSync(
-      join(homeDir, '.pcp', 'config.json'),
+      join(homeDir, '.ink', 'config.json'),
       JSON.stringify({ email: 'integration@example.com' }, null, 2)
     );
     writeFileSync(
-      join(repoDir, '.pcp', 'identity.json'),
+      join(repoDir, '.ink', 'identity.json'),
       JSON.stringify({ studioId: 'studio-test' }, null, 2)
     );
 
@@ -169,7 +169,7 @@ console.log(JSON.stringify({ session_id: process.env.FAKE_CLAUDE_SESSION_ID || '
       await runClaude('hello integration', ['hello', 'integration'], options, []);
       await waitForFile(fakeClaudeArgsPath);
 
-      const runtimePath = join(repoDir, '.pcp', 'runtime', 'sessions.json');
+      const runtimePath = join(repoDir, '.ink', 'runtime', 'sessions.json');
       await waitForFile(runtimePath);
 
       const backendArgs = JSON.parse(readFileSync(fakeClaudeArgsPath, 'utf-8')) as string[];
@@ -224,15 +224,15 @@ console.log(JSON.stringify({ session_id: process.env.FAKE_CLAUDE_SESSION_ID || '
     mkdirSync(homeDir, { recursive: true });
     mkdirSync(repoDir, { recursive: true });
     mkdirSync(binDir, { recursive: true });
-    mkdirSync(join(homeDir, '.pcp'), { recursive: true });
-    mkdirSync(join(repoDir, '.pcp'), { recursive: true });
+    mkdirSync(join(homeDir, '.ink'), { recursive: true });
+    mkdirSync(join(repoDir, '.ink'), { recursive: true });
 
     writeFileSync(
-      join(homeDir, '.pcp', 'config.json'),
+      join(homeDir, '.ink', 'config.json'),
       JSON.stringify({ email: 'integration@example.com' }, null, 2)
     );
     writeFileSync(
-      join(repoDir, '.pcp', 'identity.json'),
+      join(repoDir, '.ink', 'identity.json'),
       JSON.stringify({ studioId: 'studio-test' }, null, 2)
     );
 
@@ -357,7 +357,7 @@ console.log('fake-claude-run-complete');
       );
       expect(observedLocalSessions).toContain(delayedSessionId);
 
-      const runtimePath = join(repoDir, '.pcp', 'runtime', 'sessions.json');
+      const runtimePath = join(repoDir, '.ink', 'runtime', 'sessions.json');
       await waitForFile(runtimePath);
       const runtimeState = JSON.parse(readFileSync(runtimePath, 'utf-8')) as {
         sessions?: Array<{ pcpSessionId?: string; backendSessionId?: string }>;
@@ -409,15 +409,15 @@ console.log('fake-claude-run-complete');
     mkdirSync(homeDir, { recursive: true });
     mkdirSync(repoDir, { recursive: true });
     mkdirSync(binDir, { recursive: true });
-    mkdirSync(join(homeDir, '.pcp'), { recursive: true });
-    mkdirSync(join(repoDir, '.pcp'), { recursive: true });
+    mkdirSync(join(homeDir, '.ink'), { recursive: true });
+    mkdirSync(join(repoDir, '.ink'), { recursive: true });
 
     writeFileSync(
-      join(homeDir, '.pcp', 'config.json'),
+      join(homeDir, '.ink', 'config.json'),
       JSON.stringify({ email: 'integration@example.com' }, null, 2)
     );
     writeFileSync(
-      join(repoDir, '.pcp', 'identity.json'),
+      join(repoDir, '.ink', 'identity.json'),
       JSON.stringify({ studioId: 'studio-test' }, null, 2)
     );
 
@@ -508,7 +508,7 @@ console.log(JSON.stringify({ session_id: process.env.FAKE_CODEX_SESSION_ID || 'c
       await runClaude('hello codex', ['hello', 'codex'], options, []);
       await waitForFile(fakeCodexArgsPath);
 
-      const runtimePath = join(repoDir, '.pcp', 'runtime', 'sessions.json');
+      const runtimePath = join(repoDir, '.ink', 'runtime', 'sessions.json');
       await waitForFile(runtimePath);
 
       const backendArgs = JSON.parse(readFileSync(fakeCodexArgsPath, 'utf-8')) as string[];
@@ -559,15 +559,15 @@ console.log(JSON.stringify({ session_id: process.env.FAKE_CODEX_SESSION_ID || 'c
     mkdirSync(homeDir, { recursive: true });
     mkdirSync(repoDir, { recursive: true });
     mkdirSync(binDir, { recursive: true });
-    mkdirSync(join(homeDir, '.pcp'), { recursive: true });
-    mkdirSync(join(repoDir, '.pcp'), { recursive: true });
+    mkdirSync(join(homeDir, '.ink'), { recursive: true });
+    mkdirSync(join(repoDir, '.ink'), { recursive: true });
 
     writeFileSync(
-      join(homeDir, '.pcp', 'config.json'),
+      join(homeDir, '.ink', 'config.json'),
       JSON.stringify({ email: 'integration@example.com' }, null, 2)
     );
     writeFileSync(
-      join(repoDir, '.pcp', 'identity.json'),
+      join(repoDir, '.ink', 'identity.json'),
       JSON.stringify({ studioId: 'studio-test' }, null, 2)
     );
 
@@ -658,7 +658,7 @@ console.log(JSON.stringify({ session_id: process.env.FAKE_GEMINI_SESSION_ID || '
       await runClaude('hello gemini', ['hello', 'gemini'], options, []);
       await waitForFile(fakeGeminiArgsPath);
 
-      const runtimePath = join(repoDir, '.pcp', 'runtime', 'sessions.json');
+      const runtimePath = join(repoDir, '.ink', 'runtime', 'sessions.json');
       await waitForFile(runtimePath);
 
       const backendArgs = JSON.parse(readFileSync(fakeGeminiArgsPath, 'utf-8')) as string[];


### PR DESCRIPTION
## Summary

Fixes CI test failures on main caused by stale references from the PCP → Ink rename:

- **`claude.integration.test.ts`**: `.pcp` → `.ink` in all config, identity, and runtime session paths (20 occurrences across all 4 tests)
- **`chat.integration.test.ts`**: `'pcp [http]'` → `'inkwell [http]'` in MCP server display assertions (2 occurrences)
- **`chat.integration.test.ts`**: `end_session` → `update_session_phase` assertion for non-interactive mode — the behavior was intentionally changed to leave sessions resumable, but the test wasn't updated

## Root cause

The code paths in `claude.ts` and `session/runtime.ts` were renamed from `.pcp` to `.ink` during the v0.4.0 rebrand, but the integration tests still created `.pcp` directories and waited for files at `.pcp` paths. The `waitForFile` helpers spun until the 5s timeout.

## Test plan

- [x] All 4 `claude.integration.test.ts` tests pass locally
- [x] All `chat.integration.test.ts` tests pass locally
- [x] Full test suite: 53 files, 755 tests pass, 0 failures

— Wren