### PR TITLE
feat: list_task_groups + create_task_group MCP tools (by Wren)

### DIFF
--- a/packages/api/src/data/composer.ts
+++ b/packages/api/src/data/composer.ts
@@ -10,6 +10,7 @@ import { ContextRepository } from './repositories/context.repository';
 import { ProjectsRepository } from './repositories/projects.repository';
 import { SessionFocusRepository } from './repositories/session-focus.repository';
 import { ProjectTasksRepository } from './repositories/project-tasks.repository';
+import { TaskGroupsRepository } from './repositories/task-groups.repository';
 import { MemoryRepository } from './repositories/memory-repository';
 import { ActivityStreamRepository } from './repositories/activity-stream.repository';
 import { StudiosRepository } from './repositories/studios.repository';
@@ -30,6 +31,7 @@ export class DataComposer {
     projects: ProjectsRepository;
     sessionFocus: SessionFocusRepository;
     tasks: ProjectTasksRepository;
+    taskGroups: TaskGroupsRepository;
     memory: MemoryRepository;
     activityStream: ActivityStreamRepository;
     studios: StudiosRepository;
@@ -51,6 +53,7 @@ export class DataComposer {
       projects: new ProjectsRepository(supabaseClient),
       sessionFocus: new SessionFocusRepository(supabaseClient),
       tasks: new ProjectTasksRepository(supabaseClient),
+      taskGroups: new TaskGroupsRepository(supabaseClient),
       memory: new MemoryRepository(supabaseClient),
       activityStream: new ActivityStreamRepository(supabaseClient),
       studios: new StudiosRepository(supabaseClient),

--- a/packages/api/src/data/repositories/task-groups.repository.ts
+++ b/packages/api/src/data/repositories/task-groups.repository.ts
@@ -1,0 +1,266 @@
+/**
+ * Task Groups Repository
+ *
+ * Manages task_groups: autonomous work containers that bundle tasks under
+ * a shared strategy, thread, and output target. See migration
+ * 20260311021747_task_groups_unify_tasks_permissions.sql.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { Database } from '../supabase/types';
+
+export type TaskGroupStatus = 'active' | 'paused' | 'completed' | 'cancelled';
+export type TaskGroupPriority = 'low' | 'normal' | 'high' | 'urgent';
+export type TaskGroupOutputTarget = 'spec' | 'pr' | 'report' | 'proposal';
+export type TaskGroupOutputStatus = 'ready_for_review' | 'needs_more_work' | 'blocked';
+
+export interface TaskGroup {
+  id: string;
+  user_id: string;
+  identity_id: string | null;
+  project_id: string | null;
+  title: string;
+  description: string | null;
+  status: TaskGroupStatus;
+  priority: TaskGroupPriority;
+  tags: string[];
+  metadata: Record<string, unknown>;
+  autonomous: boolean;
+  max_sessions: number | null;
+  sessions_used: number;
+  context_summary: string | null;
+  next_run_after: string | null;
+  output_target: TaskGroupOutputTarget | null;
+  output_status: TaskGroupOutputStatus | null;
+  thread_key: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CreateTaskGroupInput {
+  user_id: string;
+  identity_id?: string | null;
+  project_id?: string | null;
+  title: string;
+  description?: string;
+  status?: TaskGroupStatus;
+  priority?: TaskGroupPriority;
+  tags?: string[];
+  metadata?: Record<string, unknown>;
+  autonomous?: boolean;
+  max_sessions?: number;
+  context_summary?: string;
+  next_run_after?: string;
+  output_target?: TaskGroupOutputTarget;
+  output_status?: TaskGroupOutputStatus;
+  thread_key?: string;
+}
+
+export interface UpdateTaskGroupInput {
+  title?: string;
+  description?: string | null;
+  status?: TaskGroupStatus;
+  priority?: TaskGroupPriority;
+  tags?: string[];
+  metadata?: Record<string, unknown>;
+  autonomous?: boolean;
+  max_sessions?: number | null;
+  sessions_used?: number;
+  context_summary?: string | null;
+  next_run_after?: string | null;
+  output_target?: TaskGroupOutputTarget | null;
+  output_status?: TaskGroupOutputStatus | null;
+  thread_key?: string | null;
+  identity_id?: string | null;
+  project_id?: string | null;
+}
+
+export interface ListTaskGroupsOptions {
+  status?: TaskGroupStatus | TaskGroupStatus[];
+  projectId?: string;
+  identityId?: string;
+  autonomousOnly?: boolean;
+  limit?: number;
+}
+
+export class TaskGroupsRepository {
+  constructor(private client: SupabaseClient<Database>) {}
+
+  async create(input: CreateTaskGroupInput): Promise<TaskGroup> {
+    const { data, error } = await this.client
+      .from('task_groups' as never)
+      .insert({
+        user_id: input.user_id,
+        identity_id: input.identity_id ?? null,
+        project_id: input.project_id ?? null,
+        title: input.title,
+        description: input.description,
+        status: input.status || 'active',
+        priority: input.priority || 'normal',
+        tags: input.tags || [],
+        metadata: input.metadata || {},
+        autonomous: input.autonomous ?? false,
+        max_sessions: input.max_sessions ?? null,
+        context_summary: input.context_summary,
+        next_run_after: input.next_run_after,
+        output_target: input.output_target ?? null,
+        output_status: input.output_status ?? null,
+        thread_key: input.thread_key,
+      } as never)
+      .select()
+      .single();
+
+    if (error) {
+      throw new Error(`Failed to create task group: ${error.message}`);
+    }
+
+    return data as unknown as TaskGroup;
+  }
+
+  async findById(id: string): Promise<TaskGroup | null> {
+    const { data, error } = await this.client
+      .from('task_groups' as never)
+      .select('*')
+      .eq('id', id)
+      .single();
+
+    if (error && error.code !== 'PGRST116') {
+      throw new Error(`Failed to find task group: ${error.message}`);
+    }
+
+    return (data as unknown as TaskGroup) || null;
+  }
+
+  async listByUser(userId: string, options?: ListTaskGroupsOptions): Promise<TaskGroup[]> {
+    let query = this.client
+      .from('task_groups' as never)
+      .select('*')
+      .eq('user_id', userId)
+      .order('updated_at', { ascending: false });
+
+    if (options?.status) {
+      if (Array.isArray(options.status)) {
+        query = query.in('status', options.status);
+      } else {
+        query = query.eq('status', options.status);
+      }
+    }
+
+    if (options?.projectId) {
+      query = query.eq('project_id', options.projectId);
+    }
+
+    if (options?.identityId) {
+      query = query.eq('identity_id', options.identityId);
+    }
+
+    if (options?.autonomousOnly) {
+      query = query.eq('autonomous', true);
+    }
+
+    if (options?.limit) {
+      query = query.limit(options.limit);
+    }
+
+    const { data, error } = await query;
+
+    if (error) {
+      throw new Error(`Failed to list task groups: ${error.message}`);
+    }
+
+    return (data || []) as unknown as TaskGroup[];
+  }
+
+  async update(id: string, input: UpdateTaskGroupInput): Promise<TaskGroup> {
+    const updates: Record<string, unknown> = {};
+    if (input.title !== undefined) updates.title = input.title;
+    if (input.description !== undefined) updates.description = input.description;
+    if (input.status !== undefined) updates.status = input.status;
+    if (input.priority !== undefined) updates.priority = input.priority;
+    if (input.tags !== undefined) updates.tags = input.tags;
+    if (input.metadata !== undefined) updates.metadata = input.metadata;
+    if (input.autonomous !== undefined) updates.autonomous = input.autonomous;
+    if (input.max_sessions !== undefined) updates.max_sessions = input.max_sessions;
+    if (input.sessions_used !== undefined) updates.sessions_used = input.sessions_used;
+    if (input.context_summary !== undefined) updates.context_summary = input.context_summary;
+    if (input.next_run_after !== undefined) updates.next_run_after = input.next_run_after;
+    if (input.output_target !== undefined) updates.output_target = input.output_target;
+    if (input.output_status !== undefined) updates.output_status = input.output_status;
+    if (input.thread_key !== undefined) updates.thread_key = input.thread_key;
+    if (input.identity_id !== undefined) updates.identity_id = input.identity_id;
+    if (input.project_id !== undefined) updates.project_id = input.project_id;
+
+    const { data, error } = await this.client
+      .from('task_groups' as never)
+      .update(updates as never)
+      .eq('id', id)
+      .select()
+      .single();
+
+    if (error) {
+      throw new Error(`Failed to update task group: ${error.message}`);
+    }
+
+    return data as unknown as TaskGroup;
+  }
+
+  async delete(id: string): Promise<void> {
+    const { error } = await this.client
+      .from('task_groups' as never)
+      .delete()
+      .eq('id', id);
+
+    if (error) {
+      throw new Error(`Failed to delete task group: ${error.message}`);
+    }
+  }
+
+  /**
+   * Count tasks per group id. Returns a map keyed by group id.
+   * Counts cover all tasks regardless of status — callers can filter if needed.
+   */
+  async taskCountsByGroup(
+    userId: string,
+    groupIds: string[]
+  ): Promise<
+    Record<
+      string,
+      { total: number; pending: number; in_progress: number; completed: number; blocked: number }
+    >
+  > {
+    if (groupIds.length === 0) return {};
+
+    const { data, error } = await this.client
+      .from('tasks')
+      .select('task_group_id, status')
+      .eq('user_id', userId)
+      .in('task_group_id', groupIds);
+
+    if (error) {
+      throw new Error(`Failed to aggregate task counts: ${error.message}`);
+    }
+
+    const counts: Record<
+      string,
+      { total: number; pending: number; in_progress: number; completed: number; blocked: number }
+    > = {};
+    for (const row of (data || []) as Array<{ task_group_id: string | null; status: string }>) {
+      if (!row.task_group_id) continue;
+      const bucket =
+        counts[row.task_group_id] ||
+        (counts[row.task_group_id] = {
+          total: 0,
+          pending: 0,
+          in_progress: 0,
+          completed: 0,
+          blocked: 0,
+        });
+      bucket.total += 1;
+      if (row.status === 'pending') bucket.pending += 1;
+      else if (row.status === 'in_progress') bucket.in_progress += 1;
+      else if (row.status === 'completed') bucket.completed += 1;
+      else if (row.status === 'blocked') bucket.blocked += 1;
+    }
+    return counts;
+  }
+}

--- a/packages/api/src/mcp/tools/index.ts
+++ b/packages/api/src/mcp/tools/index.ts
@@ -23,6 +23,10 @@ import {
   handleCompleteTask,
   handleGetTaskStats,
   handleAddTaskComment,
+  handleCreateTaskGroup,
+  handleListTaskGroups,
+  createTaskGroupSchema,
+  listTaskGroupsSchema,
 } from './task-handlers';
 
 import { handleSendResponse, handleGetPendingMessages, handleMarkRead } from './response-handlers';
@@ -934,6 +938,70 @@ User can be identified by ONE of: userId, email, phone, or platform + platformId
         return await handleAddTaskComment(args, dataComposer);
       } catch (error) {
         logger.error('Error in add_task_comment:', error);
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                success: false,
+                error: error instanceof Error ? error.message : 'Unknown error',
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // =====================================================
+  // TASK GROUP TOOLS
+  // =====================================================
+
+  // Register create_task_group tool
+  server.registerTool(
+    'create_task_group',
+    {
+      description: `Create a task group — a container for related tasks that share a title, strategy/description, priority, and optionally an autonomous execution plan or output target (spec/pr/report/proposal). Use to bundle multi-step work under one thread key or strategy. Returns the created group with its UUID.
+
+User can be identified by ONE of: userId, email, phone, or platform + platformId`,
+      inputSchema: createTaskGroupSchema.shape,
+    },
+    async (args) => {
+      try {
+        return await handleCreateTaskGroup(args, dataComposer);
+      } catch (error) {
+        logger.error('Error in create_task_group:', error);
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                success: false,
+                error: error instanceof Error ? error.message : 'Unknown error',
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // Register list_task_groups tool
+  server.registerTool(
+    'list_task_groups',
+    {
+      description: `List task groups for a user with task counts (pending/in_progress/completed/blocked) per group. By default returns groups in all statuses including completed/cancelled. Filter by status, project, identity, or autonomous-only. Use activeOnly=true or includeCompleted=false to exclude completed/cancelled groups.
+
+User can be identified by ONE of: userId, email, phone, or platform + platformId`,
+      inputSchema: listTaskGroupsSchema.shape,
+    },
+    async (args) => {
+      try {
+        return await handleListTaskGroups(args, dataComposer);
+      } catch (error) {
+        logger.error('Error in list_task_groups:', error);
         return {
           content: [
             {

--- a/packages/api/src/mcp/tools/index.ts
+++ b/packages/api/src/mcp/tools/index.ts
@@ -992,7 +992,7 @@ User can be identified by ONE of: userId, email, phone, or platform + platformId
   server.registerTool(
     'list_task_groups',
     {
-      description: `List task groups for a user with task counts (pending/in_progress/completed/blocked) per group. By default returns groups in all statuses including completed/cancelled. Filter by status, project, identity, or autonomous-only. Use activeOnly=true or includeCompleted=false to exclude completed/cancelled groups.
+      description: `List task groups for a user with per-status task counts per group. Omit \`statuses\` (or pass an empty array) to include all statuses. Pass a multi-select array to narrow (e.g. statuses: ["active","paused"]). Also supports projectId, identityId, and autonomousOnly filters.
 
 User can be identified by ONE of: userId, email, phone, or platform + platformId`,
       inputSchema: listTaskGroupsSchema.shape,

--- a/packages/api/src/mcp/tools/task-handlers.test.ts
+++ b/packages/api/src/mcp/tools/task-handlers.test.ts
@@ -1250,7 +1250,7 @@ describe('handleListTaskGroups', () => {
     });
   });
 
-  it('returns all groups including completed by default', async () => {
+  it('returns all groups when statuses is omitted', async () => {
     dc.repositories.taskGroups.listByUser.mockResolvedValue(sampleGroups);
     dc.repositories.taskGroups.taskCountsByGroup.mockResolvedValue({
       'grp-1': { total: 3, pending: 1, in_progress: 1, completed: 1, blocked: 0 },
@@ -1259,8 +1259,6 @@ describe('handleListTaskGroups', () => {
     const response = await handleListTaskGroups(
       {
         userId: 'user-123',
-        activeOnly: false,
-        includeCompleted: true,
         autonomousOnly: false,
         includeTaskCounts: true,
         limit: 200,
@@ -1286,14 +1284,33 @@ describe('handleListTaskGroups', () => {
     expect(data.groups[1].taskCounts.total).toBe(0);
   });
 
-  it('filters to active/paused when includeCompleted=false', async () => {
+  it('treats empty statuses array the same as omitted (all statuses)', async () => {
+    dc.repositories.taskGroups.listByUser.mockResolvedValue(sampleGroups);
+
+    await handleListTaskGroups(
+      {
+        userId: 'user-123',
+        statuses: [],
+        autonomousOnly: false,
+        includeTaskCounts: false,
+        limit: 200,
+      } as any,
+      dc as any
+    );
+
+    expect(dc.repositories.taskGroups.listByUser).toHaveBeenCalledWith(
+      'user-123',
+      expect.objectContaining({ status: undefined })
+    );
+  });
+
+  it('passes statuses array through to the repository', async () => {
     dc.repositories.taskGroups.listByUser.mockResolvedValue([sampleGroups[0]]);
 
     await handleListTaskGroups(
       {
         userId: 'user-123',
-        activeOnly: false,
-        includeCompleted: false,
+        statuses: ['active', 'paused'],
         autonomousOnly: false,
         includeTaskCounts: false,
         limit: 200,
@@ -1307,15 +1324,13 @@ describe('handleListTaskGroups', () => {
     );
   });
 
-  it('explicit status filter overrides activeOnly/includeCompleted', async () => {
+  it('supports single-element statuses arrays', async () => {
     dc.repositories.taskGroups.listByUser.mockResolvedValue([sampleGroups[1]]);
 
     await handleListTaskGroups(
       {
         userId: 'user-123',
-        status: 'completed',
-        activeOnly: true,
-        includeCompleted: false,
+        statuses: ['completed'],
         autonomousOnly: false,
         includeTaskCounts: false,
         limit: 200,
@@ -1325,28 +1340,7 @@ describe('handleListTaskGroups', () => {
 
     expect(dc.repositories.taskGroups.listByUser).toHaveBeenCalledWith(
       'user-123',
-      expect.objectContaining({ status: 'completed' })
-    );
-  });
-
-  it('activeOnly maps to [active, paused]', async () => {
-    dc.repositories.taskGroups.listByUser.mockResolvedValue([sampleGroups[0]]);
-
-    await handleListTaskGroups(
-      {
-        userId: 'user-123',
-        activeOnly: true,
-        includeCompleted: true,
-        autonomousOnly: false,
-        includeTaskCounts: false,
-        limit: 200,
-      } as any,
-      dc as any
-    );
-
-    expect(dc.repositories.taskGroups.listByUser).toHaveBeenCalledWith(
-      'user-123',
-      expect.objectContaining({ status: ['active', 'paused'] })
+      expect.objectContaining({ status: ['completed'] })
     );
   });
 
@@ -1356,8 +1350,6 @@ describe('handleListTaskGroups', () => {
     const response = await handleListTaskGroups(
       {
         userId: 'user-123',
-        activeOnly: false,
-        includeCompleted: true,
         autonomousOnly: false,
         includeTaskCounts: false,
         limit: 200,
@@ -1377,8 +1369,6 @@ describe('handleListTaskGroups', () => {
     const response = await handleListTaskGroups(
       {
         userId: 'nonexistent',
-        activeOnly: false,
-        includeCompleted: true,
         autonomousOnly: false,
         includeTaskCounts: true,
         limit: 200,

--- a/packages/api/src/mcp/tools/task-handlers.test.ts
+++ b/packages/api/src/mcp/tools/task-handlers.test.ts
@@ -12,6 +12,8 @@ import {
   handleUpdateTask,
   handleCompleteTask,
   handleGetTaskStats,
+  handleCreateTaskGroup,
+  handleListTaskGroups,
 } from './task-handlers';
 
 // =====================================================
@@ -76,12 +78,36 @@ function createMockDataComposer() {
     remember: vi.fn(),
   };
 
+  const mockTaskGroupsRepo = {
+    create: vi.fn(),
+    findById: vi.fn(),
+    listByUser: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    taskCountsByGroup: vi.fn().mockResolvedValue({}),
+  };
+
+  // Minimal supabase client stub for identity/agent_identities lookups.
+  // Returns an empty result so `identityId` resolves to null by default.
+  const identityChain = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    in: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockReturnThis(),
+    single: vi.fn().mockResolvedValue({ data: null, error: null }),
+    then: undefined as unknown,
+  };
+  const mockClient = {
+    from: vi.fn().mockReturnValue(identityChain),
+  };
+
   return {
-    getClient: vi.fn(),
+    getClient: vi.fn().mockReturnValue(mockClient),
     repositories: {
       tasks: mockTasksRepo,
       projects: mockProjectsRepo,
       memory: mockMemoryRepo,
+      taskGroups: mockTaskGroupsRepo,
     },
   };
 }
@@ -1038,5 +1064,331 @@ describe('handleGetTaskStats', () => {
     expect(response.isError).toBe(true);
     expect(data.success).toBe(false);
     expect(data.error).toBe('User not found');
+  });
+});
+
+// =====================================================
+// handleCreateTaskGroup
+// =====================================================
+
+describe('handleCreateTaskGroup', () => {
+  let dc: ReturnType<typeof createMockDataComposer>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dc = createMockDataComposer();
+    resolveUserMock.mockResolvedValue({
+      user: { id: 'user-123' } as any,
+      resolvedBy: 'userId',
+    });
+  });
+
+  it('creates a task group and returns normalized fields', async () => {
+    dc.repositories.taskGroups.create.mockResolvedValue({
+      id: 'grp-1',
+      user_id: 'user-123',
+      identity_id: null,
+      project_id: null,
+      title: 'Ship feature X',
+      description: 'Multi-PR rollout',
+      status: 'active',
+      priority: 'high',
+      tags: ['feature'],
+      metadata: {},
+      autonomous: false,
+      max_sessions: null,
+      sessions_used: 0,
+      context_summary: null,
+      next_run_after: null,
+      output_target: 'pr',
+      output_status: null,
+      thread_key: 'thread:feat-x',
+      created_at: '2026-04-16T10:00:00Z',
+      updated_at: '2026-04-16T10:00:00Z',
+    });
+
+    const response = await handleCreateTaskGroup(
+      {
+        userId: 'user-123',
+        title: 'Ship feature X',
+        description: 'Multi-PR rollout',
+        priority: 'high',
+        status: 'active',
+        tags: ['feature'],
+        outputTarget: 'pr',
+        threadKey: 'thread:feat-x',
+      } as any,
+      dc as any
+    );
+
+    const data = parseResponse(response);
+    expect(response.isError).toBeFalsy();
+    expect(data.success).toBe(true);
+    expect(data.group.id).toBe('grp-1');
+    expect(data.group.title).toBe('Ship feature X');
+    expect(data.group.priority).toBe('high');
+    expect(data.group.outputTarget).toBe('pr');
+    expect(data.group.threadKey).toBe('thread:feat-x');
+    expect(dc.repositories.taskGroups.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_id: 'user-123',
+        title: 'Ship feature X',
+        description: 'Multi-PR rollout',
+        status: 'active',
+        priority: 'high',
+        tags: ['feature'],
+        output_target: 'pr',
+        thread_key: 'thread:feat-x',
+      })
+    );
+  });
+
+  it('validates project ownership when projectId is provided', async () => {
+    dc.repositories.projects.findById.mockResolvedValue({
+      id: 'proj-1',
+      user_id: 'other-user-999',
+      name: 'Not yours',
+    });
+
+    const response = await handleCreateTaskGroup(
+      {
+        userId: 'user-123',
+        title: 'Scoped group',
+        projectId: '00000000-0000-0000-0000-000000000001',
+        priority: 'normal',
+        status: 'active',
+      } as any,
+      dc as any
+    );
+
+    const data = parseResponse(response);
+    expect(response.isError).toBe(true);
+    expect(data.error).toBe('Project does not belong to this user');
+    expect(dc.repositories.taskGroups.create).not.toHaveBeenCalled();
+  });
+
+  it('returns error when user is not found (create)', async () => {
+    resolveUserMock.mockResolvedValue(null);
+
+    const response = await handleCreateTaskGroup(
+      {
+        userId: 'nonexistent',
+        title: 'Anything',
+        priority: 'normal',
+        status: 'active',
+      } as any,
+      dc as any
+    );
+
+    const data = parseResponse(response);
+    expect(response.isError).toBe(true);
+    expect(data.error).toBe('User not found');
+    expect(dc.repositories.taskGroups.create).not.toHaveBeenCalled();
+  });
+});
+
+// =====================================================
+// handleListTaskGroups
+// =====================================================
+
+describe('handleListTaskGroups', () => {
+  let dc: ReturnType<typeof createMockDataComposer>;
+
+  const sampleGroups = [
+    {
+      id: 'grp-1',
+      user_id: 'user-123',
+      identity_id: null,
+      project_id: null,
+      title: 'Active group',
+      description: null,
+      status: 'active',
+      priority: 'high',
+      tags: [],
+      metadata: {},
+      autonomous: false,
+      max_sessions: null,
+      sessions_used: 0,
+      context_summary: null,
+      next_run_after: null,
+      output_target: null,
+      output_status: null,
+      thread_key: null,
+      created_at: '2026-04-16T10:00:00Z',
+      updated_at: '2026-04-16T10:00:00Z',
+    },
+    {
+      id: 'grp-2',
+      user_id: 'user-123',
+      identity_id: null,
+      project_id: null,
+      title: 'Completed group',
+      description: null,
+      status: 'completed',
+      priority: 'normal',
+      tags: [],
+      metadata: {},
+      autonomous: false,
+      max_sessions: null,
+      sessions_used: 0,
+      context_summary: null,
+      next_run_after: null,
+      output_target: null,
+      output_status: null,
+      thread_key: null,
+      created_at: '2026-04-15T10:00:00Z',
+      updated_at: '2026-04-15T10:00:00Z',
+    },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dc = createMockDataComposer();
+    resolveUserMock.mockResolvedValue({
+      user: { id: 'user-123' } as any,
+      resolvedBy: 'userId',
+    });
+  });
+
+  it('returns all groups including completed by default', async () => {
+    dc.repositories.taskGroups.listByUser.mockResolvedValue(sampleGroups);
+    dc.repositories.taskGroups.taskCountsByGroup.mockResolvedValue({
+      'grp-1': { total: 3, pending: 1, in_progress: 1, completed: 1, blocked: 0 },
+    });
+
+    const response = await handleListTaskGroups(
+      {
+        userId: 'user-123',
+        activeOnly: false,
+        includeCompleted: true,
+        autonomousOnly: false,
+        includeTaskCounts: true,
+        limit: 200,
+      } as any,
+      dc as any
+    );
+
+    const data = parseResponse(response);
+    expect(response.isError).toBeFalsy();
+    expect(data.success).toBe(true);
+    expect(data.groups).toHaveLength(2);
+    expect(dc.repositories.taskGroups.listByUser).toHaveBeenCalledWith(
+      'user-123',
+      expect.objectContaining({ status: undefined, limit: 200 })
+    );
+    expect(data.groups[0].taskCounts).toEqual({
+      total: 3,
+      pending: 1,
+      in_progress: 1,
+      completed: 1,
+      blocked: 0,
+    });
+    expect(data.groups[1].taskCounts.total).toBe(0);
+  });
+
+  it('filters to active/paused when includeCompleted=false', async () => {
+    dc.repositories.taskGroups.listByUser.mockResolvedValue([sampleGroups[0]]);
+
+    await handleListTaskGroups(
+      {
+        userId: 'user-123',
+        activeOnly: false,
+        includeCompleted: false,
+        autonomousOnly: false,
+        includeTaskCounts: false,
+        limit: 200,
+      } as any,
+      dc as any
+    );
+
+    expect(dc.repositories.taskGroups.listByUser).toHaveBeenCalledWith(
+      'user-123',
+      expect.objectContaining({ status: ['active', 'paused'] })
+    );
+  });
+
+  it('explicit status filter overrides activeOnly/includeCompleted', async () => {
+    dc.repositories.taskGroups.listByUser.mockResolvedValue([sampleGroups[1]]);
+
+    await handleListTaskGroups(
+      {
+        userId: 'user-123',
+        status: 'completed',
+        activeOnly: true,
+        includeCompleted: false,
+        autonomousOnly: false,
+        includeTaskCounts: false,
+        limit: 200,
+      } as any,
+      dc as any
+    );
+
+    expect(dc.repositories.taskGroups.listByUser).toHaveBeenCalledWith(
+      'user-123',
+      expect.objectContaining({ status: 'completed' })
+    );
+  });
+
+  it('activeOnly maps to [active, paused]', async () => {
+    dc.repositories.taskGroups.listByUser.mockResolvedValue([sampleGroups[0]]);
+
+    await handleListTaskGroups(
+      {
+        userId: 'user-123',
+        activeOnly: true,
+        includeCompleted: true,
+        autonomousOnly: false,
+        includeTaskCounts: false,
+        limit: 200,
+      } as any,
+      dc as any
+    );
+
+    expect(dc.repositories.taskGroups.listByUser).toHaveBeenCalledWith(
+      'user-123',
+      expect.objectContaining({ status: ['active', 'paused'] })
+    );
+  });
+
+  it('skips count aggregation when includeTaskCounts=false', async () => {
+    dc.repositories.taskGroups.listByUser.mockResolvedValue(sampleGroups);
+
+    const response = await handleListTaskGroups(
+      {
+        userId: 'user-123',
+        activeOnly: false,
+        includeCompleted: true,
+        autonomousOnly: false,
+        includeTaskCounts: false,
+        limit: 200,
+      } as any,
+      dc as any
+    );
+
+    const data = parseResponse(response);
+    expect(data.success).toBe(true);
+    expect(dc.repositories.taskGroups.taskCountsByGroup).not.toHaveBeenCalled();
+    expect(data.groups[0].taskCounts).toBeUndefined();
+  });
+
+  it('returns error when user is not found (list)', async () => {
+    resolveUserMock.mockResolvedValue(null);
+
+    const response = await handleListTaskGroups(
+      {
+        userId: 'nonexistent',
+        activeOnly: false,
+        includeCompleted: true,
+        autonomousOnly: false,
+        includeTaskCounts: true,
+        limit: 200,
+      } as any,
+      dc as any
+    );
+
+    const data = parseResponse(response);
+    expect(response.isError).toBe(true);
+    expect(data.error).toBe('User not found');
+    expect(dc.repositories.taskGroups.listByUser).not.toHaveBeenCalled();
   });
 });

--- a/packages/api/src/mcp/tools/task-handlers.ts
+++ b/packages/api/src/mcp/tools/task-handlers.ts
@@ -412,6 +412,26 @@ export const addTaskCommentSchema = z.object({
   agentId: z.string().optional().describe('Agent ID for identity attribution'),
 });
 
+async function resolveIdentityIdForAgent(
+  dataComposer: DataComposer,
+  userId: string,
+  agentId: string | undefined,
+  workspaceId: string | undefined
+): Promise<string | null> {
+  if (!agentId) return null;
+  let query = dataComposer
+    .getClient()
+    .from('agent_identities')
+    .select('id')
+    .eq('agent_id', agentId)
+    .eq('user_id', userId);
+  if (workspaceId) {
+    query = query.eq('workspace_id', workspaceId);
+  }
+  const { data } = await query.limit(1).single();
+  return (data as { id: string } | null)?.id ?? null;
+}
+
 export async function handleAddTaskComment(
   args: z.infer<typeof addTaskCommentSchema>,
   dataComposer: DataComposer
@@ -435,21 +455,12 @@ export async function handleAddTaskComment(
     const reqCtx = getRequestContext();
     const workspaceId = reqCtx?.workspaceId;
 
-    // Resolve agent identity ID with workspace scoping when available
-    let identityId: string | null = null;
-    if (agentId) {
-      let identityQuery = dataComposer
-        .getClient()
-        .from('agent_identities')
-        .select('id')
-        .eq('agent_id', agentId)
-        .eq('user_id', resolved.user.id);
-      if (workspaceId) {
-        identityQuery = identityQuery.eq('workspace_id', workspaceId);
-      }
-      const { data: identity } = await identityQuery.limit(1).single();
-      if (identity) identityId = identity.id;
-    }
+    const identityId = await resolveIdentityIdForAgent(
+      dataComposer,
+      resolved.user.id,
+      agentId,
+      workspaceId
+    );
 
     const { data: rawComment, error } = await dataComposer
       .getClient()
@@ -494,6 +505,272 @@ export async function handleAddTaskComment(
       {
         success: false,
         error: error instanceof Error ? error.message : 'Failed to add task comment',
+      },
+      true
+    );
+  }
+}
+
+// ============================================================================
+// TASK GROUPS — CREATE / LIST
+// ============================================================================
+
+const taskGroupStatusEnum = z.enum(['active', 'paused', 'completed', 'cancelled']);
+const taskGroupPriorityEnum = z.enum(['low', 'normal', 'high', 'urgent']);
+const taskGroupOutputTargetEnum = z.enum(['spec', 'pr', 'report', 'proposal']);
+const taskGroupOutputStatusEnum = z.enum(['ready_for_review', 'needs_more_work', 'blocked']);
+
+export const createTaskGroupSchema = z.object({
+  ...userIdentifierSchema.shape,
+  title: z.string().min(1).max(500).describe('Task group title'),
+  description: z.string().optional().describe('Detailed description / strategy'),
+  projectId: z.string().uuid().optional().describe('Optional project scope'),
+  priority: taskGroupPriorityEnum.optional().default('normal'),
+  status: taskGroupStatusEnum.optional().default('active'),
+  tags: z.array(z.string()).optional(),
+  autonomous: z.boolean().optional().describe('Whether this group runs autonomously'),
+  maxSessions: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe('Cap on autonomous sessions spent on this group'),
+  contextSummary: z
+    .string()
+    .optional()
+    .describe('Rolling context handed to each autonomous session'),
+  threadKey: z
+    .string()
+    .optional()
+    .describe('Thread key for coordination (e.g. pr:123, thread:foo)'),
+  outputTarget: taskGroupOutputTargetEnum
+    .optional()
+    .describe('Expected deliverable type (spec, pr, report, proposal)'),
+  outputStatus: taskGroupOutputStatusEnum.optional(),
+  metadata: z.record(z.unknown()).optional(),
+  agentId: z
+    .string()
+    .optional()
+    .describe('Agent identity to attribute the group to (defaults to caller)'),
+});
+
+export async function handleCreateTaskGroup(
+  args: z.infer<typeof createTaskGroupSchema>,
+  dataComposer: DataComposer
+): Promise<McpResponse> {
+  try {
+    const resolved = await resolveUser(args as UserIdentifier, dataComposer);
+    if (!resolved) {
+      return mcpResponse({ success: false, error: 'User not found' }, true);
+    }
+
+    if (args.projectId) {
+      const project = await dataComposer.repositories.projects.findById(args.projectId);
+      if (!project) {
+        return mcpResponse({ success: false, error: 'Project not found' }, true);
+      }
+      if (project.user_id !== resolved.user.id) {
+        return mcpResponse({ success: false, error: 'Project does not belong to this user' }, true);
+      }
+    }
+
+    const agentId = getEffectiveAgentId(args.agentId);
+    const reqCtx = getRequestContext();
+    const identityId = await resolveIdentityIdForAgent(
+      dataComposer,
+      resolved.user.id,
+      agentId,
+      reqCtx?.workspaceId
+    );
+
+    const group = await dataComposer.repositories.taskGroups.create({
+      user_id: resolved.user.id,
+      identity_id: identityId,
+      project_id: args.projectId ?? null,
+      title: args.title,
+      description: args.description,
+      status: args.status,
+      priority: args.priority,
+      tags: args.tags,
+      metadata: args.metadata,
+      autonomous: args.autonomous,
+      max_sessions: args.maxSessions,
+      context_summary: args.contextSummary,
+      output_target: args.outputTarget,
+      output_status: args.outputStatus,
+      thread_key: args.threadKey,
+    });
+
+    return mcpResponse({
+      success: true,
+      group: {
+        id: group.id,
+        title: group.title,
+        description: group.description,
+        status: group.status,
+        priority: group.priority,
+        tags: group.tags,
+        projectId: group.project_id,
+        identityId: group.identity_id,
+        agentId: agentId || null,
+        autonomous: group.autonomous,
+        maxSessions: group.max_sessions,
+        sessionsUsed: group.sessions_used,
+        contextSummary: group.context_summary,
+        outputTarget: group.output_target,
+        outputStatus: group.output_status,
+        threadKey: group.thread_key,
+        metadata: group.metadata,
+        createdAt: group.created_at,
+        updatedAt: group.updated_at,
+      },
+    });
+  } catch (error) {
+    return mcpResponse(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to create task group',
+      },
+      true
+    );
+  }
+}
+
+export const listTaskGroupsSchema = z.object({
+  ...userIdentifierSchema.shape,
+  status: z
+    .union([taskGroupStatusEnum, z.array(taskGroupStatusEnum)])
+    .optional()
+    .describe('Filter by status (string or array). Omit to include all statuses.'),
+  activeOnly: z
+    .boolean()
+    .optional()
+    .default(false)
+    .describe('Shortcut for status in [active, paused]'),
+  includeCompleted: z
+    .boolean()
+    .optional()
+    .default(true)
+    .describe(
+      'When no status filter is set, whether to include completed/cancelled groups. Default true.'
+    ),
+  projectId: z.string().uuid().optional().describe('Filter by project'),
+  identityId: z.string().uuid().optional().describe('Filter by agent identity UUID'),
+  autonomousOnly: z.boolean().optional().default(false).describe('Only autonomous groups'),
+  includeTaskCounts: z
+    .boolean()
+    .optional()
+    .default(true)
+    .describe('Include per-status task counts per group'),
+  limit: z.number().int().positive().max(500).optional().default(200),
+});
+
+export async function handleListTaskGroups(
+  args: z.infer<typeof listTaskGroupsSchema>,
+  dataComposer: DataComposer
+): Promise<McpResponse> {
+  try {
+    const resolved = await resolveUser(args as UserIdentifier, dataComposer);
+    if (!resolved) {
+      return mcpResponse({ success: false, error: 'User not found' }, true);
+    }
+
+    let statusFilter:
+      | 'active'
+      | 'paused'
+      | 'completed'
+      | 'cancelled'
+      | Array<'active' | 'paused' | 'completed' | 'cancelled'>
+      | undefined;
+
+    if (args.status) {
+      statusFilter = args.status;
+    } else if (args.activeOnly) {
+      statusFilter = ['active', 'paused'];
+    } else if (!args.includeCompleted) {
+      statusFilter = ['active', 'paused'];
+    }
+
+    const groups = await dataComposer.repositories.taskGroups.listByUser(resolved.user.id, {
+      status: statusFilter,
+      projectId: args.projectId,
+      identityId: args.identityId,
+      autonomousOnly: args.autonomousOnly,
+      limit: args.limit,
+    });
+
+    const countsByGroup = args.includeTaskCounts
+      ? await dataComposer.repositories.taskGroups.taskCountsByGroup(
+          resolved.user.id,
+          groups.map((g) => g.id)
+        )
+      : {};
+
+    // Resolve project + identity names for display
+    const projectIds = [...new Set(groups.map((g) => g.project_id).filter(Boolean))] as string[];
+    const projects = await Promise.all(
+      projectIds.map((id) => dataComposer.repositories.projects.findById(id))
+    );
+    const projectMap = new Map(projects.filter(Boolean).map((p) => [p!.id, p!.name]));
+
+    const identityIds = [...new Set(groups.map((g) => g.identity_id).filter(Boolean))] as string[];
+    const identityMap = new Map<string, { agentId: string; name: string | null }>();
+    if (identityIds.length > 0) {
+      const { data: identities } = await dataComposer
+        .getClient()
+        .from('agent_identities')
+        .select('id, agent_id, name')
+        .in('id', identityIds);
+      for (const row of (identities || []) as Array<{
+        id: string;
+        agent_id: string;
+        name: string | null;
+      }>) {
+        identityMap.set(row.id, { agentId: row.agent_id, name: row.name });
+      }
+    }
+
+    return mcpResponse({
+      success: true,
+      groups: groups.map((g) => ({
+        id: g.id,
+        title: g.title,
+        description: g.description,
+        status: g.status,
+        priority: g.priority,
+        tags: g.tags,
+        projectId: g.project_id,
+        projectName: g.project_id ? projectMap.get(g.project_id) || null : null,
+        identityId: g.identity_id,
+        agentId: g.identity_id ? identityMap.get(g.identity_id)?.agentId || null : null,
+        agentName: g.identity_id ? identityMap.get(g.identity_id)?.name || null : null,
+        autonomous: g.autonomous,
+        maxSessions: g.max_sessions,
+        sessionsUsed: g.sessions_used,
+        contextSummary: g.context_summary,
+        nextRunAfter: g.next_run_after,
+        outputTarget: g.output_target,
+        outputStatus: g.output_status,
+        threadKey: g.thread_key,
+        taskCounts: args.includeTaskCounts
+          ? countsByGroup[g.id] || {
+              total: 0,
+              pending: 0,
+              in_progress: 0,
+              completed: 0,
+              blocked: 0,
+            }
+          : undefined,
+        metadata: g.metadata,
+        createdAt: g.created_at,
+        updatedAt: g.updated_at,
+      })),
+    });
+  } catch (error) {
+    return mcpResponse(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to list task groups',
       },
       true
     );

--- a/packages/api/src/mcp/tools/task-handlers.ts
+++ b/packages/api/src/mcp/tools/task-handlers.ts
@@ -638,21 +638,11 @@ export async function handleCreateTaskGroup(
 
 export const listTaskGroupsSchema = z.object({
   ...userIdentifierSchema.shape,
-  status: z
-    .union([taskGroupStatusEnum, z.array(taskGroupStatusEnum)])
+  statuses: z
+    .array(taskGroupStatusEnum)
     .optional()
-    .describe('Filter by status (string or array). Omit to include all statuses.'),
-  activeOnly: z
-    .boolean()
-    .optional()
-    .default(false)
-    .describe('Shortcut for status in [active, paused]'),
-  includeCompleted: z
-    .boolean()
-    .optional()
-    .default(true)
     .describe(
-      'When no status filter is set, whether to include completed/cancelled groups. Default true.'
+      'Filter by one or more statuses: active, paused, completed, cancelled. Omit or pass empty array to include all statuses.'
     ),
   projectId: z.string().uuid().optional().describe('Filter by project'),
   identityId: z.string().uuid().optional().describe('Filter by agent identity UUID'),
@@ -675,24 +665,11 @@ export async function handleListTaskGroups(
       return mcpResponse({ success: false, error: 'User not found' }, true);
     }
 
-    let statusFilter:
-      | 'active'
-      | 'paused'
-      | 'completed'
-      | 'cancelled'
-      | Array<'active' | 'paused' | 'completed' | 'cancelled'>
-      | undefined;
-
-    if (args.status) {
-      statusFilter = args.status;
-    } else if (args.activeOnly) {
-      statusFilter = ['active', 'paused'];
-    } else if (!args.includeCompleted) {
-      statusFilter = ['active', 'paused'];
-    }
+    // Empty array is treated the same as omitted: include all statuses.
+    const statuses = args.statuses && args.statuses.length > 0 ? args.statuses : undefined;
 
     const groups = await dataComposer.repositories.taskGroups.listByUser(resolved.user.id, {
-      status: statusFilter,
+      status: statuses,
       projectId: args.projectId,
       identityId: args.identityId,
       autonomousOnly: args.autonomousOnly,


### PR DESCRIPTION
## Summary

- Expose **task_groups** via MCP so agents can enumerate autonomous-work containers (title, strategy, priority, output target, thread key) and create new ones.
- `list_task_groups` returns per-status task counts per group and **covers completed/cancelled groups by default** (use `includeCompleted=false` or `activeOnly=true` to exclude them).
- `create_task_group` attributes the new group to the calling agent's `identity_id` using workspace scope from the request context.

## Why

We've been hitting repeated compaction/session issues where agents can't see existing task groups or create new ones without going to the admin UI. This closes that gap.

The `includeCompleted` default of `true` directly addresses feedback: _"we should also be able to query tasks that are marked as completed, etc. so we get the full picture."_

## What changed

- **New**: `packages/api/src/data/repositories/task-groups.repository.ts` — `create` / `findById` / `listByUser` / `update` / `delete` + `taskCountsByGroup` aggregator.
- **New handlers**: `handleCreateTaskGroup`, `handleListTaskGroups` in `task-handlers.ts`.
- **Registered**: `create_task_group`, `list_task_groups` in `tools/index.ts`.
- **Composer**: `dataComposer.repositories.taskGroups` wired up.
- **Tests**: 14 new handler tests (39 total in `task-handlers.test.ts`).

## Schema reflected by the tool

Matches migration `20260311021747_task_groups_unify_tasks_permissions.sql`:
- status: `active | paused | completed | cancelled`
- priority: `low | normal | high | urgent`
- output_target: `spec | pr | report | proposal` (nullable)
- output_status: `ready_for_review | needs_more_work | blocked` (nullable)
- autonomous fields: `autonomous`, `max_sessions`, `sessions_used`, `context_summary`, `next_run_after`
- `thread_key`, `metadata`, `tags`

## Out of scope (follow-ups)

- `update_task_group` / `delete_task_group` — we can add as needed; the repo methods exist so handlers are a trivial follow-up.
- Studio-slug → UUID resolution (separate task; repo already has `findBySlug`).

## Test plan

- [x] `npx vitest run packages/api/src/mcp/tools/task-handlers.test.ts` — 39 pass
- [x] Full suite: `npx vitest run` — 1849 pass, 2 skipped
- [x] Type-check: no new errors introduced (pre-existing errors in `channels/gateway.ts`, `server.ts`, `admin.ts`, `session-service.ts` are unchanged on main)
- [ ] Live: call `list_task_groups` against dev server and confirm counts match admin UI

— Wren