### PR TITLE
fix: 2FA approval flow auth + env var + settings schema (by Wren)

### DIFF
--- a/packages/api/src/routes/admin-approval-requests.test.ts
+++ b/packages/api/src/routes/admin-approval-requests.test.ts
@@ -267,14 +267,16 @@ describe('POST /approval-requests', () => {
       error: null,
     });
 
+    const STUDIO_UUID = '11111111-2222-3333-4444-555555555555';
+    const SESSION_UUID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
     const handler = findRouteHandler('post', '/approval-requests');
     const req = createAuthenticatedReq({
       body: {
         tool: 'Bash',
         args: 'docker push registry/app',
         reason: 'deploy',
-        studioId: 'studio-7',
-        sessionId: 'sess-9',
+        studioId: STUDIO_UUID,
+        sessionId: SESSION_UUID,
         timeoutSeconds: 300,
       },
     });
@@ -295,13 +297,33 @@ describe('POST /approval-requests', () => {
         tool: 'Bash',
         args: 'docker push registry/app',
         reason: 'deploy',
-        studio_id: 'studio-7',
-        session_id: 'sess-9',
+        studio_id: STUDIO_UUID,
+        session_id: SESSION_UUID,
         timeout_seconds: 300,
         requesting_agent_id: 'unknown', // no x-ink-context header in this test
       })
     );
     expect(insertChain.select).toHaveBeenCalled();
