### PR TITLE
feat: update_task_group MCP tool (by Wren)

### DIFF
--- a/packages/api/src/mcp/tools/index.ts
+++ b/packages/api/src/mcp/tools/index.ts
@@ -25,8 +25,10 @@ import {
   handleAddTaskComment,
   handleCreateTaskGroup,
   handleListTaskGroups,
+  handleUpdateTaskGroup,
   createTaskGroupSchema,
   listTaskGroupsSchema,
+  updateTaskGroupSchema,
 } from './task-handlers';
 
 import { handleSendResponse, handleGetPendingMessages, handleMarkRead } from './response-handlers';
@@ -989,6 +991,39 @@ User can be identified by ONE of: userId, email, phone, or platform + platformId
         return await handleCreateTaskGroup(args, dataComposer);
       } catch (error) {
         logger.error('Error in create_task_group:', error);
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                success: false,
+                error: error instanceof Error ? error.message : 'Unknown error',
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  server.registerTool(
+    'update_task_group',
+    {
+      description: `Update a task group — change its status (active/paused/completed/cancelled), title, description, priority, tags, metadata, thread key, or owner. Use this to close a group when its work ships (status: completed) or is abandoned (status: cancelled), or to reassign ownership.
+
+Pass \`closedReason\` as a shorthand to record why a group was closed — it's stored under \`metadata.closed_reason\`.
+
+Metadata is merged into existing metadata by default. Pass \`mergeMetadata: false\` to replace wholesale.
+
+User can be identified by ONE of: userId, email, phone, or platform + platformId`,
+      inputSchema: updateTaskGroupSchema.shape,
+    },
+    async (args) => {
+      try {
+        return await handleUpdateTaskGroup(args, dataComposer);
+      } catch (error) {
+        logger.error('Error in update_task_group:', error);
         return {
           content: [
             {

--- a/packages/api/src/mcp/tools/task-handlers.integration.test.ts
+++ b/packages/api/src/mcp/tools/task-handlers.integration.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Task Handlers — Integration Tests
+ *
+ * Exercises handleUpdateTaskGroup against the real Supabase database.
+ * The repository-level `update()` is already covered by unit tests with
+ * mocks; this test verifies the MCP handler end-to-end: real DB insert,
+ * real update, real metadata merge behavior.
+ *
+ * Requires:
+ *   - .env.local with SUPABASE_URL + SUPABASE_SECRET_KEY
+ *   - ~/.ink/config.json with userId
+ *
+ * Skipped automatically in CI / when credentials are unavailable.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import dotenv from 'dotenv';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import { readFileSync, existsSync } from 'fs';
+import { resolve } from 'path';
+
+const projectRoot = resolve(__dirname, '../../../../../');
+const envLocalPath = resolve(projectRoot, '.env.local');
+if (existsSync(envLocalPath)) {
+  const parsed = dotenv.parse(readFileSync(envLocalPath));
+  for (const [key, value] of Object.entries(parsed)) {
+    if (!process.env[key]) process.env[key] = value;
+  }
+}
+
+if (!process.env.PCP_PORT_BASE) process.env.PCP_PORT_BASE = '9997';
+
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_SECRET_KEY || process.env.SUPABASE_SERVICE_KEY;
+
+const configPath = resolve(process.env.HOME || '', '.ink/config.json');
+const inkConfig = existsSync(configPath) ? JSON.parse(readFileSync(configPath, 'utf-8')) : {};
+const TEST_USER_ID: string | undefined = inkConfig.userId;
+
+const canRun = !!SUPABASE_URL && !!SUPABASE_KEY && !!TEST_USER_ID;
+
+// Bypass auth helpers that require request context in a server
+vi.mock('../../auth/enforce-identity', () => ({
+  getEffectiveAgentId: vi.fn().mockReturnValue('wren'),
+}));
+vi.mock('../../utils/request-context', () => ({
+  setSessionContext: vi.fn(),
+  pinSessionAgent: vi.fn(),
+  getPinnedAgentId: vi.fn().mockReturnValue(null),
+  getRequestContext: vi.fn().mockReturnValue(undefined),
+}));
+// resolveUser is normally called via OAuth context; short-circuit it.
+vi.mock('../../services/user-resolver', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../services/user-resolver')>();
+  return {
+    ...actual,
+    resolveUser: vi.fn(async (args: { userId?: string }) => {
+      if (!args.userId) return null;
+      return { user: { id: args.userId } as any, resolvedBy: 'userId' as const };
+    }),
+  };
+});
+
+describe.skipIf(!canRun)('handleUpdateTaskGroup (integration)', () => {
+  let client: SupabaseClient;
+  let dc: any;
+  const createdGroupIds: string[] = [];
+
+  beforeAll(async () => {
+    client = createClient(SUPABASE_URL!, SUPABASE_KEY!, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+
+    const { TaskGroupsRepository } = await import('../../data/repositories/task-groups.repository');
+
+    dc = {
+      getClient: () => client,
+      repositories: {
+        taskGroups: new TaskGroupsRepository(client),
+        projects: { findById: vi.fn().mockResolvedValue(null) },
+      },
+    };
+  }, 15_000);
+
+  afterAll(async () => {
+    if (!client || createdGroupIds.length === 0) return;
+    await client.from('task_groups').delete().in('id', createdGroupIds);
+  }, 10_000);
+
+  async function seedGroup(
+    overrides: Partial<Parameters<typeof dc.repositories.taskGroups.create>[0]> = {}
+  ): Promise<string> {
+    const group = await dc.repositories.taskGroups.create({
+      user_id: TEST_USER_ID!,
+      title: `__update_integration_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+      description: 'Integration test — safe to delete',
+      priority: 'low',
+      tags: ['__test'],
+      metadata: { seeded: true },
+      ...overrides,
+    });
+    createdGroupIds.push(group.id);
+    return group.id;
+  }
+
+  it('closes a group with status + closedReason, persisting to the real DB', async () => {
+    const { handleUpdateTaskGroup } = await import('./task-handlers');
+    const groupId = await seedGroup();
+
+    const response = await handleUpdateTaskGroup(
+      {
+        userId: TEST_USER_ID!,
+        groupId,
+        status: 'completed',
+        closedReason: 'Shipped via integration test',
+      } as any,
+      dc
+    );
+    expect(response.isError).toBeFalsy();
+
+    const { data } = await client
+      .from('task_groups')
+      .select('status, metadata')
+      .eq('id', groupId)
+      .single();
+
+    expect(data?.status).toBe('completed');
+    expect(data?.metadata).toMatchObject({
+      seeded: true,
+      closed_reason: 'Shipped via integration test',
+    });
+  });
+
+  it('merges metadata by default, preserving pre-existing keys', async () => {
+    const { handleUpdateTaskGroup } = await import('./task-handlers');
+    const groupId = await seedGroup();
+
+    await handleUpdateTaskGroup(
+      {
+        userId: TEST_USER_ID!,
+        groupId,
+        metadata: { studioSlug: 'wren-omega' },
+      } as any,
+      dc
+    );
+
+    const { data } = await client.from('task_groups').select('metadata').eq('id', groupId).single();
+
+    expect(data?.metadata).toMatchObject({ seeded: true, studioSlug: 'wren-omega' });
+  });
+
+  it('replaces metadata when mergeMetadata is false', async () => {
+    const { handleUpdateTaskGroup } = await import('./task-handlers');
+    const groupId = await seedGroup();
+
+    await handleUpdateTaskGroup(
+      {
+        userId: TEST_USER_ID!,
+        groupId,
+        metadata: { onlyThis: true },
+        mergeMetadata: false,
+      } as any,
+      dc
+    );
+
+    const { data } = await client.from('task_groups').select('metadata').eq('id', groupId).single();
+
+    expect(data?.metadata).toEqual({ onlyThis: true });
+    expect((data?.metadata as Record<string, unknown>)?.seeded).toBeUndefined();
+  });
+
+  it('refuses to update a group owned by a different user', async () => {
+    const { handleUpdateTaskGroup } = await import('./task-handlers');
+    const groupId = await seedGroup();
+
+    const response = await handleUpdateTaskGroup(
+      {
+        userId: '00000000-0000-0000-0000-000000000999',
+        groupId,
+        status: 'cancelled',
+      } as any,
+      dc
+    );
+
+    expect(response.isError).toBe(true);
+    const body = JSON.parse(response.content[0].text);
+    // resolveUser short-circuits on unknown userId → 'User not found'.
+    // If a real user happened to own this ID, ownership check fires instead —
+    // we accept either as valid rejection.
+    expect(['User not found', 'Task group does not belong to this user']).toContain(body.error);
+
+    const { data } = await client.from('task_groups').select('status').eq('id', groupId).single();
+    expect(data?.status).toBe('active');
+  });
+});

--- a/packages/api/src/mcp/tools/task-handlers.integration.test.ts
+++ b/packages/api/src/mcp/tools/task-handlers.integration.test.ts
@@ -192,4 +192,69 @@ describe.skipIf(!canRun)('handleUpdateTaskGroup (integration)', () => {
     const { data } = await client.from('task_groups').select('status').eq('id', groupId).single();
     expect(data?.status).toBe('active');
   });
+
+  it('rejects identityId that is not in agent_identities for this user', async () => {
+    const { handleUpdateTaskGroup } = await import('./task-handlers');
+    const groupId = await seedGroup();
+
+    const response = await handleUpdateTaskGroup(
+      {
+        userId: TEST_USER_ID!,
+        groupId,
+        // Valid UUID format, but will not match any row scoped to TEST_USER_ID.
+        identityId: '00000000-0000-4000-a000-000000000000',
+      } as any,
+      dc
+    );
+
+    expect(response.isError).toBe(true);
+    const body = JSON.parse(response.content[0].text);
+    expect(body.error).toBe('identityId not found or does not belong to this user/workspace.');
+
+    // Confirm no partial write — identity_id is still null.
+    const { data } = await client
+      .from('task_groups')
+      .select('identity_id')
+      .eq('id', groupId)
+      .single();
+    expect(data?.identity_id).toBeNull();
+  });
+
+  it('accepts a real identityId that belongs to this user', async () => {
+    const { handleUpdateTaskGroup } = await import('./task-handlers');
+
+    // Find any agent identity belonging to the test user — any real row works
+    // to exercise the accept path against the real DB.
+    const { data: identity } = await client
+      .from('agent_identities')
+      .select('id')
+      .eq('user_id', TEST_USER_ID!)
+      .limit(1)
+      .single();
+
+    if (!identity) {
+      // No agent_identities rows for this user — skip rather than flake.
+      return;
+    }
+
+    const groupId = await seedGroup();
+
+    const response = await handleUpdateTaskGroup(
+      {
+        userId: TEST_USER_ID!,
+        groupId,
+        identityId: identity.id,
+      } as any,
+      dc
+    );
+
+    expect(response.isError).toBeFalsy();
+
+    const { data } = await client
+      .from('task_groups')
+      .select('identity_id')
+      .eq('id', groupId)
+      .single();
+    expect(data?.identity_id).toBe(identity.id);
+  });
 });

--- a/packages/api/src/mcp/tools/task-handlers.test.ts
+++ b/packages/api/src/mcp/tools/task-handlers.test.ts
@@ -14,6 +14,7 @@ import {
   handleGetTaskStats,
   handleCreateTaskGroup,
   handleListTaskGroups,
+  handleUpdateTaskGroup,
 } from './task-handlers';
 
 // =====================================================
@@ -1295,6 +1296,168 @@ describe('handleCreateTaskGroup', () => {
     expect(response.isError).toBe(true);
     expect(data.error).toBe('User not found');
     expect(dc.repositories.taskGroups.create).not.toHaveBeenCalled();
+  });
+});
+
+// =====================================================
+// handleUpdateTaskGroup
+// =====================================================
+
+describe('handleUpdateTaskGroup', () => {
+  let dc: ReturnType<typeof createMockDataComposer>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dc = createMockDataComposer();
+    resolveUserMock.mockResolvedValue({
+      user: { id: 'user-123' } as any,
+      resolvedBy: 'userId',
+    });
+  });
+
+  const existingGroup = {
+    id: '11111111-2222-3333-4444-555555555555',
+    user_id: 'user-123',
+    identity_id: null,
+    project_id: null,
+    title: 'Feature X',
+    description: null,
+    status: 'active',
+    priority: 'normal',
+    tags: [],
+    metadata: { preset: 'wren' },
+    autonomous: false,
+    max_sessions: null,
+    sessions_used: 0,
+    context_summary: null,
+    next_run_after: null,
+    output_target: null,
+    output_status: null,
+    thread_key: null,
+    owner_agent_id: null,
+    created_at: '2026-04-18T10:00:00Z',
+    updated_at: '2026-04-18T10:00:00Z',
+  };
+
+  it('closes a group with completed status and records closedReason in metadata', async () => {
+    dc.repositories.taskGroups.findById.mockResolvedValue(existingGroup);
+    dc.repositories.taskGroups.update.mockResolvedValue({
+      ...existingGroup,
+      status: 'completed',
+      metadata: { preset: 'wren', closed_reason: 'Shipped via PR #100' },
+    });
+
+    const response = await handleUpdateTaskGroup(
+      {
+        userId: 'user-123',
+        groupId: '11111111-2222-3333-4444-555555555555',
+        status: 'completed',
+        closedReason: 'Shipped via PR #100',
+      } as any,
+      dc as any
+    );
+
+    const data = parseResponse(response);
+    expect(response.isError).toBeFalsy();
+    expect(data.success).toBe(true);
+    expect(data.group.status).toBe('completed');
+    expect(data.group.metadata).toEqual({ preset: 'wren', closed_reason: 'Shipped via PR #100' });
+
+    expect(dc.repositories.taskGroups.update).toHaveBeenCalledWith(
+      '11111111-2222-3333-4444-555555555555',
+      expect.objectContaining({
+        status: 'completed',
+        metadata: { preset: 'wren', closed_reason: 'Shipped via PR #100' },
+      })
+    );
+  });
+
+  it('merges metadata by default, preserving existing keys', async () => {
+    dc.repositories.taskGroups.findById.mockResolvedValue(existingGroup);
+    dc.repositories.taskGroups.update.mockResolvedValue({
+      ...existingGroup,
+      metadata: { preset: 'wren', studioSlug: 'wren-omega' },
+    });
+
+    await handleUpdateTaskGroup(
+      {
+        userId: 'user-123',
+        groupId: '11111111-2222-3333-4444-555555555555',
+        metadata: { studioSlug: 'wren-omega' },
+      } as any,
+      dc as any
+    );
+
+    expect(dc.repositories.taskGroups.update).toHaveBeenCalledWith(
+      '11111111-2222-3333-4444-555555555555',
+      expect.objectContaining({
+        metadata: { preset: 'wren', studioSlug: 'wren-omega' },
+      })
+    );
+  });
+
+  it('replaces metadata when mergeMetadata is false', async () => {
+    dc.repositories.taskGroups.findById.mockResolvedValue(existingGroup);
+    dc.repositories.taskGroups.update.mockResolvedValue({
+      ...existingGroup,
+      metadata: { studioSlug: 'wren-omega' },
+    });
+
+    await handleUpdateTaskGroup(
+      {
+        userId: 'user-123',
+        groupId: '11111111-2222-3333-4444-555555555555',
+        metadata: { studioSlug: 'wren-omega' },
+        mergeMetadata: false,
+      } as any,
+      dc as any
+    );
+
+    expect(dc.repositories.taskGroups.update).toHaveBeenCalledWith(
+      '11111111-2222-3333-4444-555555555555',
+      expect.objectContaining({
+        metadata: { studioSlug: 'wren-omega' },
+      })
+    );
+  });
+
+  it('rejects update when group belongs to a different user', async () => {
+    dc.repositories.taskGroups.findById.mockResolvedValue({
+      ...existingGroup,
+      user_id: 'someone-else',
+    });
+
+    const response = await handleUpdateTaskGroup(
+      {
+        userId: 'user-123',
+        groupId: '11111111-2222-3333-4444-555555555555',
+        status: 'completed',
+      } as any,
+      dc as any
+    );
+
+    const data = parseResponse(response);
+    expect(response.isError).toBe(true);
+    expect(data.error).toBe('Task group does not belong to this user');
+    expect(dc.repositories.taskGroups.update).not.toHaveBeenCalled();
+  });
+
+  it('returns error when group does not exist', async () => {
+    dc.repositories.taskGroups.findById.mockResolvedValue(null);
+
+    const response = await handleUpdateTaskGroup(
+      {
+        userId: 'user-123',
+        groupId: '11111111-2222-3333-4444-555555555555',
+        status: 'completed',
+      } as any,
+      dc as any
+    );
+
+    const data = parseResponse(response);
+    expect(response.isError).toBe(true);
+    expect(data.error).toBe('Task group not found');
+    expect(dc.repositories.taskGroups.update).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/api/src/mcp/tools/task-handlers.test.ts
+++ b/packages/api/src/mcp/tools/task-handlers.test.ts
@@ -1459,6 +1459,134 @@ describe('handleUpdateTaskGroup', () => {
     expect(data.error).toBe('Task group not found');
     expect(dc.repositories.taskGroups.update).not.toHaveBeenCalled();
   });
+
+  it('rejects identityId that does not belong to this user', async () => {
+    dc.repositories.taskGroups.findById.mockResolvedValue(existingGroup);
+    // Identity lookup returns nothing — not owned by this user
+    (dc.getClient() as any).from().single.mockResolvedValueOnce({ data: null, error: null });
+
+    const response = await handleUpdateTaskGroup(
+      {
+        userId: 'user-123',
+        groupId: '11111111-2222-3333-4444-555555555555',
+        identityId: '99999999-9999-9999-9999-999999999999',
+      } as any,
+      dc as any
+    );
+
+    const data = parseResponse(response);
+    expect(response.isError).toBe(true);
+    expect(data.error).toBe('identityId not found or does not belong to this user/workspace.');
+    expect(dc.repositories.taskGroups.update).not.toHaveBeenCalled();
+  });
+
+  it('scopes identityId lookup to the workspace when request context supplies one', async () => {
+    dc.repositories.taskGroups.findById.mockResolvedValue(existingGroup);
+    const { getRequestContext } = await import('../../utils/request-context');
+    (getRequestContext as any).mockReturnValueOnce({
+      workspaceId: 'ws-match',
+    });
+    // Identity lookup returns nothing — same user, but different workspace
+    const chain = (dc.getClient() as any).from();
+    chain.single.mockResolvedValueOnce({ data: null, error: null });
+
+    const response = await handleUpdateTaskGroup(
+      {
+        userId: 'user-123',
+        groupId: '11111111-2222-3333-4444-555555555555',
+        identityId: '77777777-7777-7777-7777-777777777777',
+      } as any,
+      dc as any
+    );
+
+    const data = parseResponse(response);
+    expect(response.isError).toBe(true);
+    expect(data.error).toBe('identityId not found or does not belong to this user/workspace.');
+    expect(chain.eq).toHaveBeenCalledWith('workspace_id', 'ws-match');
+    expect(dc.repositories.taskGroups.update).not.toHaveBeenCalled();
+  });
+
+  it('accepts identityId that belongs to this user', async () => {
+    dc.repositories.taskGroups.findById.mockResolvedValue(existingGroup);
+    (dc.getClient() as any).from().single.mockResolvedValueOnce({
+      data: { id: '77777777-7777-7777-7777-777777777777' },
+      error: null,
+    });
+    dc.repositories.taskGroups.update.mockResolvedValue({
+      ...existingGroup,
+      identity_id: '77777777-7777-7777-7777-777777777777',
+    });
+
+    const response = await handleUpdateTaskGroup(
+      {
+        userId: 'user-123',
+        groupId: '11111111-2222-3333-4444-555555555555',
+        identityId: '77777777-7777-7777-7777-777777777777',
+      } as any,
+      dc as any
+    );
+
+    const data = parseResponse(response);
+    expect(response.isError).toBeFalsy();
+    expect(data.success).toBe(true);
+    expect(dc.repositories.taskGroups.update).toHaveBeenCalledWith(
+      '11111111-2222-3333-4444-555555555555',
+      expect.objectContaining({
+        identity_id: '77777777-7777-7777-7777-777777777777',
+      })
+    );
+  });
+
+  it('accepts explicit null identityId as a clear without a lookup', async () => {
+    dc.repositories.taskGroups.findById.mockResolvedValue(existingGroup);
+    dc.repositories.taskGroups.update.mockResolvedValue({
+      ...existingGroup,
+      identity_id: null,
+    });
+
+    await handleUpdateTaskGroup(
+      {
+        userId: 'user-123',
+        groupId: '11111111-2222-3333-4444-555555555555',
+        identityId: null,
+      } as any,
+      dc as any
+    );
+
+    // No identity lookup should have been issued — null bypasses validation.
+    const fromMock = (dc.getClient() as any).from;
+    expect(fromMock).not.toHaveBeenCalledWith('agent_identities');
+    expect(dc.repositories.taskGroups.update).toHaveBeenCalledWith(
+      '11111111-2222-3333-4444-555555555555',
+      expect.objectContaining({
+        identity_id: null,
+      })
+    );
+  });
+
+  it('does not touch identity_id when identityId is not provided', async () => {
+    dc.repositories.taskGroups.findById.mockResolvedValue(existingGroup);
+    dc.repositories.taskGroups.update.mockResolvedValue({
+      ...existingGroup,
+      status: 'paused',
+    });
+
+    await handleUpdateTaskGroup(
+      {
+        userId: 'user-123',
+        groupId: '11111111-2222-3333-4444-555555555555',
+        status: 'paused',
+      } as any,
+      dc as any
+    );
+
+    const fromMock = (dc.getClient() as any).from;
+    expect(fromMock).not.toHaveBeenCalledWith('agent_identities');
+    // Repository sees undefined for identity_id — repository's upsert logic is
+    // then responsible for leaving the column alone.
+    const call = (dc.repositories.taskGroups.update as any).mock.calls[0][1];
+    expect(call.identity_id).toBeUndefined();
+  });
 });
 
 // =====================================================

--- a/packages/api/src/mcp/tools/task-handlers.ts
+++ b/packages/api/src/mcp/tools/task-handlers.ts
@@ -703,6 +703,138 @@ export async function handleCreateTaskGroup(
   }
 }
 
+// ============================================================================
+// UPDATE TASK GROUP
+// ============================================================================
+
+export const updateTaskGroupSchema = z.object({
+  ...userIdentifierSchema.shape,
+  groupId: z.string().uuid().describe('Task group UUID to update'),
+  title: z.string().min(1).max(500).optional(),
+  description: z.string().nullable().optional(),
+  status: taskGroupStatusEnum.optional().describe('active | paused | completed | cancelled'),
+  priority: taskGroupPriorityEnum.optional(),
+  tags: z.array(z.string()).optional(),
+  metadata: z
+    .record(z.unknown())
+    .optional()
+    .describe(
+      'Metadata object. When provided with mergeMetadata=true (default), keys are merged into existing metadata; otherwise metadata is replaced.'
+    ),
+  mergeMetadata: z
+    .boolean()
+    .optional()
+    .default(true)
+    .describe(
+      'If true (default), merge provided metadata with existing; if false, replace wholesale'
+    ),
+  closedReason: z
+    .string()
+    .optional()
+    .describe(
+      'Shorthand for recording why a group was closed. Stored in metadata.closed_reason. Useful with status: completed|cancelled.'
+    ),
+  contextSummary: z.string().nullable().optional(),
+  outputTarget: taskGroupOutputTargetEnum.nullable().optional(),
+  outputStatus: taskGroupOutputStatusEnum.nullable().optional(),
+  threadKey: z.string().nullable().optional(),
+  ownerAgentId: z
+    .string()
+    .nullable()
+    .optional()
+    .describe('Agent slug owning this group (e.g. "wren"). Pass null to clear.'),
+  identityId: z
+    .string()
+    .uuid()
+    .nullable()
+    .optional()
+    .describe('Agent identity UUID. Pass null to clear.'),
+});
+
+export async function handleUpdateTaskGroup(
+  args: z.infer<typeof updateTaskGroupSchema>,
+  dataComposer: DataComposer
+): Promise<McpResponse> {
+  try {
+    const resolved = await resolveUser(args as UserIdentifier, dataComposer);
+    if (!resolved) {
+      return mcpResponse({ success: false, error: 'User not found' }, true);
+    }
+
+    const existing = await dataComposer.repositories.taskGroups.findById(args.groupId);
+    if (!existing) {
+      return mcpResponse({ success: false, error: 'Task group not found' }, true);
+    }
+    if (existing.user_id !== resolved.user.id) {
+      return mcpResponse(
+        { success: false, error: 'Task group does not belong to this user' },
+        true
+      );
+    }
+
+    const merge = args.mergeMetadata !== false;
+    let nextMetadata: Record<string, unknown> | undefined;
+    if (args.metadata !== undefined || args.closedReason !== undefined) {
+      const base = merge ? { ...(existing.metadata || {}) } : {};
+      if (args.metadata !== undefined) {
+        Object.assign(base, args.metadata);
+      }
+      if (args.closedReason !== undefined) {
+        base.closed_reason = args.closedReason;
+      }
+      nextMetadata = base;
+    }
+
+    const updated = await dataComposer.repositories.taskGroups.update(args.groupId, {
+      title: args.title,
+      description: args.description,
+      status: args.status,
+      priority: args.priority,
+      tags: args.tags,
+      metadata: nextMetadata,
+      context_summary: args.contextSummary,
+      output_target: args.outputTarget,
+      output_status: args.outputStatus,
+      thread_key: args.threadKey,
+      owner_agent_id: args.ownerAgentId,
+      identity_id: args.identityId,
+    });
+
+    return mcpResponse({
+      success: true,
+      group: {
+        id: updated.id,
+        title: updated.title,
+        description: updated.description,
+        status: updated.status,
+        priority: updated.priority,
+        tags: updated.tags,
+        metadata: updated.metadata,
+        projectId: updated.project_id,
+        identityId: updated.identity_id,
+        ownerAgentId: updated.owner_agent_id,
+        autonomous: updated.autonomous,
+        maxSessions: updated.max_sessions,
+        sessionsUsed: updated.sessions_used,
+        contextSummary: updated.context_summary,
+        outputTarget: updated.output_target,
+        outputStatus: updated.output_status,
+        threadKey: updated.thread_key,
+        createdAt: updated.created_at,
+        updatedAt: updated.updated_at,
+      },
+    });
+  } catch (error) {
+    return mcpResponse(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to update task group',
+      },
+      true
+    );
+  }
+}
+
 export const listTaskGroupsSchema = z.object({
   ...userIdentifierSchema.shape,
   statuses: z

--- a/packages/api/src/mcp/tools/task-handlers.ts
+++ b/packages/api/src/mcp/tools/task-handlers.ts
@@ -785,6 +785,38 @@ export async function handleUpdateTaskGroup(
       nextMetadata = base;
     }
 
+    // Security: service-role DB access bypasses RLS, so a direct `identityId`
+    // must be validated against the caller's user (and workspace, when known)
+    // before it's written. Without this, any caller who knows another
+    // agent_identities.id could rebind a task group across workspace boundaries.
+    // `undefined` means "don't touch"; `null` means "explicitly detach" and is
+    // allowed without a lookup.
+    let nextIdentityId: string | null | undefined = args.identityId;
+    if (typeof args.identityId === 'string') {
+      const reqCtx = getRequestContext();
+      const workspaceId = reqCtx?.workspaceId;
+      let q = dataComposer
+        .getClient()
+        .from('agent_identities')
+        .select('id')
+        .eq('id', args.identityId)
+        .eq('user_id', resolved.user.id);
+      if (workspaceId) {
+        q = q.eq('workspace_id', workspaceId);
+      }
+      const { data: owned } = await q.limit(1).single();
+      if (!owned) {
+        return mcpResponse(
+          {
+            success: false,
+            error: 'identityId not found or does not belong to this user/workspace.',
+          },
+          true
+        );
+      }
+      nextIdentityId = args.identityId;
+    }
+
     const updated = await dataComposer.repositories.taskGroups.update(args.groupId, {
       title: args.title,
       description: args.description,
@@ -797,7 +829,7 @@ export async function handleUpdateTaskGroup(
       output_status: args.outputStatus,
       thread_key: args.threadKey,
       owner_agent_id: args.ownerAgentId,
-      identity_id: args.identityId,
+      identity_id: nextIdentityId,
     });
 
     return mcpResponse({


### PR DESCRIPTION
## Summary

Adds `update_task_group` MCP tool. Previously the only way to mark a task group `completed` or `cancelled`, reassign ownership, or merge metadata was direct SQL against `task_groups` — surfaced tonight during group cleanup when closing 6 shipped groups + reassigning 2.

Thin wrapper around the existing `TaskGroupsRepository.update()` with ownership check + metadata merge semantics. No repo or schema changes.

## What it exposes

- `status` — active | paused | completed | cancelled (primary use: closing groups)
- `title`, `description`, `priority`, `tags`
- `metadata` — merged by default; pass `mergeMetadata: false` to replace
- `closedReason` — shorthand that writes to `metadata.closed_reason` (pairs well with `status: completed|cancelled`)
- `contextSummary`, `outputTarget`, `outputStatus`, `threadKey`
- `ownerAgentId`, `identityId` — pass null to clear

Server verifies the group belongs to the resolved user before touching it.

## Tests

**Unit (mocked DataComposer) — 5 cases:**
- closes with status + closedReason, verifies metadata.closed_reason written
- merges metadata by default (preserves existing keys)
- replaces metadata when `mergeMetadata: false`
- refuses update when group belongs to a different user
- returns error when group does not exist

**Integration (real local Supabase via `vitest.integration.db.config.ts`) — 4 cases:**
- seed a real group → call the MCP handler → assert against the real row
- covers the same four shapes as the unit tests, but the assertions read from `task_groups` via a fresh Supabase client — no mocks between the handler and the DB

Pairing unit + integration here matches the guidance from PR #328 (mocked-only tests caught 0/5 of the 2FA bugs; the real gap is at the DB/auth boundary). This isn't a boundary-heavy tool, but having the integration suite in place means future changes to metadata-merge semantics or ownership checks land with real coverage.

## Test plan

- [x] Unit tests: `npx vitest run packages/api/src/mcp/tools/task-handlers.test.ts` — 49/49 passing (5 new)
- [x] Integration: `cd packages/api && npx vitest run -c vitest.integration.db.config.ts src/mcp/tools/task-handlers.integration.test.ts` — 4/4 passing against local Supabase
- [x] Typecheck: no new errors in changed files
- [ ] Review by Lumen

## Non-goals

- Changing `TaskGroupsRepository` (already has a full `update()` with per-field undefined handling)
- Exposing strategy fields (`strategy`, `strategy_config`, `verification_mode`, etc.) — those are managed by `start_strategy` / `pause_strategy` / `resume_strategy` and shouldn't be touched via raw update

— Wren