### PR TITLE
feat: cross-project 'main' resolution via repo_root (by Wren)

### DIFF
--- a/packages/api/src/mcp/server.ts
+++ b/packages/api/src/mcp/server.ts
@@ -307,6 +307,7 @@ export class MCPServer {
         ...(studioIdHeader ? { workspaceId: studioIdHeader } : {}),
         ...(contextToken?.cliAttached ? { cliAttached: true } : {}),
         ...(contextToken?.runtime ? { runtime: contextToken.runtime } : {}),
+        ...(contextToken?.repoRoot ? { repoRoot: contextToken.repoRoot } : {}),
       });
 
       // Resolve studioId from session when x-ink-session-id is provided

--- a/packages/api/src/mcp/tools/inbox-handlers.ts
+++ b/packages/api/src/mcp/tools/inbox-handlers.ts
@@ -127,9 +127,7 @@ export function isThreadOwnedByStudio(
   if (!agentMessages.length) return true; // no messages from us — broadcast
 
   return agentMessages.some((m) => {
-    const pcp = (m.metadata as Record<string, unknown>)?.pcp as
-      | Record<string, unknown>
-      | undefined;
+    const pcp = (m.metadata as Record<string, unknown>)?.pcp as Record<string, unknown> | undefined;
     // Check sender studioId (standard ownership)
     const sender = pcp?.sender as Record<string, unknown> | undefined;
     if (sender?.studioId === callerStudioId) return true;
@@ -376,8 +374,13 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
       try {
         // Reuse the shared resolution function (worktree path → branch fallback
         // for 'main', slug match for named hints).
+        const reqCtxForHint = getRequestContext();
         resolvedRecipientStudioId = await resolveStudioHint(
-          supabase, resolved.user.id, recipientStudioHint, senderAgentId
+          supabase,
+          resolved.user.id,
+          recipientStudioHint,
+          senderAgentId,
+          reqCtxForHint?.repoRoot
         );
       } catch {
         // Best-effort resolution — proceed without stamping
@@ -398,9 +401,7 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
           sessionId: senderSessionId,
           studioId: senderStudioId,
         },
-        ...(selfStudioRecipient
-          ? { recipient: { studioId: resolvedRecipientStudioId } }
-          : {}),
+        ...(selfStudioRecipient ? { recipient: { studioId: resolvedRecipientStudioId } } : {}),
       },
     };
 

--- a/packages/api/src/services/sessions/claude-runner.ts
+++ b/packages/api/src/services/sessions/claude-runner.ts
@@ -228,6 +228,7 @@ export class ClaudeRunner implements IRunner {
             accessToken: config.pcpAccessToken,
             agentId: config.agentId,
             runtime: 'claude',
+            repoRoot: config.repoRoot,
           }),
         },
         stdio: ['pipe', 'pipe', 'pipe'],

--- a/packages/api/src/services/sessions/codex-runner.ts
+++ b/packages/api/src/services/sessions/codex-runner.ts
@@ -201,6 +201,7 @@ export class CodexRunner implements IRunner {
             accessToken: config.pcpAccessToken,
             agentId: config.agentId,
             runtime: 'codex',
+            repoRoot: config.repoRoot,
           }),
         },
         stdio: ['ignore', 'pipe', 'pipe'],

--- a/packages/api/src/services/sessions/gemini-runner.ts
+++ b/packages/api/src/services/sessions/gemini-runner.ts
@@ -218,6 +218,7 @@ export class GeminiRunner implements IRunner {
             accessToken: config.pcpAccessToken,
             agentId: config.agentId,
             runtime: 'gemini',
+            repoRoot: config.repoRoot,
           }),
         },
         stdio: ['ignore', 'pipe', 'pipe'],

