### PR TITLE
fix: pcp-managed → ink-managed in codex config markers (by Wren)

### DIFF
--- a/packages/cli/src/commands/mcp.test.ts
+++ b/packages/cli/src/commands/mcp.test.ts
@@ -64,10 +64,10 @@ describe('syncMcpConfig', () => {
     expect(existsSync(join(TEST_DIR, '.codex', 'config.toml'))).toBe(true);
 
     const toml = readFileSync(join(TEST_DIR, '.codex', 'config.toml'), 'utf-8');
-    expect(toml).toContain('# pcp-managed:start mcp_servers');
+    expect(toml).toContain('# ink-managed:start mcp_servers');
     expect(toml).toContain('[mcp_servers.inkwell]');
     expect(toml).toContain('url = "http://localhost:3001/mcp"');
-    expect(toml).toContain('# pcp-managed:end mcp_servers');
+    expect(toml).toContain('# ink-managed:end mcp_servers');
   });
 
   it('should create .gemini/settings.json from .mcp.json', () => {
@@ -402,10 +402,10 @@ describe('syncMcpConfig', () => {
         '[hooks]',
         'enabled = true',
         '',
-        '# pcp-managed:start mcp_servers',
+        '# ink-managed:start mcp_servers',
         '[mcp_servers.old]',
         'url = "http://old"',
-        '# pcp-managed:end mcp_servers',
+        '# ink-managed:end mcp_servers',
         '',
       ].join('\n')
     );

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -37,8 +37,11 @@ interface SyncSource {
   from: 'local' | 'main';
 }
 
-const CODEX_MANAGED_START = '# pcp-managed:start mcp_servers';
-const CODEX_MANAGED_END = '# pcp-managed:end mcp_servers';
+const CODEX_MANAGED_START = '# ink-managed:start mcp_servers';
+const CODEX_MANAGED_END = '# ink-managed:end mcp_servers';
+// Backward compat: detect old markers during replacement
+const CODEX_MANAGED_START_LEGACY = '# pcp-managed:start mcp_servers';
+const CODEX_MANAGED_END_LEGACY = '# pcp-managed:end mcp_servers';
 
 // ============================================================================
 // Env file parsing
@@ -283,12 +286,17 @@ function mergeCodexConfig(existing: string | undefined, managedBlock: string): s
     return managedBlock;
   }
 
-  const hasManagedBlock =
+  // Detect current or legacy managed block markers
+  const hasCurrentBlock =
     existing.includes(CODEX_MANAGED_START) && existing.includes(CODEX_MANAGED_END);
+  const hasLegacyBlock =
+    existing.includes(CODEX_MANAGED_START_LEGACY) && existing.includes(CODEX_MANAGED_END_LEGACY);
 
-  if (hasManagedBlock) {
+  if (hasCurrentBlock || hasLegacyBlock) {
+    const startMarker = hasCurrentBlock ? CODEX_MANAGED_START : CODEX_MANAGED_START_LEGACY;
+    const endMarker = hasCurrentBlock ? CODEX_MANAGED_END : CODEX_MANAGED_END_LEGACY;
     const pattern = new RegExp(
-      `${escapeRegExp(CODEX_MANAGED_START)}[\\s\\S]*?${escapeRegExp(CODEX_MANAGED_END)}\\n?`,
+      `${escapeRegExp(startMarker)}[\\s\\S]*?${escapeRegExp(endMarker)}\\n?`,
       'm'
     );
     return ensureTrailingNewline(existing.replace(pattern, managedBlock));


### PR DESCRIPTION
Renames config markers. Backward compat: detects old pcp-managed markers and replaces on next sync.