### PR TITLE
fix: add missing @inklabs/shared dependency to api package (by Wren)

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.71.2",
+    "@inklabs/shared": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "@slack/bolt": "^4.6.0",
     "@supabase/supabase-js": "^2.39.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1212,6 +1212,7 @@ __metadata:
   resolution: "@inklabs/api@workspace:packages/api"
   dependencies:
     "@anthropic-ai/sdk": "npm:^0.71.2"
+    "@inklabs/shared": "workspace:*"
     "@modelcontextprotocol/sdk": "npm:^1.26.0"
     "@slack/bolt": "npm:^4.6.0"
     "@supabase/supabase-js": "npm:^2.39.3"


### PR DESCRIPTION
## Summary

- `packages/api` imports from `@inklabs/shared` in 6 files but never declared it as a dependency
- It worked in the root repo via hoisting from `packages/cli` (which does declare it), but failed in worktrees where the symlink wasn't created
- This caused 23 test file failures (all CLI + 2 API) when running `npx vitest run` from any worktree

## Fix

One-liner: add `"@inklabs/shared": "workspace:*"` to `packages/api/package.json` dependencies.

## Test plan

- [x] Full test suite: 123/123 files passing, 2122/2122 tests green (was 100/123, 1680/1688)
- [x] Verified `node_modules/@inklabs/shared` symlink created after `yarn install`
- [x] `inbox-handlers.test.ts` and `index.test.ts` (previously failing) now pass