### PR TITLE
feat: ephemeral studios — auto-create worktree + container for autonomous work (by Wren)

### DIFF
--- a/packages/api/src/data/repositories/task-groups.repository.ts
+++ b/packages/api/src/data/repositories/task-groups.repository.ts
@@ -74,6 +74,9 @@ export interface StrategyConfig {
   sandboxPolicy?: 'required' | 'preferred';
   /** Backend auth dirs to mount in the sandbox (default: ['claude']) */
   sandboxBackendAuth?: Array<'claude' | 'codex' | 'gemini'>;
+  /** Automatically create an ephemeral git worktree + studio for sandbox work (default: false).
+   *  When true + sandbox: true, strategy creates a fresh studio at startup and cleans it up on completion. */
+  ephemeralStudio?: boolean;
 }
 
 export interface CreateTaskGroupInput {

--- a/packages/api/src/services/strategy.service.test.ts
+++ b/packages/api/src/services/strategy.service.test.ts
@@ -544,13 +544,14 @@ describe('StrategyService', () => {
 
     it('should include planUri when set', async () => {
       const group = createMockGroup({ strategy: null });
+      const updatedGroup = { ...group, plan_uri: 'ink://specs/my-plan' };
       const task = createMockTask();
 
-      dc.repositories.taskGroups.findById.mockResolvedValue(group);
-      dc.repositories.taskGroups.update.mockResolvedValue({
-        ...group,
-        plan_uri: 'ink://specs/my-plan',
-      });
+      // findById called twice: initial load + re-read after sandbox setup
+      dc.repositories.taskGroups.findById
+        .mockResolvedValueOnce(group)
+        .mockResolvedValueOnce(updatedGroup);
+      dc.repositories.taskGroups.update.mockResolvedValue(updatedGroup);
 
       const mockClient = dc.getClient();
       mockClient.from.mockReturnValue({
@@ -1360,7 +1361,10 @@ describe('StrategyService', () => {
       };
       const task = createMockTask({ id: 'task-1', title: 'Ship the migration' });
 
-      dc.repositories.taskGroups.findById.mockResolvedValue(group);
+      // findById called twice: initial load + re-read after sandbox setup
+      dc.repositories.taskGroups.findById
+        .mockResolvedValueOnce(group)
+        .mockResolvedValueOnce(updatedGroup);
       dc.repositories.taskGroups.update.mockResolvedValue(updatedGroup);
       setupChains(dc, [chainTaskFound(task)]);
 
@@ -1398,7 +1402,10 @@ describe('StrategyService', () => {
       const updatedGroup = { ...group, strategy: 'persistence', status: 'active' };
       const task = createMockTask();
 
-      dc.repositories.taskGroups.findById.mockResolvedValue(group);
+      // findById called twice: initial load + re-read after sandbox setup
+      dc.repositories.taskGroups.findById
+        .mockResolvedValueOnce(group)
+        .mockResolvedValueOnce(updatedGroup);
       dc.repositories.taskGroups.update.mockResolvedValue(updatedGroup);
       setupChains(dc, [chainTaskFound(task)]);
 
@@ -1431,7 +1438,10 @@ describe('StrategyService', () => {
       };
       const task = createMockTask();
 
-      dc.repositories.taskGroups.findById.mockResolvedValue(group);
+      // findById called twice: initial load + re-read after sandbox setup
+      dc.repositories.taskGroups.findById
+        .mockResolvedValueOnce(group)
+        .mockResolvedValueOnce(updatedGroup);
       dc.repositories.taskGroups.update.mockResolvedValue(updatedGroup);
       setupChains(dc, [chainTaskFound(task)]);
 

--- a/packages/api/src/services/strategy.service.test.ts
+++ b/packages/api/src/services/strategy.service.test.ts
@@ -23,6 +23,20 @@ vi.mock('../mcp/tools/inbox-handlers', () => ({
   handleSendToInbox: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock('child_process', () => ({
+  execFile: vi.fn((_cmd: string, _args: string[], _opts: unknown, cb?: Function) => {
+    if (cb) cb(null, 'worktree /repo\n', '');
+  }),
+}));
+
+vi.mock('fs', () => ({
+  existsSync: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock('./studio-settings', () => ({
+  ensureStudioSettings: vi.fn().mockResolvedValue(true),
+}));
+
 // ============================================================================
 // Mock Helpers
 // ============================================================================
@@ -128,6 +142,19 @@ function createMockDataComposer() {
       },
       studios: {
         findById: vi.fn().mockResolvedValue(null),
+        create: vi.fn().mockResolvedValue({
+          id: 'studio-ephemeral-1',
+          userId: 'user-123',
+          agentId: 'wren',
+          repoRoot: '/repo',
+          worktreePath: '/repo--ephemeral-test',
+          branch: 'wren/sandbox/ephemeral-test',
+          baseBranch: 'main',
+          status: 'active',
+          slug: 'ephemeral-test',
+          metadata: { ephemeral: true },
+        }),
+        markCleaned: vi.fn().mockResolvedValue({}),
       },
     },
   };
@@ -1804,6 +1831,233 @@ describe('StrategyService', () => {
       expect(result.action).toBe('group_complete');
       expect(result.sandbox?.success).toBe(false);
       expect(result.prompt).toContain('Sandbox spin-up failed');
+    });
+  });
+
+  describe('ephemeral studio', () => {
+    it('creates ephemeral studio when ephemeralStudio + sandbox are true and no studioId', async () => {
+      const group = createMockGroup({
+        strategy: null,
+        status: 'active',
+        metadata: { repoRoot: '/repo' },
+      });
+      const task = createMockTask();
+      const mockOrchestrator = {
+        spinUp: vi.fn().mockResolvedValue({
+          containerName: 'ink-sandbox-wren-ephemeral-12345678',
+          success: true,
+        }),
+        isRunning: vi.fn(),
+      };
+
+      dc.repositories.taskGroups.findById.mockResolvedValue(group);
+      dc.repositories.taskGroups.update.mockImplementation(async (_id: string, data: any) => ({
+        ...group,
+        strategy: 'persistence',
+        status: 'active',
+        strategy_config: { sandbox: true, ephemeralStudio: true },
+        metadata: { ...group.metadata, ...data.metadata },
+        ...data,
+      }));
+
+      const mockTasks = {
+        findById: vi.fn(),
+        startTask: vi.fn().mockResolvedValue({}),
+      };
+      dc.repositories.tasks = mockTasks as any;
+
+      // Mock getTaskByOrder via the supabase chain
+      dc.getClient.mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                in: vi.fn().mockReturnValue({
+                  limit: vi.fn().mockReturnValue({
+                    single: vi.fn().mockResolvedValue({ data: task, error: null }),
+                  }),
+                }),
+                order: vi.fn().mockReturnValue({
+                  order: vi.fn().mockReturnValue({
+                    limit: vi.fn().mockResolvedValue({ data: [task], error: null }),
+                  }),
+                }),
+                single: vi.fn().mockResolvedValue({ data: task, error: null }),
+              }),
+            }),
+          }),
+          insert: vi.fn().mockResolvedValue({ data: null, error: null }),
+          update: vi.fn().mockReturnValue({
+            contains: vi.fn().mockResolvedValue({ data: null, error: null }),
+          }),
+        }),
+      });
+
+      // Studio created by createEphemeralStudio
+      dc.repositories.studios.findById.mockResolvedValue({
+        id: 'studio-ephemeral-1',
+        userId: 'user-123',
+        agentId: 'wren',
+        repoRoot: '/repo',
+        worktreePath: '/repo--ephemeral-test-strategy-group',
+        branch: 'wren/sandbox/ephemeral-test-strategy-group',
+        baseBranch: 'main',
+        status: 'active',
+        slug: 'ephemeral-test-strategy-group',
+      });
+
+      const serviceWithSandbox = new StrategyService(dc as any, mockOrchestrator as any);
+      const result = await serviceWithSandbox.startStrategy({
+        groupId: 'group-1',
+        userId: 'user-123',
+        strategy: 'persistence',
+        ownerAgentId: 'wren',
+        config: { sandbox: true, ephemeralStudio: true },
+      });
+
+      // Should have created the studio via repository
+      expect(dc.repositories.studios.create).toHaveBeenCalled();
+      const createCall = dc.repositories.studios.create.mock.calls[0][0];
+      expect(createCall.userId).toBe('user-123');
+      expect(createCall.agentId).toBe('wren');
+      expect(createCall.metadata).toEqual(
+        expect.objectContaining({ ephemeral: true, taskGroupId: 'group-1' })
+      );
+
+      // Should have updated group metadata with ephemeralStudioId
+      const updateCalls = dc.repositories.taskGroups.update.mock.calls;
+      const metadataUpdate = updateCalls.find((c: any) => c[1]?.metadata?.ephemeralStudioId);
+      expect(metadataUpdate).toBeDefined();
+
+      // Should have spun up sandbox
+      expect(mockOrchestrator.spinUp).toHaveBeenCalled();
+      expect(result.action).not.toBe('group_complete');
+    });
+
+    it('fails when ephemeralStudio is true but no repoRoot in metadata', async () => {
+      const group = createMockGroup({
+        strategy: null,
+        status: 'active',
+        metadata: {}, // no repoRoot
+      });
+      const task = createMockTask();
+      const mockOrchestrator = {
+        spinUp: vi.fn(),
+        isRunning: vi.fn(),
+      };
+
+      dc.repositories.taskGroups.findById.mockResolvedValue(group);
+      dc.repositories.taskGroups.update.mockResolvedValue({
+        ...group,
+        strategy: 'persistence',
+        status: 'active',
+        strategy_config: { sandbox: true, ephemeralStudio: true },
+      });
+
+      dc.getClient.mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                in: vi.fn().mockReturnValue({
+                  limit: vi.fn().mockReturnValue({
+                    single: vi.fn().mockResolvedValue({ data: task, error: null }),
+                  }),
+                }),
+                order: vi.fn().mockReturnValue({
+                  order: vi.fn().mockReturnValue({
+                    limit: vi.fn().mockResolvedValue({ data: [task], error: null }),
+                  }),
+                }),
+                single: vi.fn().mockResolvedValue({ data: task, error: null }),
+              }),
+            }),
+          }),
+          insert: vi.fn().mockResolvedValue({ data: null, error: null }),
+          update: vi.fn().mockReturnValue({
+            contains: vi.fn().mockResolvedValue({ data: null, error: null }),
+          }),
+        }),
+      });
+
+      const serviceWithSandbox = new StrategyService(dc as any, mockOrchestrator as any);
+      const result = await serviceWithSandbox.startStrategy({
+        groupId: 'group-1',
+        userId: 'user-123',
+        strategy: 'persistence',
+        ownerAgentId: 'wren',
+        config: { sandbox: true, ephemeralStudio: true },
+      });
+
+      expect(mockOrchestrator.spinUp).not.toHaveBeenCalled();
+      expect(result.action).toBe('group_complete');
+      expect(result.sandbox?.success).toBe(false);
+      expect(result.sandbox?.error).toContain('repoRoot');
+    });
+
+    it('cleans up ephemeral studio on strategy completion', async () => {
+      const group = createMockGroup({
+        metadata: {
+          ephemeralStudioId: 'studio-ephemeral-1',
+          studioId: 'studio-ephemeral-1',
+        },
+      });
+
+      dc.repositories.studios.findById.mockResolvedValue({
+        id: 'studio-ephemeral-1',
+        worktreePath: '/repo--ephemeral-test',
+        repoRoot: '/repo',
+      });
+
+      const mockOrchestrator = {
+        spinUp: vi.fn(),
+        isRunning: vi.fn(),
+        listSandboxes: vi.fn().mockResolvedValue([]),
+        stop: vi.fn().mockResolvedValue(true),
+      };
+
+      dc.repositories.taskGroups.findById.mockResolvedValue(group);
+
+      const serviceWithSandbox = new StrategyService(dc as any, mockOrchestrator as any);
+      await serviceWithSandbox.cleanupStrategyResources('group-1');
+
+      expect(dc.repositories.studios.markCleaned).toHaveBeenCalledWith('studio-ephemeral-1');
+    });
+
+    it('stops sandbox container during ephemeral teardown', async () => {
+      const group = createMockGroup({
+        metadata: {
+          ephemeralStudioId: 'studio-ephemeral-1',
+          studioId: 'studio-ephemeral-1',
+        },
+      });
+
+      dc.repositories.studios.findById.mockResolvedValue({
+        id: 'studio-ephemeral-1',
+        worktreePath: '/repo--ephemeral-test',
+        repoRoot: '/repo',
+      });
+
+      const mockOrchestrator = {
+        spinUp: vi.fn(),
+        isRunning: vi.fn(),
+        listSandboxes: vi.fn().mockResolvedValue([
+          {
+            containerName: 'ink-sandbox-test',
+            running: true,
+            labels: { 'ink.studio-id': 'studio-ephemeral-1' },
+          },
+        ]),
+        stop: vi.fn().mockResolvedValue(true),
+      };
+
+      dc.repositories.taskGroups.findById.mockResolvedValue(group);
+
+      const serviceWithSandbox = new StrategyService(dc as any, mockOrchestrator as any);
+      await serviceWithSandbox.cleanupStrategyResources('group-1');
+
+      expect(mockOrchestrator.stop).toHaveBeenCalledWith('ink-sandbox-test');
+      expect(dc.repositories.studios.markCleaned).toHaveBeenCalledWith('studio-ephemeral-1');
     });
   });
 });

