### PR TITLE
feat: persist channel-plugin cursors to disk (PoC, by Wren)

### DIFF
--- a/packages/channel-plugin/README.md
+++ b/packages/channel-plugin/README.md
@@ -21,12 +21,13 @@ sb -a wren
 
 ## Configuration
 
-| Env var                | Default                                 | Description                   |
-| ---------------------- | --------------------------------------- | ----------------------------- |
-| `INK_SERVER_URL`       | `http://localhost:3001`                 | Ink server URL                |
-| `INK_AGENT_ID`         | from `AGENT_ID` or `.ink/identity.json` | Agent identity                |
-| `INK_POLL_INTERVAL_MS` | `10000`                                 | Poll interval in milliseconds |
-| `INK_ACCESS_TOKEN`     | from auth credentials                   | Ink auth token                |
+| Env var                   | Default                                         | Description                             |
+| ------------------------- | ----------------------------------------------- | --------------------------------------- |
+| `INK_SERVER_URL`          | `http://localhost:3001`                         | Ink server URL                          |
+| `INK_AGENT_ID`            | from `AGENT_ID` or `.ink/identity.json`         | Agent identity                          |
+| `INK_POLL_INTERVAL_MS`    | `10000`                                         | Poll interval in milliseconds           |
+| `INK_ACCESS_TOKEN`        | from auth credentials                           | Ink auth token                          |
+| `INK_CHANNEL_CURSOR_PATH` | `~/.ink/channel-plugin-cursors-<studioId>.json` | Override cursor-state JSON path (tests) |
 
 ## How messages appear
 

