### PR TITLE
feat: auto-generate studio permissions + per-session overlays (by Wren)

### DIFF
--- a/packages/api/src/mcp/tools/studio-handlers.ts
+++ b/packages/api/src/mcp/tools/studio-handlers.ts
@@ -13,6 +13,7 @@ import { existsSync } from 'fs';
 import type { DataComposer } from '../../data/composer';
 import { resolveUserOrThrow, userIdentifierBaseSchema } from '../../services/user-resolver';
 import { logger } from '../../utils/logger';
+import { ensureStudioSettings } from '../../services/studio-settings';
 
 // ============== Helpers ==============
 
@@ -218,6 +219,17 @@ export async function handleCreateStudio(args: unknown, dataComposer: DataCompos
       logger.error('Git worktree creation failed', { error: errorMessage, branch, worktreePath });
       return errorResponse(`Failed to create git worktree: ${errorMessage}`);
     }
+  }
+
+  // Generate .claude/settings.local.json with default permissions + hooks
+  try {
+    await ensureStudioSettings(worktreePath);
+  } catch (settingsError) {
+    // Non-fatal — studio is usable without auto-generated settings
+    logger.warn('Failed to generate studio settings', {
+      worktreePath,
+      error: settingsError instanceof Error ? settingsError.message : String(settingsError),
+    });
   }
 
   // Insert studio record into the database
@@ -543,6 +555,16 @@ export async function handleAdoptStudio(args: unknown, dataComposer: DataCompose
 
   if (!studio) {
     return errorResponse('Studio not found');
+  }
+
+  // Ensure settings exist in the worktree (may be first time adopting an old studio)
+  try {
+    await ensureStudioSettings(studio.worktreePath);
+  } catch (settingsError) {
+    logger.warn('Failed to ensure studio settings on adopt', {
+      worktreePath: studio.worktreePath,
+      error: settingsError instanceof Error ? settingsError.message : String(settingsError),
+    });
   }
 
   // Link session and set to active

--- a/packages/api/src/services/sessions/claude-runner.ts
+++ b/packages/api/src/services/sessions/claude-runner.ts
@@ -20,7 +20,7 @@ import { formatInjectedContext } from './context-builder.js';
 import { logger } from '../../utils/logger.js';
 import { resolveBinaryPath, buildSpawnPath } from './resolve-binary.js';
 import { injectSessionHeaders, buildSessionEnv, writeRuntimeSessionHint } from '@inklabs/shared';
-import { ensureStudioSettings } from '../studio-settings.js';
+import { ensureStudioSettings, applyPermissionOverlay } from '../studio-settings.js';
 
 /** Maximum time (ms) to wait for a Claude Code subprocess before killing it.
  *  Override with CLAUDE_PROCESS_TIMEOUT_MS env var. */
@@ -209,6 +209,23 @@ export class ClaudeRunner implements IRunner {
       }
     }
 
