### PR TITLE
fix: retry+backoff on Supabase calls, Docker log rotation (by Wren)

### DIFF
--- a/docs/runbooks/supabase-disk-full.md
+++ b/docs/runbooks/supabase-disk-full.md
@@ -1,0 +1,92 @@
+# Runbook: Local Supabase disk full / Docker VM out of space
+
+## Symptom
+
+- Supabase local stack suddenly fails. The Inkwell server logs:
+  ```
+  code: 'PGRST002',
+  message: 'Could not query the database for the schema cache. Retrying.'
+  ```
+- `docker ps` shows containers running but DB operations hang or 503.
+- Supabase Studio (localhost:54323) returns 502/503.
+- `docker system df` shows the VM filesystem at or near 100%.
+
+## Quick diagnosis
+
+Always check two things, in this order:
+
+1. **Docker VM disk** — the Linux VM that hosts containers has a fixed-size
+   disk image (`~/Library/Containers/com.docker.docker/Data/vms/0/data/Docker.raw`
+   on macOS, 64 GiB by default). If it fills up, Postgres can't write WAL.
+   ```bash
+   docker run --rm --privileged -v /:/host alpine df -h /host/var/lib/docker
+   ```
+2. **Container log sizes** — the default json-file driver has no rotation
+   and grows forever.
+   ```bash
+   docker run --rm --privileged -v /:/host alpine \
+     sh -c 'du -sh /host/var/lib/docker/containers/*/*.log 2>/dev/null | sort -h | tail -10'
+   ```
+
+On 2026-04-19 the culprit was a single Kong container log at **46.8 GB**
+(9.4 GB/day × 5 days of no rotation) caused by a retry stampede hammering
+a 503-ing PostgREST.
+
+## Recovery (non-destructive)
+
+Truncate the offending container log in place — Docker tolerates this and
+the container keeps running:
+
+```bash
+# Find the biggest offender.
+docker run --rm --privileged -v /:/host alpine \
+  sh -c 'du -sh /host/var/lib/docker/containers/*/*.log 2>/dev/null | sort -h | tail -5'
+
+# Truncate it (substitute the container ID prefix).
+docker run --rm --privileged -v /:/host alpine \
+  truncate -s 0 /host/var/lib/docker/containers/<prefix>/<prefix>-json.log
+```
+
+Postgres should recover via WAL replay within seconds. Verify:
+
+```bash
+docker exec supabase_db_pcp psql -U postgres -c 'select 1;'
+# expect: ?column? → 1
+```
+
+If Postgres doesn't come back on its own, restart just the DB container
+(do NOT `docker compose down -v` — that drops data):
+
+```bash
+docker restart supabase_db_pcp
+```
+
+## Root cause & prevention
+
+Two amplifying factors turned a normal brownout into an outage:
+
+1. **No Docker log rotation.** The default json-file driver keeps logs
+   forever. See `docs/setup/docker-log-rotation.md` for the fix: set
+   `max-size` / `max-file` in `~/.docker/daemon.json`.
+
+2. **Retry stampedes with no backoff.** Callers like `ink wait` and the
+   Inkwell server's `resolveUser` were hitting PostgREST every 15s or on
+   every tool call during the brownout. Each 503 became a Kong log entry.
+   Fixed in the same PR:
+   - `packages/api/src/utils/supabase-retry.ts` — retry + circuit breaker
+     for Supabase calls.
+   - `packages/api/src/services/user-resolver.ts` — wrapped in
+     `withSupabaseRetry`.
+   - `packages/cli/src/commands/wait.ts` — exponential backoff on
+     consecutive poll errors.
+
+## After recovery
+
+- Check for pathological callers that have been hot-retrying for hours:
+  ```bash
+  docker logs --since 1h supabase_kong_pcp 2>&1 | grep -c '503'
+  ```
+- Confirm `~/.docker/daemon.json` has rotation enabled. Restart Docker
+  Desktop after changing it.
+- Consider raising the Docker VM disk size (Docker Desktop → Settings →
+  Resources → Advanced → Disk image size) if your dataset genuinely needs it.

--- a/docs/setup/docker-log-rotation.md
+++ b/docs/setup/docker-log-rotation.md
@@ -1,0 +1,53 @@
+# Docker log rotation for local Supabase
+
+## Why
+
+By default, Docker's `json-file` logging driver keeps container logs
+forever. On 2026-04-19 a single Kong container grew to **46.8 GB** of JSON
+logs in five days and filled the entire Docker Desktop VM disk, taking
+the local Supabase stack offline until logs were truncated.
+
+Rotation is a one-line config. We should all enable it.
+
+## Fix (macOS / Docker Desktop, Linux)
+
+Create or edit `~/.docker/daemon.json`:
+
+```json
+{
+  "log-driver": "json-file",
+  "log-opts": {
+    "max-size": "50m",
+    "max-file": "3",
+    "compress": "true"
+  }
+}
+```
+
+This caps each container at ~150 MB of retained logs (3 rotations × 50 MB)
+with gzip compression. Re-start Docker Desktop for it to take effect.
+
+## Apply via script
+
+```bash
+./scripts/setup-docker-log-rotation.sh
+```
+
+The script writes `~/.docker/daemon.json` (merging with any existing keys
+using `jq`) and prompts you to restart Docker Desktop.
+
+## Gotchas
+
+- **Existing containers don't pick up the new driver.** The settings
+  apply to _newly created_ containers. To apply to the Supabase stack,
+  restart it:
+  ```bash
+  supabase stop
+  supabase start
+  ```
+  (Data is preserved — `supabase start` reuses the named volumes.)
+- **Don't lower `max-size` below ~10m.** Debug logs around a real outage
+  are useful; overly aggressive rotation hides them.
+- If a single container is growing by gigabytes/day, rotation alone
+  isn't the answer — investigate the caller (see
+  `docs/runbooks/supabase-disk-full.md`).