--- a/packages/api/src/services/sessions/route-patterns.test.ts
+++ b/packages/api/src/services/sessions/route-patterns.test.ts
@@ -152,38 +152,39 @@ describe('route resolution (multi-studio)', () => {
 // ── "main" resolution contract ──
 
 describe('main studio resolution contract', () => {
-  // "main" = the root repo. The resolution is consistent across all code paths:
-  // 1. resolveMainStudioId: exact path at server CWD → undefined
-  // 2. resolveStudioHint('main'): exact path at process.cwd() → undefined
-  // 3. handleListSessions(studioId: 'main'): undefined (unscoped)
+  // "main" = the root repo. Resolution uses repo_root column to find studios
+  // in the target project. All code paths are consistent:
+  // 1. resolveMainStudioId(userId, repoRoot): .eq('repo_root', repoRoot)
+  // 2. resolveStudioHint('main', repoRoot): same query
+  // 3. handleListSessions(studioId: 'main'): filters studio_id IS NULL
   // 4. resolveStudioId(explicitStudioId: 'main'): delegates to resolveMainStudioId
-  //
-  // When undefined, the runner falls back to defaultWorkingDirectory (the root repo).
-  // No branch='main' guessing. No sibling matching. Simple and predictable.
-
-  it('resolveWorkingDirectory uses defaultWorkingDirectory when studioId is undefined', () => {
-    // This is the core contract: undefined studioId → root repo CWD
-    const studioId: string | undefined = undefined;
-    const defaultDir = '/ws/pcp/inkwell';
-    const resolvedDir = !studioId ? defaultDir : '/some/studio/path';
-    expect(resolvedDir).toBe(defaultDir);
-  });
 
   it('studioId "main" is not treated as a UUID', () => {
     const studioId = 'main';
     const isUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(studioId);
     expect(isUuid).toBe(false);
-    expect(studioId).toBe('main');
   });
 
-  it('no branch matching — main is a path concept, not a git branch', () => {
-    // Previously resolveMainStudioId fell back to .eq('branch', 'main').
-    // This was removed: studios are on feature branches, not main.
-    // The root repo IS main, regardless of what branch any studio is on.
-    const studioSlug = 'wren';
-    const studioBranch = 'wren/feat/workspace-sessions';
-    expect(studioBranch).not.toBe('main');
-    // The studio is still valid for work — its branch doesn't determine
-    // whether it's the "main" studio.
+  it('repo_root distinguishes projects — not branch name', () => {
+    // Studios in different projects share the same agent but different repo_roots.
+    // "main" for inkwell != "main" for inkah.
+    const inkwellStudio = { repo_root: '/ws/pcp/inkwell', slug: 'wren' };
+    const inkahStudio = { repo_root: '/ws/inkah', slug: 'wren' };
+    expect(inkwellStudio.repo_root).not.toBe(inkahStudio.repo_root);
+    expect(inkwellStudio.slug).toBe(inkahStudio.slug); // same agent, different projects
+  });
+
+  it('repo_root is derived from worktree_path by stripping --<name>', () => {
+    // Convention: worktree_path = <repo_root>--<studio_slug>
+    const worktreePath = '/ws/pcp/inkwell--wren';
+    const repoRoot = worktreePath.replace(/--[^/]+$/, '');
+    expect(repoRoot).toBe('/ws/pcp/inkwell');
+  });
+
+  it('resolveWorkingDirectory uses defaultWorkingDirectory when studioId is undefined', () => {
+    const studioId: string | undefined = undefined;
+    const defaultDir = '/ws/pcp/inkwell';
+    const resolvedDir = !studioId ? defaultDir : '/some/studio/path';
+    expect(resolvedDir).toBe(defaultDir);
   });
 });

--- a/packages/api/src/services/sessions/session-service.ts
+++ b/packages/api/src/services/sessions/session-service.ts
@@ -230,6 +230,7 @@ export class SessionService implements ISessionService {
         studioHint: metadata?.studioHint,
         recipientSessionId: metadata?.recipientSessionId,
         contactId: metadata?.contactId,
+        repoRoot: metadata?.repoRoot,
       });
 
       // 2. Build lock key - must be per agent + session to support sub-agents
@@ -425,6 +426,8 @@ export class SessionService implements ISessionService {
       agentId,
       ...(session.studioId ? { studioId: session.studioId } : {}),
       ...(sandboxBypass ? { sandboxBypass: true } : {}),
+      // Propagate repo root so spawned backend's context token carries it
+      repoRoot: resolvedWorkingDirectory.replace(/--[^/]+$/, ''),
     };
 
     // 5. Run with selected backend
@@ -646,6 +649,7 @@ export class SessionService implements ISessionService {
       studioHint?: string;
       recipientSessionId?: string;
       contactId?: string;
+      repoRoot?: string;
     }
   ): Promise<Session> {
     const type = options?.type || 'primary';
@@ -656,6 +660,7 @@ export class SessionService implements ISessionService {
       explicitStudioId: options?.studioId,
       studioHint: options?.studioHint,
       recipientSessionId: options?.recipientSessionId,
+      repoRoot: options?.repoRoot,
       backend,
     });
 
@@ -796,12 +801,13 @@ export class SessionService implements ISessionService {
       studioHint?: string;
       recipientSessionId?: string;
       backend?: string;
+      repoRoot?: string;
     }
   ): Promise<string | undefined> {
     if (options.explicitStudioId) {
       // 'main' is a reserved convention — resolve it the same way studioHint does
       if (options.explicitStudioId === 'main') {
-        const mainId = await this.resolveMainStudioId(userId);
+        const mainId = await this.resolveMainStudioId(userId, options.repoRoot);
         if (mainId) return mainId;
         logger.warn('[StudioResolve] explicitStudioId=main but no main studio found', {
           userId,
@@ -821,7 +827,7 @@ export class SessionService implements ISessionService {
     // Other hints resolve by matching the studio name for this user + agent.
     if (options.studioHint) {
       if (options.studioHint === 'main') {
-        const mainId = await this.resolveMainStudioId(userId);
+        const mainId = await this.resolveMainStudioId(userId, options.repoRoot);
         if (mainId) return mainId;
         // studioHint was explicit — don't silently fall through to unrelated studios
         logger.warn('[StudioResolve] studioHint=main but no main studio found, skipping fallback', {
@@ -976,7 +982,7 @@ export class SessionService implements ISessionService {
     // inherit the bad studio. The studios table is the authoritative source.
 
     // 5) Shared per-user main studio fallback
-    const mainStudioId = await this.resolveMainStudioId(userId);
+    const mainStudioId = await this.resolveMainStudioId(userId, options.repoRoot);
     if (mainStudioId) return mainStudioId;
 
     // Codex is worktree-sensitive: keep a deterministic warning when no studio could be resolved.
@@ -994,24 +1000,28 @@ export class SessionService implements ISessionService {
     return undefined;
   }
 
-  private async resolveMainStudioId(userId: string): Promise<string | undefined> {
+  private async resolveMainStudioId(
+    userId: string,
+    repoRoot?: string
+  ): Promise<string | undefined> {
     if (!this.supabase) return undefined;
 
-    // "Main" = the root repo, not a worktree. If a studio exists at the
-    // server's CWD, use it. Otherwise return undefined — the runner falls
-    // back to defaultWorkingDirectory (the root repo), which is correct.
-    // TODO: for cross-project resolution (e.g., inkah vs inkwell), this
-    // needs a repo_root parameter. See task: repo_root column on studios.
-    const { data: exactMatch } = await this.supabase
+    // "Main" = the root repo. Find the most recently used studio whose
+    // repo_root matches the target project. Falls back to server CWD
+    // when no repoRoot is provided (e.g., from the context token).
+    const targetRoot = repoRoot || this.config.defaultWorkingDirectory;
+
+    const { data: match } = await this.supabase
       .from('studios')
-      .select('id')
+      .select('id, updated_at')
       .eq('user_id', userId)
-      .eq('worktree_path', this.config.defaultWorkingDirectory)
-      .neq('status', 'cleaned')
+      .eq('repo_root', targetRoot)
+      .in('status', ['active', 'idle', 'archived'])
+      .order('updated_at', { ascending: false })
       .limit(1)
       .maybeSingle();
 
-    return exactMatch?.id || undefined;
+    return match?.id || undefined;
   }
 
   private async resolveWorkingDirectory(
@@ -1158,6 +1168,7 @@ This session will continue with a fresh context after compaction. Your identity,
         ),
         ...(runtimeModel ? { model: runtimeModel } : {}),
         ...(compactionToken ? { pcpAccessToken: compactionToken } : {}),
+        repoRoot: compactionWorkingDirectory.replace(/--[^/]+$/, ''),
       };
 
       const runner =
@@ -1429,28 +1440,29 @@ This session will continue with a fresh context after compaction. Your identity,
  * Resolve a studio hint to a studioId. Shared by SessionService (private
  * resolveStudioId) and inbox-handlers (cross-studio self-messaging metadata).
  *
- * For 'main': check if a studio exists at the server CWD, otherwise undefined.
+ * For 'main': find the most recent studio in the target project via repo_root.
  * For named hints: slug match.
  */
 export async function resolveStudioHint(
   supabase: SupabaseClient<Database>,
   userId: string,
   hint: string,
-  agentId?: string
+  agentId?: string,
+  repoRoot?: string
 ): Promise<string | undefined> {
   if (hint === 'main') {
-    // "Main" = the root repo. Check for a studio at the server's CWD.
-    // If none exists, return undefined — the runner uses defaultWorkingDirectory.
-    // TODO: cross-project resolution needs repo_root on studios.
-    const { data: mainByPath } = await supabase
+    // "Main" = the root repo. Find the most recent studio in this project.
+    const targetRoot = repoRoot || process.cwd();
+    const { data: mainByRepo } = await supabase
       .from('studios')
-      .select('id')
+      .select('id, updated_at')
       .eq('user_id', userId)
-      .eq('worktree_path', process.cwd())
-      .neq('status', 'cleaned')
+      .eq('repo_root', targetRoot)
+      .in('status', ['active', 'idle', 'archived'])
+      .order('updated_at', { ascending: false })
       .limit(1)
       .maybeSingle();
-    return mainByPath?.id || undefined;
+    return mainByRepo?.id || undefined;
   }
 
   // Named hint: match by slug

--- a/packages/api/src/services/sessions/types.ts
+++ b/packages/api/src/services/sessions/types.ts
@@ -133,6 +133,8 @@ export interface SessionRequest {
     sessionType?: SessionType;
     taskDescription?: string;
     parentSessionId?: string;
+    // Root repo path for cross-project 'main' studio resolution
+    repoRoot?: string;
   };
 }
 
@@ -416,6 +418,8 @@ export interface ClaudeRunnerConfig {
   studioId?: string;
   /** When true, bypass sandbox restrictions (e.g., Codex --dangerously-bypass-approvals-and-sandbox). Opt-in per studio. */
   sandboxBypass?: boolean;
+  /** Root repo path — propagated via context token for cross-project 'main' resolution */
+  repoRoot?: string;
 }
 
 export interface RunnerResult {

--- a/packages/api/src/utils/request-context.ts
+++ b/packages/api/src/utils/request-context.ts
@@ -51,6 +51,8 @@ export interface RequestContextData {
   cliAttached?: boolean;
   /** Backend runtime: 'claude' | 'codex' | 'gemini' */
   runtime?: string;
+  /** Root repo path for cross-project 'main' studio resolution */
+  repoRoot?: string;
 }
 
 const asyncLocalStorage = new AsyncLocalStorage<RequestContextData>();

--- a/packages/shared/src/runner/mcp-config.ts
+++ b/packages/shared/src/runner/mcp-config.ts
@@ -164,6 +164,7 @@ export interface PcpContextToken {
   agentId: string;
   cliAttached: boolean;
   runtime: string; // 'claude' | 'codex' | 'gemini'
+  repoRoot?: string; // root repo path for cross-project 'main' resolution
 }
 
 /**
@@ -208,6 +209,7 @@ export function buildSessionEnv(options: {
   agentId?: string;
   cliAttached?: boolean;
   runtime?: string;
+  repoRoot?: string;
 }): Record<string, string> {
   const env: Record<string, string> = {};
 
@@ -235,6 +237,7 @@ export function buildSessionEnv(options: {
       agentId: options.agentId,
       cliAttached: options.cliAttached || false,
       runtime: options.runtime || 'claude',
+      ...(options.repoRoot ? { repoRoot: options.repoRoot } : {}),
     });
   }
 


### PR DESCRIPTION
## Summary

`resolveMainStudioId` and `resolveStudioHint` now use the `repo_root` column (already exists and populated on all studios) instead of `worktree_path` matching. This enables cross-project 'main' resolution:

- `studioId: 'main'` in the inkwell project → finds inkwell studios
- `studioId: 'main'` in the inkah project → finds inkah studios
- Same agent (`wren`) in both projects, distinguished by `repo_root`

Both functions accept an optional `repoRoot` parameter. Falls back to server CWD when not provided.

No migration needed — `repo_root` column already exists with correct data.

## Test plan
- [x] 98 session tests pass
- [x] 203 affected tests pass (sessions + memory + inbox handlers)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)