### PR TITLE
fix: validate studioId is UUID before setting as workspaceId (by Wren)

### DIFF
--- a/packages/api/src/mcp/server.ts
+++ b/packages/api/src/mcp/server.ts
@@ -301,10 +301,16 @@ export class MCPServer {
         callerProfileHeader === 'runtime' ? 'runtime' : 'agent';
       const sessionIdHeader = contextToken?.sessionId || req.header('x-ink-session-id')?.trim();
       const studioIdHeader = contextToken?.studioId || req.header('x-ink-studio-id')?.trim();
+      // Only set workspaceId when the studio header is a UUID.
+      // Non-UUID values (e.g., "main") are studio hints, not workspace IDs.
+      // Passing a hint as workspaceId breaks Zod UUID validation in tool handlers.
+      const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+      const studioIdIsUuid = studioIdHeader && UUID_RE.test(studioIdHeader);
       Object.assign(ctx, {
         callerProfile,
         ...(sessionIdHeader ? { sessionId: sessionIdHeader } : {}),
-        ...(studioIdHeader ? { workspaceId: studioIdHeader } : {}),
+        ...(studioIdIsUuid ? { workspaceId: studioIdHeader } : {}),
+        ...(studioIdHeader && !studioIdIsUuid ? { studioHint: studioIdHeader } : {}),
         ...(contextToken?.cliAttached ? { cliAttached: true } : {}),
         ...(contextToken?.runtime ? { runtime: contextToken.runtime } : {}),
         ...(contextToken?.repoRoot ? { repoRoot: contextToken.repoRoot } : {}),


### PR DESCRIPTION
## Summary

- When `.ink/identity.json` has `studioId: "main"` (a hint string, not a UUID), the MCP server was passing it directly as `workspaceId` in the request context
- `mergeWithContext()` then injected `"main"` into tool args, breaking Zod UUID validation on every tool that accepts `workspaceId` (`create_artifact`, `remember`, etc.)
- Fix: validate `studioIdHeader` against UUID format before setting it as `workspaceId`. Non-UUID values are stored as `studioHint` instead, and workspace resolution falls through to the existing agent-identity derivation path

## Root cause

The `x-ink-studio-id` header (or context token `studioId` field) accepted any string value and mapped it directly to `workspaceId` in the request context. For main worktree sessions without a studio UUID, `.ink/identity.json` contains `studioId: "main"` — a routing hint, not a workspace UUID.

## Test plan

- [x] Verified `create_artifact` succeeds after fix (was failing with "Invalid uuid" on `workspaceId`)
- [x] Verified `remember` succeeds after fix
- [x] Confirmed workspace resolution falls through to agent-identity derivation when studioId is a hint
- [ ] Sibling review

🤖 Generated with [Claude Code](https://claude.com/claude-code)