--- a/packages/api/src/data/repositories/base.repository.ts
+++ b/packages/api/src/data/repositories/base.repository.ts
@@ -12,4 +12,20 @@ export abstract class BaseRepository {
     logger.error(`Repository error during ${operation}:`, error);
     throw error;
   }
+
+  /**
+   * Attach the HTTP status from a Supabase response to its PostgrestError
+   * before rethrowing. Without this, `PostgrestError` only carries
+   * `{ message, details, hint, code }` — the 503 / 429 that a retry helper
+   * needs to classify an error as transient gets stripped at the destructure
+   * boundary. Callers that rethrow errors they intend to be retried should
+   * route through this helper.
+   */
+  protected preserveStatus<E>(error: E, status: number | undefined): E {
+    if (error && typeof error === 'object' && status !== undefined) {
+      const errObj = error as Record<string, unknown>;
+      if (errObj.status === undefined) errObj.status = status;
+    }
+    return error;
+  }
 }

--- a/packages/api/src/data/repositories/users.repository.test.ts
+++ b/packages/api/src/data/repositories/users.repository.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi } from 'vitest';
+import { UsersRepository } from './users.repository';
+import { isTransientSupabaseError } from '../../utils/supabase-retry';
+
+/**
+ * Regression test for the blocker Lumen flagged on PR #333:
+ * `PostgrestError` only carries `{ message, details, hint, code }` — the
+ * HTTP status lives on the response wrapper, and our repository used to
+ * drop it on rethrow. That silently defeated the 5xx / 429 branch of
+ * `isTransientSupabaseError`, so the retry wrapper only kicked in on
+ * PostgREST-specific codes and network errors.
+ */
+
+function makeSingle(response: { data: unknown; error: unknown; status: number }): {
+  single: () => Promise<{ data: unknown; error: unknown; status: number }>;
+} {
+  return { single: () => Promise.resolve(response) };
+}
+
+function mockClient(response: { data: unknown; error: unknown; status: number }) {
+  // Minimal chain to satisfy .from().select().eq().single()
+  const eqStub = makeSingle(response);
+  return {
+    from: vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue(eqStub),
+      }),
+    }),
+  } as any;
+}
+
+describe('UsersRepository — preserves HTTP status on rethrow', () => {
+  it('findById attaches status=503 to rethrown PostgrestError', async () => {
+    const pgErr = { code: 'XX000', message: 'Service Unavailable', details: '', hint: '' };
+    const repo = new UsersRepository(mockClient({ data: null, error: pgErr, status: 503 }));
+    try {
+      await repo.findById('u1');
+      throw new Error('expected throw');
+    } catch (err) {
+      expect((err as Record<string, unknown>).status).toBe(503);
+      expect((err as Record<string, unknown>).code).toBe('XX000');
+      // And crucially: the retry classifier must now recognize it as transient.
+      expect(isTransientSupabaseError(err)).toBe(true);
+    }
+  });
+
+  it('findByEmail attaches status=429 to rethrown error', async () => {
+    const pgErr = { code: 'XX000', message: 'Too Many Requests', details: '', hint: '' };
+    const repo = new UsersRepository(mockClient({ data: null, error: pgErr, status: 429 }));
+    try {
+      await repo.findByEmail('a@b.co');
+      throw new Error('expected throw');
+    } catch (err) {
+      expect((err as Record<string, unknown>).status).toBe(429);
+      expect(isTransientSupabaseError(err)).toBe(true);
+    }
+  });
+
+  it('does NOT throw on PGRST116 (not found) — returns null, no status attached', async () => {
+    const pgErr = { code: 'PGRST116', message: 'not found', details: '', hint: '' };
+    const repo = new UsersRepository(mockClient({ data: null, error: pgErr, status: 406 }));
+    const result = await repo.findById('missing');
+    expect(result).toBeNull();
+  });
+
+  it('findByPhoneNumber preserves status=500', async () => {
+    const pgErr = { code: 'XX000', message: 'Internal', details: '', hint: '' };
+    const repo = new UsersRepository(mockClient({ data: null, error: pgErr, status: 500 }));
+    try {
+      await repo.findByPhoneNumber('+15555555555');
+      throw new Error('expected throw');
+    } catch (err) {
+      expect((err as Record<string, unknown>).status).toBe(500);
+      expect(isTransientSupabaseError(err)).toBe(true);
+    }
+  });
+});

