### PR TITLE
feat: observability for dispatch routing fall-through (by Wren)

### DIFF
--- a/packages/api/src/channels/agent-gateway.ts
+++ b/packages/api/src/channels/agent-gateway.ts
@@ -151,6 +151,11 @@ export class AgentGateway extends EventEmitter {
       to: payload.toAgentId,
       type: payload.triggerType,
       priority: payload.priority,
+      threadKey: payload.threadKey || null,
+      threadMessageId: payload.threadMessageId || null,
+      recipientSessionId: payload.recipientSessionId || null,
+      studioId: payload.studioId || null,
+      studioHint: payload.studioHint || null,
     });
 
     const { handler, isDefaultHandler } = this.resolveHandler(payload);

--- a/packages/api/src/mcp/tools/inbox-handlers.ts
+++ b/packages/api/src/mcp/tools/inbox-handlers.ts
@@ -484,6 +484,10 @@ export async function handleSendToInbox(args: unknown, dataComposer: DataCompose
       type: messageType,
       isNewThread: thread.isNew,
       triggering: agentsToTrigger,
+      recipientStudioId: recipientStudioId || null,
+      recipientStudioHint: recipientStudioHint || null,
+      resolvedRecipientStudioId: resolvedRecipientStudioId || null,
+      effectiveRecipientSessionId: effectiveRecipientSessionId || null,
     });
 
     // Dispatch triggers with session routing from thread history

--- a/packages/api/src/services/sessions/session-service.ts
+++ b/packages/api/src/services/sessions/session-service.ts
@@ -943,7 +943,25 @@ export class SessionService implements ISessionService {
             agentId,
             matchCount: matches.length,
           });
+        } else {
+          // matches.length === 0 — the common silent fall-through case: studios
+          // exist for this agent but none of their patterns match this threadKey.
+          // Previously invisible; now log so dispatch-routing failures are
+          // traceable (see thread:pcp-to-ink-rename 2026-04-17 post-mortem).
+          logger.warn('[StudioResolve] No studio pattern matched threadKey, falling through', {
+            threadKey: options.threadKey,
+            agentId,
+            candidateStudios: patternStudios.map((s) => ({
+              id: s.id,
+              patterns: s.route_patterns,
+            })),
+          });
         }
+      } else {
+        logger.debug('[StudioResolve] No studios with route_patterns for agent', {
+          threadKey: options.threadKey,
+          agentId,
+        });
       }
     }
 
@@ -959,6 +977,11 @@ export class SessionService implements ISessionService {
       .maybeSingle();
 
     if (agentStudio?.id) {
+      logger.debug("[StudioResolve] Fell back to agent's most recent studio", {
+        threadKey: options.threadKey || null,
+        agentId,
+        studioId: agentStudio.id,
+      });
       return agentStudio.id;
     }
 
@@ -968,7 +991,14 @@ export class SessionService implements ISessionService {
 
     // 5) Shared per-user main studio fallback
     const mainStudioId = await this.resolveMainStudioId(userId, options.repoRoot, agentId);
-    if (mainStudioId) return mainStudioId;
+    if (mainStudioId) {
+      logger.debug('[StudioResolve] Fell back to main studio', {
+        threadKey: options.threadKey || null,
+        agentId,
+        studioId: mainStudioId,
+      });
+      return mainStudioId;
+    }
 
     // Codex is worktree-sensitive: keep a deterministic warning when no studio could be resolved.
     if (options.backend === 'codex-cli') {


### PR DESCRIPTION
## Summary

The 2026-04-17 `thread:pcp-to-ink-rename` misroute happened inside a black box. `send_to_inbox` didn't pass `recipientStudioId`, no route pattern matched `thread:*`, and `resolveStudioId()` silently picked an idle fallback studio that never woke. Zero logs between "Thread message sent" and the eventual no-op.

This PR lights up every stage of the dispatch path:

1. **`inbox-handlers.ts` "Thread message sent"** — extends with `recipientStudioId`, `recipientStudioHint`, `resolvedRecipientStudioId`, `effectiveRecipientSessionId`. Now visible from the send side whether any studio hint was passed.

2. **`agent-gateway.ts` "Dispatching trigger"** — extends with `threadKey`, `threadMessageId`, `recipientSessionId`, `studioId`, `studioHint`. The payload landing at the gateway is now visible (was: from/to/type/priority only).

3. **`session-service.ts` `resolveStudioId` route-pattern step** — the critical one:
   - **WARN** when `route_patterns` exist for this agent but none match this threadKey (`matches.length === 0` was silent — this is the common silent fall-through that masked the bug). Log includes candidate studios + their patterns.
   - **DEBUG** when the agent has no studios with `route_patterns` at all.
   - **DEBUG** when falling back to agent's most recent studio (step 4).
   - **DEBUG** when falling back to the main studio (step 5).

## Why

Blocks re-dispatching `thread:pcp-to-ink-rename` — until we can see why the `--wren` shadow studio wasn't picked, we're guessing. Conor's words from the session: "the simple truth is we didn't include the studio id." Now future mis-routes leave a breadcrumb trail.

No behavioral change — logs only.

## Test plan

- [x] `npx vitest run packages/api/src/mcp/tools/thread-handlers.test.ts packages/api/src/channels/agent-gateway.test.ts packages/api/src/services/sessions/` — 142 passing
- [x] Type-check clean for the three touched files

— Wren