### PR TITLE
fix: set ended_at on session completion + filter completed sessions from threadKey lookup (by Wren)

### DIFF
--- a/packages/api/src/mcp/tools/memory-handlers.test.ts
+++ b/packages/api/src/mcp/tools/memory-handlers.test.ts
@@ -1119,6 +1119,70 @@ describe('handleUpdateSessionPhase', () => {
       expect(parsed.message).toContain('workingDir updated');
     });
 
+    it('should set endedAt when status is completed', async () => {
+      mockDataComposer.repositories.memory.getActiveSession.mockResolvedValue(mockSession);
+      mockDataComposer.repositories.memory.updateSession.mockResolvedValue({
+        ...mockSession,
+        status: 'completed',
+        lifecycle: 'completed',
+        endedAt: new Date(),
+      });
+
+      await handleUpdateSessionPhase(
+        { email: 'test@test.com', phase: 'complete', status: 'completed' },
+        mockDataComposer as never
+      );
+
+      expect(mockDataComposer.repositories.memory.updateSession).toHaveBeenCalledWith(
+        'session-123',
+        expect.objectContaining({
+          endedAt: expect.any(Date),
+          status: 'completed',
+          lifecycle: 'completed',
+        })
+      );
+    });
+
+    it('should set endedAt when lifecycle is explicitly completed', async () => {
+      mockDataComposer.repositories.memory.getActiveSession.mockResolvedValue(mockSession);
+      mockDataComposer.repositories.memory.updateSession.mockResolvedValue({
+        ...mockSession,
+        lifecycle: 'completed',
+        endedAt: new Date(),
+      });
+
+      await handleUpdateSessionPhase(
+        { email: 'test@test.com', phase: 'complete', lifecycle: 'completed' },
+        mockDataComposer as never
+      );
+
+      expect(mockDataComposer.repositories.memory.updateSession).toHaveBeenCalledWith(
+        'session-123',
+        expect.objectContaining({
+          endedAt: expect.any(Date),
+          lifecycle: 'completed',
+        })
+      );
+    });
+
+    it('should NOT set endedAt for non-completed status', async () => {
+      mockDataComposer.repositories.memory.getActiveSession.mockResolvedValue(mockSession);
+      mockDataComposer.repositories.memory.updateSession.mockResolvedValue({
+        ...mockSession,
+        status: 'active',
+      });
+
+      await handleUpdateSessionPhase(
+        { email: 'test@test.com', phase: 'implementing', status: 'active' },
+        mockDataComposer as never
+      );
+
+      expect(mockDataComposer.repositories.memory.updateSession).toHaveBeenCalledWith(
+        'session-123',
+        expect.not.objectContaining({ endedAt: expect.anything() })
+      );
+    });
+
     it('should include session info in response', async () => {
       const sessionWithWorkspace = {
         ...mockSession,

--- a/packages/api/src/mcp/tools/memory-handlers.ts
+++ b/packages/api/src/mcp/tools/memory-handlers.ts
@@ -1411,6 +1411,7 @@ export async function handleUpdateSessionPhase(args: unknown, dataComposer: Data
     context?: string;
     workingDir?: string;
     cliAttached?: boolean;
+    endedAt?: Date | null;
   } = {};
 
   // Map runtime: prefix phases to lifecycle (backward compat for old callers)
@@ -1441,6 +1442,9 @@ export async function handleUpdateSessionPhase(args: unknown, dataComposer: Data
   }
   if (params.status !== undefined) {
     updates.status = params.status;
+  }
+  if (params.status === 'completed' || updates.lifecycle === 'completed') {
+    updates.endedAt = new Date();
   }
   if (params.backendSessionId !== undefined) {
     updates.backendSessionId = params.backendSessionId;

--- a/packages/api/src/services/sessions/session-repository.ts
+++ b/packages/api/src/services/sessions/session-repository.ts
@@ -202,7 +202,7 @@ export class SessionRepository implements ISessionRepository {
       .eq('agent_id', agentId)
       .eq('thread_key', threadKey)
       .is('ended_at', null)
-      .neq('lifecycle', 'failed')
+      .not('lifecycle', 'in', '(completed,cancelled,failed)')
       .order('started_at', { ascending: false })
       .limit(1);
 


### PR DESCRIPTION
## Summary

- **`update_session_phase(status: 'completed')` now sets `ended_at`** — previously it only set lifecycle and status fields, leaving `ended_at = NULL`. This made completed sessions invisible to the `ended_at IS NULL` filter in `findByThreadKey`, causing strategy triggers to route to dead sessions.
- **`findByThreadKey` now filters completed/cancelled/failed lifecycle states** — defense in depth so even if `ended_at` is somehow not set, terminal sessions won't be picked up.

## Root Cause

Strategy watchdog triggers route to sessions via `findByThreadKey(threadKey: "strategy:<groupId>")`. The query filtered `.is('ended_at', null)` to find "active" sessions and `.neq('lifecycle', 'failed')` as the only lifecycle guard. A session marked "completed" via `update_session_phase` had `ended_at = NULL` (never set), so the query kept returning it. The spawned Claude Code instance resumed the old conversation, saw nothing to do, and exited in 8-10 seconds — every 10 minutes, indefinitely.

## Test Plan

- [x] 3 new tests: endedAt set on status=completed, endedAt set on lifecycle=completed, endedAt NOT set for non-completed
- [x] `npx vitest run packages/api/src/mcp/tools/memory-handlers.test.ts` — 100 passed
- [x] DB fix applied: `UPDATE sessions SET ended_at = now() WHERE id = '12cea35f...'`

— Wren