--- a/packages/api/src/services/strategy.service.ts
+++ b/packages/api/src/services/strategy.service.ts
@@ -12,6 +12,10 @@
  * New sessions are only created by heartbeat recovery if one dies.
  */
 
+import path from 'path';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { existsSync } from 'fs';
 import type { DataComposer } from '../data/composer';
 import { getRequestContext } from '../utils/request-context';
 import type {
@@ -23,7 +27,10 @@ import type {
 import type { ProjectTask, TaskAssignment } from '../data/repositories/project-tasks.repository';
 import { handleSendToInbox } from '../mcp/tools/inbox-handlers';
 import { logger } from '../utils/logger';
+import { ensureStudioSettings } from './studio-settings';
 import type { SandboxOrchestrator, SandboxSpinUpResult } from './sandbox/orchestrator';
+
+const execFileAsync = promisify(execFile);
 
 // ============================================================================
 // Types
@@ -403,8 +410,8 @@ export class StrategyService {
           : `Strategy complete. ${completed}/${tasks.length} tasks done.`,
       });
 
-      // Cancel watchdog — strategy is done
-      await this.cancelWatchdogReminder(group.id);
+      // Clean up strategy resources (watchdog, ephemeral studio, sandbox)
+      await this.cleanupStrategyResources(group.id);
 
       await this.logStrategyEvent(
         group,
@@ -608,7 +615,7 @@ export class StrategyService {
     if (group.status === 'completed') throw new Error('Strategy is already completed');
     if (group.status === 'cancelled') throw new Error('Strategy is already cancelled');
 
-    await this.cancelWatchdogReminder(groupId);
+    await this.cleanupStrategyResources(groupId);
 
     const summary = reason
       ? `Strategy cancelled on "${group.title}": ${reason}`
@@ -918,10 +925,179 @@ export class StrategyService {
   }
 
   /**
+   * Create an ephemeral git worktree + studio for sandbox work.
+   * Returns the studio record or null on failure.
+   */
+  private async createEphemeralStudio(
+    group: TaskGroup,
+    repoRoot: string
+  ): Promise<{ studioId: string; worktreePath: string; branch: string } | null> {
+    const agentId = group.owner_agent_id || 'agent';
+    const slugBase = (group.title || 'task')
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-|-$/g, '')
+      .slice(0, 30);
+    const slug = `ephemeral-${slugBase}`;
+    const branch = `${agentId}/sandbox/${slug}`;
+
+    // Resolve to the main worktree root
+    let mainRoot = repoRoot;
+    try {
+      const { stdout } = await execFileAsync('git', ['worktree', 'list', '--porcelain'], {
+        cwd: repoRoot,
+      });
+      const match = stdout.match(/^worktree\s+(.+)$/m);
+      if (match) mainRoot = match[1];
+    } catch {
+      // Fall through with original repoRoot
+    }
+
+    const worktreePath = path.join(path.dirname(mainRoot), `${path.basename(mainRoot)}--${slug}`);
+
+    // Create git worktree
+    try {
+      await execFileAsync('git', ['worktree', 'add', '-b', branch, worktreePath, 'main'], {
+        cwd: mainRoot,
+      });
+      logger.info('Ephemeral studio worktree created', { branch, worktreePath, groupId: group.id });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      logger.error('Ephemeral studio worktree creation failed', {
+        error: msg,
+        branch,
+        worktreePath,
+      });
+      return null;
+    }
+
+    // Install dependencies (non-blocking on failure)
+    if (existsSync(path.join(worktreePath, 'package.json'))) {
+      try {
+        await execFileAsync('yarn', ['install'], { cwd: worktreePath, timeout: 120_000 });
+      } catch (err) {
+        logger.warn('Ephemeral studio yarn install failed (non-fatal)', {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
+    // Generate studio settings
+    try {
+      await ensureStudioSettings(worktreePath);
+    } catch {
+      // Non-fatal
+    }
+
+    // Insert studio record
+    try {
+      const studio = await this.dataComposer.repositories.studios.create({
+        userId: group.user_id,
+        agentId,
+        repoRoot: mainRoot,
+        worktreePath,
+        branch,
+        baseBranch: 'main',
+        purpose: `Ephemeral sandbox for: ${group.title}`,
+        workType: 'feature',
+        metadata: { ephemeral: true, taskGroupId: group.id },
+      });
+
+      // Update the task group metadata with the new studioId
+      const existingMeta = (group.metadata || {}) as Record<string, unknown>;
+      await this.dataComposer.repositories.taskGroups.update(group.id, {
+        metadata: {
+          ...existingMeta,
+          studioId: studio.id,
+          studioSlug: slug,
+          ephemeralStudioId: studio.id,
+        },
+      });
+
+      await this.logStrategyEvent(
+        group,
+        'ephemeral_studio_created',
+        `Ephemeral studio created: ${worktreePath}`,
+        { studioId: studio.id, branch, worktreePath }
+      );
+
+      return { studioId: studio.id, worktreePath, branch };
+    } catch (err) {
+      // DB failed — clean up the worktree
+      const msg = err instanceof Error ? err.message : String(err);
+      logger.error('Ephemeral studio DB insert failed, cleaning up worktree', { error: msg });
+      try {
+        await execFileAsync('git', ['worktree', 'remove', worktreePath], { cwd: mainRoot });
+      } catch {
+        // Best-effort
+      }
+      return null;
+    }
+  }
+
+  /**
+   * Tear down an ephemeral studio: stop sandbox container, remove worktree, mark cleaned.
+   */
+  private async teardownEphemeralStudio(group: TaskGroup): Promise<void> {
+    const metadata = (group.metadata || {}) as Record<string, unknown>;
+    const ephemeralStudioId =
+      typeof metadata.ephemeralStudioId === 'string' ? metadata.ephemeralStudioId : undefined;
+    if (!ephemeralStudioId) return;
+
+    const studio = await this.dataComposer.repositories.studios.findById(ephemeralStudioId);
+    if (!studio) return;
+
+    // Stop sandbox container if running
+    if (this.sandboxOrchestrator) {
+      const sandboxes = await this.sandboxOrchestrator.listSandboxes();
+      const match = sandboxes.find(
+        (s) => s.running && s.labels?.['ink.studio-id'] === ephemeralStudioId
+      );
+      if (match) {
+        await this.sandboxOrchestrator.stop(match.containerName).catch((err) => {
+          logger.warn('Failed to stop ephemeral sandbox container', {
+            containerName: match.containerName,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        });
+      }
+    }
+
+    // Remove git worktree
+    try {
+      await execFileAsync('git', ['worktree', 'remove', studio.worktreePath], {
+        cwd: studio.repoRoot,
+      });
+    } catch (err) {
+      logger.warn('Failed to remove ephemeral worktree (may already be gone)', {
+        worktreePath: studio.worktreePath,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+
+    // Mark studio as cleaned in DB
+    try {
+      await this.dataComposer.repositories.studios.markCleaned(ephemeralStudioId);
+    } catch {
+      // Best-effort
+    }
+
+    await this.logStrategyEvent(
+      group,
+      'ephemeral_studio_cleaned',
+      `Ephemeral studio cleaned: ${studio.worktreePath}`,
+      { studioId: ephemeralStudioId, worktreePath: studio.worktreePath }
+    );
+  }
+
+  /**
    * Spin up a sandbox Docker container for the strategy's owner agent.
    * Resolves the studio from DB metadata, builds a SandboxSpinUpRequest,
    * and delegates to the orchestrator. Returns null if sandbox mode is
    * not enabled or no orchestrator is configured.
+   *
+   * When ephemeralStudio is true and no studioId exists in metadata,
+   * automatically creates a fresh git worktree + studio for the work.
    */
   private async maybeSpinUpSandbox(group: TaskGroup): Promise<SandboxSpinUpResult | null> {
     const config = group.strategy_config as StrategyConfig;
@@ -933,10 +1109,34 @@ export class StrategyService {
       return { containerName: '', success: false, error: msg };
     }
 
-    const metadata = (group.metadata || {}) as Record<string, unknown>;
-    const studioId = typeof metadata.studioId === 'string' ? metadata.studioId : undefined;
+    let metadata = (group.metadata || {}) as Record<string, unknown>;
+    let studioId = typeof metadata.studioId === 'string' ? metadata.studioId : undefined;
+
+    // Ephemeral studio: auto-create if none assigned
+    if (!studioId && config.ephemeralStudio) {
+      const repoRoot = typeof metadata.repoRoot === 'string' ? metadata.repoRoot : undefined;
+      if (!repoRoot) {
+        const msg = `Ephemeral studio requested but no repoRoot in metadata`;
+        logger.warn(`Strategy group ${group.id}: ${msg}`);
+        return { containerName: '', success: false, error: msg };
+      }
+
+      const ephemeral = await this.createEphemeralStudio(group, repoRoot);
+      if (!ephemeral) {
+        const msg = `Failed to create ephemeral studio`;
+        return { containerName: '', success: false, error: msg };
+      }
+
+      studioId = ephemeral.studioId;
+      // Re-read metadata since createEphemeralStudio updated it
+      const refreshed = await this.dataComposer.repositories.taskGroups.findById(group.id);
+      if (refreshed) {
+        metadata = (refreshed.metadata || {}) as Record<string, unknown>;
+      }
+    }
+
     if (!studioId) {
-      const msg = `Sandbox requested but no studioId in metadata`;
+      const msg = `Sandbox requested but no studioId in metadata (set ephemeralStudio: true in strategy config to auto-create)`;
       logger.warn(`Strategy group ${group.id}: ${msg}`);
       return { containerName: '', success: false, error: msg };
     }
@@ -1178,6 +1378,17 @@ export class StrategyService {
    */
   async cleanupStrategyResources(groupId: string): Promise<void> {
     await this.cancelWatchdogReminder(groupId);
+
+    // Tear down ephemeral studio + sandbox if present
+    const group = await this.dataComposer.repositories.taskGroups.findById(groupId);
+    if (group) {
+      await this.teardownEphemeralStudio(group).catch((err) => {
+        logger.warn('Ephemeral studio teardown failed (non-fatal)', {
+          groupId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
+    }
   }
 
   private async cancelWatchdogReminder(groupId: string): Promise<void> {

--- a/packages/api/src/services/strategy.service.ts
+++ b/packages/api/src/services/strategy.service.ts
@@ -233,15 +233,14 @@ export class StrategyService {
       };
     }
 
-    // Mark the first task as in_progress with assignment metadata
-    await this.dataComposer.repositories.tasks.startTask(nextTask.id, this.getAssignment(updated));
-
     // Create a watchdog reminder so the heartbeat checks progress periodically
     await this.createWatchdogReminder(updated, input.userId);
 
     // Spin up sandbox BEFORE triggering the agent — if sandboxPolicy is
     // 'required' (default), a failed sandbox aborts the strategy instead
     // of silently degrading to host execution.
+    // Note: maybeSpinUpSandbox may create an ephemeral studio and update
+    // group metadata in the DB, so we re-read the group afterward.
     const config = updated.strategy_config as StrategyConfig;
     const sandboxResult = await this.maybeSpinUpSandbox(updated);
     const sandboxPolicy = config.sandboxPolicy || 'required';
@@ -270,13 +269,26 @@ export class StrategyService {
       };
     }
 
+    // Re-read group after sandbox setup — createEphemeralStudio may have
+    // written studioId/studioSlug to metadata that triggerOwnerAgent needs
+    // for correct studio routing.
+    const currentGroup =
+      (await this.dataComposer.repositories.taskGroups.findById(input.groupId)) || updated;
+
+    // Mark the first task as in_progress with assignment metadata.
+    // Done after sandbox setup so the assignment reflects the ephemeral studioId.
+    await this.dataComposer.repositories.tasks.startTask(
+      nextTask.id,
+      this.getAssignment(currentGroup)
+    );
+
     // Trigger the owner agent in the assigned studio. The trigger spawns
     // (or resumes) a session in the target studio so work actually begins.
     // Pass the sandbox container name so the triggered session routes
     // CLI execution into the container.
     const sandboxContainer = sandboxResult?.success ? sandboxResult.containerName : undefined;
     const triggered = await this.triggerOwnerAgent(
-      updated,
+      currentGroup,
       nextTask,
       'strategy_kickoff',
       sandboxContainer
@@ -284,9 +296,9 @@ export class StrategyService {
 
     // Log strategy start
     await this.logStrategyEvent(
-      updated,
+      currentGroup,
       'strategy_started',
-      `Strategy "${input.strategy}" started on "${updated.title}"`,
+      `Strategy "${input.strategy}" started on "${currentGroup.title}"`,
       {
         firstTaskId: nextTask.id,
         firstTaskTitle: nextTask.title,
@@ -297,7 +309,7 @@ export class StrategyService {
       }
     );
 
-    const prompt = STRATEGY_PROMPTS[input.strategy](updated, nextTask);
+    const prompt = STRATEGY_PROMPTS[input.strategy](currentGroup, nextTask);
 
     return {
       action: 'next_task',
@@ -938,7 +950,8 @@ export class StrategyService {
       .replace(/[^a-z0-9]+/g, '-')
       .replace(/^-|-$/g, '')
       .slice(0, 30);
-    const slug = `ephemeral-${slugBase}`;
+    const uniqueSuffix = Date.now().toString(36).slice(-6);
+    const slug = `ephemeral-${slugBase}-${uniqueSuffix}`;
     const branch = `${agentId}/sandbox/${slug}`;
 
     // Resolve to the main worktree root
@@ -1073,6 +1086,20 @@ export class StrategyService {
         worktreePath: studio.worktreePath,
         error: err instanceof Error ? err.message : String(err),
       });
+    }
+
+    // Delete the ephemeral branch (prevents collisions on retry)
+    if (studio.branch) {
+      try {
+        await execFileAsync('git', ['branch', '-d', studio.branch], {
+          cwd: studio.repoRoot,
+        });
+      } catch (err) {
+        logger.warn('Failed to delete ephemeral branch (may have unmerged changes)', {
+          branch: studio.branch,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
     }
 
     // Mark studio as cleaned in DB


### PR DESCRIPTION
## Summary

When a strategy has `sandbox: true` + `ephemeralStudio: true`, the strategy service now auto-creates a fresh git worktree, registers it as a studio in the DB, and spins up a Docker container mounted to it — all as a single unit. On strategy completion or cancellation, both the container and worktree are torn down automatically.

This means autonomous task groups no longer need a pre-existing studio. The full isolation stack (git branch + Docker container) is dynamic and purpose-built for each piece of work.

### What changed

- **`StrategyConfig.ephemeralStudio`** — new boolean flag that enables auto-creation
- **`createEphemeralStudio()`** — async method in strategy service that:
  - Creates a git worktree (`git worktree add -b <branch> <path> main`)
  - Installs dependencies if `package.json` exists
  - Generates studio settings (`.claude/settings.local.json`)
  - Inserts a studio DB record with `metadata: { ephemeral: true, taskGroupId }`
  - Updates the task group metadata with `studioId` + `ephemeralStudioId`
- **`teardownEphemeralStudio()`** — cleanup method that:
  - Stops any sandbox container matched by `ink.studio-id` label
  - Removes the git worktree
  - Marks the studio as `cleaned` in the DB
- **`cleanupStrategyResources()`** — now calls teardown on both completion and cancellation paths
- **`maybeSpinUpSandbox()`** — when no `studioId` in metadata and `ephemeralStudio: true`, auto-creates one before spinning up the container. Requires `repoRoot` in task group metadata.
- All git operations use async `execFileAsync` (never `execSync`) to avoid blocking the event loop

### Usage

```typescript
await strategyService.startStrategy({
  groupId: 'group-1',
  userId: 'user-123',
  strategy: 'persistence',
  ownerAgentId: 'wren',
  config: {
    sandbox: true,
    ephemeralStudio: true,  // new
  },
});
// Task group metadata must include: { repoRoot: '/path/to/repo' }
```

## Test plan

- [x] Creates ephemeral studio when `ephemeralStudio + sandbox` are true and no studioId in metadata
- [x] Fails gracefully when `ephemeralStudio` is true but no `repoRoot` in metadata
- [x] Cleans up ephemeral studio (marks cleaned in DB) on strategy completion
- [x] Stops sandbox container during ephemeral teardown (matched by `ink.studio-id` label)
- [x] All 47 strategy service tests pass (43 existing + 4 new)
- [x] Full suite: 2325 tests across 131 files
- [ ] Live Docker integration: strategy with `ephemeralStudio: true` creates real worktree + container

Generated with [Claude Code](https://claude.com/claude-code)

— Wren