### PR TITLE
fix(deps): patch handlebars 4.7.9 — NumberLiteral RCE (by Wren)

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "undici": "6.24.0",
     "lodash": "4.18.0",
     "brace-expansion": "1.1.13",
-    "@slack/bolt/path-to-regexp": "8.4.0"
+    "@slack/bolt/path-to-regexp": "8.4.0",
+    "handlebars": "4.7.9"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7139,9 +7139,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"handlebars@npm:^4.7.8":
-  version: 4.7.8
-  resolution: "handlebars@npm:4.7.8"
+"handlebars@npm:4.7.9":
+  version: 4.7.9
+  resolution: "handlebars@npm:4.7.9"
   dependencies:
     minimist: "npm:^1.2.5"
     neo-async: "npm:^2.6.2"
@@ -7153,7 +7153,7 @@ __metadata:
       optional: true
   bin:
     handlebars: bin/handlebars
-  checksum: 10/bd528f4dd150adf67f3f857118ef0fa43ff79a153b1d943fa0a770f2599e38b25a7a0dbac1a3611a4ec86970fd2325a81310fb788b5c892308c9f8743bd02e11
+  checksum: 10/e755433d652e8a15fc02f83d7478e652359e7a4d354c4328818853ed4f8a39d4a09e1d22dad3c7213c5240864a65b3c840970b8b181745575dd957dd258f2b8d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Patches handlebars 4.7.8 → 4.7.9 via yarn resolution. NumberLiteral AST injection could execute arbitrary JS via Handlebars.compile(). Transitive via ts-jest.