### PR TITLE
feat: cancel_strategy MCP tool (terminal state transition) (by Wren)

### DIFF
--- a/packages/api/src/mcp/tools/index.ts
+++ b/packages/api/src/mcp/tools/index.ts
@@ -291,10 +291,12 @@ import {
   handleStartStrategy,
   handlePauseStrategy,
   handleResumeStrategy,
+  handleCancelStrategy,
   handleGetStrategyStatus,
   startStrategySchema,
   pauseStrategySchema,
   resumeStrategySchema,
+  cancelStrategySchema,
   getStrategyStatusSchema,
 } from './strategy-handlers';
 
@@ -1190,6 +1192,35 @@ User can be identified by ONE of: userId, email, phone, or platform + platformId
         return await handleResumeStrategy(args, dataComposer);
       } catch (error) {
         logger.error('Error in resume_strategy:', error);
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                success: false,
+                error: error instanceof Error ? error.message : 'Unknown error',
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  server.registerTool(
+    'cancel_strategy',
+    {
+      description: `Cancel an active or paused strategy on a task group. Transitions the group to the terminal 'cancelled' state, cancels the watchdog reminder, and logs the optional reason to the activity stream. Cannot be called on groups that are already completed or cancelled. Tasks themselves are not modified — cancelling the strategy stops autonomous progression but leaves task records intact for audit.
+
+User can be identified by ONE of: userId, email, phone, or platform + platformId`,
+      inputSchema: cancelStrategySchema.shape,
+    },
+    async (args) => {
+      try {
+        return await handleCancelStrategy(args, dataComposer);
+      } catch (error) {
+        logger.error('Error in cancel_strategy:', error);
         return {
           content: [
             {

--- a/packages/api/src/mcp/tools/strategy-handlers.test.ts
+++ b/packages/api/src/mcp/tools/strategy-handlers.test.ts
@@ -11,6 +11,7 @@ import {
   handleStartStrategy,
   handlePauseStrategy,
   handleResumeStrategy,
+  handleCancelStrategy,
   handleGetStrategyStatus,
 } from './strategy-handlers';
 
@@ -23,6 +24,7 @@ const mocks = vi.hoisted(() => ({
   startStrategy: vi.fn(),
   pauseStrategy: vi.fn(),
   resumeStrategy: vi.fn(),
+  cancelStrategy: vi.fn(),
   getStrategyStatus: vi.fn(),
 }));
 
@@ -32,6 +34,7 @@ vi.mock('../../services/strategy.service', () => ({
     startStrategy = mocks.startStrategy;
     pauseStrategy = mocks.pauseStrategy;
     resumeStrategy = mocks.resumeStrategy;
+    cancelStrategy = mocks.cancelStrategy;
     getStrategyStatus = mocks.getStrategyStatus;
   },
 }));
@@ -312,6 +315,65 @@ describe('handleResumeStrategy', () => {
     const data = parseResponse(response);
     expect(response.isError).toBe(true);
     expect(data.error).toBe('Strategy is not paused');
+  });
+});
+
+describe('handleCancelStrategy', () => {
+  let dc: ReturnType<typeof createMockDataComposer>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dc = createMockDataComposer();
+    resolveUserMock.mockResolvedValue({
+      user: { id: 'user-123' } as any,
+      resolvedBy: 'userId',
+    });
+  });
+
+  it('should cancel strategy and pass reason to service', async () => {
+    mocks.cancelStrategy.mockResolvedValue({
+      id: 'group-1',
+      title: 'My Strategy',
+      status: 'cancelled',
+      strategy: 'persistence',
+    });
+
+    const response = await handleCancelStrategy(
+      { userId: 'user-123', groupId: 'group-1', reason: 'scope changed' },
+      dc
+    );
+
+    const data = parseResponse(response);
+    expect(data.success).toBe(true);
+    expect(data.status).toBe('cancelled');
+    expect(data.reason).toBe('scope changed');
+    expect(mocks.cancelStrategy).toHaveBeenCalledWith('group-1', 'user-123', 'scope changed');
+  });
+
+  it('should work without a reason', async () => {
+    mocks.cancelStrategy.mockResolvedValue({
+      id: 'group-1',
+      title: 'My Strategy',
+      status: 'cancelled',
+      strategy: 'persistence',
+    });
+
+    const response = await handleCancelStrategy({ userId: 'user-123', groupId: 'group-1' }, dc);
+
+    const data = parseResponse(response);
+    expect(data.success).toBe(true);
+    expect(data.reason).toBeNull();
+    expect(mocks.cancelStrategy).toHaveBeenCalledWith('group-1', 'user-123', undefined);
+  });
+
+  it('should return error when strategy is already completed', async () => {
+    mocks.cancelStrategy.mockRejectedValue(new Error('Strategy is already completed'));
+
+    const response = await handleCancelStrategy({ userId: 'user-123', groupId: 'group-1' }, dc);
+
+    const data = parseResponse(response);
+    expect(response.isError).toBe(true);
+    expect(data.error).toBe('Strategy is already completed');
   });
 });
 

--- a/packages/api/src/mcp/tools/strategy-handlers.ts
+++ b/packages/api/src/mcp/tools/strategy-handlers.ts
@@ -248,6 +248,52 @@ export async function handleResumeStrategy(
 }
 
 // ============================================================================
+// CANCEL STRATEGY
+// ============================================================================
+
+export const cancelStrategySchema = z.object({
+  ...userIdentifierSchema.shape,
+  groupId: z.string().uuid().describe('Task group ID to cancel'),
+  reason: z
+    .string()
+    .max(500)
+    .optional()
+    .describe('Human-readable reason for cancellation (logged to activity stream)'),
+});
+
+export async function handleCancelStrategy(
+  args: z.infer<typeof cancelStrategySchema>,
+  dataComposer: DataComposer
+): Promise<McpResponse> {
+  try {
+    const resolved = await resolveUser(args as UserIdentifier, dataComposer);
+    if (!resolved) {
+      return mcpResponse({ success: false, error: 'User not found' }, true);
+    }
+
+    const service = new StrategyService(dataComposer);
+    const group = await service.cancelStrategy(args.groupId, resolved.user.id, args.reason);
+
+    return mcpResponse({
+      success: true,
+      groupId: group.id,
+      title: group.title,
+      status: group.status,
+      strategy: group.strategy,
+      reason: args.reason || null,
+    });
+  } catch (error) {
+    return mcpResponse(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to cancel strategy',
+      },
+      true
+    );
+  }
+}
+
+// ============================================================================
 // GET STRATEGY STATUS
 // ============================================================================
 

--- a/packages/api/src/services/strategy.service.test.ts
+++ b/packages/api/src/services/strategy.service.test.ts
@@ -307,6 +307,87 @@ describe('StrategyService', () => {
     });
   });
 