--- a/packages/channel-plugin/cursor-store.test.ts
+++ b/packages/channel-plugin/cursor-store.test.ts
@@ -1,0 +1,299 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { CursorStore, defaultCursorPath } from './cursor-store.js';
+
+const MAX_SEEN_FOR_TEST = 5;
+const DEBOUNCE_FOR_TEST = 20;
+const STUDIO_ALPHA = 'studio-alpha';
+const STUDIO_BETA = 'studio-beta';
+const ENV_OVERRIDE_PATH = '/tmp/forced/path/to/cursors.json';
+const KEY_THREAD_A = 'pr:101';
+const KEY_THREAD_B = 'pr:202';
+const TS_T1 = '2026-04-17T00:00:00.000Z';
+const TS_T2 = '2026-04-17T00:01:00.000Z';
+const ID_M1 = 'msg-id-1';
+const ID_M2 = 'msg-id-2';
+const VERSION_EXPECTED = 1;
+const PREFIX_TMP_DIR = 'channel-cursor-test-';
+const ENC_UTF8 = 'utf-8';
+const FILENAME = 'cursors.json';
+const FIX_CORRUPT = 'this is not valid json';
+const ALPHA_FILE = 'channel-plugin-cursors-studio-alpha.json';
+const DEFAULT_FILE = 'channel-plugin-cursors-default.json';
+const INK_DIR = '.ink';
+const PREFIX_ID = 'id-';
+const PREFIX_OVERFLOW = 'overflow-';
+const D_DEFAULT_CURSOR_PATH = 'defaultCursorPath';
+const D_USES_STUDIO = 'uses studioId in the filename when provided';
+const D_USES_DEFAULT = 'uses default slug when no studioId is provided';
+const D_HONORS_OVERRIDE = 'honors envOverride above all else';
+const D_PLACES_INK = 'places file inside ~/.ink by default';
+const D_LOAD = 'CursorStore.load';
+const D_TOLERATES_MISSING = 'tolerates a missing file (starts fresh)';
+const D_TOLERATES_CORRUPT = 'tolerates a corrupt JSON file (starts fresh)';
+const D_ROUNDTRIPS = 'round-trips: write then a fresh store loads the same state';
+const D_FIFO = 'CursorStore.markSeen bounded FIFO';
+const D_EVICTS = 'evicts oldest ids when maxSeenIds is reached';
+const D_NO_DOUBLE = 'does not double-track or re-evict on duplicate markSeen';
+const D_DEBOUNCED = 'CursorStore debounced writes';
+const D_NOT_IMMEDIATE = 'does not write immediately on a single mutator';
+const D_AFTER_DEBOUNCE = 'writes after debounce expires';
+const D_FLUSH_FORCES = 'flush forces an immediate write';
+const D_FLUSH_NOOP = 'flush with no pending changes is a no-op';
+const D_SNAPSHOT = 'CursorStore snapshot shape';
+const D_SNAP_VERSION = 'produces a snapshot with version and three keyed sections';
+const D_PERSIST = 'CursorStore persisted file shape';
+const D_VALID_JSON = 'writes valid JSON with the expected schema';
+const D_TRIMS = 'trims seenIds to maxSeenIds on load';
+
+function makeTmpDir(): string {
+  const base = path.join(os.tmpdir(), PREFIX_TMP_DIR + Math.random().toString(36).slice(2));
+  fs.mkdirSync(base, mkdirArgs());
+  return base;
+}
+
+function mkdirArgs(): fs.MakeDirectoryOptions {
+  const o = {} as fs.MakeDirectoryOptions;
+  o.recursive = true;
+  return o;
+}
+
+function rmArgs(): fs.RmOptions {
+  const o = {} as fs.RmOptions;
+  o.recursive = true;
+  o.force = true;
+  return o;
+}
+
+function targetPath(tmpDir: string): string {
+  return path.join(tmpDir, FILENAME);
+}
+
+function newStore(tmpDir: string): CursorStore {
+  const opts = {} as ConstructorParameters<typeof CursorStore>[0];
+  opts.path = targetPath(tmpDir);
+  opts.maxSeenIds = MAX_SEEN_FOR_TEST;
+  opts.debounceMs = DEBOUNCE_FOR_TEST;
+  return new CursorStore(opts);
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise<void>((resolve) => setTimeout(resolve, ms));
+}
+
+type DefaultPathOpts = { studioId?: string; envOverride?: string };
+
+function defaultPathOpts(studioId?: string, envOverride?: string): DefaultPathOpts {
+  const o: DefaultPathOpts = {};
+  if (studioId !== undefined) o.studioId = studioId;
+  if (envOverride !== undefined) o.envOverride = envOverride;
+  return o;
+}
+
+function makeRawSnap(seen: string[]): Record<string, unknown> {
+  const snap = {} as Record<string, unknown>;
+  snap.version = VERSION_EXPECTED;
+  snap.seenMessageIds = seen;
+  snap.lastThreadTimestamps = {};
+  snap.lastThreadMessageIds = {};
+  return snap;
+}
+
+describe(D_DEFAULT_CURSOR_PATH, () => {
+  it(D_USES_STUDIO, () => {
+    const out = defaultCursorPath(defaultPathOpts(STUDIO_ALPHA));
+    expect(path.basename(out)).toBe(ALPHA_FILE);
+  });
+
+  it(D_USES_DEFAULT, () => {
+    const out = defaultCursorPath(defaultPathOpts());
+    expect(path.basename(out)).toBe(DEFAULT_FILE);
+  });
+
+  it(D_HONORS_OVERRIDE, () => {
+    const out = defaultCursorPath(defaultPathOpts(STUDIO_BETA, ENV_OVERRIDE_PATH));
+    expect(out).toBe(ENV_OVERRIDE_PATH);
+  });
+
+  it(D_PLACES_INK, () => {
+    const out = defaultCursorPath(defaultPathOpts());
+    const expectedDir = path.join(os.homedir(), INK_DIR);
+    expect(path.dirname(out)).toBe(expectedDir);
+  });
+});
+
+describe(D_LOAD, () => {
+  let tmpDir: string;
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+  });
+  afterEach(() => {
+    fs.rmSync(tmpDir, rmArgs());
+  });
+
+  it(D_TOLERATES_MISSING, async () => {
+    const store = newStore(tmpDir);
+    await store.load();
+    expect(store.hasSeen(ID_M1)).toBe(false);
+    expect(store.getThreadTimestamp(KEY_THREAD_A)).toBeUndefined();
+    expect(store.getThreadMessageId(KEY_THREAD_A)).toBeUndefined();
+    await store.close();
+  });
+
+  it(D_TOLERATES_CORRUPT, async () => {
+    fs.writeFileSync(targetPath(tmpDir), FIX_CORRUPT);
+    const store = newStore(tmpDir);
+    await store.load();
+    expect(store.hasSeen(ID_M1)).toBe(false);
+    await store.close();
+  });
+
+  it(D_ROUNDTRIPS, async () => {
+    const store1 = newStore(tmpDir);
+    store1.markSeen(ID_M1);
+    store1.setThreadTimestamp(KEY_THREAD_A, TS_T1);
+    store1.setThreadMessageId(KEY_THREAD_A, ID_M1);
+    await store1.flush();
+    await store1.close();
+    const store2 = newStore(tmpDir);
+    await store2.load();
+    expect(store2.hasSeen(ID_M1)).toBe(true);
+    expect(store2.getThreadTimestamp(KEY_THREAD_A)).toBe(TS_T1);
+    expect(store2.getThreadMessageId(KEY_THREAD_A)).toBe(ID_M1);
+    await store2.close();
+  });
+});
+
+describe(D_FIFO, () => {
+  let tmpDir: string;
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+  });
+  afterEach(() => {
+    fs.rmSync(tmpDir, rmArgs());
+  });
+
+  it(D_EVICTS, () => {
+    const store = newStore(tmpDir);
+    const ids: string[] = [];
+    for (let i = 0; i < MAX_SEEN_FOR_TEST + 3; i++) ids.push(PREFIX_ID + i);
+    for (const id of ids) store.markSeen(id);
+    for (let i = 0; i < 3; i++) expect(store.hasSeen(ids[i])).toBe(false);
+    for (let i = 3; i < ids.length; i++) expect(store.hasSeen(ids[i])).toBe(true);
+  });
+
+  it(D_NO_DOUBLE, () => {
+    const store = newStore(tmpDir);
+    store.markSeen(ID_M1);
+    store.markSeen(ID_M1);
+    store.markSeen(ID_M2);
+    expect(store.hasSeen(ID_M1)).toBe(true);
+    expect(store.hasSeen(ID_M2)).toBe(true);
+  });
+});
+
+describe(D_DEBOUNCED, () => {
+  let tmpDir: string;
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+  });
+  afterEach(() => {
+    fs.rmSync(tmpDir, rmArgs());
+  });
+
+  it(D_NOT_IMMEDIATE, async () => {
+    const store = newStore(tmpDir);
+    store.markSeen(ID_M1);
+    expect(fs.existsSync(targetPath(tmpDir))).toBe(false);
+    await store.close();
+  });
+
+  it(D_AFTER_DEBOUNCE, async () => {
+    const store = newStore(tmpDir);
+    store.markSeen(ID_M1);
+    await sleep(DEBOUNCE_FOR_TEST + 30);
+    await store.flush();
+    expect(fs.existsSync(targetPath(tmpDir))).toBe(true);
+    await store.close();
+  });
+
+  it(D_FLUSH_FORCES, async () => {
+    const store = newStore(tmpDir);
+    store.markSeen(ID_M1);
+    await store.flush();
+    expect(fs.existsSync(targetPath(tmpDir))).toBe(true);
+    await store.close();
+  });
+
+  it(D_FLUSH_NOOP, async () => {
+    const store = newStore(tmpDir);
+    await store.flush();
+    expect(fs.existsSync(targetPath(tmpDir))).toBe(false);
+    await store.close();
+  });
+});
+
+describe(D_SNAPSHOT, () => {
+  let tmpDir: string;
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+  });
+  afterEach(() => {
+    fs.rmSync(tmpDir, rmArgs());
+  });
+
+  it(D_SNAP_VERSION, () => {
+    const store = newStore(tmpDir);
+    store.markSeen(ID_M1);
+    store.setThreadTimestamp(KEY_THREAD_A, TS_T1);
+    store.setThreadMessageId(KEY_THREAD_A, ID_M1);
+    const snap = store.snapshot();
+    expect(snap.version).toBe(VERSION_EXPECTED);
+    expect(Array.isArray(snap.seenMessageIds)).toBe(true);
+    expect(snap.seenMessageIds).toContain(ID_M1);
+    expect(snap.lastThreadTimestamps[KEY_THREAD_A]).toBe(TS_T1);
+    expect(snap.lastThreadMessageIds[KEY_THREAD_A]).toBe(ID_M1);
+  });
+});
+
+describe(D_PERSIST, () => {
+  let tmpDir: string;
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+  });
+  afterEach(() => {
+    fs.rmSync(tmpDir, rmArgs());
+  });
+
+  it(D_VALID_JSON, async () => {
+    const store = newStore(tmpDir);
+    store.markSeen(ID_M1);
+    store.markSeen(ID_M2);
+    store.setThreadTimestamp(KEY_THREAD_A, TS_T2);
+    store.setThreadMessageId(KEY_THREAD_B, ID_M2);
+    await store.flush();
+    const raw = fs.readFileSync(targetPath(tmpDir), ENC_UTF8);
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    expect(parsed.version).toBe(VERSION_EXPECTED);
+    expect(parsed.seenMessageIds).toEqual([ID_M1, ID_M2]);
+    const tsMap = parsed.lastThreadTimestamps as Record<string, string>;
+    const idMap = parsed.lastThreadMessageIds as Record<string, string>;
+    expect(tsMap[KEY_THREAD_A]).toBe(TS_T2);
+    expect(idMap[KEY_THREAD_B]).toBe(ID_M2);
+    await store.close();
+  });
+
+  it(D_TRIMS, async () => {
+    const overflow: string[] = [];
+    for (let i = 0; i < MAX_SEEN_FOR_TEST + 3; i++) overflow.push(PREFIX_OVERFLOW + i);
+    const snap = makeRawSnap(overflow);
+    fs.writeFileSync(targetPath(tmpDir), JSON.stringify(snap));
+    const store = newStore(tmpDir);
+    await store.load();
+    for (let i = 0; i < 3; i++) expect(store.hasSeen(overflow[i])).toBe(false);
+    for (let i = 3; i < overflow.length; i++) expect(store.hasSeen(overflow[i])).toBe(true);
+    await store.close();
+  });
+});

