### PR TITLE
fix: use owner agent as sender in strategy triggers, not 'system' (by Wren)

### DIFF
--- a/packages/api/src/services/strategy.service.test.ts
+++ b/packages/api/src/services/strategy.service.test.ts
@@ -1379,7 +1379,7 @@ describe('StrategyService', () => {
       const call = (sendMock as unknown as { mock: { calls: unknown[][] } }).mock.calls[0];
       const payload = call[0] as Record<string, unknown>;
       expect(payload.recipientAgentId).toBe('wren');
-      expect(payload.senderAgentId).toBe('system');
+      expect(payload.senderAgentId).toBe('wren');
       expect(payload.messageType).toBe('session_resume');
       expect(payload.trigger).toBe(true);
       expect(payload.recipientStudioId).toBe('studio-uuid-omega');

--- a/packages/api/src/services/strategy.service.ts
+++ b/packages/api/src/services/strategy.service.ts
@@ -872,7 +872,7 @@ export class StrategyService {
         {
           userId: group.user_id,
           recipientAgentId: group.owner_agent_id,
-          senderAgentId: 'system',
+          senderAgentId: group.owner_agent_id,
           // Prefer studioId (UUID); fall back to slug only when UUID is absent.
           recipientStudioId: studioId,
           recipientStudioSlug: studioId ? undefined : studioSlug,


### PR DESCRIPTION
## Summary

- Changes `senderAgentId` in `triggerOwnerAgent` from `'system'` to `group.owner_agent_id`
- 'system' is not a registered agent identity — trigger failure notifications sent back to it cause cascading `Unknown agent for user: system` errors
- Found during live e2e test of ephemeral studios + sandbox strategy execution

## Test plan

- [x] Strategy service tests pass (47/47)
- [x] Verified the cascading error stops after this fix

— Wren