### PR TITLE
feat: strategy lifecycle observability — activity stream correlation (by Wren)

### DIFF
--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -894,6 +894,10 @@ When you complete a task_request, mark it as completed using update_inbox_messag
         studioId: payload.studioId,
         studioHint: payload.studioHint,
         recipientSessionId: payload.recipientSessionId,
+        taskGroupId:
+          payload.metadata && typeof payload.metadata.groupId === 'string'
+            ? payload.metadata.groupId
+            : undefined,
       },
     };
 

--- a/packages/api/src/services/sessions/session-service.ts
+++ b/packages/api/src/services/sessions/session-service.ts
@@ -510,6 +510,32 @@ export class SessionService implements ISessionService {
           error: e,
         });
       });
+      this.activityStream
+        .logActivity({
+          userId,
+          agentId,
+          type: 'error',
+          subtype: `backend_crash:${resolvedBackend}`,
+          content:
+            `Backend crashed (${resolvedBackend}): ${runnerError instanceof Error ? runnerError.message : String(runnerError)}`.slice(
+              0,
+              500
+            ),
+          sessionId: session.id,
+          taskGroupId,
+          payload: {
+            backend: resolvedBackend,
+            durationMs: Date.now() - turnStartMs,
+            studioId: session.studioId,
+            ...(triggerSource ? { triggerSource } : {}),
+            ...(taskGroupId ? { taskGroupId } : {}),
+            error: (runnerError instanceof Error ? runnerError.message : String(runnerError)).slice(
+              0,
+              2000
+            ),
+          } as unknown as Json,
+        })
+        .catch(() => {});
       throw runnerError;
     }
 

--- a/packages/api/src/services/sessions/session-service.ts
+++ b/packages/api/src/services/sessions/session-service.ts
@@ -90,6 +90,7 @@ export interface IActivityStream {
     sessionId?: string;
     platform?: string;
     platformChatId?: string;
+    taskGroupId?: string;
   }): Promise<{ id: string }>;
 }
 
