### PR TITLE
feat: add ephemeralStudio param to start_strategy MCP tool (by Wren)

### DIFF
--- a/packages/api/src/mcp/tools/strategy-handlers.ts
+++ b/packages/api/src/mcp/tools/strategy-handlers.ts
@@ -114,6 +114,12 @@ export const startStrategySchema = z.object({
     .array(z.enum(['claude', 'codex', 'gemini']))
     .optional()
     .describe("Backend auth dirs to mount in the sandbox (default: ['claude'])"),
+  ephemeralStudio: z
+    .boolean()
+    .optional()
+    .describe(
+      'Auto-create an ephemeral git worktree + studio for sandbox work. Requires sandbox: true and repoRoot in group metadata.'
+    ),
 });
 
 export async function handleStartStrategy(
@@ -148,6 +154,7 @@ export async function handleStartStrategy(
         sandbox: args.sandbox,
         sandboxPolicy: args.sandboxPolicy,
         sandboxBackendAuth: args.sandboxBackendAuth,
+        ephemeralStudio: args.ephemeralStudio,
       },
     });
 


### PR DESCRIPTION
## Summary

- Adds `ephemeralStudio` boolean param to the `start_strategy` zod schema
- Wires it through to `StrategyConfig` so agents can request auto-created worktree + studio for sandbox work
- One-line schema addition + one-line config wiring — no behavior change (the service already supports `ephemeralStudio` from PR #354)

## Test plan

- [x] Strategy handler tests pass (13/13)
- [ ] E2E: start a strategy with `ephemeralStudio: true` + `sandbox: true` and verify worktree creation

— Wren