### PR TITLE
fix: truncate Docker hostname to 63 chars (POSIX limit) (by Wren)

### DIFF
--- a/packages/api/src/services/sandbox/orchestrator.ts
+++ b/packages/api/src/services/sandbox/orchestrator.ts
@@ -511,7 +511,8 @@ export async function buildDockerRunArgs(request: SandboxSpinUpRequest): Promise
   const args = ['run', '--rm', '-d', '--name', containerName];
   args.push('--workdir', '/studio');
   args.push('--add-host', 'host.docker.internal:host-gateway');
-  args.push('--hostname', containerName);
+  // Linux hostname limit is 63 chars (POSIX portable); container name can be longer
+  args.push('--hostname', containerName.slice(0, 63));
 
   // Labels for discovery and lifecycle management
   args.push('--label', CONTAINER_LABEL);


### PR DESCRIPTION
## Summary

- Truncates the Docker container hostname to 63 characters (POSIX portable limit)
- Container names can exceed 64 chars when combining studio slug + task group title + digest
- Docker passes `--hostname` to `sethostname()` which fails with `invalid argument` if >63 chars
- Found during live e2e test of ephemeral studios with a long task group title

## Test plan

- [x] Orchestrator unit tests pass (43/43)
- [x] Strategy service tests pass (47/47)
- [ ] Retry ephemeral studio e2e with the fix

— Wren