@@ -459,6 +460,7 @@ export class SessionService implements ISessionService {
 
     // 5a. Log backend spawn to activity stream (fire-and-forget)
     const triggerSource = metadata?.triggerType as string | undefined;
+    const taskGroupId = (metadata?.taskGroupId as string) || undefined;
     // Derive studio hint (worktree folder name) for mission display so it
     // doesn't depend on the session still being active when the feed renders.
     const worktreeFolder = resolvedWorkingDirectory
@@ -472,6 +474,7 @@ export class SessionService implements ISessionService {
         subtype: `backend_cli:${resolvedBackend}`,
         content: `Backend turn started (${resolvedBackend})`,
         sessionId: session.id,
+        taskGroupId,
         payload: {
           backend: resolvedBackend,
           studioId: session.studioId,
@@ -479,6 +482,7 @@ export class SessionService implements ISessionService {
           ...(triggerSource ? { triggerSource } : {}),
           ...(request.sender?.id ? { triggeredBy: request.sender.id } : {}),
           ...(metadata?.threadKey ? { threadKey: metadata.threadKey } : {}),
+          ...(taskGroupId ? { taskGroupId } : {}),
         } as unknown as Json,
       })
       .catch((err) => {
@@ -525,6 +529,7 @@ export class SessionService implements ISessionService {
           ? `Backend turn completed (${resolvedBackend}, ${Math.round(turnDurationMs / 1000)}s)`
           : `Backend turn failed (${resolvedBackend}): ${result.error?.slice(0, 500) || 'unknown error'}`,
         sessionId: session.id,
+        taskGroupId,
         payload: {
           backend: resolvedBackend,
           durationMs: turnDurationMs,
@@ -533,6 +538,7 @@ export class SessionService implements ISessionService {
           ...(triggerSource ? { triggerSource } : {}),
           ...(request.sender?.id ? { triggeredBy: request.sender.id } : {}),
           ...(metadata?.threadKey ? { threadKey: metadata.threadKey } : {}),
+          ...(taskGroupId ? { taskGroupId } : {}),
           ...(result.error ? { error: result.error.slice(0, 2000) } : {}),
           ...(errorClassification
             ? {

--- a/packages/api/src/services/sessions/types.ts
+++ b/packages/api/src/services/sessions/types.ts
@@ -136,6 +136,8 @@ export interface SessionRequest {
     parentSessionId?: string;
     // Root repo path for cross-project 'main' studio resolution
     repoRoot?: string;
+    // Task group ID for strategy lifecycle correlation
+    taskGroupId?: string;
   };
 }
 

--- a/packages/api/src/services/strategy.service.test.ts
+++ b/packages/api/src/services/strategy.service.test.ts
@@ -1086,7 +1086,67 @@ describe('StrategyService', () => {
       // Verify task was started
       expect(dc.repositories.tasks.startTask).toHaveBeenCalledWith('task-3');
 
-      // Verify approval_granted event was logged (iterations_since_approval > 0)
+      // Verify strategy_resumed event was logged (no pauseReason in metadata = manual resume)
+      expect(dc.repositories.activityStream.logActivity).toHaveBeenCalledWith(
+        expect.objectContaining({
+          subtype: 'strategy_resumed',
+          taskGroupId: 'group-1',
+        })
+      );
+    });
+
+    it('should log approval_granted when resuming from approval gate pause', async () => {
+      const group = createMockGroup({
+        status: 'paused',
+        strategy: 'persistence',
+        current_task_index: 2,
+        iterations_since_approval: 5,
+        metadata: { pauseReason: 'approval_gate' },
+        strategy_paused_at: '2026-04-10T12:00:00Z',
+      });
+      const currentTask = createMockTask({
+        id: 'task-3',
+        title: 'Third task',
+        task_order: 2,
+        status: 'pending',
+      });
+
+      dc.repositories.taskGroups.findById.mockResolvedValue(group);
+      dc.repositories.taskGroups.update.mockResolvedValue({
+        ...group,
+        status: 'active',
+        strategy_paused_at: null,
+        iterations_since_approval: 0,
+        metadata: {},
+      });
+
+      const mockClient = dc.getClient();
+      const taskChain = {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              in: vi.fn().mockReturnValue({
+                limit: vi.fn().mockReturnValue({
+                  single: vi.fn().mockResolvedValue({ data: currentTask, error: null }),
+                }),
+              }),
+              limit: vi.fn().mockReturnValue({
+                single: vi.fn().mockResolvedValue({ data: null, error: null }),
+              }),
+            }),
+            single: vi.fn().mockResolvedValue({ data: null, error: null }),
+          }),
+        }),
+        insert: vi.fn().mockResolvedValue({ data: null, error: null }),
+        update: vi.fn().mockReturnValue({
+          contains: vi.fn().mockResolvedValue({ data: null, error: null }),
+        }),
+      };
+      mockClient.from.mockReturnValue(taskChain);
+
+      await service.resumeStrategy('group-1', 'user-123');
+
+      // Verify approval_granted event was logged (pauseReason = approval_gate)
       expect(dc.repositories.activityStream.logActivity).toHaveBeenCalledWith(
         expect.objectContaining({
           subtype: 'approval_granted',

--- a/packages/api/src/services/strategy.service.test.ts
+++ b/packages/api/src/services/strategy.service.test.ts
@@ -1086,10 +1086,10 @@ describe('StrategyService', () => {
       // Verify task was started
       expect(dc.repositories.tasks.startTask).toHaveBeenCalledWith('task-3');
 
-      // Verify strategy_resumed event was logged
+      // Verify approval_granted event was logged (iterations_since_approval > 0)
       expect(dc.repositories.activityStream.logActivity).toHaveBeenCalledWith(
         expect.objectContaining({
-          subtype: 'strategy_resumed',
+          subtype: 'approval_granted',
           taskGroupId: 'group-1',
         })
       );

--- a/packages/api/src/services/strategy.service.ts
+++ b/packages/api/src/services/strategy.service.ts
@@ -855,10 +855,20 @@ export class StrategyService {
       logger.warn(`Strategy watchdog: group ${groupId} not found, skipping`);
       return false;
     }
+
+    // Log every cron wakeup so we can trace heartbeat frequency in the activity stream
+    this.logStrategyEvent(group, 'watchdog_wakeup', `Watchdog cron fired for "${group.title}"`, {
+      groupStatus: group.status,
+      strategy: group.strategy,
+    }).catch(() => {});
+
     if (group.status !== 'active' || !group.strategy) {
       logger.info(
         `Strategy watchdog: group ${groupId} is ${group.status} (strategy=${group.strategy ?? 'null'}), skipping`
       );
+      this.logStrategyEvent(group, 'watchdog_skip', `Watchdog skipped: group is ${group.status}`, {
+        reason: 'inactive_group',
+      }).catch(() => {});
       return false;
     }
 
@@ -873,6 +883,15 @@ export class StrategyService {
       logger.info(
         `Strategy watchdog: group ${groupId} has no in_progress or pending task, skipping`
       );
+      this.logStrategyEvent(
+        group,
+        'watchdog_skip',
+        `Watchdog skipped: no pending/in-progress task`,
+        {
+          reason: 'no_current_task',
+          currentTaskIndex: group.current_task_index,
+        }
+      ).catch(() => {});
       return false;
     }
 

--- a/packages/api/src/services/strategy.service.ts
+++ b/packages/api/src/services/strategy.service.ts
@@ -279,6 +279,14 @@ export class StrategyService {
         context_summary: summary,
       });
 
+      // Notify dispatcher
+      const notified = await this.notifyDispatcher(
+        group,
+        config.approvalNotify,
+        `Approval needed: completed ${newIterations} tasks in "${group.title}". ${summary}`,
+        userId
+      );
+
       await this.logStrategyEvent(
         group,
         'approval_required',
@@ -286,15 +294,9 @@ export class StrategyService {
         {
           iterationsSinceApproval: newIterations,
           progressSummary: summary,
+          routedTo: config.approvalNotify || null,
+          notified,
         }
-      );
-
-      // Notify dispatcher
-      const notified = await this.notifyDispatcher(
-        group,
-        config.approvalNotify,
-        `Approval needed: completed ${newIterations} tasks in "${group.title}". ${summary}`,
-        userId
       );
 
       return {
@@ -492,7 +494,15 @@ export class StrategyService {
     // Re-create watchdog reminder
     await this.createWatchdogReminder(group, userId);
 
-    await this.logStrategyEvent(group, 'strategy_resumed', `Strategy resumed on "${group.title}"`);
+    const wasAwaitingApproval = group.iterations_since_approval > 0;
+    await this.logStrategyEvent(
+      group,
+      wasAwaitingApproval ? 'approval_granted' : 'strategy_resumed',
+      wasAwaitingApproval
+        ? `Approval granted after ${group.iterations_since_approval} iterations on "${group.title}"`
+        : `Strategy resumed on "${group.title}"`,
+      wasAwaitingApproval ? { iterationsSinceApproval: group.iterations_since_approval } : undefined
+    );
 
     const nextTask = await this.getTaskByOrder(groupId, group.current_task_index);
 

--- a/packages/api/src/services/strategy.service.ts
+++ b/packages/api/src/services/strategy.service.ts
@@ -272,11 +272,13 @@ export class StrategyService {
     if (maxIterations && newIterations >= maxIterations) {
       const summary = await this.buildProgressSummary(group, newIndex);
 
-      // Pause for approval
+      // Pause for approval — set pauseReason so resumeStrategy can distinguish
+      // approval-gate pauses from manual pauses (Lumen review, PR #338)
       await this.dataComposer.repositories.taskGroups.update(groupId, {
         strategy_paused_at: new Date().toISOString(),
         status: 'paused',
         context_summary: summary,
+        metadata: { ...group.metadata, pauseReason: 'approval_gate' },
       });
 
       // Notify dispatcher
@@ -485,16 +487,22 @@ export class StrategyService {
     if (group.status !== 'paused') throw new Error('Strategy is not paused');
     if (!group.strategy) throw new Error('No strategy set on this group');
 
+    const wasAwaitingApproval = group.metadata?.pauseReason === 'approval_gate';
+
+    // Clear pauseReason on resume so it doesn't persist into the next pause cycle
+    const cleanedMetadata = { ...group.metadata };
+    delete cleanedMetadata.pauseReason;
+
     await this.dataComposer.repositories.taskGroups.update(groupId, {
       status: 'active',
       strategy_paused_at: null,
       iterations_since_approval: 0,
+      metadata: cleanedMetadata,
     });
 
     // Re-create watchdog reminder
     await this.createWatchdogReminder(group, userId);
 
-    const wasAwaitingApproval = group.iterations_since_approval > 0;
     await this.logStrategyEvent(
       group,
       wasAwaitingApproval ? 'approval_granted' : 'strategy_resumed',

--- a/packages/api/src/services/strategy.service.ts
+++ b/packages/api/src/services/strategy.service.ts
@@ -797,12 +797,39 @@ export class StrategyService {
       logger.info(
         `Strategy trigger sent to ${group.owner_agent_id} for group ${group.id} (task ${task.id}, reason: ${reason}${studioId ? `, studio: ${studioId}` : studioSlug ? `, studioSlug: ${studioSlug}` : ''})`
       );
+
+      await this.logStrategyEvent(
+        group,
+        'strategy_trigger',
+        `Triggered ${group.owner_agent_id} for task: ${task.title}`,
+        {
+          reason,
+          taskId: task.id,
+          taskTitle: task.title,
+          studioId: studioId || studioSlug || null,
+          ownerAgentId: group.owner_agent_id,
+        }
+      );
+
       return true;
     } catch (err) {
       logger.warn(
         `Strategy triggerOwnerAgent failed for group ${group.id} (reason: ${reason}):`,
         err
       );
+
+      // Log trigger failure to activity stream too
+      this.logStrategyEvent(
+        group,
+        'strategy_trigger_failed',
+        `Failed to trigger ${group.owner_agent_id} for task: ${task.title}`,
+        {
+          reason,
+          taskId: task.id,
+          error: err instanceof Error ? err.message : String(err),
+        }
+      ).catch(() => {});
+
       return false;
     }
   }


### PR DESCRIPTION
## Summary

- **Propagate `task_group_id` through trigger → session → activity chain**: When a strategy triggers an agent, the `groupId` now flows from the trigger payload metadata through `SessionRequest.metadata.taskGroupId` to both `agent_spawn` and `agent_complete`/`error` activity entries. Adds `taskGroupId` to the `SessionRequest` metadata type and the `IActivityStream` interface.

- **Log strategy triggers to activity stream**: `triggerOwnerAgent` now writes `strategy_trigger` and `strategy_trigger_failed` events to the activity stream (in addition to existing winston logs).

- **Log watchdog wakeups and runner crashes**: Every cron wakeup logs `watchdog_wakeup`, and skips log `watchdog_skip` with reason. Runner crashes (spawn failures, capacity errors) now write `backend_crash` error entries with `taskGroupId` before re-throwing.

- **Log approval routing with metadata**: `approval_required` events now include `routedTo` and `notified` fields. `resumeStrategy` distinguishes `approval_granted` (when resuming from approval pause) from `strategy_resumed` (manual resume).

- **Spec updated to v5** (`ink://specs/work-strategies`): Codifies cron reminder vs watchdog distinction, adds activity stream observability section with full event taxonomy, clarifies inline advancement vs cross-session continuation, adds Phase 1.5 to ship plan.

## Activity stream events added/enhanced

| Subtype | When |
|---------|------|
| `strategy_trigger` | Agent triggered for a task (with reason, studioId) |
| `strategy_trigger_failed` | Trigger attempt failed |
| `watchdog_wakeup` | Cron reminder fired |
| `watchdog_skip` | Cron decided not to trigger (with reason) |
| `approval_required` | Now includes routedTo + notified |
| `approval_granted` | New: when resume follows approval pause |
| `backend_crash` | New: runner process crashed |

## Test plan

- [x] Type-check passes (zero new errors — 6 pre-existing in gateway.ts, server.ts, admin.ts)
- [x] `strategy.service.test.ts` — 37/37 passing
- [x] `session-service.test.ts` — 45/45 passing
- [ ] Integration test: trigger a strategy and verify activity stream entries have `task_group_id`
- [ ] Verify watchdog_wakeup events appear in activity feed for an active strategy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Wren