+    // Apply per-session permission overlay (from strategy config or 2FA grant).
+    // The restore function is called after the process exits to revert the overlay.
+    let restoreOverlay: (() => Promise<void>) | null = null;
+    if (config.workingDirectory && config.permissionOverlay) {
+      try {
+        restoreOverlay = await applyPermissionOverlay(
+          config.workingDirectory,
+          config.permissionOverlay
+        );
+      } catch (err) {
+        logger.warn('Failed to apply permission overlay (non-fatal)', {
+          cwd: config.workingDirectory,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
     // If headers were injected, patch the --mcp-config arg to point to the temp file
     if (mcpInjection?.modified) {
       const mcpIdx = args.indexOf('--mcp-config');
@@ -370,6 +387,7 @@ export class ClaudeRunner implements IRunner {
       proc.on('error', (error) => {
         clearTimeout(timeout);
         clearTimeout(idleTimer);
+        restoreOverlay?.().catch(() => {});
         if (!settled) {
           settled = true;
           reject(new Error(`Failed to spawn Claude: ${error.message}`));
@@ -380,6 +398,7 @@ export class ClaudeRunner implements IRunner {
         clearTimeout(timeout);
         clearTimeout(idleTimer);
         mcpInjection?.cleanup();
+        restoreOverlay?.().catch(() => {});
         if (settled) return; // Already resolved by timeout
         settled = true;
 

--- a/packages/api/src/services/sessions/claude-runner.ts
+++ b/packages/api/src/services/sessions/claude-runner.ts
@@ -20,6 +20,7 @@ import { formatInjectedContext } from './context-builder.js';
 import { logger } from '../../utils/logger.js';
 import { resolveBinaryPath, buildSpawnPath } from './resolve-binary.js';
 import { injectSessionHeaders, buildSessionEnv, writeRuntimeSessionHint } from '@inklabs/shared';
+import { ensureStudioSettings } from '../studio-settings.js';
 
 /** Maximum time (ms) to wait for a Claude Code subprocess before killing it.
  *  Override with CLAUDE_PROCESS_TIMEOUT_MS env var. */
@@ -194,6 +195,19 @@ export class ClaudeRunner implements IRunner {
             accessToken: config.pcpAccessToken,
           })
         : null;
+
+    // Safety net: ensure .claude/settings.local.json exists before spawning.
+    // Non-fatal — if it fails, Claude still spawns with default permissions.
+    if (config.workingDirectory) {
+      try {
+        await ensureStudioSettings(config.workingDirectory);
+      } catch (err) {
+        logger.debug('ensureStudioSettings pre-spawn check failed (non-fatal)', {
+          cwd: config.workingDirectory,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
 
     // If headers were injected, patch the --mcp-config arg to point to the temp file
     if (mcpInjection?.modified) {

--- a/packages/api/src/services/sessions/types.ts
+++ b/packages/api/src/services/sessions/types.ts
@@ -420,6 +420,15 @@ export interface ClaudeRunnerConfig {
   sandboxBypass?: boolean;
   /** Root repo path — propagated via context token for cross-project 'main' resolution */
   repoRoot?: string;
+  /**
+   * Additional permission rules to merge into .claude/settings.local.json
+   * before this session's spawn. Restored to the original after the process
+   * exits. Used by strategy configs and 2FA permission grants.
+   */
+  permissionOverlay?: {
+    allow?: string[];
+    deny?: string[];
+  };
 }
 
 export interface RunnerResult {

--- a/packages/api/src/services/studio-settings.test.ts
+++ b/packages/api/src/services/studio-settings.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtemp, rm, readFile, mkdir, writeFile } from 'fs/promises';
+import { mkdtemp, rm, readFile, mkdir, writeFile, access } from 'fs/promises';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { ensureStudioSettings, applyPermissionOverlay } from './studio-settings';
@@ -144,7 +144,9 @@ describe('applyPermissionOverlay', () => {
     expect(settings.permissions.allow).toEqual(['mcp__playwright__*']);
     expect(settings.permissions.deny).toEqual(['Bash(rm -rf /)']);
 
-    // Restore removes the file content (original was null)
+    // Restore removes the file (original was null)
     await restore();
+
+    await expect(access(join(tempDir, '.claude', 'settings.local.json'))).rejects.toThrow();
   });
 });

--- a/packages/api/src/services/studio-settings.test.ts
+++ b/packages/api/src/services/studio-settings.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtemp, rm, readFile, mkdir, writeFile } from 'fs/promises';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { ensureStudioSettings } from './studio-settings';
+import { ensureStudioSettings, applyPermissionOverlay } from './studio-settings';
 
 describe('ensureStudioSettings', () => {
   let tempDir: string;
@@ -75,5 +75,76 @@ describe('ensureStudioSettings', () => {
     await ensureStudioSettings(tempDir);
     const raw = await readFile(join(tempDir, '.claude', 'settings.local.json'), 'utf-8');
     expect(JSON.parse(raw)).toBeDefined();
+  });
+});
+
+describe('applyPermissionOverlay', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'overlay-test-'));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('merges overlay rules into existing settings', async () => {
+    // Set up base settings
+    await ensureStudioSettings(tempDir);
+
+    const restore = await applyPermissionOverlay(tempDir, {
+      allow: ['mcp__playwright__*', 'Bash(docker *)'],
+    });
+
+    const raw = await readFile(join(tempDir, '.claude', 'settings.local.json'), 'utf-8');
+    const settings = JSON.parse(raw);
+
+    // Original rules still present
+    expect(settings.permissions.allow).toContain('mcp__*');
+    expect(settings.permissions.allow).toContain('Bash(*)');
+    // Overlay rules added
+    expect(settings.permissions.allow).toContain('mcp__playwright__*');
+    expect(settings.permissions.allow).toContain('Bash(docker *)');
+
+    // Restore original
+    await restore();
+
+    const restored = JSON.parse(
+      await readFile(join(tempDir, '.claude', 'settings.local.json'), 'utf-8')
+    );
+    expect(restored.permissions.allow).not.toContain('mcp__playwright__*');
+    expect(restored.permissions.allow).not.toContain('Bash(docker *)');
+  });
+
+  it('deduplicates overlay rules', async () => {
+    await ensureStudioSettings(tempDir);
+
+    await applyPermissionOverlay(tempDir, {
+      allow: ['mcp__*', 'Bash(*)'], // already in defaults
+    });
+
+    const raw = await readFile(join(tempDir, '.claude', 'settings.local.json'), 'utf-8');
+    const settings = JSON.parse(raw);
+
+    // No duplicates
+    const mcpCount = settings.permissions.allow.filter((r: string) => r === 'mcp__*').length;
+    expect(mcpCount).toBe(1);
+  });
+
+  it('works on an empty worktree', async () => {
+    const restore = await applyPermissionOverlay(tempDir, {
+      allow: ['mcp__playwright__*'],
+      deny: ['Bash(rm -rf /)'],
+    });
+
+    const raw = await readFile(join(tempDir, '.claude', 'settings.local.json'), 'utf-8');
+    const settings = JSON.parse(raw);
+
+    expect(settings.permissions.allow).toEqual(['mcp__playwright__*']);
+    expect(settings.permissions.deny).toEqual(['Bash(rm -rf /)']);
+
+    // Restore removes the file content (original was null)
+    await restore();
   });
 });

--- a/packages/api/src/services/studio-settings.test.ts
+++ b/packages/api/src/services/studio-settings.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, readFile, mkdir, writeFile } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { ensureStudioSettings } from './studio-settings';
+
+describe('ensureStudioSettings', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'studio-settings-test-'));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('generates settings in an empty worktree', async () => {
+    const wrote = await ensureStudioSettings(tempDir);
+    expect(wrote).toBe(true);
+
+    const raw = await readFile(join(tempDir, '.claude', 'settings.local.json'), 'utf-8');
+    const settings = JSON.parse(raw);
+
+    expect(settings.permissions.allow).toContain('mcp__*');
+    expect(settings.permissions.allow).toContain('Bash(*)');
+    expect(settings.permissions.deny).toContain('Bash(rm -rf *)');
+    expect(settings.enableAllProjectMcpServers).toBe(true);
+    expect(settings.hooks).toBeDefined();
+    expect(settings.hooks.PreCompact).toBeDefined();
+    expect(settings.hooks.Stop).toBeDefined();
+  });
+
+  it('skips generation when permissions already exist', async () => {
+    await mkdir(join(tempDir, '.claude'), { recursive: true });
+    const existing = {
+      permissions: { allow: ['mcp__inkwell__*'], deny: [] },
+      hooks: { custom: true },
+    };
+    await writeFile(join(tempDir, '.claude', 'settings.local.json'), JSON.stringify(existing));
+
+    const wrote = await ensureStudioSettings(tempDir);
+    expect(wrote).toBe(false);
+
+    // Verify original file unchanged
+    const raw = await readFile(join(tempDir, '.claude', 'settings.local.json'), 'utf-8');
+    const settings = JSON.parse(raw);
+    expect(settings.permissions.allow).toEqual(['mcp__inkwell__*']);
+    expect(settings.hooks).toEqual({ custom: true });
+  });
+
+  it('preserves existing non-permission settings', async () => {
+    await mkdir(join(tempDir, '.claude'), { recursive: true });
+    const existing = {
+      enabledMcpjsonServers: ['supabase', 'inkstand'],
+      hooks: { PreCompact: [{ custom: true }] },
+    };
+    await writeFile(join(tempDir, '.claude', 'settings.local.json'), JSON.stringify(existing));
+
+    const wrote = await ensureStudioSettings(tempDir);
+    expect(wrote).toBe(true);
+
+    const raw = await readFile(join(tempDir, '.claude', 'settings.local.json'), 'utf-8');
+    const settings = JSON.parse(raw);
+
+    // New permissions added
+    expect(settings.permissions.allow).toContain('mcp__*');
+    // Existing settings preserved
+    expect(settings.enabledMcpjsonServers).toEqual(['supabase', 'inkstand']);
+    // Existing hooks preserved (not overwritten with generated ones)
+    expect(settings.hooks).toEqual({ PreCompact: [{ custom: true }] });
+  });
+
+  it('creates .claude directory if missing', async () => {
+    await ensureStudioSettings(tempDir);
+    const raw = await readFile(join(tempDir, '.claude', 'settings.local.json'), 'utf-8');
+    expect(JSON.parse(raw)).toBeDefined();
+  });
+});

--- a/packages/api/src/services/studio-settings.ts
+++ b/packages/api/src/services/studio-settings.ts
@@ -145,3 +145,76 @@ export async function ensureStudioSettings(worktreePath: string): Promise<boolea
 
   return true;
 }
+
+/**
+ * Read the current settings file content (for backup before overlay).
+ */
+async function readSettings(worktreePath: string): Promise<string | null> {
+  try {
+    return await readFile(join(worktreePath, CLAUDE_SETTINGS_REL), 'utf-8');
+  } catch {
+    return null;
+  }
+}
+
+export interface PermissionOverlay {
+  allow?: string[];
+  deny?: string[];
+}
+
+/**
+ * Apply a temporary permission overlay to `.claude/settings.local.json`.
+ *
+ * Merges the overlay rules into the existing settings (deduplicating).
+ * Returns a restore function that writes back the original content.
+ * Call the restore function when the session process exits.
+ */
+export async function applyPermissionOverlay(
+  worktreePath: string,
+  overlay: PermissionOverlay
+): Promise<() => Promise<void>> {
+  const settingsPath = join(worktreePath, CLAUDE_SETTINGS_REL);
+  const originalContent = await readSettings(worktreePath);
+
+  let settings: ClaudeSettings = {};
+  if (originalContent) {
+    try {
+      settings = JSON.parse(originalContent);
+    } catch {
+      // unparseable — start from current defaults
+    }
+  }
+
+  // Merge overlay rules (deduplicate with Set)
+  const existingAllow = settings.permissions?.allow || [];
+  const existingDeny = settings.permissions?.deny || [];
+
+  settings.permissions = {
+    allow: [...new Set([...existingAllow, ...(overlay.allow || [])])],
+    deny: [...new Set([...existingDeny, ...(overlay.deny || [])])],
+  };
+
+  await mkdir(join(worktreePath, '.claude'), { recursive: true });
+  await writeFile(settingsPath, JSON.stringify(settings, null, 2) + '\n');
+
+  logger.info('Applied permission overlay', {
+    worktreePath,
+    addedAllow: overlay.allow?.length || 0,
+    addedDeny: overlay.deny?.length || 0,
+  });
+
+  // Return restore function
+  return async () => {
+    try {
+      if (originalContent) {
+        await writeFile(settingsPath, originalContent);
+      }
+      logger.debug('Restored original settings after overlay', { worktreePath });
+    } catch (err) {
+      logger.warn('Failed to restore settings after overlay', {
+        worktreePath,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  };
+}

--- a/packages/api/src/services/studio-settings.ts
+++ b/packages/api/src/services/studio-settings.ts
@@ -6,7 +6,7 @@
  * net before Claude Code spawn.
  */
 
-import { mkdir, readFile, writeFile } from 'fs/promises';
+import { mkdir, readFile, writeFile, rm } from 'fs/promises';
 import { existsSync } from 'fs';
 import { join, dirname } from 'path';
 import { logger } from '../utils/logger';
@@ -208,6 +208,9 @@ export async function applyPermissionOverlay(
     try {
       if (originalContent) {
         await writeFile(settingsPath, originalContent);
+      } else {
+        // File didn't exist before overlay — remove it
+        await rm(settingsPath, { force: true });
       }
       logger.debug('Restored original settings after overlay', { worktreePath });
     } catch (err) {

--- a/packages/api/src/services/studio-settings.ts
+++ b/packages/api/src/services/studio-settings.ts
@@ -1,0 +1,147 @@
+/**
+ * Studio Settings Generator
+ *
+ * Generates `.claude/settings.local.json` with default permissions and hooks
+ * for studio worktrees. Called during studio creation (MCP) and as a safety
+ * net before Claude Code spawn.
+ */
+
+import { mkdir, readFile, writeFile } from 'fs/promises';
+import { existsSync } from 'fs';
+import { join, dirname } from 'path';
+import { logger } from '../utils/logger';
+
+const CLAUDE_SETTINGS_REL = '.claude/settings.local.json';
+
+/**
+ * Default deny rules — destructive commands that should always require
+ * confirmation, even in fully auto-approved studios.
+ */
+const DEFAULT_DENY_RULES: string[] = [
+  'Bash(rm -rf *)',
+  'Bash(git push --force *)',
+  'Bash(git push -f *)',
+  'Bash(git reset --hard *)',
+  'Bash(git clean -fd *)',
+  'Bash(git clean -f *)',
+  'Bash(git checkout -- .)',
+];
+
+/**
+ * Default allow rules — broad permissions for automated development work.
+ * Matches the CLI's `ink permissions auto` defaults plus mcp__* for all MCP
+ * servers (not just inkwell/github/supabase individually).
+ */
+const DEFAULT_ALLOW_RULES: string[] = [
+  'Bash(*)',
+  'Edit(*)',
+  'Write(*)',
+  'Read(*)',
+  'WebFetch(*)',
+  'WebSearch',
+  'mcp__*',
+];
+
+interface ClaudeSettings {
+  permissions?: {
+    allow?: string[];
+    deny?: string[];
+  };
+  hooks?: Record<string, unknown>;
+  enableAllProjectMcpServers?: boolean;
+  [key: string]: unknown;
+}
+
+/**
+ * Resolve the `ink` CLI binary path for hook commands.
+ * Checks well-known locations; falls back to bare `ink` (relies on PATH).
+ */
+function resolveInkBinaryPath(worktreePath: string): string {
+  // 1. Global install location (symlinked by `yarn workspace @personal-context/cli install:cli`)
+  const globalPath = join(process.env.HOME || '~', '.local', 'bin', 'ink');
+  if (existsSync(globalPath)) return globalPath;
+
+  // 2. Main worktree node_modules (for PM2/server environments)
+  //    The main worktree is typically the parent dir without the `--slug` suffix
+  const base = dirname(worktreePath);
+  const mainName = worktreePath
+    .split('/')
+    .pop()
+    ?.replace(/--[^/]+$/, '');
+  if (mainName) {
+    const mainBin = join(base, mainName, 'node_modules', '.bin', 'ink');
+    if (existsSync(mainBin)) return mainBin;
+  }
+
+  // 3. Bare fallback
+  return 'ink';
+}
+
+/**
+ * Build Claude Code lifecycle hooks that mirror `ink hooks install --claude-code`.
+ */
+function buildHooks(inkPath: string): Record<string, unknown> {
+  const cmd = (hookName: string) => `${inkPath} hooks ${hookName} --backend claude-code`;
+
+  return {
+    PreCompact: [{ hooks: [{ type: 'command', command: cmd('pre-compact') }] }],
+    SessionStart: [
+      { matcher: 'compact', hooks: [{ type: 'command', command: cmd('post-compact') }] },
+      { matcher: 'startup', hooks: [{ type: 'command', command: cmd('on-session-start') }] },
+    ],
+    UserPromptSubmit: [{ hooks: [{ type: 'command', command: cmd('on-prompt') }] }],
+    Stop: [{ hooks: [{ type: 'command', command: cmd('on-stop') }] }],
+  };
+}
+
+/**
+ * Generate or update `.claude/settings.local.json` in a worktree.
+ *
+ * Merges with existing settings — never overwrites hooks or permissions
+ * that are already configured. Returns true if a file was written.
+ */
+export async function ensureStudioSettings(worktreePath: string): Promise<boolean> {
+  const settingsPath = join(worktreePath, CLAUDE_SETTINGS_REL);
+
+  let existing: ClaudeSettings = {};
+  try {
+    const raw = await readFile(settingsPath, 'utf-8');
+    existing = JSON.parse(raw);
+  } catch {
+    // File doesn't exist or isn't parseable — start fresh
+  }
+
+  // Skip if permissions are already configured (user or CLI set them up)
+  if (existing.permissions?.allow?.length) {
+    logger.debug('Studio settings already have permissions, skipping generation', {
+      worktreePath,
+      existingAllowCount: existing.permissions.allow.length,
+    });
+    return false;
+  }
+
+  const inkPath = resolveInkBinaryPath(worktreePath);
+
+  const settings: ClaudeSettings = {
+    ...existing,
+    permissions: {
+      allow: DEFAULT_ALLOW_RULES,
+      deny: DEFAULT_DENY_RULES,
+    },
+    hooks: existing.hooks || buildHooks(inkPath),
+    enableAllProjectMcpServers: existing.enableAllProjectMcpServers ?? true,
+  };
+
+  await mkdir(join(worktreePath, '.claude'), { recursive: true });
+  await writeFile(settingsPath, JSON.stringify(settings, null, 2) + '\n');
+
+  logger.info('Generated studio settings', {
+    worktreePath,
+    settingsPath,
+    allowRules: DEFAULT_ALLOW_RULES.length,
+    denyRules: DEFAULT_DENY_RULES.length,
+    hooksGenerated: !existing.hooks,
+  });
+
+  return true;
+}


### PR DESCRIPTION
## Summary
- Auto-generate `.claude/settings.local.json` with default permissions and hooks when studios are created via MCP (`create_studio`, `adopt_studio`)
- Add safety-net check in `ClaudeRunner.spawnProcess()` that ensures settings exist before every spawn
- Add per-session permission overlay support: `ClaudeRunnerConfig.permissionOverlay` merges extra allow/deny rules before spawn and restores the original after the process exits
- Foundation for 2FA permission grants and strategy-specific elevated permissions

Closes the gap where CLI-created studios inherited parent settings but MCP-created studios (used by strategies) got no permissions at all — which was the root cause of the wren-omega permission failures during task group validation.

## Files
- **`packages/api/src/services/studio-settings.ts`** (NEW) — `ensureStudioSettings()` + `applyPermissionOverlay()` utilities
- **`packages/api/src/services/studio-settings.test.ts`** (NEW) — 7 tests covering generation, skip-if-exists, preserve-existing, overlay merge/restore
- **`packages/api/src/mcp/tools/studio-handlers.ts`** — calls `ensureStudioSettings()` in `handleCreateStudio` and `handleAdoptStudio`
- **`packages/api/src/services/sessions/claude-runner.ts`** — pre-spawn safety net + overlay apply/restore lifecycle
- **`packages/api/src/services/sessions/types.ts`** — `permissionOverlay` field on `ClaudeRunnerConfig`

## Test plan
- [x] `ensureStudioSettings` generates defaults in empty worktree
- [x] Skips generation when permissions already exist
- [x] Preserves existing hooks and non-permission settings
- [x] `applyPermissionOverlay` merges rules and deduplicates
- [x] Overlay restore function reverts to original content
- [x] Overlay works on empty worktree
- [ ] Manual: create a studio via MCP, verify `.claude/settings.local.json` appears
- [ ] Manual: trigger a shadow clone, verify permissions work without prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Wren