--- a/packages/api/src/data/repositories/users.repository.ts
+++ b/packages/api/src/data/repositories/users.repository.ts
@@ -10,9 +10,13 @@ export class UsersRepository extends BaseRepository {
 
   async findById(id: string): Promise<User | null> {
     try {
-      const { data, error } = await this.client.from('users').select('*').eq('id', id).single();
+      const { data, error, status } = await this.client
+        .from('users')
+        .select('*')
+        .eq('id', id)
+        .single();
 
-      if (error && error.code !== 'PGRST116') throw error; // PGRST116 is "not found"
+      if (error && error.code !== 'PGRST116') throw this.preserveStatus(error, status);
       return data;
     } catch (error) {
       this.handleError(error, 'findById');
@@ -21,13 +25,13 @@ export class UsersRepository extends BaseRepository {
 
   async findByTelegramId(telegramId: number): Promise<User | null> {
     try {
-      const { data, error } = await this.client
+      const { data, error, status } = await this.client
         .from('users')
         .select('*')
         .eq('telegram_id', telegramId)
         .single();
 
-      if (error && error.code !== 'PGRST116') throw error; // PGRST116 is "not found"
+      if (error && error.code !== 'PGRST116') throw this.preserveStatus(error, status);
       return data;
     } catch (error) {
       this.handleError(error, 'findByTelegramId');
@@ -36,13 +40,13 @@ export class UsersRepository extends BaseRepository {
 
   async findByEmail(email: string): Promise<User | null> {
     try {
-      const { data, error } = await this.client
+      const { data, error, status } = await this.client
         .from('users')
         .select('*')
         .eq('email', email)
         .single();
 
-      if (error && error.code !== 'PGRST116') throw error;
+      if (error && error.code !== 'PGRST116') throw this.preserveStatus(error, status);
       return data;
     } catch (error) {
       this.handleError(error, 'findByEmail');
@@ -51,13 +55,13 @@ export class UsersRepository extends BaseRepository {
 
   async findByPhoneNumber(phoneNumber: string): Promise<User | null> {
     try {
-      const { data, error } = await this.client
+      const { data, error, status } = await this.client
         .from('users')
         .select('*')
         .eq('phone_number', phoneNumber)
         .single();
 
-      if (error && error.code !== 'PGRST116') throw error;
+      if (error && error.code !== 'PGRST116') throw this.preserveStatus(error, status);
       return data;
     } catch (error) {
       this.handleError(error, 'findByPhoneNumber');
@@ -66,13 +70,13 @@ export class UsersRepository extends BaseRepository {
 
   async findByWhatsAppId(whatsappId: string): Promise<User | null> {
     try {
-      const { data, error } = await this.client
+      const { data, error, status } = await this.client
         .from('users')
         .select('*')
         .eq('whatsapp_id', whatsappId)
         .single();
 
-      if (error && error.code !== 'PGRST116') throw error;
+      if (error && error.code !== 'PGRST116') throw this.preserveStatus(error, status);
       return data;
     } catch (error) {
       this.handleError(error, 'findByWhatsAppId');
@@ -81,13 +85,13 @@ export class UsersRepository extends BaseRepository {
 
   async findByDiscordId(discordId: string): Promise<User | null> {
     try {
-      const { data, error } = await this.client
+      const { data, error, status } = await this.client
         .from('users')
         .select('*')
         .eq('discord_id', discordId)
         .single();
 
-      if (error && error.code !== 'PGRST116') throw error;
+      if (error && error.code !== 'PGRST116') throw this.preserveStatus(error, status);
       return data;
     } catch (error) {
       this.handleError(error, 'findByDiscordId');
@@ -96,13 +100,13 @@ export class UsersRepository extends BaseRepository {
 
   async findBySlackId(slackId: string): Promise<User | null> {
     try {
-      const { data, error } = await this.client
+      const { data, error, status } = await this.client
         .from('users')
         .select('*')
         .eq('slack_id', slackId)
         .single();
 
-      if (error && error.code !== 'PGRST116') throw error;
+      if (error && error.code !== 'PGRST116') throw this.preserveStatus(error, status);
       return data;
     } catch (error) {
       this.handleError(error, 'findBySlackId');

--- a/packages/api/src/services/user-resolver.test.ts
+++ b/packages/api/src/services/user-resolver.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { resolveUser } from './user-resolver';
+import { resetSharedBreakerForTests } from '../utils/supabase-retry';
+
+// getUserFromContext is a hard dependency on AsyncLocalStorage; stub it out.
+vi.mock('../utils/request-context', () => ({
+  getUserFromContext: vi.fn().mockReturnValue(undefined),
+}));
+
+function makeDc(usersRepo: unknown) {
+  return {
+    repositories: { users: usersRepo },
+  } as unknown as Parameters<typeof resolveUser>[1];
+}
+
+describe('resolveUser — retry integration', () => {
+  beforeEach(() => {
+    resetSharedBreakerForTests();
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+  });
+
+  it('retries a transient 503 from findById and succeeds on the second try', async () => {
+    const user = { id: 'u1', email: 'a@b.co' };
+    const findById = vi
+      .fn()
+      .mockRejectedValueOnce({ status: 503, message: 'service unavailable' })
+      .mockResolvedValueOnce(user);
+
+    const result = await resolveUser({ userId: 'u1' } as any, makeDc({ findById }));
+
+    expect(result).toEqual({ user, resolvedBy: 'userId' });
+    expect(findById).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry a PGRST116 "not found" (non-transient); returns null', async () => {
+    // usersRepo normalizes PGRST116 to null via handleError path — the
+    // repository catches and returns null, so resolveUser sees null, not throw.
+    const findById = vi.fn().mockResolvedValue(null);
+    const findByEmail = vi.fn().mockResolvedValue(null);
+    const result = await resolveUser(
+      { userId: 'missing', email: 'nope@example.com' } as any,
+      makeDc({ findById, findByEmail })
+    );
+    expect(result).toBeNull();
+    expect(findById).toHaveBeenCalledTimes(1);
+    expect(findByEmail).toHaveBeenCalledTimes(1);
+  });
+
+  it('rethrows a non-transient error without retrying', async () => {
+    const err = { status: 400, message: 'bad request' };
+    const findById = vi.fn().mockRejectedValue(err);
+    await expect(resolveUser({ userId: 'u1' } as any, makeDc({ findById }))).rejects.toEqual(err);
+    expect(findById).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/api/src/services/user-resolver.ts
+++ b/packages/api/src/services/user-resolver.ts
@@ -3,6 +3,7 @@ import type { DataComposer } from '../data/composer';
 import type { User } from '../data/models/user.model';
 import { logger } from '../utils/logger';
 import { getUserFromContext } from '../utils/request-context';
+import { withSupabaseRetry } from '../utils/supabase-retry';
 
 /**
  * Base schema for user identification fields.
@@ -116,9 +117,18 @@ export async function resolveUser(
     }
   }
 
+  // Each lookup is wrapped in withSupabaseRetry so a transient PostgREST
+  // 503 / DB connection blip doesn't immediately fail the request and
+  // doesn't get instantly retried by upstream callers (which on 2026-04-19
+  // amplified a brownout into a 47GB Kong log spiral). The shared circuit
+  // breaker also short-circuits the rest of the pipeline once the DB
+  // really is down.
+
   // 1. Try userId first (most specific)
   if (effectiveIdentifier.userId) {
-    const user = await usersRepo.findById(effectiveIdentifier.userId);
+    const user = await withSupabaseRetry(() => usersRepo.findById(effectiveIdentifier.userId!), {
+      label: 'resolveUser.findById',
+    });
     if (user) {
       logger.debug(`User resolved by userId: ${effectiveIdentifier.userId}`);
       return { user, resolvedBy: 'userId' };
@@ -127,7 +137,9 @@ export async function resolveUser(
 
   // 2. Try email
   if (effectiveIdentifier.email) {
-    const user = await usersRepo.findByEmail(effectiveIdentifier.email);
+    const user = await withSupabaseRetry(() => usersRepo.findByEmail(effectiveIdentifier.email!), {
+      label: 'resolveUser.findByEmail',
+    });
     if (user) {
       logger.debug(`User resolved by email: ${effectiveIdentifier.email}`);
       return { user, resolvedBy: 'email' };
@@ -136,9 +148,10 @@ export async function resolveUser(
 
   // 3. Try platform + platformId
   if (effectiveIdentifier.platform && effectiveIdentifier.platformId) {
-    const user = await usersRepo.findByPlatformId(
-      effectiveIdentifier.platform,
-      effectiveIdentifier.platformId
+    const user = await withSupabaseRetry(
+      () =>
+        usersRepo.findByPlatformId(effectiveIdentifier.platform!, effectiveIdentifier.platformId!),
+      { label: 'resolveUser.findByPlatformId' }
     );
     if (user) {
       logger.debug(
@@ -150,7 +163,10 @@ export async function resolveUser(
 
   // 4. Try phone number
   if (effectiveIdentifier.phone) {
-    const user = await usersRepo.findByPhoneNumber(effectiveIdentifier.phone);
+    const user = await withSupabaseRetry(
+      () => usersRepo.findByPhoneNumber(effectiveIdentifier.phone!),
+      { label: 'resolveUser.findByPhoneNumber' }
+    );
     if (user) {
       logger.debug(`User resolved by phone: ${effectiveIdentifier.phone}`);
       return { user, resolvedBy: 'phone' };

--- a/packages/api/src/utils/supabase-retry.test.ts
+++ b/packages/api/src/utils/supabase-retry.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { CircuitOpenError, createSupabaseRetry, isTransientSupabaseError } from './supabase-retry';
+
+describe('isTransientSupabaseError', () => {
+  it('treats PGRST002 as transient (schema cache unreachable)', () => {
+    expect(isTransientSupabaseError({ code: 'PGRST002' })).toBe(true);
+  });
+
+  it('treats Postgres cannot_connect_now / admin_shutdown as transient', () => {
+    expect(isTransientSupabaseError({ code: '57P03' })).toBe(true);
+    expect(isTransientSupabaseError({ code: '57P01' })).toBe(true);
+  });
+
+  it('treats 5xx HTTP status as transient', () => {
+    expect(isTransientSupabaseError({ status: 500 })).toBe(true);
+    expect(isTransientSupabaseError({ status: 503 })).toBe(true);
+    expect(isTransientSupabaseError({ status: 599 })).toBe(true);
+  });
+
+  it('treats 429 rate-limit as transient', () => {
+    expect(isTransientSupabaseError({ status: 429 })).toBe(true);
+  });
+
+  it('treats fetch/network errors as transient', () => {
+    expect(isTransientSupabaseError(new Error('fetch failed'))).toBe(true);
+    expect(isTransientSupabaseError(new Error('ECONNRESET'))).toBe(true);
+    expect(isTransientSupabaseError(new Error('socket hang up'))).toBe(true);
+  });
+
+  it('does NOT treat 4xx (besides 429) or PGRST116 as transient', () => {
+    expect(isTransientSupabaseError({ status: 400 })).toBe(false);
+    expect(isTransientSupabaseError({ status: 404 })).toBe(false);
+    expect(isTransientSupabaseError({ code: 'PGRST116' })).toBe(false);
+  });
+
+  it('returns false for non-object inputs', () => {
+    expect(isTransientSupabaseError(null)).toBe(false);
+    expect(isTransientSupabaseError('oops')).toBe(false);
+    expect(isTransientSupabaseError(undefined)).toBe(false);
+  });
+});
+
+describe('createSupabaseRetry', () => {
+  // Deterministic jitter — Math.random() returns 0 so delay is always 0.
+  beforeEach(() => {
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns the result on first success without retrying', async () => {
+    const retry = createSupabaseRetry();
+    const fn = vi.fn().mockResolvedValue('ok');
+    await expect(retry.run(fn)).resolves.toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(retry.getState().consecutiveFailures).toBe(0);
+  });
+
+  it('retries transient failures up to maxAttempts and eventually succeeds', async () => {
+    const retry = createSupabaseRetry();
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce({ status: 503 })
+      .mockRejectedValueOnce({ code: 'PGRST002' })
+      .mockResolvedValueOnce('recovered');
+    await expect(retry.run(fn, { maxAttempts: 4 })).resolves.toBe('recovered');
+    expect(fn).toHaveBeenCalledTimes(3);
+    // Success should reset the breaker state.
+    expect(retry.getState().consecutiveFailures).toBe(0);
+  });
+
+  it('rethrows non-transient errors without retrying', async () => {
+    const retry = createSupabaseRetry();
+    const err = { status: 404, message: 'not found' };
+    const fn = vi.fn().mockRejectedValue(err);
+    await expect(retry.run(fn)).rejects.toEqual(err);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(retry.getState().consecutiveFailures).toBe(0);
+  });
+
+  it('rethrows after exhausting attempts on persistent transient failure', async () => {
+    const retry = createSupabaseRetry({ failureThreshold: 100 }); // don't trip breaker
+    const err = { status: 503 };
+    const fn = vi.fn().mockRejectedValue(err);
+    await expect(retry.run(fn, { maxAttempts: 3 })).rejects.toEqual(err);
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  it('opens the circuit after failureThreshold consecutive transient failures', async () => {
+    const retry = createSupabaseRetry({ failureThreshold: 2, cooldownMs: 5000 });
+    const err = { status: 503 };
+    const fn = vi.fn().mockRejectedValue(err);
+
+    // First call: 2 transient failures → breaker trips, throws err.
+    await expect(retry.run(fn, { maxAttempts: 5 })).rejects.toEqual(err);
+    expect(retry.getState().consecutiveFailures).toBeGreaterThanOrEqual(2);
+    expect(retry.getState().openUntil).toBeGreaterThan(Date.now());
+
+    // Second call: breaker open → CircuitOpenError, no call to fn.
+    const callsBefore = fn.mock.calls.length;
+    await expect(retry.run(fn)).rejects.toBeInstanceOf(CircuitOpenError);
+    expect(fn).toHaveBeenCalledTimes(callsBefore);
+  });
+
+  it('closes the breaker after a successful call', async () => {
+    const retry = createSupabaseRetry({ failureThreshold: 2, cooldownMs: 0 });
+    const err = { status: 503 };
+
+    // Trip it.
+    await expect(retry.run(() => Promise.reject(err), { maxAttempts: 5 })).rejects.toEqual(err);
+    expect(retry.getState().consecutiveFailures).toBeGreaterThanOrEqual(2);
+
+    // cooldownMs: 0 → openUntil is in the past almost immediately.
+    await new Promise((r) => setTimeout(r, 1));
+
+    await expect(retry.run(() => Promise.resolve('ok'))).resolves.toBe('ok');
+    expect(retry.getState().consecutiveFailures).toBe(0);
+    expect(retry.getState().openUntil).toBe(0);
+  });
+
+  it('respects AbortSignal between attempts', async () => {
+    const retry = createSupabaseRetry();
+    const controller = new AbortController();
+    const fn = vi.fn().mockImplementation(async () => {
+      controller.abort(new Error('user cancelled'));
+      throw { status: 503 };
+    });
+    await expect(
+      retry.run(fn, { maxAttempts: 5, signal: controller.signal, initialDelayMs: 1 })
+    ).rejects.toMatchObject({ message: 'user cancelled' });
+    // First attempt runs, then the next sleep aborts.
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/api/src/utils/supabase-retry.ts
+++ b/packages/api/src/utils/supabase-retry.ts
@@ -1,0 +1,260 @@
+/**
+ * Retry + circuit breaker helper for Supabase / PostgREST calls.
+ *
+ * Motivation: on 2026-04-19 the local Supabase Docker VM disk filled up
+ * because Kong logged every 503 from PostgREST at full detail. The 503s
+ * themselves were amplified by hot-path callers (inbox polling via the
+ * ink CLI, `resolveUser` inside tool handlers) that retried instantly
+ * without any backoff. Each failing request left an audit trail in Kong.
+ *
+ * This helper gives callers a tiny, zero-config wrapper that:
+ *   1. Retries a handful of times on transient errors (5xx, PostgREST
+ *      "cannot connect to DB" codes, fetch/network errors).
+ *   2. Uses exponential backoff + jitter so concurrent callers don't
+ *      synchronize and resonate.
+ *   3. Short-circuits (fails fast) once a shared circuit breaker trips
+ *      after a burst of failures — avoiding the stampede pattern that
+ *      pushed Kong into meltdown.
+ *
+ * The circuit breaker is process-local (a module-level singleton) so it
+ * protects a single server's shared Supabase client, which is what we
+ * want: if Postgres is down for us, every concurrent request sees it
+ * within milliseconds, and we want them to back off together.
+ */
+
+import { logger } from './logger';
+
+export interface RetryOptions {
+  /** Max attempts including the initial call. Default 4. */
+  maxAttempts?: number;
+  /** Initial backoff in ms. Default 100. Doubles each attempt, capped. */
+  initialDelayMs?: number;
+  /** Cap on any single backoff (before jitter). Default 2000. */
+  maxDelayMs?: number;
+  /** Label for logs, e.g. "resolveUser.findById". */
+  label?: string;
+  /**
+   * Override the default "is this transient" classifier. Returns true if
+   * the error should trigger a retry. Defaults to `isTransientSupabaseError`.
+   */
+  isTransient?: (err: unknown) => boolean;
+  /**
+   * Optional abort signal. If aborted, retries stop immediately and the
+   * current attempt's error is rethrown.
+   */
+  signal?: AbortSignal;
+}
+
+export interface CircuitBreakerState {
+  /** Consecutive transient failures observed globally. */
+  consecutiveFailures: number;
+  /** Timestamp (ms since epoch) when the breaker may be probed again. */
+  openUntil: number;
+}
+
+export interface CircuitBreakerOptions {
+  /** Trip after this many consecutive transient failures. Default 5. */
+  failureThreshold?: number;
+  /** How long to stay open before allowing a probe. Default 10s. */
+  cooldownMs?: number;
+}
+
+const DEFAULT_RETRY: Required<Pick<RetryOptions, 'maxAttempts' | 'initialDelayMs' | 'maxDelayMs'>> =
+  {
+    maxAttempts: 4,
+    initialDelayMs: 100,
+    maxDelayMs: 2000,
+  };
+
+const DEFAULT_BREAKER: Required<CircuitBreakerOptions> = {
+  failureThreshold: 5,
+  cooldownMs: 10_000,
+};
+
+export class CircuitOpenError extends Error {
+  readonly code = 'CIRCUIT_OPEN';
+  constructor(openForMs: number, label?: string) {
+    super(
+      `Supabase circuit breaker is open${label ? ` for ${label}` : ''}; retry in ${openForMs}ms`
+    );
+    this.name = 'CircuitOpenError';
+  }
+}
+
+/**
+ * Default transient-error classifier. Conservative — only retries things
+ * we're confident are safe to retry (idempotent reads + upserts). Callers
+ * using non-idempotent mutations should pass their own classifier.
+ */
+export function isTransientSupabaseError(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false;
+
+  const anyErr = err as Record<string, unknown>;
+
+  // PostgREST error codes — see https://postgrest.org/en/stable/references/errors.html
+  // PGRST002 = cannot query schema cache (DB unreachable)
+  // 57P03 / 57P01 = Postgres cannot_connect_now / admin_shutdown
+  const code = typeof anyErr.code === 'string' ? anyErr.code : undefined;
+  if (code === 'PGRST002' || code === '57P03' || code === '57P01') return true;
+
+  // HTTP status on Supabase-js errors (status + statusText set on PostgrestError)
+  const status = typeof anyErr.status === 'number' ? anyErr.status : undefined;
+  if (status !== undefined && status >= 500 && status < 600) return true;
+  if (status === 429) return true; // rate-limit
+
+  // fetch / undici network failures
+  const message = typeof anyErr.message === 'string' ? anyErr.message.toLowerCase() : '';
+  if (
+    message.includes('fetch failed') ||
+    message.includes('econnreset') ||
+    message.includes('econnrefused') ||
+    message.includes('etimedout') ||
+    message.includes('socket hang up') ||
+    message.includes('network error')
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+function nextDelay(attempt: number, initial: number, cap: number): number {
+  const exp = initial * 2 ** attempt;
+  const base = Math.min(exp, cap);
+  // Full jitter: pick uniformly in [0, base]. Prevents thundering herd.
+  return Math.floor(Math.random() * base);
+}
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(signal.reason ?? new Error('aborted'));
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(signal?.reason ?? new Error('aborted'));
+    };
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+/**
+ * Creates a fresh circuit-breaker + retry context. Exported for tests that
+ * need isolation between cases. Production code uses `withSupabaseRetry`,
+ * which uses a shared process-level breaker.
+ */
+export function createSupabaseRetry(breakerOpts: CircuitBreakerOptions = {}) {
+  const opts = { ...DEFAULT_BREAKER, ...breakerOpts };
+  const state: CircuitBreakerState = {
+    consecutiveFailures: 0,
+    openUntil: 0,
+  };
+
+  async function run<T>(fn: () => Promise<T>, retryOpts: RetryOptions = {}): Promise<T> {
+    const {
+      maxAttempts = DEFAULT_RETRY.maxAttempts,
+      initialDelayMs = DEFAULT_RETRY.initialDelayMs,
+      maxDelayMs = DEFAULT_RETRY.maxDelayMs,
+      label,
+      isTransient = isTransientSupabaseError,
+      signal,
+    } = retryOpts;
+
+    const now = Date.now();
+    if (state.openUntil > now) {
+      throw new CircuitOpenError(state.openUntil - now, label);
+    }
+
+    let lastErr: unknown;
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      if (signal?.aborted) throw signal.reason ?? new Error('aborted');
+
+      try {
+        const result = await fn();
+        // Success — close the breaker if it was probing back.
+        if (state.consecutiveFailures > 0) {
+          logger.debug('Supabase circuit breaker recovered', {
+            label,
+            previousFailures: state.consecutiveFailures,
+          });
+          state.consecutiveFailures = 0;
+          state.openUntil = 0;
+        }
+        return result;
+      } catch (err) {
+        lastErr = err;
+        if (!isTransient(err)) {
+          // Non-transient — bubble up untouched, don't pollute breaker.
+          throw err;
+        }
+
+        state.consecutiveFailures += 1;
+        if (state.consecutiveFailures >= opts.failureThreshold) {
+          state.openUntil = Date.now() + opts.cooldownMs;
+          logger.warn('Supabase circuit breaker opened', {
+            label,
+            failures: state.consecutiveFailures,
+            cooldownMs: opts.cooldownMs,
+          });
+          throw err;
+        }
+
+        if (attempt === maxAttempts - 1) {
+          // Out of attempts — rethrow after last failure.
+          throw err;
+        }
+
+        const delay = nextDelay(attempt, initialDelayMs, maxDelayMs);
+        logger.debug('Supabase call transient failure, retrying', {
+          label,
+          attempt: attempt + 1,
+          maxAttempts,
+          delayMs: delay,
+        });
+        await sleep(delay, signal);
+      }
+    }
+
+    // Unreachable — loop either returns or throws.
+    throw lastErr ?? new Error('supabase retry exhausted');
+  }
+
+  return {
+    run,
+    getState: () => ({ ...state }),
+    reset: () => {
+      state.consecutiveFailures = 0;
+      state.openUntil = 0;
+    },
+  };
+}
+
+const sharedRetry = createSupabaseRetry();
+
+/**
+ * Wrap a Supabase call with retry + shared circuit breaker.
+ *
+ * Usage:
+ *   const user = await withSupabaseRetry(
+ *     () => usersRepo.findById(id),
+ *     { label: 'users.findById' }
+ *   );
+ */
+export function withSupabaseRetry<T>(fn: () => Promise<T>, options: RetryOptions = {}): Promise<T> {
+  return sharedRetry.run(fn, options);
+}
+
+/** Exposed for tests / metrics endpoints. */
+export function getSharedBreakerState(): CircuitBreakerState {
+  return sharedRetry.getState();
+}
+
+/** Exposed for tests — do not call in production. */
+export function resetSharedBreakerForTests(): void {
+  sharedRetry.reset();
+}

--- a/packages/cli/src/commands/wait.ts
+++ b/packages/cli/src/commands/wait.ts
@@ -101,8 +101,24 @@ export function registerWaitCommand(program: Command): void {
         console.log(`[ink wait] Baseline: ${baselineInboxCount} unread`);
       }
 
+      // Exponential backoff on consecutive poll errors. This stops `ink wait`
+      // from hammering the server when it's brownouting (the 2026-04-19
+      // incident: background waits retried every 15s through a 503 storm
+      // and helped fill Docker's disk with Kong error logs).
+      let consecutiveErrors = 0;
+      const maxBackoffSec = Math.max(intervalSec, 120); // cap the pause at ~2 min
+
       while (Date.now() < deadline) {
-        await new Promise((resolve) => setTimeout(resolve, intervalSec * 1000));
+        const sleepMs =
+          consecutiveErrors === 0
+            ? intervalSec * 1000
+            : Math.min(
+                maxBackoffSec * 1000,
+                intervalSec * 1000 * 2 ** Math.min(consecutiveErrors, 6)
+              ) *
+              (0.5 + Math.random() * 0.5); // 50–100% jitter
+
+        await new Promise((resolve) => setTimeout(resolve, sleepMs));
 
         try {
           // Check pending queue only when --pending is explicitly passed
@@ -208,10 +224,19 @@ export function registerWaitCommand(program: Command): void {
             }
           }
 
+          // Successful poll — reset backoff.
+          consecutiveErrors = 0;
           console.log('[ink wait] No new messages yet...');
         } catch (error) {
+          consecutiveErrors += 1;
           const msg = error instanceof Error ? error.message : String(error);
-          console.log(`[ink wait] Poll error (will retry): ${msg.slice(0, 100)}`);
+          const nextBackoffSec = Math.min(
+            maxBackoffSec,
+            intervalSec * 2 ** Math.min(consecutiveErrors, 6)
+          );
+          console.log(
+            `[ink wait] Poll error #${consecutiveErrors} (next retry in ~${nextBackoffSec}s): ${msg.slice(0, 100)}`
+          );
         }
       }
 

--- a/scripts/setup-docker-log-rotation.sh
+++ b/scripts/setup-docker-log-rotation.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#
+# setup-docker-log-rotation.sh
+#
+# Configures ~/.docker/daemon.json with json-file log rotation so local
+# Supabase containers don't silently fill your Docker VM disk.
+# See docs/setup/docker-log-rotation.md and
+# docs/runbooks/supabase-disk-full.md for the full story.
+
+set -euo pipefail
+
+DAEMON_JSON="${HOME}/.docker/daemon.json"
+TMP_JSON="$(mktemp -t daemon.json.XXXXXX)"
+trap 'rm -f "$TMP_JSON"' EXIT
+
+DESIRED=$(cat <<'EOF'
+{
+  "log-driver": "json-file",
+  "log-opts": {
+    "max-size": "50m",
+    "max-file": "3",
+    "compress": "true"
+  }
+}
+EOF
+)
+
+mkdir -p "$(dirname "$DAEMON_JSON")"
+
+if [[ -s "$DAEMON_JSON" ]]; then
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "Error: $DAEMON_JSON already exists and jq is not installed." >&2
+    echo "Install jq (brew install jq) or merge the keys manually." >&2
+    echo "Desired contents:" >&2
+    echo "$DESIRED" >&2
+    exit 1
+  fi
+  # Merge desired keys on top of existing config.
+  jq -s '.[0] * .[1]' "$DAEMON_JSON" <(echo "$DESIRED") > "$TMP_JSON"
+else
+  echo "$DESIRED" > "$TMP_JSON"
+fi
+
+mv "$TMP_JSON" "$DAEMON_JSON"
+trap - EXIT
+
+echo "Wrote $DAEMON_JSON:"
+cat "$DAEMON_JSON"
+echo ""
+echo "Next steps:"
+echo "  1. Restart Docker Desktop so the new logging driver applies."
+echo "  2. Restart the Supabase stack to re-create containers with rotation:"
+echo "       supabase stop && supabase start"
+echo ""
+echo "Existing container logs are not rotated retroactively. To reclaim"
+echo "space from a runaway log without restarting the container:"
+echo "  docker run --rm --privileged -v /:/host alpine \\"
+echo "    truncate -s 0 /host/var/lib/docker/containers/<prefix>/<prefix>-json.log"


### PR DESCRIPTION
## Why

On 2026-04-19 the local Supabase stack went down: Kong's json-file log grew to **46.8 GB** (9.4 GB/day, no rotation) and filled the Docker VM disk, stalling Postgres WAL writes. Recovery was a `truncate` on the log file; Postgres came back via WAL replay.

The brownout was amplified by hot-path callers that retried instantly on 503 — every retry left another Kong audit line, accelerating the spiral. See \`docs/runbooks/supabase-disk-full.md\` for the full postmortem.

## What changed

**1. Retry + circuit breaker for Supabase calls**
- \`packages/api/src/utils/supabase-retry.ts\` — small wrapper with exponential backoff + full jitter and a shared process-level circuit breaker that short-circuits after N consecutive transient failures (5xx, \`PGRST002\`, Postgres \`57P0x\`, network errors).
- \`packages/api/src/services/user-resolver.ts\` — wraps all \`findBy*\` lookups in \`withSupabaseRetry\`. This is the single hottest path during an outage (every tool call → \`resolveUser\`).
- \`packages/cli/src/commands/wait.ts\` — exponential backoff on consecutive poll errors (capped ~2 min) instead of hammering every 15 s through an outage.

**2. Docker log rotation**
- \`docs/runbooks/supabase-disk-full.md\` — diagnosis + non-destructive recovery playbook.
- \`docs/setup/docker-log-rotation.md\` + \`scripts/setup-docker-log-rotation.sh\` — writes json-file rotation (50 MB × 3 files, compressed) into \`~/.docker/daemon.json\`. Merges with existing config via \`jq\`.

## Design notes

- **Transient classifier is conservative.** Only retries errors we're confident are safe to retry (idempotent reads, upserts by primary key). Callers running non-idempotent mutations can pass their own \`isTransient\` callback.
- **Breaker is process-local, not per-key.** If Postgres is down for us, every concurrent request sees it within ms — we want them to back off together, not each trip their own breaker.
- **\`ink wait\` backoff only triggers on errors.** Normal \"no new messages\" polls keep the configured interval; the backoff only kicks in once consecutive polls throw.

## Test plan

- [x] 17 new unit tests: retry classifier (PGRST codes, 5xx, network messages), backoff exhaustion, breaker trip + cooldown + recovery, AbortSignal support, resolveUser wiring.
- [x] Full test suite green: \`2013 passed, 2 skipped\` across 121 files.
- [x] TypeScript clean in both touched packages (\`packages/api\`, \`packages/cli\`).
- [ ] Lumen review — this touches auth-adjacent code and I want a second pair of eyes on the circuit-breaker semantics.
- [ ] Once merged, run \`./scripts/setup-docker-log-rotation.sh\` locally + \`supabase stop && supabase start\` to pick up the new logging driver.

## Out of scope

- Applying \`withSupabaseRetry\` beyond \`resolveUser\`. Other hot paths (inbox polling, \`handleGetAgentSummaries\`) would benefit but are a larger change — happy to follow up in a separate PR if we want it.
- Raising the Docker VM disk size. That's a per-dev setting and shouldn't land in the repo.

— Wren

🤖 Generated with [Claude Code](https://claude.com/claude-code)