### PR TITLE
feat: recipientStudioSlug alias on send_to_inbox (by Wren)

### DIFF
--- a/packages/api/src/mcp/tools/inbox-handlers.ts
+++ b/packages/api/src/mcp/tools/inbox-handlers.ts
@@ -63,10 +63,20 @@ const sendToInboxSchema = userIdentifierBaseSchema.extend({
     .uuid()
     .optional()
     .describe('Recipient studio ID hint for session routing'),
+  recipientStudioSlug: z
+    .string()
+    .min(1)
+    .max(100)
+    .optional()
+    .describe(
+      'Recipient studio slug for routing (matches studios.slug). Pass "main" to target the user\'s root-repo studio. Preferred over recipientStudioHint — accepts any studio slug, not just "main".'
+    ),
   recipientStudioHint: z
     .enum(['main'])
     .optional()
-    .describe('Recipient studio routing hint (e.g., "main")'),
+    .describe(
+      'DEPRECATED — use recipientStudioSlug instead. Kept for backward compatibility with callers that pass the literal string "main".'
+    ),
   relatedArtifactUri: z.string().optional().describe('Related artifact URI'),
   metadata: z.record(z.unknown()).optional().describe('Additional metadata'),
   expiresAt: z.string().datetime().optional().describe('When this message expires'),
@@ -217,6 +227,7 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
     priority = 'normal',
     recipientSessionId,
     recipientStudioId,
+    recipientStudioSlug,
     recipientStudioHint,
     relatedArtifactUri,
     metadata = {},
@@ -228,6 +239,12 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
     triggerAgents,
   } = parsed;
 
+  // Merge recipientStudioSlug (preferred) and recipientStudioHint (legacy alias).
+  // Downstream code treats these uniformly — both resolve via resolveStudioHint,
+  // which does isMainStudio + slug lookup. If both are provided, slug wins.
+  const recipientStudioSlugOrHint: string | undefined =
+    recipientStudioSlug || recipientStudioHint || undefined;
+
   // Validate: exactly one of recipientAgentId or recipients
   const hasSingle = !!recipientAgentId;
   const hasMany = !!recipients?.length;
@@ -237,9 +254,9 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
   if (hasMany && !threadKey) {
     throw new Error('threadKey is required when using recipients[]');
   }
-  if (recipients && (recipientSessionId || recipientStudioId || recipientStudioHint)) {
+  if (recipients && (recipientSessionId || recipientStudioId || recipientStudioSlugOrHint)) {
     throw new Error(
-      'recipientSessionId/recipientStudioId/recipientStudioHint are only valid for single-recipient sends'
+      'recipientSessionId/recipientStudioId/recipientStudioSlug/recipientStudioHint are only valid for single-recipient sends'
     );
   }
 
@@ -368,9 +385,9 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
         : {};
     // Cross-studio self-messaging: stamp recipient studio on the message
     // so the channelPoll filter can recognize the target studio as an owner.
-    // Resolve recipientStudioHint to a studioId if needed.
+    // Resolve recipientStudioSlug/Hint to a studioId if needed.
     let resolvedRecipientStudioId: string | undefined = recipientStudioId || undefined;
-    if (!resolvedRecipientStudioId && recipientStudioHint && senderAgentId) {
+    if (!resolvedRecipientStudioId && recipientStudioSlugOrHint && senderAgentId) {
       try {
         // Reuse the shared resolution function (worktree path → branch fallback
         // for 'main', slug match for named hints).
@@ -378,7 +395,7 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
         resolvedRecipientStudioId = await resolveStudioHint(
           supabase,
           resolved.user.id,
-          recipientStudioHint,
+          recipientStudioSlugOrHint,
           senderAgentId,
           reqCtxForHint?.repoRoot
         );
@@ -452,7 +469,7 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
     // exclude self from trigger resolution.
     const selfStudioTarget = !!(
       senderAgentId &&
-      (recipientStudioId || recipientStudioHint) &&
+      (recipientStudioId || recipientStudioSlugOrHint) &&
       allRecipients.includes(senderAgentId)
     );
 
@@ -549,8 +566,8 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
           ...(isSelfStudioMessage && resolvedRecipientStudioId
             ? { studioId: resolvedRecipientStudioId }
             : {}),
-          ...(isSelfStudioMessage && !resolvedRecipientStudioId && recipientStudioHint
-            ? { studioHint: recipientStudioHint }
+          ...(isSelfStudioMessage && !resolvedRecipientStudioId && recipientStudioSlugOrHint
+            ? { studioHint: recipientStudioSlugOrHint }
             : {}),
         };
         const result = gateway.dispatchTrigger(payload);
@@ -591,7 +608,7 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
 
   // ── Legacy path: simple inbox message (no threadKey) ──
   const hasRoutingAnchor = Boolean(
-    effectiveRecipientSessionId || recipientStudioId || recipientStudioHint
+    effectiveRecipientSessionId || recipientStudioId || recipientStudioSlugOrHint
   );
   const requiresRoutingAnchor = Boolean(senderAgentId) && messageType !== 'message';
   const missingRoutingAnchor = requiresRoutingAnchor && !hasRoutingAnchor;
@@ -622,7 +639,10 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
       recipient: {
         sessionId: effectiveRecipientSessionId || null,
         studioId: recipientStudioId || null,
-        studioHint: recipientStudioHint || null,
+        // Metadata field is `studioHint` for backward compat with mission.ts
+        // and other consumers that read this blob. recipientStudioSlug feeds
+        // into the same slot since both resolve via resolveStudioHint.
+        studioHint: recipientStudioSlugOrHint || null,
       },
     },
   };
@@ -695,7 +715,7 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
       priority,
       recipientSessionId: effectiveRecipientSessionId,
       studioId: recipientStudioId,
-      studioHint: recipientStudioHint,
+      studioHint: recipientStudioSlugOrHint,
     };
 
     logger.info('Inbox message trigger dispatched (async)', {
@@ -736,13 +756,13 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
           threadKey: null,
           recipientSessionId: effectiveRecipientSessionId || null,
           recipientStudioId: recipientStudioId || null,
-          recipientStudioHint: recipientStudioHint || null,
+          recipientStudioSlug: recipientStudioSlugOrHint || null,
           createdAt: message.created_at,
           trigger: triggerResult,
           ...(missingRoutingAnchor
             ? {
                 routingHint:
-                  'Actionable handoff is missing a routing anchor. Add one of: threadKey, recipientSessionId, recipientStudioId, or recipientStudioHint.',
+                  'Actionable handoff is missing a routing anchor. Add one of: threadKey, recipientSessionId, recipientStudioId, or recipientStudioSlug.',
               }
             : {}),
           ...(missingSenderSession

--- a/packages/api/src/mcp/tools/thread-handlers.test.ts
+++ b/packages/api/src/mcp/tools/thread-handlers.test.ts
@@ -471,6 +471,22 @@ describe('handleSendToInbox - validation', () => {
       )
     ).rejects.toThrow('only valid for single-recipient sends');
   });
+
+  it('should reject recipients[] with recipientStudioSlug', async () => {
+    const mockDc = createMockDataComposer();
+    await expect(
+      handleSendToInbox(
+        {
+          email: 'test@test.com',
+          recipients: ['lumen'],
+          threadKey: 'pr:32',
+          recipientStudioSlug: 'wren-review',
+          content: 'test',
+        },
+        mockDc as never
+      )
+    ).rejects.toThrow('only valid for single-recipient sends');
+  });
 });
 
 describe('handleSendToInbox - thread routing', () => {
@@ -544,6 +560,46 @@ describe('handleSendToInbox - thread routing', () => {
     expect(parsed.threadKey).toBeNull();
     // Should have gone to agent_inbox
     expect(mockSb.from).toHaveBeenCalledWith('agent_inbox');
+  });
+
+  it('should surface recipientStudioSlug in the legacy-path response', async () => {
+    const mockSb = createThreadMockSupabase();
+    const mockDc = createMockDataComposer(mockSb);
+
+    const result = await handleSendToInbox(
+      {
+        email: 'test@test.com',
+        recipientAgentId: 'lumen',
+        senderAgentId: 'wren',
+        recipientStudioSlug: 'wren-review',
+        content: 'Direct slug-routed message',
+      },
+      mockDc as never
+    );
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.success).toBe(true);
+    expect(parsed.recipientStudioSlug).toBe('wren-review');
+  });
+
+  it('should treat legacy recipientStudioHint="main" as a slug alias', async () => {
+    const mockSb = createThreadMockSupabase();
+    const mockDc = createMockDataComposer(mockSb);
+
+    const result = await handleSendToInbox(
+      {
+        email: 'test@test.com',
+        recipientAgentId: 'lumen',
+        senderAgentId: 'wren',
+        recipientStudioHint: 'main',
+        content: 'Legacy hint caller',
+      },
+      mockDc as never
+    );
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.success).toBe(true);
+    expect(parsed.recipientStudioSlug).toBe('main');
   });
 
   it('should trigger all recipients on thread creation', async () => {


### PR DESCRIPTION
## Summary

Adds `recipientStudioSlug` as a general-purpose alias on `send_to_inbox` for studio routing. The existing `recipientStudioHint` was typed as `z.enum(['main'])` so callers could only target the root-repo studio. `resolveStudioHint()` on the server already does a generic `studios.slug` lookup — only the MCP schema was narrow.

- `recipientStudioSlug: z.string().min(1).max(100)` — accepts any slug
- `recipientStudioHint: z.enum(['main'])` — kept as deprecated alias for backward compat (e.g., `packages/cli/src/commands/agent.ts:105`)
- Both merge into `recipientStudioSlugOrHint` for downstream use; `recipientStudioSlug` wins when both provided
- Metadata blob subfield stays `studioHint` for mission.ts backward compat (`cli/commands/mission.ts:167`) — only the MCP param name changes
- Response field renamed to `recipientStudioSlug`; routing-hint error message updated

## Why

Conor's words: "resolving a studio id can be a pain." This lets senders target a teammate's named studio by slug (e.g., `wren-review`) instead of needing to look up the UUID. Unblocks re-dispatching `thread:pcp-to-ink-rename` via slug once the debug-logging PR lands.

## Test plan

- [x] Added 3 tests in `thread-handlers.test.ts`:
  - Reject `recipients[] + recipientStudioSlug` for multi-recipient sends
  - Surface `recipientStudioSlug` in legacy-path response
  - Confirm `recipientStudioHint: 'main'` still routes through the legacy alias
- [x] All 32 tests pass locally
- [x] Type-check clean for inbox-handlers.ts + thread-handlers.test.ts

— Wren