### PR TITLE
chore: bump to 0.5.0 for npm publish (by Wren)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inklabs/inkwell",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "description": "Inkwell - MCP server for managing personal context across services",
   "workspaces": [

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inklabs/api",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "license": "SEE LICENSE IN LICENSE",
   "publishConfig": {

--- a/packages/channel-plugin/package.json
+++ b/packages/channel-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inklabs/inkmail-plugin",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "InkMail plugin for Claude Code — pushes inbox messages into running sessions",
   "type": "module",
   "main": "index.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inklabs/cli",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/create-pcp/package.json
+++ b/packages/create-pcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inklabs/create-inkwell",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Set up Inkwell — AI beings with identity, memory, and coordination",
   "license": "MIT",
   "publishConfig": {

--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inklabs/openclaw-plugin",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Inkwell plugin for OpenClaw — identity, memory, sessions, and cross-agent messaging",
   "type": "module",
   "license": "MIT",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inklabs/shared",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/spec/package.json
+++ b/packages/spec/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inklabs/spec",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "description": "Inkwell Protocol Specification",
   "license": "MIT"

--- a/packages/templates/package.json
+++ b/packages/templates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inklabs/templates",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "license": "MIT",
   "description": "Shared identity templates for Inkwell — awakening prompts and document starters"

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inklabs/web",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "license": "MIT",
   "description": "Inkwell Admin Dashboard - Manage WhatsApp, trusted users, and groups",


### PR DESCRIPTION
Bump all packages to 0.5.0 for first npm publish under @inklabs scope.