### PR TITLE
feat: complete identityId → sbId migration across web, CLI, and API (by Wren)

### DIFF
--- a/packages/api/src/mcp/tools/task-handlers.ts
+++ b/packages/api/src/mcp/tools/task-handlers.ts
@@ -818,7 +818,7 @@ export async function handleAddTaskGroupComment(
     const reqCtx = getRequestContext();
     const workspaceId = reqCtx?.workspaceId;
 
-    const identityId = await resolveIdentityIdForAgent(
+    const sbId = await resolveIdentityIdForAgent(
       dataComposer,
       resolved.user.id,
       agentId,
@@ -834,7 +834,7 @@ export async function handleAddTaskGroupComment(
         content: args.content.trim(),
         comment_type: args.commentType || 'comment',
         agent_id: agentId || null,
-        created_by_sb_id: identityId,
+        created_by_sb_id: sbId,
       } as never)
       .select()
       .single();
@@ -1060,7 +1060,7 @@ export async function handleCloseTaskGroup(
     const agentId = getEffectiveAgentId(args.agentId);
     const reqCtx = getRequestContext();
     const workspaceId = reqCtx?.workspaceId;
-    const identityId = await resolveIdentityIdForAgent(
+    const sbId = await resolveIdentityIdForAgent(
       dataComposer,
       resolved.user.id,
       agentId,
@@ -1076,7 +1076,7 @@ export async function handleCloseTaskGroup(
         content: autoConclusion,
         comment_type: 'conclusion',
         agent_id: agentId || null,
-        created_by_sb_id: identityId,
+        created_by_sb_id: sbId,
       } as never);
 
     if (commentError) {

--- a/packages/api/src/services/strategy.service.ts
+++ b/packages/api/src/services/strategy.service.ts
@@ -1343,7 +1343,7 @@ export class StrategyService {
       }
 
       // Resolve the owner agent's identity for reminder routing
-      let identityId: string | null = null;
+      let sbId: string | null = null;
       if (group.owner_agent_id) {
         const { data: identity } = await this.dataComposer
           .getClient()
@@ -1353,7 +1353,7 @@ export class StrategyService {
           .eq('user_id', userId)
           .limit(1)
           .single();
-        if (identity) identityId = identity.id;
+        if (identity) sbId = identity.id;
       }
 
       await this.dataComposer
@@ -1373,7 +1373,7 @@ export class StrategyService {
           ]
             .filter(Boolean)
             .join(' '),
-          sb_id: identityId,
+          sb_id: sbId,
           cron_expression: `*/${intervalMinutes} * * * *`,
           next_run_at: nextRunAt.toISOString(),
           status: 'active',
@@ -1436,13 +1436,13 @@ export class StrategyService {
    * Resolve an identity UUID to an agent_id slug for notification routing.
    * notifyDispatcher/handleSendToInbox accept slugs, but we store identity UUIDs.
    */
-  private async resolveAgentSlug(identityId: string): Promise<string | null> {
+  private async resolveAgentSlug(sbId: string): Promise<string | null> {
     try {
       const { data } = await this.dataComposer
         .getClient()
         .from('agent_identities')
         .select('agent_id')
-        .eq('id', identityId)
+        .eq('id', sbId)
         .single();
       return data ? (data as { agent_id: string }).agent_id : null;
     } catch {

--- a/packages/cli/src/backends/identity.ts
+++ b/packages/cli/src/backends/identity.ts
@@ -24,7 +24,7 @@ export interface RuntimePreferences {
 
 export interface IdentityJson {
   agentId: string;
-  identityId?: string;
+  sbId?: string;
   context?: string;
   backend?: string;
   role?: string;

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -588,7 +588,7 @@ function getPcpConfig(): PcpConfig | null {
 
 function getIdentityContextFromIdentityJson(cwd = process.cwd()): {
   studioId?: string;
-  identityId?: string;
+  sbId?: string;
   studioName?: string;
 } {
   const identityPath = join(cwd, '.ink', 'identity.json');
@@ -596,12 +596,12 @@ function getIdentityContextFromIdentityJson(cwd = process.cwd()): {
   try {
     const identity = JSON.parse(readFileSync(identityPath, 'utf-8')) as {
       studioId?: string;
-      identityId?: string;
+      sbId?: string;
       studio?: string;
     };
     return {
       studioId: identity.studioId,
-      identityId: identity.identityId,
+      sbId: identity.sbId,
       studioName: identity.studio,
     };
   } catch {
@@ -615,7 +615,7 @@ function getIdentityContextFromIdentityJson(cwd = process.cwd()): {
  */
 async function resolveStudioId(cwd: string): Promise<{
   studioId?: string;
-  identityId?: string;
+  sbId?: string;
   studioName?: string;
 }> {
   const local = getIdentityContextFromIdentityJson(cwd);
@@ -2394,7 +2394,7 @@ async function persistBackendSessionLink(options: {
   agentId: string;
   runtimeLinkId?: string;
   studioId?: string;
-  identityId?: string;
+  sbId?: string;
   email?: string;
 }): Promise<void> {
   if (!options.pcpSessionId || !options.backendSessionId) return;
@@ -2404,7 +2404,7 @@ async function persistBackendSessionLink(options: {
     pcpSessionId: options.pcpSessionId,
     backend: options.backend,
     agentId: options.agentId,
-    ...(options.identityId ? { identityId: options.identityId } : {}),
+    ...(options.sbId ? { sbId: options.sbId } : {}),
     ...(options.studioId ? { studioId: options.studioId } : {}),
     ...(options.runtimeLinkId ? { runtimeLinkId: options.runtimeLinkId } : {}),
     backendSessionId: options.backendSessionId,
@@ -2477,7 +2477,7 @@ async function ensurePcpSessionContext(
   const config = getPcpConfig();
   const email = config?.email;
   const cwd = process.cwd();
-  const { studioId, identityId } = await resolveStudioId(cwd);
+  const { studioId, sbId } = await resolveStudioId(cwd);
   const currentGitBranch = getCurrentGitBranch(cwd);
   const localSessionLimit = options.listCandidates || options.listCandidatesJson ? 120 : 40;
   const pcpSessionLimit = options.listCandidates || options.listCandidatesJson ? 80 : 40;
@@ -2827,7 +2827,7 @@ async function ensurePcpSessionContext(
         backend,
         agentId,
         studioId,
-        identityId,
+        sbId,
         email,
       });
       sbDebugLog('claude', 'ensure_context_override_linked', {
@@ -3349,7 +3349,7 @@ async function ensurePcpSessionContext(
     pcpSessionId: chosen.id,
     backend,
     agentId,
-    ...(identityId ? { identityId } : {}),
+    ...(sbId ? { sbId } : {}),
     ...(studioId ? { studioId } : {}),
     ...(chosen.threadKey ? { threadKey: chosen.threadKey } : {}),
     ...(effectiveBackendSessionId ? { backendSessionId: effectiveBackendSessionId } : {}),
@@ -3358,7 +3358,7 @@ async function ensurePcpSessionContext(
   });
   setCurrentRuntimeSession(cwd, chosen.id, backend, {
     agentId,
-    ...(identityId ? { identityId } : {}),
+    ...(sbId ? { sbId } : {}),
     ...(studioId ? { studioId } : {}),
   });
 
@@ -3441,14 +3441,14 @@ export async function runClaude(
     : {};
   const runtimeLinkId = options.session ? randomUUID() : undefined;
   const currentGitBranch = getCurrentGitBranch(process.cwd());
-  const { studioId, identityId } = await resolveStudioId(process.cwd());
+  const { studioId, sbId } = await resolveStudioId(process.cwd());
 
   if (sessionContext.pcpSessionId && runtimeLinkId) {
     upsertRuntimeSession(process.cwd(), {
       pcpSessionId: sessionContext.pcpSessionId,
       backend: options.backend,
       agentId,
-      ...(identityId ? { identityId } : {}),
+      ...(sbId ? { sbId } : {}),
       ...(studioId ? { studioId } : {}),
       runtimeLinkId,
       ...(sessionContext.backendSessionId
@@ -3603,7 +3603,7 @@ export async function runClaude(
       agentId,
       runtimeLinkId,
       studioId,
-      identityId,
+      sbId,
       email: pcpConfig?.email,
     });
     await finalizeExecution(code ?? null);
@@ -3657,14 +3657,14 @@ export async function runClaudeInteractive(
     : {};
   const runtimeLinkId = options.session ? randomUUID() : undefined;
   const currentGitBranch = getCurrentGitBranch(process.cwd());
-  const { studioId, identityId } = await resolveStudioId(process.cwd());
+  const { studioId, sbId } = await resolveStudioId(process.cwd());
 
   if (sessionContext.pcpSessionId && runtimeLinkId) {
     upsertRuntimeSession(process.cwd(), {
       pcpSessionId: sessionContext.pcpSessionId,
       backend: options.backend,
       agentId,
-      ...(identityId ? { identityId } : {}),
+      ...(sbId ? { sbId } : {}),
       ...(studioId ? { studioId } : {}),
       runtimeLinkId,
       ...(sessionContext.backendSessionId
@@ -3833,7 +3833,7 @@ export async function runClaudeInteractive(
       agentId,
       runtimeLinkId,
       studioId,
-      identityId,
+      sbId,
       email: pcpConfig?.email,
     });
 

--- a/packages/cli/src/commands/hooks.ts
+++ b/packages/cli/src/commands/hooks.ts
@@ -507,7 +507,7 @@ function resolveActivePcpSessionId(cwd: string): string | undefined {
 
 function getIdentitySessionContext(cwd: string): {
   studioId?: string;
-  identityId?: string;
+  sbId?: string;
   studioName?: string;
   role?: string;
 } {
@@ -517,13 +517,13 @@ function getIdentitySessionContext(cwd: string): {
   try {
     const identity = JSON.parse(readFileSync(identityPath, 'utf-8')) as {
       studioId?: string;
-      identityId?: string;
+      sbId?: string;
       studio?: string;
       role?: string;
     };
     return {
       studioId: identity.studioId,
-      identityId: identity.identityId,
+      sbId: identity.sbId,
       studioName: identity.studio,
       role: identity.role,
     };
@@ -610,7 +610,7 @@ async function reconcileBackendSignal(
     runtimeLinkId: runtimeLinkId || null,
     stdinKeys: Object.keys(stdin),
   });
-  const { studioId, identityId } = getIdentitySessionContext(cwd);
+  const { studioId, sbId } = getIdentitySessionContext(cwd);
 
   let pcpSessionId = options?.initialPcpSessionId || resolveActivePcpSessionId(cwd);
   let threadKey = options?.initialThreadKey;
@@ -697,7 +697,7 @@ async function reconcileBackendSignal(
       threadKey: threadKey || null,
       backendSessionId: backendSessionId || null,
       studioId: studioId || null,
-      identityId: identityId || null,
+      sbId: sbId || null,
     });
     return {
       ...(backendSessionId ? { backendSessionId } : {}),
@@ -709,7 +709,7 @@ async function reconcileBackendSignal(
     pcpSessionId,
     backend: sessionBackend,
     agentId,
-    ...(identityId ? { identityId } : {}),
+    ...(sbId ? { sbId } : {}),
     ...(studioId ? { studioId } : {}),
     ...(threadKey ? { threadKey } : {}),
     ...(runtimeLinkId ? { runtimeLinkId } : {}),
@@ -719,7 +719,7 @@ async function reconcileBackendSignal(
   });
   setCurrentRuntimeSession(cwd, pcpSessionId, sessionBackend, {
     agentId,
-    ...(identityId ? { identityId } : {}),
+    ...(sbId ? { sbId } : {}),
     ...(studioId ? { studioId } : {}),
   });
   sbDebugLog('hooks', 'reconcile_result', {
@@ -728,7 +728,7 @@ async function reconcileBackendSignal(
     threadKey: threadKey || null,
     backendSessionId: backendSessionId || null,
     studioId: studioId || null,
-    identityId: identityId || null,
+    sbId: sbId || null,
   });
 
   return {

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -202,8 +202,8 @@ async function statusCommand(options: { backend?: string }): Promise<void> {
   console.log(chalk.bold('\nSB Status\n'));
   console.log(`  ${chalk.bold('Agent:')}   ${agentId}`);
   console.log(`  ${chalk.bold('Backend:')} ${backend}`);
-  if (identity?.identityId) {
-    console.log(`  ${chalk.bold('Identity:')} ${chalk.dim(identity.identityId)}`);
+  if (identity?.sbId) {
+    console.log(`  ${chalk.bold('Identity:')} ${chalk.dim(identity.sbId)}`);
   }
   if (identity?.studio) {
     console.log(`  ${chalk.bold('Studio:')}  ${identity.studio}`);

--- a/packages/cli/src/commands/studio.ts
+++ b/packages/cli/src/commands/studio.ts
@@ -50,7 +50,7 @@ const __dirname = dirname(__filename);
 
 interface StudioIdentity {
   agentId: string;
-  identityId?: string;
+  sbId?: string;
   context: string;
   backend?: string;
   role?: string;
@@ -967,18 +967,18 @@ async function createStudioInner(
   const pcpDir = join(wsPath, '.ink');
   mkdirSync(pcpDir, { recursive: true });
 
-  let identityId: string | undefined;
+  let sbId: string | undefined;
   const auth = loadAuth();
   if (auth && !isTokenExpired(auth)) {
     const payload = decodeJwtPayload(auth.access_token);
     if (payload?.identityId) {
-      identityId = payload.identityId;
+      sbId = payload.identityId;
     }
   }
 
   const identity: StudioIdentity = {
     agentId,
-    ...(identityId ? { identityId } : {}),
+    ...(sbId ? { sbId } : {}),
     context: `studio-${name}`,
     ...(options.backend ? { backend: options.backend } : {}),
     ...(options.template ? { role: options.template } : {}),

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -7,7 +7,7 @@
 
 export interface StudioIdentity {
   agentId: string;
-  identityId?: string;
+  sbId?: string;
   context: string;
   description: string;
   studioId?: string;

--- a/packages/cli/src/session/runtime.ts
+++ b/packages/cli/src/session/runtime.ts
@@ -5,7 +5,7 @@ export interface RuntimeSessionRecord {
   pcpSessionId: string;
   backend: string;
   agentId?: string;
-  identityId?: string;
+  sbId?: string;
   studioId?: string;
   threadKey?: string;
   gitBranch?: string;
@@ -22,7 +22,7 @@ interface RuntimeSessionState {
     pcpSessionId: string;
     backend: string;
     agentId?: string;
-    identityId?: string;
+    sbId?: string;
     studioId?: string;
     updatedAt: string;
   };
@@ -161,14 +161,14 @@ export function setCurrentRuntimeSession(
   cwd: string,
   pcpSessionId: string,
   backend: string,
-  options?: { agentId?: string; identityId?: string; studioId?: string }
+  options?: { agentId?: string; sbId?: string; studioId?: string }
 ): void {
   const state = readRuntimeState(cwd);
   state.current = {
     pcpSessionId,
     backend,
     ...(options?.agentId ? { agentId: options.agentId } : {}),
-    ...(options?.identityId ? { identityId: options.identityId } : {}),
+    ...(options?.sbId ? { sbId: options.sbId } : {}),
     ...(options?.studioId ? { studioId: options.studioId } : {}),
     updatedAt: new Date().toISOString(),
   };
@@ -209,7 +209,7 @@ export function getCurrentRuntimeSession(
         s.pcpSessionId === state.current!.pcpSessionId &&
         s.backend === state.current!.backend &&
         (!state.current!.agentId || s.agentId === state.current!.agentId) &&
-        (!state.current!.identityId || s.identityId === state.current!.identityId) &&
+        (!state.current!.sbId || s.sbId === state.current!.sbId) &&
         (!state.current!.studioId || s.studioId === state.current!.studioId) &&
         (!backend || s.backend === backend)
     );

--- a/packages/web/src/app/(dashboard)/artifacts/[artifactId]/page.tsx
+++ b/packages/web/src/app/(dashboard)/artifacts/[artifactId]/page.tsx
@@ -205,7 +205,7 @@ export default function ArtifactDetailPage() {
     () => new Map(identityOptions.map((identity) => [identity.id, identity.name] as const)),
     [identityOptions]
   );
-  const identityIdByAgentId = useMemo(
+  const sbIdByAgentId = useMemo(
     () =>
       new Map(
         (identitiesData?.individuals ?? []).map(
@@ -222,14 +222,12 @@ export default function ArtifactDetailPage() {
         (artifact.editors || [])
           .map((value) => value.trim())
           .filter((value) => value.length > 0)
-          .map((value) =>
-            identityNameById.get(value) ? value : identityIdByAgentId.get(value) || value
-          )
+          .map((value) => (identityNameById.get(value) ? value : sbIdByAgentId.get(value) || value))
       )
     );
     setPermissionEditMode(artifact.editMode || 'workspace');
     setPermissionEditorIdentityIds(normalizedEditorIds);
-  }, [artifact, identityNameById, identityIdByAgentId]);
+  }, [artifact, identityNameById, sbIdByAgentId]);
 
   useEffect(() => {
     if (!permissionSuccess) return;
@@ -470,12 +468,12 @@ export default function ArtifactDetailPage() {
             <span>
               Editors:{' '}
               {artifact.editors
-                .map((identityId) => {
-                  const identityName = identityNameById.get(identityId);
+                .map((sbId) => {
+                  const identityName = identityNameById.get(sbId);
                   if (identityName) return identityName;
-                  const remappedId = identityIdByAgentId.get(identityId);
+                  const remappedId = sbIdByAgentId.get(sbId);
                   const remappedIdentityName = remappedId ? identityNameById.get(remappedId) : null;
-                  return remappedIdentityName || identityId;
+                  return remappedIdentityName || sbId;
                 })
                 .join(', ')}
             </span>

--- a/packages/web/src/app/(dashboard)/individuals/[agentId]/inbox/page.tsx
+++ b/packages/web/src/app/(dashboard)/individuals/[agentId]/inbox/page.tsx
@@ -36,9 +36,9 @@ interface InboxMessage {
   priority: string;
   status: string;
   senderAgentId: string | null;
-  senderIdentityId: string | null;
+  senderSbId: string | null;
   recipientAgentId: string;
-  recipientIdentityId: string | null;
+  recipientSbId: string | null;
   threadKey: string | null;
   recipientSessionId: string | null;
   relatedArtifactUri: string | null;
@@ -868,11 +868,7 @@ export default function InboxPage() {
                   </h3>
                   <div className="space-y-3">
                     <RoutingField label="Agent ID" value={routingMessage.senderAgentId} />
-                    <RoutingField
-                      label="Identity ID"
-                      value={routingMessage.senderIdentityId}
-                      mono
-                    />
+                    <RoutingField label="Identity ID" value={routingMessage.senderSbId} mono />
                   </div>
                 </div>
 
@@ -882,11 +878,7 @@ export default function InboxPage() {
                   </h3>
                   <div className="space-y-3">
                     <RoutingField label="Agent ID" value={routingMessage.recipientAgentId} />
-                    <RoutingField
-                      label="Identity ID"
-                      value={routingMessage.recipientIdentityId}
-                      mono
-                    />
+                    <RoutingField label="Identity ID" value={routingMessage.recipientSbId} mono />
                   </div>
                 </div>
 

--- a/packages/web/src/app/(dashboard)/page.tsx
+++ b/packages/web/src/app/(dashboard)/page.tsx
@@ -35,7 +35,7 @@ interface AgentWithStudios {
   agentName: string;
   agentRole: string | null;
   backend: string | null;
-  identityId: string;
+  sbId: string;
   latestSession: AgentLatestSession | null;
   studios: StudioInfo[];
 }

--- a/packages/web/src/app/(dashboard)/routing/[agentId]/page.tsx
+++ b/packages/web/src/app/(dashboard)/routing/[agentId]/page.tsx
@@ -25,7 +25,7 @@ import { Input } from '@/components/ui/input';
 
 interface AgentRoute {
   id: string;
-  identityId: string;
+  sbId: string;
   agentId: string | null;
   agentName: string | null;
   agentRole: string | null;
@@ -54,7 +54,7 @@ interface AgentReminder {
   status: 'active' | 'paused' | 'completed' | 'cancelled' | 'failed';
   runCount: number;
   maxRuns: number | null;
-  identityId: string | null;
+  sbId: string | null;
   studioHint: string | null;
 }
 
@@ -164,8 +164,8 @@ export default function AgentRoutingPage() {
   const [homeStudioValue, setHomeStudioValue] = useState('');
 
   const updateHomeStudioMutation = useMutation({
-    mutationFn: ({ identityId, studioHint }: { identityId: string; studioHint: string }) =>
-      apiPatch(`/api/admin/routing/identities/${identityId}`, { studioHint }),
+    mutationFn: ({ sbId, studioHint }: { sbId: string; studioHint: string }) =>
+      apiPatch(`/api/admin/routing/identities/${sbId}`, { studioHint }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['routing'] });
       queryClient.invalidateQueries({ queryKey: ['routing-agent', agentId] });
@@ -413,7 +413,7 @@ export default function AgentRoutingPage() {
                       disabled={updateHomeStudioMutation.isPending}
                       onClick={() =>
                         updateHomeStudioMutation.mutate({
-                          identityId: data.agent.id,
+                          sbId: data.agent.id,
                           studioHint: homeStudioValue,
                         })
                       }
@@ -883,7 +883,7 @@ export default function AgentRoutingPage() {
               event.preventDefault();
               if (!data?.agent?.id) return;
               createRouteMutation.mutate({
-                identityId: data.agent.id,
+                sbId: data.agent.id,
                 platform: newRoute.platform,
                 platformAccountId: newRoute.platformAccountId || null,
                 chatId: newRoute.chatId || null,

--- a/packages/web/src/app/(dashboard)/routing/page.tsx
+++ b/packages/web/src/app/(dashboard)/routing/page.tsx
@@ -38,7 +38,7 @@ interface RoutingIdentity {
 
 interface RoutingRoute {
   id: string;
-  identityId: string;
+  sbId: string;
   agentId: string | null;
   agentName: string | null;
   agentRole: string | null;
@@ -69,7 +69,7 @@ interface RoutingResponse {
 }
 
 interface CreateRouteInput {
-  identityId: string;
+  sbId: string;
   platform: string;
   platformAccountId?: string | null;
   chatId?: string | null;
@@ -80,7 +80,7 @@ interface SBGroup {
   agentId: string;
   agentName: string;
   agentRole: string | null;
-  identityId: string;
+  sbId: string;
   studioHint: string;
   routes: RoutingRoute[];
   totalReminders: number;
@@ -150,7 +150,7 @@ export default function RoutingPage() {
   const queryClient = useQueryClient();
   const [showCreateForm, setShowCreateForm] = useState(false);
   const [newRoute, setNewRoute] = useState<CreateRouteInput>({
-    identityId: '',
+    sbId: '',
     platform: 'telegram',
     platformAccountId: '',
     chatId: '',
@@ -169,7 +169,7 @@ export default function RoutingPage() {
         queryClient.invalidateQueries({ queryKey: ['routing'] });
         setShowCreateForm(false);
         setNewRoute({
-          identityId: '',
+          sbId: '',
           platform: 'telegram',
           platformAccountId: '',
           chatId: '',
@@ -208,14 +208,14 @@ export default function RoutingPage() {
   const sbGroups = useMemo<SBGroup[]>(() => {
     const groups = new Map<string, SBGroup>();
     for (const route of routes) {
-      const key = route.agentId || route.identityId;
+      const key = route.agentId || route.sbId;
       if (!groups.has(key)) {
-        const identity = identityMap.get(route.identityId);
+        const identity = identityMap.get(route.sbId);
         groups.set(key, {
           agentId: route.agentId || 'unknown',
           agentName: route.agentName || route.agentId || 'Unknown agent',
           agentRole: route.agentRole || null,
-          identityId: route.identityId,
+          sbId: route.sbId,
           studioHint: identity?.studioHint || 'home',
           routes: [],
           totalReminders: 0,
@@ -300,7 +300,7 @@ export default function RoutingPage() {
               onSubmit={(e) => {
                 e.preventDefault();
                 createRouteMutation.mutate({
-                  identityId: newRoute.identityId,
+                  sbId: newRoute.sbId,
                   platform: newRoute.platform,
                   platformAccountId: newRoute.platformAccountId || null,
                   chatId: newRoute.chatId || null,
@@ -313,8 +313,8 @@ export default function RoutingPage() {
                   <label className="text-sm font-medium text-gray-700">SB</label>
                   <select
                     className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
-                    value={newRoute.identityId}
-                    onChange={(e) => setNewRoute((p) => ({ ...p, identityId: e.target.value }))}
+                    value={newRoute.sbId}
+                    onChange={(e) => setNewRoute((p) => ({ ...p, sbId: e.target.value }))}
                     required
                   >
                     <option value="">Select an SB...</option>

--- a/packages/web/src/components/permissions/object-permissions-editor.tsx
+++ b/packages/web/src/components/permissions/object-permissions-editor.tsx
@@ -64,8 +64,8 @@ export function ObjectPermissionsEditor({
     setNextEditorId('');
   };
 
-  const removeEditor = (identityId: string) => {
-    onEditorIdentityIdsChange(editorIdentityIds.filter((current) => current !== identityId));
+  const removeEditor = (sbId: string) => {
+    onEditorIdentityIdsChange(editorIdentityIds.filter((current) => current !== sbId));
   };
 
   const submitDisabled = isActionPending || (mode === 'editors' && editorIdentityIds.length === 0);
@@ -120,19 +120,19 @@ export function ObjectPermissionsEditor({
               <p className="text-sm text-red-700">Select at least one editor.</p>
             ) : (
               <div className="space-y-2">
-                {editorIdentityIds.map((identityId) => {
-                  const identity = identitiesById.get(identityId);
+                {editorIdentityIds.map((sbId) => {
+                  const identity = identitiesById.get(sbId);
                   return (
                     <div
-                      key={identityId}
+                      key={sbId}
                       className="flex items-center justify-between rounded-md border border-gray-200 bg-white px-3 py-2 text-sm text-gray-800"
                     >
                       <span>{identity?.name || 'Unknown identity'}</span>
                       <button
                         type="button"
-                        onClick={() => removeEditor(identityId)}
+                        onClick={() => removeEditor(sbId)}
                         className="rounded p-1 text-gray-500 hover:bg-gray-100 hover:text-gray-700"
-                        aria-label={`Remove ${identity ? identity.name : identityId}`}
+                        aria-label={`Remove ${identity ? identity.name : sbId}`}
                       >
                         <X className="h-3 w-3" />
                       </button>


### PR DESCRIPTION
## Summary

Completes the application-layer migration of `identityId` → `sbId` across all three packages, following the DB column rename in PR #351.

- **Web dashboard**: All component interfaces, state variables, memos, and map lookups (`routing`, `inbox`, `artifacts`, `permissions`, `dashboard`)
- **CLI**: `StudioIdentity`, `IdentityJson`, and all command files (`claude.ts`, `hooks.ts`, `studio.ts`, `runtime.ts`). JWT wire format (`JwtPayload.identityId`) intentionally preserved — claim names are a wire contract
- **API**: Local variables in `task-handlers.ts` (2 locations) and `strategy.service.ts` (3 locations including `resolveAgentSlug` param). REST backward-compat aliases in `admin.ts` and `pcp-auth-provider` are intentionally unchanged

## What's NOT changed (by design)

- `JwtPayload.identityId` — JWT claim name, changing it would break all existing tokens
- `admin.ts` request body aliases — accepts both `sbId` and `identityId` for backward compat
- `pcp-auth-provider` backward compat layer
- `user_identity_history.identity_id` — organic human identity column, not agent/SB

## Test plan

- [x] Full test suite passes: 2122 tests, 123 files, 0 failures
- [x] `grep -rn identityId` confirms only intentional backward-compat refs remain
- [x] JWT token tests still verify correct claim names

— Wren