+  });
+
+  it('coerces non-UUID studio_id/session_id to null (e.g. "main" from root repo)', async () => {
+    installInsertMock({
+      data: { id: 'req-main', status: 'pending', expires_at: futureIso() },
+      error: null,
+    });
+
+    const handler = findRouteHandler('post', '/approval-requests');
+    const req = createAuthenticatedReq({
+      body: { tool: 'Bash', args: 'ls', studioId: 'main', sessionId: 'not-a-uuid' },
+    });
+    const res = createMockRes();
+    await handler!(req as Request, res as unknown as Response);
+
+    expect(res._status).toBe(201);
+    const insertFn = mockSupabaseFrom.mock.results[0].value.insert as ReturnType<typeof vi.fn>;
+    expect(insertFn).toHaveBeenCalledWith(
+      expect.objectContaining({ studio_id: null, session_id: null })
+    );
   });
 
   it('resolves requestingAgentId from the x-ink-context header', async () => {

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -6748,12 +6748,19 @@ router.post('/approval-requests', async (req: Request, res: Response) => {
       }
     }
 
+    // studio_id is a UUID column. The CLI sends the literal string "main"
+    // for the root repo (see .ink/identity.json), which would fail insert —
+    // coerce non-UUID values to null.
+    const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    const studioIdForInsert = studioId && UUID_RE.test(studioId) ? studioId : null;
+    const sessionIdForInsert = sessionId && UUID_RE.test(sessionId) ? sessionId : null;
+
     const { data, error } = await supabase
       .from('approval_requests')
       .insert({
         user_id: authReq.pcpUserId,
-        studio_id: studioId || null,
-        session_id: sessionId || null,
+        studio_id: studioIdForInsert,
+        session_id: sessionIdForInsert,
         requesting_agent_id: requestingAgentId,
         tool,
         args: args || null,
@@ -6765,6 +6772,13 @@ router.post('/approval-requests', async (req: Request, res: Response) => {
       .single();
 
     if (error) {
+      logger.error('Failed to insert approval request', {
+        error: error.message,
+        code: error.code,
+        studioId,
+        sessionId,
+        tool,
+      });
       res.status(500).json(errorJson('Failed to create approval request', error));
       return;
     }

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -94,6 +94,7 @@ const ADMIN_ACCESS_TOKEN_LIFETIME_SECONDS = 3600; // 1 hour
 const ADMIN_REFRESH_TOKEN_LIFETIME_DAYS = 90;
 const ADMIN_CLIENT_ID = 'dashboard';
 const MCP_CLI_TRANSCRIPT_ROUTE = /^\/sessions(?:\/synced|\/[^/]+\/(?:sync-transcript|transcript))$/;
+const MCP_CLI_APPROVAL_ROUTE = /^\/approval-requests(?:\/[^/]+\/status)?$/;
 const DEFAULT_SESSION_LOG_LIMIT = 50;
 const MAX_SESSION_LOG_LIMIT = 200;
 const ACTIVITY_PREVIEW_LIMIT_PER_SESSION = 3;
@@ -963,12 +964,13 @@ async function adminAuthMiddleware(req: Request, res: Response, next: NextFuncti
       userEmail = payload.email;
     }
 
-    // Convenience path: allow standard MCP access tokens for transcript sync,
-    // so CLI users can run sync without dashboard cookie auth.
+    // Convenience path: allow standard MCP access tokens for CLI-driven flows
+    // (transcript sync, 2FA approval requests) so CLI users can operate without
+    // dashboard cookie auth.
     if (
       !pcpUserId &&
       (req.method === 'POST' || req.method === 'GET') &&
-      MCP_CLI_TRANSCRIPT_ROUTE.test(req.path)
+      (MCP_CLI_TRANSCRIPT_ROUTE.test(req.path) || MCP_CLI_APPROVAL_ROUTE.test(req.path))
     ) {
       const mcpPayload = verifyPcpAccessToken(token, 'mcp_access');
       if (mcpPayload) {

--- a/packages/cli/src/commands/hooks.test.ts
+++ b/packages/cli/src/commands/hooks.test.ts
@@ -944,19 +944,33 @@ describe('loadApprovalSet', () => {
     expect(loadApprovalSet(TEST_DIR)).toEqual([]);
   });
 
-  it('returns approvalRequired array from settings.local.json', () => {
+  it('returns permissions.approvalRequired array from settings.local.json', () => {
     const configDir = join(TEST_DIR, '.claude');
     mkdirSync(configDir, { recursive: true });
     writeFileSync(
       join(configDir, 'settings.local.json'),
       JSON.stringify({
-        approvalRequired: ['Bash(docker push *)', 'mcp__supabase__apply_migration'],
+        permissions: {
+          approvalRequired: ['Bash(docker push *)', 'mcp__supabase__apply_migration'],
+        },
       })
     );
     expect(loadApprovalSet(TEST_DIR)).toEqual([
       'Bash(docker push *)',
       'mcp__supabase__apply_migration',
     ]);
+  });
+
+  it('falls back to top-level approvalRequired for backcompat', () => {
+    const configDir = join(TEST_DIR, '.claude');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(
+      join(configDir, 'settings.local.json'),
+      JSON.stringify({
+        approvalRequired: ['Bash(docker push *)'],
+      })
+    );
+    expect(loadApprovalSet(TEST_DIR)).toEqual(['Bash(docker push *)']);
   });
 
   it('returns empty array when approvalRequired key is absent', () => {

--- a/packages/cli/src/commands/hooks.ts
+++ b/packages/cli/src/commands/hooks.ts
@@ -2003,7 +2003,10 @@ export function loadApprovalSet(cwd: string): string[] {
     const settingsPath = join(cwd, '.claude', 'settings.local.json');
     if (!existsSync(settingsPath)) return [];
     const settings = JSON.parse(readFileSync(settingsPath, 'utf-8'));
-    return settings.approvalRequired || [];
+    // Claude Code rejects unknown top-level fields; nest under `permissions`
+    // which accepts additionalProperties. Fall back to top-level for
+    // backcompat with any config written before this fix.
+    return settings.permissions?.approvalRequired || settings.approvalRequired || [];
   } catch {
     return [];
   }
@@ -2068,7 +2071,7 @@ async function onToolApprovalHandler(options?: { backend?: string }): Promise<vo
   if (token) headers.Authorization = `Bearer ${token}`;
 
   // Forward context header so server knows the agent/studio
-  const contextToken = process.env.INK_CONTEXT_TOKEN?.trim();
+  const contextToken = process.env.INK_CONTEXT?.trim();
   if (contextToken) headers['x-ink-context'] = contextToken;
 
   const sessionId = process.env.INK_SESSION_ID?.trim() || undefined;

--- a/packages/cli/src/commands/hooks.ts
+++ b/packages/cli/src/commands/hooks.ts
@@ -2047,11 +2047,20 @@ async function onToolApprovalHandler(options?: { backend?: string }): Promise<vo
   const cwd = process.cwd();
 
   // Claude Code PreToolUse passes: { tool_name, tool_input }
+  // For Bash, tool_input is { command, description } — match against command
+  // so patterns like `Bash(docker push *)` work (Claude Code native syntax).
+  // For other tools, fall back to JSON so patterns can still inspect the full
+  // input shape if ever needed.
   const toolName = (stdin.tool_name as string) || '';
-  const toolInput =
-    typeof stdin.tool_input === 'string'
-      ? stdin.tool_input
-      : JSON.stringify(stdin.tool_input || '');
+  const rawInput = stdin.tool_input;
+  let toolInput: string;
+  if (typeof rawInput === 'string') {
+    toolInput = rawInput;
+  } else if (rawInput && typeof (rawInput as { command?: unknown }).command === 'string') {
+    toolInput = (rawInput as { command: string }).command;
+  } else {
+    toolInput = JSON.stringify(rawInput || '');
+  }
 
   hookLog('on_tool_approval', { toolName, toolInputPreview: toolInput.substring(0, 100) });
 


### PR DESCRIPTION
## Summary

Five bugs found while testing PR #321's 2FA approval flow end-to-end. All five now fixed, full live test passed.

**1. Stale env var `INK_CONTEXT_TOKEN` → `INK_CONTEXT`**
PR #322 renamed the context env var but the CLI PreToolUse hook still read the old name, so context was always empty on POST.

**2. Admin middleware rejected `mcp_access` tokens on `/approval-requests`**
The existing convenience path only covered transcript sync. Extended to a new `MCP_CLI_APPROVAL_ROUTE` (POST + status GET) so CLI-driven 2FA works without dashboard cookie auth.

**3. Claude Code `settings.local.json` rejects unknown top-level fields**
The schema permits `additionalProperties` under `permissions.*` but not at the top level. Moved `approvalRequired` under `permissions.approvalRequired`. Updated `loadApprovalSet` to prefer the nested location with a top-level fallback for backcompat.

**4. Hook pattern matching never matched Bash patterns**
`matchesApprovalSet` was being called against `JSON.stringify(tool_input)` — e.g. `{"command":"docker push ..."}` — so `Bash(docker push *)` patterns could never anchor. Now extract `tool_input.command` for Bash (matching Claude Code's native permission semantics) and fall back to JSON for other tools.

**5. Server silently 500'd on `studioId: "main"`**
`.ink/identity.json` uses the literal string `"main"` for the root repo. The server passed it verbatim into an `UUID` column, triggering a Postgres error — and the handler returned 500 with no `logger.error`, so the failure was invisible in `combined.log`. Coerce non-UUID `studio_id`/`session_id` to null before insert, and add a log line so the next bug at this layer shows up.

## Verification (full end-to-end)

```
echo 2fa-test final e2e
  ↓ PreToolUse hook matches Bash(echo 2fa-test*)
  ↓ POST /api/admin/approval-requests → 201, requestId=8e76290d-be04-441a-8ad6-897bea03f696
  ↓ Telegram chat 726555973, message 1393
  ↓ (user approves in Telegram)
  ↓ /status returns granted, hook exits 0
  ↓ tool runs → "2fa-test final e2e"
```

## Test plan

- [x] admin-auth + admin-approval-requests unit tests pass (47 tests)
- [x] hooks.test.ts passes — added backcompat test for top-level `approvalRequired`
- [x] Live end-to-end: pattern match → POST → Telegram → approve → unblock → tool runs

— Wren