### PR TITLE
feat: cross-agent media sharing — Gmail downloads, WhatsApp media, Telegram crash guard (by Wren)

### DIFF
--- a/packages/api/src/channels/gateway.ts
+++ b/packages/api/src/channels/gateway.ts
@@ -1417,6 +1417,7 @@ export class ChannelGateway extends EventEmitter {
         { id: senderId, name: message.sender.name },
         message.body,
         {
+          media: message.media,
           chatType: message.chatType,
           mentions: message.mentions,
           platformAccountId: message.accountId,

--- a/packages/api/src/channels/telegram-listener.ts
+++ b/packages/api/src/channels/telegram-listener.ts
@@ -282,21 +282,37 @@ export class TelegramListener extends EventEmitter {
     const { join } = await import('path');
     const { homedir } = await import('os');
     const fs = await import('fs/promises');
+    const { writeFileSync, mkdirSync } = await import('fs');
     const crypto = await import('crypto');
 
     const tokenHash = crypto.createHash('sha256').update(this.token).digest('hex').slice(0, 12);
     const lockDir = join(homedir(), '.ink', 'locks');
-    await fs.mkdir(lockDir, { recursive: true });
+    mkdirSync(lockDir, { recursive: true });
     this.lockFilePath = join(lockDir, `telegram-${tokenHash}.lock`);
 
+    const lockData = JSON.stringify({ pid: process.pid, startedAt: new Date().toISOString() });
+
+    // Try exclusive create — fails atomically if file already exists
+    try {
+      writeFileSync(this.lockFilePath, lockData, { flag: 'wx' });
+      return; // Lock acquired
+    } catch (err: unknown) {
+      if (
+        !(err instanceof Error) ||
+        !('code' in err) ||
+        (err as NodeJS.ErrnoException).code !== 'EEXIST'
+      ) {
+        throw err;
+      }
+    }
+
+    // Lock file exists — check if the owning process is still alive
     try {
       const existing = await fs.readFile(this.lockFilePath, 'utf-8');
       const { pid } = JSON.parse(existing);
 
-      // Check if the process is still alive
       try {
         process.kill(pid, 0);
-        // Process exists — another listener is running
         const msg = `Another Telegram listener is already running (PID ${pid}). Aborting to prevent message conflicts.`;
         logger.error(msg);
         throw new Error(msg);
@@ -312,24 +328,14 @@ export class TelegramListener extends EventEmitter {
         }
       }
     } catch (err: unknown) {
-      if (
-        err instanceof Error &&
-        'code' in err &&
-        (err as NodeJS.ErrnoException).code === 'ENOENT'
-      ) {
-        // No lock file — proceed
-      } else if (err instanceof Error && err.message.includes('Another Telegram listener')) {
+      if (err instanceof Error && err.message.includes('Another Telegram listener')) {
         throw err;
-      } else {
-        // JSON parse error or other — stale file, take over
-        logger.warn('Invalid Telegram lock file — taking over');
       }
+      logger.warn('Invalid Telegram lock file — taking over');
     }
 
-    await fs.writeFile(
-      this.lockFilePath,
-      JSON.stringify({ pid: process.pid, startedAt: new Date().toISOString() })
-    );
+    // Stale or invalid lock — overwrite
+    await fs.writeFile(this.lockFilePath, lockData);
   }
 
   private async releaseLock(): Promise<void> {

--- a/packages/api/src/channels/telegram-listener.ts
+++ b/packages/api/src/channels/telegram-listener.ts
@@ -180,6 +180,7 @@ export class TelegramListener extends EventEmitter {
   private mediaGroupBuffer: MediaGroupBuffer | null = null;
   private authService: AuthorizationService;
   private botUsername: string | null = null;
+  private lockFilePath: string | null = null;
 
   // Ephemeral message cache - keyed by chatId, stores last N messages
   // Auto-cleaned periodically, never persisted to disk
@@ -221,6 +222,9 @@ export class TelegramListener extends EventEmitter {
       return;
     }
 
+    // Crash guard: prevent two listeners on the same bot token
+    await this.acquireLock();
+
     logger.info('Starting Telegram listener...');
     this.isRunning = true;
 
@@ -233,6 +237,7 @@ export class TelegramListener extends EventEmitter {
     } catch (error) {
       logger.error('Failed to connect to Telegram:', error);
       this.isRunning = false;
+      await this.releaseLock();
       throw error;
     }
 
@@ -263,8 +268,79 @@ export class TelegramListener extends EventEmitter {
     }
 
     this.mediaGroupBuffer?.destroy();
+    await this.releaseLock();
 
     this.emit('disconnected');
+  }
+
+  /**
+   * Acquire a lockfile to prevent duplicate listeners on the same bot token.
+   * The lock contains the PID — if the owning process is dead, the lock is stale
+   * and we take over.
+   */
+  private async acquireLock(): Promise<void> {
+    const { join } = await import('path');
+    const { homedir } = await import('os');
+    const fs = await import('fs/promises');
+    const crypto = await import('crypto');
+
+    const tokenHash = crypto.createHash('sha256').update(this.token).digest('hex').slice(0, 12);
+    const lockDir = join(homedir(), '.ink', 'locks');
+    await fs.mkdir(lockDir, { recursive: true });
+    this.lockFilePath = join(lockDir, `telegram-${tokenHash}.lock`);
+
+    try {
+      const existing = await fs.readFile(this.lockFilePath, 'utf-8');
+      const { pid } = JSON.parse(existing);
+
+      // Check if the process is still alive
+      try {
+        process.kill(pid, 0);
+        // Process exists — another listener is running
+        const msg = `Another Telegram listener is already running (PID ${pid}). Aborting to prevent message conflicts.`;
+        logger.error(msg);
+        throw new Error(msg);
+      } catch (killErr: unknown) {
+        if (
+          killErr instanceof Error &&
+          'code' in killErr &&
+          (killErr as NodeJS.ErrnoException).code === 'ESRCH'
+        ) {
+          logger.warn(`Stale Telegram lock from dead process ${pid} — taking over`);
+        } else {
+          throw killErr;
+        }
+      }
+    } catch (err: unknown) {
+      if (
+        err instanceof Error &&
+        'code' in err &&
+        (err as NodeJS.ErrnoException).code === 'ENOENT'
+      ) {
+        // No lock file — proceed
+      } else if (err instanceof Error && err.message.includes('Another Telegram listener')) {
+        throw err;
+      } else {
+        // JSON parse error or other — stale file, take over
+        logger.warn('Invalid Telegram lock file — taking over');
+      }
+    }
+
+    await fs.writeFile(
+      this.lockFilePath,
+      JSON.stringify({ pid: process.pid, startedAt: new Date().toISOString() })
+    );
+  }
+
+  private async releaseLock(): Promise<void> {
+    if (!this.lockFilePath) return;
+    try {
+      const fs = await import('fs/promises');
+      await fs.unlink(this.lockFilePath);
+    } catch {
+      // Best-effort cleanup
+    }
+    this.lockFilePath = null;
   }
 
   /**

--- a/packages/api/src/channels/whatsapp-listener.ts
+++ b/packages/api/src/channels/whatsapp-listener.ts
@@ -247,7 +247,8 @@ export class WhatsAppListener extends EventEmitter {
 
     // Extract text content
     const text = this.extractMessageText(msg);
-    if (!text) return;
+    const hasMedia = this.hasMediaContent(msg);
+    if (!text && !hasMedia) return;
 
     // Normalize sender ID to E.164
     const senderE164 = this.jidToE164(senderId);
@@ -260,7 +261,7 @@ export class WhatsAppListener extends EventEmitter {
 
       if (!isAuthorized) {
         // Only respond to /authorize command
-        if (this.isAuthorizeCommand(text)) {
+        if (text && this.isAuthorizeCommand(text)) {
           await this.handleAuthorizeCommand(msg, chatId, text);
           return;
         }
@@ -281,7 +282,7 @@ export class WhatsAppListener extends EventEmitter {
       }
 
       // Handle DM commands for trusted users
-      if (await this.handleTrustedUserCommand(msg, chatId, senderE164, text)) {
+      if (text && (await this.handleTrustedUserCommand(msg, chatId, senderE164, text))) {
         return;
       }
     }
@@ -317,6 +318,15 @@ export class WhatsAppListener extends EventEmitter {
         this.emit('error', error);
       }
     }
+  }
+
+  /**
+   * Check if message contains downloadable media
+   */
+  private hasMediaContent(msg: WAMessage): boolean {
+    const m = msg.message;
+    if (!m) return false;
+    return !!(m.imageMessage || m.videoMessage || m.documentMessage || m.audioMessage);
   }
 
   /**
@@ -638,6 +648,34 @@ export class WhatsAppListener extends EventEmitter {
       };
     }
 
+    // Download media attachments
+    if (this.hasMediaContent(msg)) {
+      const m = msg.message!;
+      const mediaType = m.imageMessage
+        ? 'image'
+        : m.videoMessage
+          ? 'video'
+          : m.documentMessage
+            ? 'document'
+            : 'audio';
+
+      const localPath = await this.downloadMedia(
+        msg,
+        mediaType as 'image' | 'video' | 'document' | 'audio'
+      );
+      if (localPath) {
+        const mediaMsg = m.imageMessage || m.videoMessage || m.documentMessage || m.audioMessage;
+        message.media = [
+          {
+            type: mediaType as 'image' | 'video' | 'audio' | 'document',
+            path: localPath,
+            contentType: mediaMsg?.mimetype || undefined,
+            filename: m.documentMessage?.fileName || undefined,
+          },
+        ];
+      }
+    }
+
     message.raw = msg;
 
     return message;
@@ -749,6 +787,52 @@ export class WhatsAppListener extends EventEmitter {
     });
 
     logger.info(`Sent video to WhatsApp chat ${jid}`, { size: bytes.byteLength });
+  }
+
+  /**
+   * Download media from a WhatsApp message.
+   * Uses Baileys' downloadMediaMessage which handles decryption.
+   */
+  async downloadMedia(
+    msg: WAMessage,
+    mediaType: 'image' | 'video' | 'document' | 'audio'
+  ): Promise<string | null> {
+    try {
+      const baileys = await import('@whiskeysockets/baileys');
+      const buffer: Buffer = await baileys.downloadMediaMessage(msg, 'buffer', {});
+
+      const fs = await import('fs/promises');
+      const path = await import('path');
+      const os = await import('os');
+
+      const dir = path.join(os.homedir(), '.ink', 'files', 'whatsapp');
+      await fs.mkdir(dir, { recursive: true });
+
+      const m = msg.message!;
+      const mediaMsg = m.imageMessage || m.videoMessage || m.documentMessage || m.audioMessage;
+      const mimetype: string = mediaMsg?.mimetype || 'application/octet-stream';
+      const ext = mimetype.split('/')[1]?.split(';')[0] || 'bin';
+      const originalName: string | undefined = m.documentMessage?.fileName;
+      const sanitized = originalName
+        ? originalName.replace(/[^a-zA-Z0-9._-]/g, '_')
+        : `${mediaType}_${Date.now()}`;
+      const filename = originalName ? `${Date.now()}_${sanitized}` : `${sanitized}.${ext}`;
+      const filePath = path.join(dir, filename);
+
+      await fs.writeFile(filePath, buffer);
+
+      logger.info('Downloaded WhatsApp media', {
+        mediaType,
+        filePath,
+        size: buffer.byteLength,
+        mimetype,
+      });
+
+      return filePath;
+    } catch (error) {
+      logger.error('Failed to download WhatsApp media:', error);
+      return null;
+    }
   }
 
   /**

--- a/packages/api/src/mcp/tools/index.ts
+++ b/packages/api/src/mcp/tools/index.ts
@@ -213,6 +213,7 @@ import {
   handleDraftEmail,
   handleListLabels,
   handleModifyEmails,
+  handleDownloadAttachment,
   listEmailsSchema,
   getEmailSchema,
   sendEmailSchema,
@@ -220,6 +221,7 @@ import {
   draftEmailSchema,
   listLabelsSchema,
   modifyEmailsSchema,
+  downloadAttachmentSchema,
 } from '../../stories/gmail/handlers';
 
 import {
@@ -4692,6 +4694,41 @@ User can be identified by ONE of: userId, email, phone, or platform + platformId
         return await handleModifyEmails(args, dataComposer);
       } catch (error) {
         logger.error('Error in modify_emails:', error);
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                success: false,
+                error: error instanceof Error ? error.message : 'Unknown error',
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  server.registerTool(
+    'download_email_attachment',
+    {
+      description: `Download an email attachment to disk (~/.ink/files/gmail/).
+
+Returns the absolute file path, which can be used with send_response media
+or shared with other agents. Attachment IDs come from the attachments array
+returned by get_email.
+
+User must have connected their Google account with Gmail permissions.
+
+User can be identified by ONE of: userId, email, phone, or platform + platformId`,
+      inputSchema: downloadAttachmentSchema,
+    },
+    async (args) => {
+      try {
+        return await handleDownloadAttachment(args, dataComposer);
+      } catch (error) {
+        logger.error('Error in download_email_attachment:', error);
         return {
           content: [
             {

--- a/packages/api/src/stories/gmail/handlers.test.ts
+++ b/packages/api/src/stories/gmail/handlers.test.ts
@@ -12,6 +12,7 @@ import {
   ALLOWED_ADD_LABELS,
   ALLOWED_REMOVE_LABELS,
   BLOCKED_ADD_LABELS,
+  downloadAttachmentSchema,
 } from './handlers';
 
 describe('Gmail Label Whitelist', () => {
@@ -237,6 +238,51 @@ describe('validateLabelOperations', () => {
       const error = validateLabelOperations([], []);
       expect(error).toBeNull();
     });
+  });
+});
+
+describe('downloadAttachmentSchema', () => {
+  it('should accept valid params', () => {
+    const result = downloadAttachmentSchema.safeParse({
+      messageId: '19abc123',
+      attachmentId: 'ANGjdJ-abc123',
+      filename: 'document.pdf',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject missing messageId', () => {
+    const result = downloadAttachmentSchema.safeParse({
+      attachmentId: 'ANGjdJ-abc123',
+      filename: 'document.pdf',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject missing attachmentId', () => {
+    const result = downloadAttachmentSchema.safeParse({
+      messageId: '19abc123',
+      filename: 'document.pdf',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject missing filename', () => {
+    const result = downloadAttachmentSchema.safeParse({
+      messageId: '19abc123',
+      attachmentId: 'ANGjdJ-abc123',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should accept optional user identifiers', () => {
+    const result = downloadAttachmentSchema.safeParse({
+      email: 'test@example.com',
+      messageId: '19abc123',
+      attachmentId: 'ANGjdJ-abc123',
+      filename: 'photo.jpg',
+    });
+    expect(result.success).toBe(true);
   });
 });
 

--- a/packages/api/src/stories/gmail/handlers.ts
+++ b/packages/api/src/stories/gmail/handlers.ts
@@ -203,6 +203,14 @@ export const modifyEmailsSchema = userIdentifierBaseSchema.extend({
     .describe('Label IDs to remove (e.g., ["UNREAD", "INBOX"])'),
 });
 
+export const downloadAttachmentSchema = userIdentifierBaseSchema.extend({
+  messageId: z.string().describe('The email message ID containing the attachment'),
+  attachmentId: z
+    .string()
+    .describe('The attachment ID (from the attachments array returned by get_email)'),
+  filename: z.string().describe('Original filename of the attachment'),
+});
+
 // ============================================================================
 // Handlers
 // ============================================================================
@@ -788,6 +796,79 @@ export async function handleModifyEmails(
               hint: message.includes('gmail.modify')
                 ? 'User needs to re-authorize Google with Gmail modify permissions'
                 : undefined,
+            },
+            null,
+            2
+          ),
+        },
+      ],
+      isError: true,
+    };
+  }
+}
+
+/**
+ * Download an email attachment to disk
+ */
+export async function handleDownloadAttachment(
+  args: unknown,
+  dataComposer: DataComposer
+): Promise<ToolResult> {
+  const params = downloadAttachmentSchema.parse(args);
+  const { user } = await resolveUserOrThrow(params, dataComposer);
+
+  const gmailService = getGmailService();
+
+  try {
+    const result = await gmailService.downloadAttachment(
+      user.id,
+      params.messageId,
+      params.attachmentId,
+      params.filename
+    );
+
+    logger.info('Downloaded email attachment', {
+      userId: user.id,
+      messageId: params.messageId,
+      filename: result.filename,
+      path: result.path,
+    });
+
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(
+            {
+              success: true,
+              path: result.path,
+              filename: result.filename,
+              size: result.size,
+              hint: 'Use this absolute path with send_response media or share with other agents',
+            },
+            null,
+            2
+          ),
+        },
+      ],
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    logger.error('Failed to download attachment', {
+      userId: user.id,
+      messageId: params.messageId,
+      attachmentId: params.attachmentId,
+      error: message,
+    });
+
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(
+            {
+              success: false,
+              error: message,
             },
             null,
             2

--- a/packages/api/src/stories/gmail/service.test.ts
+++ b/packages/api/src/stories/gmail/service.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { join } from 'path';
+import { homedir } from 'os';
+
+const { mockAttachmentGet, mockMkdir, mockWriteFile, MockOAuth2 } = vi.hoisted(() => {
+  class _MockOAuth2 {
+    setCredentials = vi.fn();
+  }
+  return {
+    mockAttachmentGet: vi.fn(),
+    mockMkdir: vi.fn().mockResolvedValue(undefined),
+    mockWriteFile: vi.fn().mockResolvedValue(undefined),
+    MockOAuth2: _MockOAuth2,
+  };
+});
+
+vi.mock('googleapis', () => ({
+  google: {
+    auth: { OAuth2: MockOAuth2 },
+    gmail: vi.fn().mockReturnValue({
+      users: {
+        messages: {
+          attachments: { get: mockAttachmentGet },
+        },
+      },
+    }),
+  },
+}));
+
+vi.mock('../../services/oauth', () => ({
+  getOAuthService: vi.fn().mockReturnValue({
+    getValidAccessToken: vi.fn().mockResolvedValue('mock-token'),
+  }),
+}));
+
+vi.mock('fs/promises', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    mkdir: (...args: unknown[]) => mockMkdir(...args),
+    writeFile: (...args: unknown[]) => mockWriteFile(...args),
+  };
+});
+
+import { GmailService } from './service';
+
+const expectedDir = join(homedir(), '.ink', 'files', 'gmail');
+
+describe('GmailService.downloadAttachment', () => {
+  let service: GmailService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new GmailService();
+  });
+
+  it('should download and save attachment with correct path', async () => {
+    const testData = Buffer.from('hello world').toString('base64url');
+    mockAttachmentGet.mockResolvedValue({ data: { data: testData, size: 11 } });
+
+    const result = await service.downloadAttachment('user-1', 'msg-1', 'att-1', 'report.pdf');
+
+    expect(result.path).toMatch(/\.ink\/files\/gmail\/\d+_report\.pdf$/);
+    expect(result.filename).toBe('report.pdf');
+    expect(result.size).toBe(11);
+    expect(mockWriteFile).toHaveBeenCalledWith(
+      expect.stringContaining('report.pdf'),
+      expect.any(Buffer)
+    );
+  });
+
+  it('should sanitize special characters in filename', async () => {
+    const testData = Buffer.from('data').toString('base64url');
+    mockAttachmentGet.mockResolvedValue({ data: { data: testData, size: 4 } });
+
+    const result = await service.downloadAttachment(
+      'user-1',
+      'msg-1',
+      'att-1',
+      'my file (copy).pdf'
+    );
+
+    expect(result.filename).toBe('my_file__copy_.pdf');
+    expect(result.path).toContain('my_file__copy_.pdf');
+  });
+
+  it('should throw when attachment data is empty', async () => {
+    mockAttachmentGet.mockResolvedValue({ data: { data: null } });
+
+    await expect(
+      service.downloadAttachment('user-1', 'msg-1', 'att-1', 'empty.pdf')
+    ).rejects.toThrow('Attachment data is empty');
+  });
+
+  it('should create the gmail directory', async () => {
+    const testData = Buffer.from('test').toString('base64url');
+    mockAttachmentGet.mockResolvedValue({ data: { data: testData, size: 4 } });
+
+    await service.downloadAttachment('user-1', 'msg-1', 'att-1', 'test.txt');
+
+    expect(mockMkdir).toHaveBeenCalledWith(expectedDir, { recursive: true });
+  });
+
+  it('should call Gmail API with correct params', async () => {
+    const testData = Buffer.from('test').toString('base64url');
+    mockAttachmentGet.mockResolvedValue({ data: { data: testData, size: 4 } });
+
+    await service.downloadAttachment('user-1', 'msg-abc', 'att-xyz', 'file.txt');
+
+    expect(mockAttachmentGet).toHaveBeenCalledWith({
+      userId: 'me',
+      messageId: 'msg-abc',
+      id: 'att-xyz',
+    });
+  });
+});

--- a/packages/api/src/stories/gmail/service.ts
+++ b/packages/api/src/stories/gmail/service.ts
@@ -566,6 +566,53 @@ export class GmailService {
   }
 
   /**
+   * Download an email attachment to ~/.ink/files/gmail/
+   */
+  async downloadAttachment(
+    userId: string,
+    messageId: string,
+    attachmentId: string,
+    filename: string
+  ): Promise<{ path: string; filename: string; size: number }> {
+    const gmail = await this.getClient(userId);
+
+    const response = await gmail.users.messages.attachments.get({
+      userId: 'me',
+      messageId,
+      id: attachmentId,
+    });
+
+    if (!response.data.data) {
+      throw new Error('Attachment data is empty');
+    }
+
+    const buffer = Buffer.from(response.data.data, 'base64url');
+
+    const { join } = await import('path');
+    const { mkdir, writeFile } = await import('fs/promises');
+    const { homedir } = await import('os');
+
+    const dir = join(homedir(), '.ink', 'files', 'gmail');
+    await mkdir(dir, { recursive: true });
+
+    const sanitized = filename.replace(/[^a-zA-Z0-9._-]/g, '_');
+    const destFilename = `${Date.now()}_${sanitized}`;
+    const filePath = join(dir, destFilename);
+
+    await writeFile(filePath, buffer);
+
+    logger.info('Downloaded Gmail attachment', {
+      userId,
+      messageId,
+      filename: sanitized,
+      filePath,
+      size: buffer.byteLength,
+    });
+
+    return { path: filePath, filename: sanitized, size: buffer.byteLength };
+  }
+
+  /**
    * Extract attachments from message payload
    */
   private extractAttachments(payload?: gmail_v1.Schema$MessagePart): EmailAttachment[] {


### PR DESCRIPTION
## Summary

- **`download_email_attachment` MCP tool** — downloads Gmail attachments via the Gmail API, saves to `~/.ink/files/gmail/` with sanitized filenames, returns absolute path for cross-agent sharing. Uses existing OAuth tokens from the Google integration.
- **WhatsApp media download** — `downloadMedia()` using Baileys' built-in decryption, saves to `~/.ink/files/whatsapp/`. Incoming image/video/document messages are now processed (previously silently dropped if they had no text caption).
- **Telegram crash guard** — PID-based lockfile (`~/.ink/locks/telegram-<hash>.lock`) prevents two listeners from competing for `getUpdates` on the same bot token. Stale locks from dead processes are automatically reclaimed.

Closes the "Cross-agent media sharing" task group. Media directory convention: `~/.ink/files/<channel>/` with absolute paths throughout.

## Test plan

- [x] Gmail download: 5 unit tests (happy path, filename sanitization, empty data, directory creation, API params)
- [x] Gmail handler: 5 schema validation tests (valid params, missing fields, optional identifiers)
- [x] All 218 channel + Gmail tests pass
- [x] Type-check clean (no new errors)
- [ ] Smoke: Myra downloads a Gmail attachment and forwards to Telegram
- [ ] Smoke: WhatsApp image message is received and saved to disk

— Wren