+  describe('cancelStrategy', () => {
+    it('should cancel an active strategy, log reason, and set status=cancelled', async () => {
+      const group = createMockGroup({ status: 'active' });
+      dc.repositories.taskGroups.findById.mockResolvedValue(group);
+      dc.repositories.taskGroups.update.mockResolvedValue({ ...group, status: 'cancelled' });
+
+      const result = await service.cancelStrategy('group-1', 'user-123', 'blocked by upstream');
+
+      expect(result.status).toBe('cancelled');
+      expect(dc.repositories.taskGroups.update).toHaveBeenCalledWith('group-1', {
+        status: 'cancelled',
+        strategy_paused_at: null,
+      });
+      expect(dc.repositories.activityStream.logActivity).toHaveBeenCalledWith(
+        expect.objectContaining({
+          subtype: 'strategy_cancelled',
+          taskGroupId: 'group-1',
+          content: expect.stringContaining('blocked by upstream'),
+          payload: expect.objectContaining({
+            reason: 'blocked by upstream',
+            previousStatus: 'active',
+          }),
+        })
+      );
+    });
+
+    it('should cancel a paused strategy without a reason', async () => {
+      const group = createMockGroup({ status: 'paused' });
+      dc.repositories.taskGroups.findById.mockResolvedValue(group);
+      dc.repositories.taskGroups.update.mockResolvedValue({ ...group, status: 'cancelled' });
+
+      const result = await service.cancelStrategy('group-1', 'user-123');
+
+      expect(result.status).toBe('cancelled');
+      expect(dc.repositories.activityStream.logActivity).toHaveBeenCalledWith(
+        expect.objectContaining({
+          subtype: 'strategy_cancelled',
+          payload: expect.objectContaining({
+            reason: null,
+            previousStatus: 'paused',
+          }),
+        })
+      );
+    });
+
+    it('should reject if already completed', async () => {
+      const group = createMockGroup({ status: 'completed' });
+      dc.repositories.taskGroups.findById.mockResolvedValue(group);
+
+      await expect(service.cancelStrategy('group-1', 'user-123')).rejects.toThrow(
+        'already completed'
+      );
+      expect(dc.repositories.taskGroups.update).not.toHaveBeenCalled();
+    });
+
+    it('should reject if already cancelled', async () => {
+      const group = createMockGroup({ status: 'cancelled' });
+      dc.repositories.taskGroups.findById.mockResolvedValue(group);
+
+      await expect(service.cancelStrategy('group-1', 'user-123')).rejects.toThrow(
+        'already cancelled'
+      );
+      expect(dc.repositories.taskGroups.update).not.toHaveBeenCalled();
+    });
+
+    it('should reject if group not found', async () => {
+      dc.repositories.taskGroups.findById.mockResolvedValue(null);
+
+      await expect(service.cancelStrategy('group-1', 'user-123')).rejects.toThrow('not found');
+    });
+
+    it('should reject if user does not own the group', async () => {
+      const group = createMockGroup({ status: 'active', user_id: 'someone-else' });
+      dc.repositories.taskGroups.findById.mockResolvedValue(group);
+
+      await expect(service.cancelStrategy('group-1', 'user-123')).rejects.toThrow(
+        'does not belong'
+      );
+    });
+  });
+
   describe('getStrategyStatus', () => {
     it('should return comprehensive status with human-friendly summary', async () => {
       const group = createMockGroup({

--- a/packages/api/src/services/strategy.service.ts
+++ b/packages/api/src/services/strategy.service.ts
@@ -516,6 +516,35 @@ export class StrategyService {
   }
 
   /**
+   * Cancel a strategy. Transitions a non-terminal group to the `cancelled`
+   * terminal state, cancels the watchdog, and logs a reason. Idempotent-adjacent:
+   * already-cancelled groups throw; completed groups throw (they're terminal).
+   */
+  async cancelStrategy(groupId: string, userId: string, reason?: string): Promise<TaskGroup> {
+    const group = await this.dataComposer.repositories.taskGroups.findById(groupId);
+    if (!group) throw new Error('Task group not found');
+    if (group.user_id !== userId) throw new Error('Task group does not belong to this user');
+    if (group.status === 'completed') throw new Error('Strategy is already completed');
+    if (group.status === 'cancelled') throw new Error('Strategy is already cancelled');
+
+    await this.cancelWatchdogReminder(groupId);
+
+    const summary = reason
+      ? `Strategy cancelled on "${group.title}": ${reason}`
+      : `Strategy cancelled on "${group.title}"`;
+
+    await this.logStrategyEvent(group, 'strategy_cancelled', summary, {
+      reason: reason || null,
+      previousStatus: group.status,
+    });
+
+    return this.dataComposer.repositories.taskGroups.update(groupId, {
+      status: 'cancelled',
+      strategy_paused_at: null,
+    });
+  }
+
+  /**
    * Get comprehensive strategy status with human-friendly summary.
    */
   async getStrategyStatus(groupId: string, userId: string): Promise<StrategyStatus> {


### PR DESCRIPTION
## Summary

Strategies previously had no MCP surface to reach the `cancelled` terminal state:
- `pause_strategy` is non-terminal (can be resumed)
- Auto-transitions to `completed` only when all tasks finish
- The task-groups repo has `archive()` but nothing exposed it

Adds `StrategyService.cancelStrategy(groupId, userId, reason?)` and the `cancel_strategy` MCP tool.

## Behavior

- Allowed from `active` or `paused`
- Rejects already-`completed` or already-`cancelled` groups
- Cancels the watchdog reminder so a halted strategy stops re-waking the owner
- Logs `strategy_cancelled` to the activity stream with `reason` + `previousStatus`
- Tasks untouched — cancelling the strategy halts autonomous progression but leaves task records intact for audit

## Test plan

- [x] Unit: service — cancel from active (with reason), cancel from paused (no reason), reject completed, reject cancelled, group-not-found, ownership mismatch
- [x] Unit: handler — delegates reason arg, omits reason arg, surfaces service errors
- [x] Full API suite: 1286/1286 pass
- [x] Type-check: no new errors (pre-existing unrelated errors in `channels/gateway.ts`, `mcp/server.ts`, `routes/admin.ts` only)

— Wren