### PR TITLE
fix(deps): patch vite 7.3.2 — WebSocket fetchModule bypass (by Wren)

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -59,7 +59,7 @@
     "postcss": "^8.4.49",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.3.3",
-    "vite": "^7.3.1",
+    "vite": "^7.3.2",
     "vitest": "^4.0.18"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1366,7 +1366,7 @@ __metadata:
     tailwindcss: "npm:^3.4.17"
     tiptap-markdown: "npm:^0.9.0"
     typescript: "npm:^5.3.3"
-    vite: "npm:^7.3.1"
+    vite: "npm:^7.3.2"
     vitest: "npm:^4.0.18"
   languageName: unknown
   linkType: soft
@@ -13407,9 +13407,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:^7.3.1":
-  version: 7.3.1
-  resolution: "vite@npm:7.3.1"
+"vite@npm:^7.3.2":
+  version: 7.3.2
+  resolution: "vite@npm:7.3.2"
   dependencies:
     esbuild: "npm:^0.27.0"
     fdir: "npm:^6.5.0"
@@ -13458,7 +13458,7 @@ __metadata:
       optional: true
   bin:
     vite: bin/vite.js
-  checksum: 10/62e48ffa4283b688f0049005405a004447ad38ffc99a0efea4c3aa9b7eed739f7402b43f00668c0ee5a895b684dc953d62f0722d8a92c5b2f6c95f051bceb208
+  checksum: 10/c5f7a9a60011c41c836cedf31c8ee7624102aff9b6a7f3aab2ff47639721bba0916f81994c3a3ea6577a16c4f0dfee1e7dbd244e0da8edd5954e3c6d48daaaa2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
Bumps vite from 7.3.1 → 7.3.2. WebSocket fetchModule method bypassed server.fs access control, allowing arbitrary file reads on dev servers exposed to the network.

## Test plan
- [x] All 1822 tests pass locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)