### PR TITLE
feat: surface task group comments in mission detail dashboard (by Wren)

### DIFF
--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -6605,6 +6605,102 @@ router.get('/task-groups/:id/activity', async (req: Request, res: Response) => {
 });
 
 /**
+ * GET /api/admin/task-groups/:id/comments
+ * List comments for a task group
+ */
+router.get('/task-groups/:id/comments', async (req: Request, res: Response) => {
+  try {
+    const { id } = req.params;
+    const supabase = createClient(env.SUPABASE_URL, env.SUPABASE_SECRET_KEY, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+    const authReq = req as AdminAuthRequest;
+
+    const { data: group } = await supabase
+      .from('task_groups')
+      .select('id')
+      .eq('id', id)
+      .eq('user_id', authReq.pcpUserId)
+      .single();
+
+    if (!group) {
+      res.status(404).json({ error: 'Task group not found' });
+      return;
+    }
+
+    const { data: comments, error } = await supabase
+      .from('task_group_comments')
+      .select('*')
+      .eq('task_group_id', id)
+      .is('deleted_at', null)
+      .order('created_at', { ascending: true });
+
+    if (error) {
+      logger.error('Failed to list task group comments:', error);
+      res.status(500).json(errorJson('Failed to list task group comments', error));
+      return;
+    }
+
+    const sbIds = Array.from(
+      new Set((comments || []).map((c) => c.created_by_sb_id).filter(Boolean) as string[])
+    );
+
+    const identitiesById = new Map<
+      string,
+      { id: string; agent_id: string; name: string; backend: string | null }
+    >();
+
+    if (sbIds.length > 0) {
+      const { data: identities, error: identitiesError } = await supabase
+        .from('agent_identities')
+        .select('id, agent_id, name, backend')
+        .in('id', sbIds);
+
+      if (identitiesError) {
+        logger.error('Failed to resolve task group comment identities:', identitiesError);
+        res.status(500).json(errorJson('Failed to resolve comment identities', identitiesError));
+        return;
+      }
+
+      for (const identity of identities || []) {
+        identitiesById.set(identity.id, identity);
+      }
+    }
+
+    res.json({
+      groupId: id,
+      comments: (comments || []).map((comment) => {
+        const identity = comment.created_by_sb_id
+          ? (identitiesById.get(comment.created_by_sb_id) ?? null)
+          : null;
+        return {
+          id: comment.id,
+          taskGroupId: comment.task_group_id,
+          commentType: comment.comment_type,
+          content: comment.content,
+          agentId: comment.agent_id,
+          metadata: comment.metadata,
+          createdBySbId: comment.created_by_sb_id,
+          createdByIdentity: identity
+            ? {
+                id: identity.id,
+                agentId: identity.agent_id,
+                name: identity.name,
+                backend: identity.backend,
+              }
+            : null,
+          createdAt: comment.created_at,
+          updatedAt: comment.updated_at,
+        };
+      }),
+    });
+  } catch (error) {
+    logger.error('Failed to list task group comments:', error);
+    res.status(500).json(errorJson('Failed to list task group comments', error));
+  }
+});
+
+/**
  * GET /api/admin/tasks/:id/comments
  * List comments for a task
  */

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -6632,6 +6632,7 @@ router.get('/task-groups/:id/comments', async (req: Request, res: Response) => {
       .from('task_group_comments')
       .select('*')
       .eq('task_group_id', id)
+      .eq('user_id', authReq.pcpUserId)
       .is('deleted_at', null)
       .order('created_at', { ascending: true });
 

--- a/packages/web/src/app/(dashboard)/missions/[groupId]/page.tsx
+++ b/packages/web/src/app/(dashboard)/missions/[groupId]/page.tsx
@@ -28,6 +28,8 @@ import {
   Target,
   Hash,
   Timer,
+  MessageSquare,
+  FileCheck,
 } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { useApiQuery } from '@/lib/api';
@@ -92,6 +94,31 @@ interface ActivityEvent {
 
 interface ActivityResponse {
   events: ActivityEvent[];
+}
+
+interface CommentIdentity {
+  id: string;
+  agentId: string;
+  name: string;
+  backend: string | null;
+}
+
+interface TaskGroupComment {
+  id: string;
+  taskGroupId: string;
+  commentType: 'comment' | 'conclusion' | 'status_change';
+  content: string;
+  agentId: string | null;
+  metadata: Record<string, unknown>;
+  createdBySbId: string | null;
+  createdByIdentity: CommentIdentity | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface CommentsResponse {
+  groupId: string;
+  comments: TaskGroupComment[];
 }
 
 // ─── Constants ───
@@ -482,6 +509,109 @@ function LiveTimeline({ groupId, isActive }: { groupId: string; isActive: boolea
   );
 }
 
+// ─── Comments Thread ───
+
+function CommentsThread({ groupId }: { groupId: string }) {
+  const { data, isLoading } = useApiQuery<CommentsResponse>(
+    ['mission-comments', groupId],
+    `/api/admin/task-groups/${groupId}/comments`
+  );
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center gap-2 text-sm text-gray-400 py-6 justify-center">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        Loading comments...
+      </div>
+    );
+  }
+
+  const comments = data?.comments ?? [];
+  if (comments.length === 0) {
+    return (
+      <div className="text-center py-6">
+        <MessageSquare className="h-8 w-8 mx-auto text-gray-200 mb-2" />
+        <p className="text-sm text-gray-400">No comments yet.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {comments.map((comment) => {
+        const isConclusion = comment.commentType === 'conclusion';
+        const isStatusChange = comment.commentType === 'status_change';
+        const authorName =
+          comment.createdByIdentity?.name ||
+          comment.createdByIdentity?.agentId ||
+          comment.agentId ||
+          'Unknown';
+        const agentBadge = comment.agentId
+          ? (AGENT_BADGE_COLORS[comment.agentId] ?? 'bg-gray-100 text-gray-600')
+          : null;
+
+        if (isStatusChange) {
+          return (
+            <div key={comment.id} className="flex items-center gap-2 py-1">
+              <div className="flex-1 h-px bg-gray-100" />
+              <span className="text-[11px] text-gray-400 italic">{comment.content}</span>
+              <div className="flex-1 h-px bg-gray-100" />
+            </div>
+          );
+        }
+
+        return (
+          <div
+            key={comment.id}
+            className={clsx(
+              'rounded-lg border p-4',
+              isConclusion ? 'bg-emerald-50/50 border-emerald-200' : 'bg-white border-gray-200'
+            )}
+          >
+            <div className="flex items-center justify-between mb-2">
+              <div className="flex items-center gap-2">
+                {isConclusion && <FileCheck className="h-3.5 w-3.5 text-emerald-600" />}
+                {agentBadge && (
+                  <span
+                    className={clsx(
+                      'text-[11px] font-medium px-1.5 py-0.5 rounded-full',
+                      agentBadge
+                    )}
+                  >
+                    {authorName}
+                  </span>
+                )}
+                {!agentBadge && (
+                  <span className="text-xs font-medium text-gray-700">{authorName}</span>
+                )}
+                {isConclusion && (
+                  <span className="text-[10px] font-medium text-emerald-600 uppercase tracking-wider">
+                    Conclusion
+                  </span>
+                )}
+                {comment.createdByIdentity?.backend && (
+                  <span className="text-[10px] text-gray-400">
+                    via {comment.createdByIdentity.backend}
+                  </span>
+                )}
+              </div>
+              <span className="text-[11px] text-gray-400">{formatDateTime(comment.createdAt)}</span>
+            </div>
+            <p
+              className={clsx(
+                'text-sm whitespace-pre-wrap',
+                isConclusion ? 'text-emerald-900' : 'text-gray-700'
+              )}
+            >
+              {comment.content}
+            </p>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
 // ─── Main Page ───
 
 export default function MissionDetailPage() {
@@ -671,6 +801,17 @@ export default function MissionDetailPage() {
             </div>
             <LiveTimeline groupId={groupId} isActive={isActive} />
           </div>
+        </div>
+      </div>
+
+      {/* Comments Thread */}
+      <div className="mt-6">
+        <div className="rounded-xl border bg-white p-5">
+          <div className="flex items-center gap-2 mb-4">
+            <MessageSquare className="h-4 w-4 text-gray-400" />
+            <h2 className="text-sm font-semibold text-gray-700">Comments</h2>
+          </div>
+          <CommentsThread groupId={groupId} />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

- Add `GET /api/admin/task-groups/:id/comments` endpoint with identity resolution (follows artifact comments pattern)
- Add CommentsThread component to mission detail page with:
  - Conclusion comments: green border/background, "Conclusion" label, FileCheck icon
  - Status change comments: inline separator style
  - Regular comments: white card with agent attribution badges
  - Agent color-coded badges matching existing palette (wren=sky, lumen=amber, etc.)

## Context

This is the last task in the "Task group lifecycle fidelity" task group (d1edf928). The backend (MCP tools `add_task_group_comment`, `list_task_group_comments`, and the `task_group_comments` table) was completed in earlier tasks. This adds the dashboard UI.

## Test plan

- [x] Web type-check passes clean
- [x] API endpoint follows established artifact comments pattern
- [x] Could not test in-browser — dev server runs from root repo (main), not this worktree. Visual verification needed post-merge.

— Wren