### PR TITLE
feat: session context philosophy + update_task_group autonomous toggle (by Wren)

### DIFF
--- a/packages/api/src/mcp/tools/index.ts
+++ b/packages/api/src/mcp/tools/index.ts
@@ -1988,12 +1988,15 @@ User can be identified by ONE of: userId, email, phone, or platform + platformId
 
 Session resolution: sessionId (explicit) > studioId (scoped lookup) > most recent active session.
 For parallel worktrees, pass studioId to target the correct session.
+
 Phase: Communicates real-time work status to other agents.
 - Active work phases (no auto-memory): investigating, implementing, reviewing
 - Significant transitions (auto-creates memory): blocked:<reason>, waiting:<reason>, complete
 - Optional: paused
 
-Also sets: backendSessionId (for resume), status (active/paused/resumable/completed), context, workingDir.
+Context: The session context column is for **transient runtime state** — facts that are too ephemeral for a memory but too important to lose on compaction. Examples: "server running on port 4001", "vitest watching in background", "PR #341 open awaiting review". The real spine of continuity is memories ("completed X", "decided Y because Z") which flow through bootstrap. Context fills the gap for durable-right-now facts that don't warrant a memory. Use it as a scratch board for active state.
+
+Also sets: backendSessionId (for resume), status (active/paused/resumable/completed), workingDir.
 
 User can be identified by ONE of: userId, email, phone, or platform + platformId`,
       inputSchema: {
@@ -2036,7 +2039,12 @@ User can be identified by ONE of: userId, email, phone, or platform + platformId
           .enum(['active', 'paused', 'resumable', 'completed'])
           .optional()
           .describe('Session status'),
-        context: z.string().optional().describe('Brief context of current work state'),
+        context: z
+          .string()
+          .optional()
+          .describe(
+            'Transient runtime state — active facts too ephemeral for a memory but important to preserve across compaction. E.g. "server on :4001", "waiting on PR #341 review", "vitest running in background". Use as a scratch board; memories handle durable decisions.'
+          ),
         workingDir: z.string().optional().describe('Working directory'),
       },
     },

--- a/packages/api/src/mcp/tools/index.ts
+++ b/packages/api/src/mcp/tools/index.ts
@@ -2017,7 +2017,9 @@ User can be identified by ONE of: userId, email, phone, or platform + platformId
         phase: z
           .string()
           .optional()
-          .describe('Work phase (e.g., "implementing", "blocked:awaiting-input", "waiting:build")'),
+          .describe(
+            'Work phase (agent-set). Core phases: investigating, implementing, reviewing, paused, complete. Use waiting:<reason> when awaiting an async response within normal flow (review, merge, feedback). Use blocked:<reason> ONLY when extraordinary intervention is required outside normal process — something has gone wrong (permissions denied, infrastructure broken, unresolvable conflict). Both auto-create memories. Do NOT use runtime: prefix — use lifecycle instead.'
+          ),
         note: z
           .string()
           .optional()

--- a/packages/api/src/mcp/tools/memory-handlers.ts
+++ b/packages/api/src/mcp/tools/memory-handlers.ts
@@ -474,7 +474,7 @@ export const updateSessionPhaseSchema = userIdentifierBaseSchema.extend({
     .string()
     .optional()
     .describe(
-      'Work phase (agent-set). Core phases: investigating, implementing, reviewing, paused, complete. Use blocked:<reason> or waiting:<reason> for transitions that auto-create memories. Do NOT use runtime: prefix — use lifecycle instead.'
+      'Work phase (agent-set). Core phases: investigating, implementing, reviewing, paused, complete. Use waiting:<reason> when awaiting an async response within normal flow (review, merge, feedback). Use blocked:<reason> ONLY when extraordinary intervention is required outside normal process — something has gone wrong (permissions denied, infrastructure broken, unresolvable conflict). Both auto-create memories. Do NOT use runtime: prefix — use lifecycle instead.'
     ),
   note: z
     .string()

--- a/packages/api/src/mcp/tools/task-handlers.test.ts
+++ b/packages/api/src/mcp/tools/task-handlers.test.ts
@@ -19,6 +19,7 @@ import {
   handleCloseTaskGroup,
   handleAddTaskGroupComment,
   handleListTaskGroupComments,
+  updateTaskGroupSchema,
 } from './task-handlers';
 
 // =====================================================
@@ -1613,6 +1614,148 @@ describe('handleUpdateTaskGroup', () => {
     // then responsible for leaving the column alone.
     const call = (dc.repositories.taskGroups.update as any).mock.calls[0][1];
     expect(call.identity_id).toBeUndefined();
+  });
+
+  it('enables autonomous mode and sets maxSessions', async () => {
+    dc.repositories.taskGroups.findById.mockResolvedValue(existingGroup);
+    dc.repositories.taskGroups.update.mockResolvedValue({
+      ...existingGroup,
+      autonomous: true,
+      max_sessions: 5,
+    });
+
+    const response = await handleUpdateTaskGroup(
+      {
+        userId: 'user-123',
+        groupId: '11111111-2222-3333-4444-555555555555',
+        autonomous: true,
+        maxSessions: 5,
+      } as any,
+      dc as any
+    );
+
+    const data = parseResponse(response);
+    expect(response.isError).toBeFalsy();
+    expect(data.success).toBe(true);
+    expect(data.group.autonomous).toBe(true);
+    expect(data.group.maxSessions).toBe(5);
+
+    expect(dc.repositories.taskGroups.update).toHaveBeenCalledWith(
+      '11111111-2222-3333-4444-555555555555',
+      expect.objectContaining({
+        autonomous: true,
+        max_sessions: 5,
+      })
+    );
+  });
+
+  it('clears maxSessions by passing null', async () => {
+    dc.repositories.taskGroups.findById.mockResolvedValue({
+      ...existingGroup,
+      autonomous: true,
+      max_sessions: 5,
+    });
+    dc.repositories.taskGroups.update.mockResolvedValue({
+      ...existingGroup,
+      autonomous: true,
+      max_sessions: null,
+    });
+
+    const response = await handleUpdateTaskGroup(
+      {
+        userId: 'user-123',
+        groupId: '11111111-2222-3333-4444-555555555555',
+        maxSessions: null,
+      } as any,
+      dc as any
+    );
+
+    const data = parseResponse(response);
+    expect(data.success).toBe(true);
+    expect(data.group.maxSessions).toBeNull();
+
+    expect(dc.repositories.taskGroups.update).toHaveBeenCalledWith(
+      '11111111-2222-3333-4444-555555555555',
+      expect.objectContaining({
+        max_sessions: null,
+      })
+    );
+  });
+
+  it('does not pass autonomous/max_sessions when not provided', async () => {
+    dc.repositories.taskGroups.findById.mockResolvedValue(existingGroup);
+    dc.repositories.taskGroups.update.mockResolvedValue({
+      ...existingGroup,
+      title: 'Renamed',
+    });
+
+    await handleUpdateTaskGroup(
+      {
+        userId: 'user-123',
+        groupId: '11111111-2222-3333-4444-555555555555',
+        title: 'Renamed',
+      } as any,
+      dc as any
+    );
+
+    const call = (dc.repositories.taskGroups.update as any).mock.calls[0][1];
+    expect(call.autonomous).toBeUndefined();
+    expect(call.max_sessions).toBeUndefined();
+  });
+});
+
+// =====================================================
+// updateTaskGroupSchema — validation
+// =====================================================
+
+describe('updateTaskGroupSchema', () => {
+  it('accepts autonomous boolean', () => {
+    const result = updateTaskGroupSchema.safeParse({
+      groupId: '11111111-2222-3333-4444-555555555555',
+      autonomous: true,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.autonomous).toBe(true);
+  });
+
+  it('accepts maxSessions as positive integer', () => {
+    const result = updateTaskGroupSchema.safeParse({
+      groupId: '11111111-2222-3333-4444-555555555555',
+      maxSessions: 10,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.maxSessions).toBe(10);
+  });
+
+  it('accepts maxSessions as null (clearing)', () => {
+    const result = updateTaskGroupSchema.safeParse({
+      groupId: '11111111-2222-3333-4444-555555555555',
+      maxSessions: null,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.maxSessions).toBeNull();
+  });
+
+  it('rejects maxSessions as zero or negative', () => {
+    const zeroResult = updateTaskGroupSchema.safeParse({
+      groupId: '11111111-2222-3333-4444-555555555555',
+      maxSessions: 0,
+    });
+    expect(zeroResult.success).toBe(false);
+
+    const negResult = updateTaskGroupSchema.safeParse({
+      groupId: '11111111-2222-3333-4444-555555555555',
+      maxSessions: -1,
+    });
+    expect(negResult.success).toBe(false);
+  });
+
+  it('rejects maxSessions as non-integer', () => {
+    const result = updateTaskGroupSchema.safeParse({
+      groupId: '11111111-2222-3333-4444-555555555555',
+      maxSessions: 3.5,
+    });
+    expect(result.success).toBe(false);
   });
 });
 

--- a/packages/api/src/mcp/tools/task-handlers.ts
+++ b/packages/api/src/mcp/tools/task-handlers.ts
@@ -1294,6 +1294,14 @@ export const updateTaskGroupSchema = z.object({
     .nullable()
     .optional()
     .describe('Agent identity UUID. Pass null to clear.'),
+  autonomous: z.boolean().optional().describe('Whether this group runs autonomously'),
+  maxSessions: z
+    .number()
+    .int()
+    .positive()
+    .nullable()
+    .optional()
+    .describe('Cap on autonomous sessions spent on this group'),
 });
 
 export async function handleUpdateTaskGroup(
@@ -1375,6 +1383,8 @@ export async function handleUpdateTaskGroup(
       thread_key: args.threadKey,
       owner_agent_id: args.ownerAgentId,
       identity_id: nextIdentityId,
+      autonomous: args.autonomous,
+      max_sessions: args.maxSessions,
     });
 
     return mcpResponse({


### PR DESCRIPTION
## Summary\n\n- **Session context philosophy** — enriched `update_session_phase` tool description and `context` field to explain the role of session context vs memories. Context is for **transient runtime state** (\"server on :4001\", \"vitest watching\") — too ephemeral for memory, too important to lose on compaction. Memories remain the spine of continuity.\n- **`waiting:` vs `blocked:` convention** — clarified `phase` field description: `waiting:` = normal async hold (reviews, CI, feedback); `blocked:` = extraordinary intervention required (permissions, infrastructure). Myra monitors `blocked:` sessions and escalates.\n- **`update_task_group` autonomous toggle** — exposed `autonomous` and `maxSessions` fields in the MCP schema for `update_task_group`. Previously these were only settable at creation time via `create_task_group`, even though the repository layer already supported them.\n\n### Also updated (not in this diff)\n- Team process document (`save_team_constitution`) — added \"Session Context\" section with philosophy, examples, and \"what belongs where\" table\n- Myra's heartbeat document — added blocked session escalation monitoring\n\n## Test plan\n- [x] 159 unit tests pass (task-handlers + memory-handlers)\n- [x] 2 index registration tests pass\n- [x] Type-check: no new errors (pre-existing errors unchanged)\n- [x] Prettier/lint passes via pre-commit hook\n\n— Wren"