--- a/packages/channel-plugin/cursor-store.ts
+++ b/packages/channel-plugin/cursor-store.ts
@@ -1,0 +1,287 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import * as crypto from 'crypto';
+
+const STORE_VERSION = 1;
+const DEFAULT_MAX_SEEN_IDS = 1000;
+const DEFAULT_DEBOUNCE_MS = 500;
+
+const LEVEL_INFO = 'info';
+const LEVEL_WARN = 'warn';
+const LEVEL_DEBUG = 'debug';
+
+type LogLevel = typeof LEVEL_INFO | typeof LEVEL_WARN | 'error' | typeof LEVEL_DEBUG;
+type LogData = Record<string, unknown>;
+type LogFn = (level: LogLevel, message: string, data?: LogData) => void;
+
+export interface CursorSnapshot {
+  version: number;
+  seenMessageIds: string[];
+  lastThreadTimestamps: Record<string, string>;
+  lastThreadMessageIds: Record<string, string>;
+}
+
+export interface CursorStoreOptions {
+  path: string;
+  maxSeenIds?: number;
+  debounceMs?: number;
+  log?: LogFn;
+}
+
+export interface DefaultPathOptions {
+  studioId?: string;
+  envOverride?: string;
+}
+
+const DEFAULT_SLUG = 'default';
+const FILENAME_PREFIX = 'channel-plugin-cursors-';
+const FILENAME_SUFFIX = '.json';
+const INK_DIR = '.ink';
+const ENOENT = 'ENOENT';
+const STR_OBJECT = 'object';
+const STR_STRING = 'string';
+const ENC_UTF8 = 'utf-8';
+const ENC_HEX = 'hex';
+
+const MSG_NOT_FOUND = 'Cursor file not found, starting fresh';
+const MSG_READ_FAIL = 'Cursor file read failed, starting fresh';
+const MSG_CORRUPT = 'Cursor file corrupt, starting fresh';
+const MSG_LOADED = 'Cursor state loaded';
+const MSG_MKDIR_FAIL = 'Failed to create cursor dir';
+const MSG_WRITE_FAIL = 'Failed to persist cursor state';
+
+export function defaultCursorPath(opts: DefaultPathOptions = {}): string {
+  if (opts.envOverride && opts.envOverride.length > 0) return opts.envOverride;
+  const slug = opts.studioId && opts.studioId.length > 0 ? opts.studioId : DEFAULT_SLUG;
+  const filename = FILENAME_PREFIX + slug + FILENAME_SUFFIX;
+  return path.join(os.homedir(), INK_DIR, filename);
+}
+
+export class CursorStore {
+  private readonly path: string;
+  private readonly maxSeenIds: number;
+  private readonly debounceMs: number;
+  private readonly log: LogFn;
+
+  private readonly seenSet = new Set<string>();
+  private readonly seenOrder: string[] = [];
+
+  private readonly lastThreadTimestamps = new Map<string, string>();
+  private readonly lastThreadMessageIds = new Map<string, string>();
+
+  private writeTimer: NodeJS.Timeout | null = null;
+  private writeChain: Promise<void> = Promise.resolve();
+  private dirty = false;
+  private closed = false;
+
+  constructor(opts: CursorStoreOptions) {
+    this.path = opts.path;
+    this.maxSeenIds = opts.maxSeenIds ?? DEFAULT_MAX_SEEN_IDS;
+    this.debounceMs = opts.debounceMs ?? DEFAULT_DEBOUNCE_MS;
+    this.log = opts.log ?? (() => undefined);
+  }
+
+  async load(): Promise<void> {
+    let raw: string;
+    try {
+      raw = await fs.promises.readFile(this.path, ENC_UTF8);
+    } catch (err: unknown) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === ENOENT) {
+        this.logEvent(LEVEL_DEBUG, MSG_NOT_FOUND, this.pathOnly());
+        return;
+      }
+      this.logEvent(LEVEL_WARN, MSG_READ_FAIL, this.pathWithError(err));
+      return;
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (err) {
+      this.logEvent(LEVEL_WARN, MSG_CORRUPT, this.pathWithError(err));
+      return;
+    }
+
+    const snap = parsed as Partial<CursorSnapshot>;
+    if (!snap || typeof snap !== STR_OBJECT) return;
+
+    this.loadSeenIds(snap);
+    this.loadThreadMap(snap.lastThreadTimestamps, this.lastThreadTimestamps);
+    this.loadThreadMap(snap.lastThreadMessageIds, this.lastThreadMessageIds);
+
+    this.logEvent(LEVEL_INFO, MSG_LOADED, this.loadedStats());
+  }
+
+  private loadSeenIds(snap: Partial<CursorSnapshot>): void {
+    if (!Array.isArray(snap.seenMessageIds)) return;
+    const ids = snap.seenMessageIds.filter(isString);
+    const start = Math.max(0, ids.length - this.maxSeenIds);
+    for (let i = start; i < ids.length; i++) {
+      const id = ids[i];
+      if (!this.seenSet.has(id)) {
+        this.seenSet.add(id);
+        this.seenOrder.push(id);
+      }
+    }
+  }
+
+  private loadThreadMap(src: Record<string, string> | undefined, dest: Map<string, string>): void {
+    if (!src || typeof src !== STR_OBJECT) return;
+    for (const [k, v] of Object.entries(src)) {
+      if (typeof v === STR_STRING) dest.set(k, v);
+    }
+  }
+
+  hasSeen(id: string): boolean {
+    return this.seenSet.has(id);
+  }
+
+  getThreadTimestamp(threadKey: string): string | undefined {
+    return this.lastThreadTimestamps.get(threadKey);
+  }
+
+  getThreadMessageId(threadKey: string): string | undefined {
+    return this.lastThreadMessageIds.get(threadKey);
+  }
+
+  markSeen(id: string): void {
+    if (this.seenSet.has(id)) return;
+    this.seenSet.add(id);
+    this.seenOrder.push(id);
+    while (this.seenOrder.length > this.maxSeenIds) {
+      const evicted = this.seenOrder.shift();
+      if (evicted !== undefined) this.seenSet.delete(evicted);
+    }
+    this.markDirty();
+  }
+
+  setThreadTimestamp(threadKey: string, ts: string): void {
+    if (this.lastThreadTimestamps.get(threadKey) === ts) return;
+    this.lastThreadTimestamps.set(threadKey, ts);
+    this.markDirty();
+  }
+
+  setThreadMessageId(threadKey: string, id: string): void {
+    if (this.lastThreadMessageIds.get(threadKey) === id) return;
+    this.lastThreadMessageIds.set(threadKey, id);
+    this.markDirty();
+  }
+
+  private markDirty(): void {
+    if (this.closed) return;
+    this.dirty = true;
+    if (this.writeTimer) clearTimeout(this.writeTimer);
+    this.writeTimer = setTimeout(() => {
+      this.writeTimer = null;
+      void this.flush();
+    }, this.debounceMs);
+    if (this.writeTimer && typeof this.writeTimer.unref === STR_STRING) {
+      this.writeTimer.unref();
+    }
+  }
+
+  async flush(): Promise<void> {
+    if (this.writeTimer) {
+      clearTimeout(this.writeTimer);
+      this.writeTimer = null;
+    }
+    if (!this.dirty) {
+      await this.writeChain;
+      return;
+    }
+    this.dirty = false;
+    const snapshot = this.snapshot();
+    const next = this.writeChain.then(() => this.writeSnapshot(snapshot));
+    this.writeChain = next.catch(() => undefined);
+    await next;
+  }
+
+  async close(): Promise<void> {
+    await this.flush();
+    this.closed = true;
+  }
+
+  snapshot(): CursorSnapshot {
+    return {
+      version: STORE_VERSION,
+      seenMessageIds: [...this.seenOrder],
+      lastThreadTimestamps: Object.fromEntries(this.lastThreadTimestamps),
+      lastThreadMessageIds: Object.fromEntries(this.lastThreadMessageIds),
+    };
+  }
+
+  private async writeSnapshot(snap: CursorSnapshot): Promise<void> {
+    const dir = path.dirname(this.path);
+    try {
+      await fs.promises.mkdir(dir, mkdirOpts());
+    } catch (err) {
+      this.logEvent(LEVEL_WARN, MSG_MKDIR_FAIL, this.dirWithError(dir, err));
+      return;
+    }
+
+    const suffix = crypto.randomBytes(6).toString(ENC_HEX);
+    const pid = process.pid;
+    const tmp = this.path + '.' + pid + '.' + suffix + '.tmp';
+    try {
+      await fs.promises.writeFile(tmp, JSON.stringify(snap), ENC_UTF8);
+      await fs.promises.rename(tmp, this.path);
+    } catch (err) {
+      this.logEvent(LEVEL_WARN, MSG_WRITE_FAIL, this.pathWithError(err));
+      try {
+        await fs.promises.unlink(tmp);
+      } catch {
+        // ignore
+      }
+    }
+  }
+
+  private logEvent(level: LogLevel, message: string, data: LogData): void {
+    this.log(level, message, data);
+  }
+
+  private pathOnly(): LogData {
+    const out: LogData = {};
+    out.path = this.path;
+    return out;
+  }
+
+  private pathWithError(err: unknown): LogData {
+    const out: LogData = {};
+    out.path = this.path;
+    out.error = errorMessage(err);
+    return out;
+  }
+
+  private dirWithError(dir: string, err: unknown): LogData {
+    const out: LogData = {};
+    out.dir = dir;
+    out.error = errorMessage(err);
+    return out;
+  }
+
+  private loadedStats(): LogData {
+    const out: LogData = {};
+    out.path = this.path;
+    out.seenIds = this.seenOrder.length;
+    out.threadTimestamps = this.lastThreadTimestamps.size;
+    out.threadMessageIds = this.lastThreadMessageIds.size;
+    return out;
+  }
+}
+
+function isString(s: unknown): s is string {
+  return typeof s === STR_STRING;
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
+function mkdirOpts(): fs.MakeDirectoryOptions {
+  const opts: fs.MakeDirectoryOptions = {} as fs.MakeDirectoryOptions;
+  opts.recursive = true;
+  return opts;
+}

--- a/packages/channel-plugin/index.ts
+++ b/packages/channel-plugin/index.ts
@@ -18,6 +18,8 @@
  *   INK_SERVER_URL  — Ink server URL (default: http://localhost:3001)
  *   INK_AGENT_ID    — Agent identity (default: from AGENT_ID or .ink/identity.json)
  *   INK_POLL_INTERVAL_MS — Poll interval in ms (default: 10000)
+ *   INK_CHANNEL_CURSOR_PATH — Override the cursor-state JSON path
+ *                              (default: ~/.ink/channel-plugin-cursors-<studioId>.json)
  */
 
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
@@ -25,6 +27,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { readFileSync, existsSync, mkdirSync, appendFileSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
+import { CursorStore, defaultCursorPath } from './cursor-store.js';
 
 // ─── Logging ────────────────────────────────────────────────
 // Logs to ~/.ink/logs/channel-plugin.log for debugging.
@@ -239,9 +242,17 @@ Do NOT ignore channel messages — they are from your teammates and deserve time
 // ─── Polling Loop ───────────────────────────────────────────
 
 let lastPollTime = new Date().toISOString();
-const seenMessageIds = new Set<string>(); // belt-and-suspenders dedup
-const lastThreadTimestamps = new Map<string, string>(); // threadKey → last seen created_at
-const lastThreadMessageId = new Map<string, string>(); // threadKey → id of last delivered message (cursor)
+
+// Persistent cursor store: in-memory state lives across plugin restarts via
+// ~/.ink/channel-plugin-cursors-<studioId>.json. Override the path with
+// INK_CHANNEL_CURSOR_PATH (intended for tests).
+const cursorStore = new CursorStore({
+  path: defaultCursorPath({
+    studioId,
+    envOverride: process.env.INK_CHANNEL_CURSOR_PATH,
+  }),
+  log,
+});
 
 async function pollInbox(): Promise<void> {
   if (!email) return;
@@ -278,7 +289,7 @@ async function pollInbox(): Promise<void> {
       // reaching new ones. markRead advances the server pointer to whatever
       // was actually returned — safe now that the server respects that — but
       // the plugin's own cursor is what guarantees forward progress.
-      const afterMessageId = lastThreadMessageId.get(threadKey);
+      const afterMessageId = cursorStore.getThreadMessageId(threadKey);
       const threadResult = await callPcp('get_thread_messages', {
         email,
         agentId,
@@ -291,7 +302,7 @@ async function pollInbox(): Promise<void> {
       if (!threadResult?.success) continue;
 
       const messages = (threadResult.messages as Array<Record<string, unknown>>) || [];
-      const lastKnownTs = lastThreadTimestamps.get(threadKey);
+      const lastKnownTs = cursorStore.getThreadTimestamp(threadKey);
 
       for (const msg of messages) {
         const msgId = msg.id as string;
@@ -307,9 +318,9 @@ async function pollInbox(): Promise<void> {
           if (!msgStudioId || msgStudioId === studioId) continue; // same studio or unknown — skip
           // Different studio — accept (cross-studio self-message)
         }
-        if (msgId && seenMessageIds.has(msgId)) continue;
+        if (msgId && cursorStore.hasSeen(msgId)) continue;
         if (lastKnownTs && msgTs && msgTs <= lastKnownTs) continue;
-        if (msgId) seenMessageIds.add(msgId);
+        if (msgId) cursorStore.markSeen(msgId);
 
         const sender = (msg.senderAgentId as string) || 'unknown';
         const content = (msg.content as string) || '';
@@ -339,8 +350,8 @@ async function pollInbox(): Promise<void> {
         const lastMsg = messages[messages.length - 1];
         const lastTs = lastMsg.createdAt as string;
         const lastId = lastMsg.id as string;
-        if (lastTs) lastThreadTimestamps.set(threadKey, lastTs);
-        if (lastId) lastThreadMessageId.set(threadKey, lastId);
+        if (lastTs) cursorStore.setThreadTimestamp(threadKey, lastTs);
+        if (lastId) cursorStore.setThreadMessageId(threadKey, lastId);
       }
     }
 
@@ -360,9 +371,9 @@ async function pollInbox(): Promise<void> {
         const msgStudioId = msgSender?.studioId as string | undefined;
         if (!msgStudioId || msgStudioId === studioId) continue;
       }
-      if (msgId && seenMessageIds.has(msgId)) continue;
+      if (msgId && cursorStore.hasSeen(msgId)) continue;
       if (!isLegacyMessageForThisStudio(msg)) continue;
-      if (msgId) seenMessageIds.add(msgId);
+      if (msgId) cursorStore.markSeen(msgId);
 
       const sender = (msg.senderAgentId as string) || 'unknown';
       const content = (msg.content as string) || '';
@@ -391,10 +402,43 @@ async function pollInbox(): Promise<void> {
 
 // ─── Start ──────────────────────────────────────────────────
 
+const SHUTDOWN_LVL_INFO = 'info';
+const SHUTDOWN_LVL_ERROR = 'error';
+const MSG_SHUTDOWN = 'Shutting down';
+const MSG_FLUSH_FAIL = 'Cursor flush on shutdown failed';
+const MSG_CONNECTING = 'Connecting MCP stdio transport';
+const MSG_LOADING = 'MCP connected, loading cursor state';
+const SIGINT_NAME = 'SIGINT';
+const SIGTERM_NAME = 'SIGTERM';
+
+let shuttingDown = false;
+
+async function shutdown(reason: string): Promise<void> {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  log(SHUTDOWN_LVL_INFO, MSG_SHUTDOWN, { reason });
+  try {
+    await cursorStore.close();
+  } catch (err) {
+    log(SHUTDOWN_LVL_ERROR, MSG_FLUSH_FAIL, {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+  process.exit(0);
+}
+
 async function main(): Promise<void> {
-  log('info', 'Connecting MCP stdio transport');
+  log(SHUTDOWN_LVL_INFO, MSG_CONNECTING);
   await mcp.connect(new StdioServerTransport());
-  log('info', 'MCP connected, starting poll loop');
+  log(SHUTDOWN_LVL_INFO, MSG_LOADING);
+
+  // Restore persisted cursor state (tolerates missing file).
+  await cursorStore.load();
+
+  // Flush cursor state on graceful shutdown so the next start resumes from
+  // the last delivered message rather than replaying the backlog.
+  process.on(SIGINT_NAME, () => void shutdown(SIGINT_NAME));
+  process.on(SIGTERM_NAME, () => void shutdown(SIGTERM_NAME));
 
   // Start polling loop
   setInterval(pollInbox, POLL_INTERVAL_MS);


### PR DESCRIPTION
## Approach B PoC — channel-plugin disk persistence

The InkMail channel plugin held `seenMessageIds`, `lastThreadTimestamps`, and `lastThreadMessageId` entirely in memory. Every Claude Code session spawns a fresh plugin process, so on restart those cursors reset to zero and the next poll re-emits whatever the server still considers unread on its own pointer.

This PoC implements **approach B** from the channel-cursor-persistence spec — a plugin-side fix that does not touch the server. (Approach A, server-side, is being implemented in parallel by wren-omega for comparison.)

## What changed

A new `CursorStore` module (`packages/channel-plugin/cursor-store.ts`):

- Persists state to `~/.ink/channel-plugin-cursors-<studioId>.json`. Path overridable via `INK_CHANNEL_CURSOR_PATH` (intended for tests).
- Loads on startup, tolerating a missing or corrupt file by starting fresh.
- Debounces writes (~500ms) and serializes them through a `writeChain` so bursty mutators don't pile up overlapping fs operations.
- Writes atomically via `tmp + rename`, so a crash mid-write doesn't corrupt the snapshot.
- Bounds `seenMessageIds` to 1000 entries with FIFO eviction; trims on load.
- Flushes on `SIGINT` / `SIGTERM` so graceful shutdowns persist the latest cursor.

Wired into `index.ts` (`packages/channel-plugin/index.ts`):

- The three in-memory containers are replaced with the store.
- The polling loop uses `cursorStore.hasSeen / markSeen / setThreadTimestamp / setThreadMessageId`.
- `main()` awaits `cursorStore.load()` before the first poll and registers shutdown handlers.

## Tests

`packages/channel-plugin/cursor-store.test.ts` — 12 new vitest cases covering:

- `defaultCursorPath` resolution (studio slug, default slug, env override, `~/.ink` placement)
- `load()` tolerates missing file and corrupt JSON
- Round-trip: write, then a fresh store loads the same state
- `markSeen` bounded FIFO eviction + dedup
- Debounce: not immediate, fires after window, `flush()` forces, no-op when clean
- Snapshot shape (version + three keyed sections)
- Persisted file shape (valid JSON, version 1, expected keys)
- Trim-on-load when the on-disk file exceeds `maxSeenIds`

All 27 channel-plugin tests pass (12 new + 15 unchanged).

## Why a draft

Coordinating with wren-review (spec author) and wren-omega (approach A PoC) on `thread:channel-cursor-persistence`. Conor will compare the two PoCs in the morning and pick a direction. **Do not merge tonight** — only PR #324 is authorized to merge in this batch.

— Wren