### PR TITLE
feat: artifact search — text + semantic search for collective knowledge (by Wren)

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -28,6 +28,7 @@
     "benchmark:memory-recall": "tsx src/scripts/benchmark-memory-recall.ts",
     "benchmark:bootstrap-relevance": "tsx src/scripts/benchmark-bootstrap-relevance.ts",
     "backfill:memory-embeddings": "tsx src/scripts/backfill-memory-embeddings.ts",
+    "backfill:artifact-embeddings": "tsx src/scripts/backfill-artifact-embeddings.ts",
     "lint": "eslint src --ext .ts",
     "type-check": "yarn workspace @inklabs/shared build && tsc --noEmit",
     "clean": "rm -rf dist"

--- a/packages/api/src/data/composer.ts
+++ b/packages/api/src/data/composer.ts
@@ -17,6 +17,7 @@ import { StudiosRepository } from './repositories/studios.repository';
 import { WorkspacesRepository } from './repositories/workspaces.repository';
 import { ContactsRepository } from './repositories/contacts-repository';
 import { RecallFeedbackRepository } from './repositories/recall-feedback.repository';
+import { ArtifactSearchRepository } from './repositories/artifact-search.repository';
 import { logger } from '../utils/logger';
 
 export class DataComposer {
@@ -39,6 +40,7 @@ export class DataComposer {
     workspaces: WorkspacesRepository;
     contacts: ContactsRepository;
     recallFeedback: RecallFeedbackRepository;
+    artifactSearch: ArtifactSearchRepository;
   };
 
   private constructor(supabaseClient: SupabaseClient<Database>) {
@@ -62,6 +64,7 @@ export class DataComposer {
       workspaces: new WorkspacesRepository(supabaseClient),
       contacts: new ContactsRepository(supabaseClient),
       recallFeedback: new RecallFeedbackRepository(supabaseClient),
+      artifactSearch: new ArtifactSearchRepository(supabaseClient),
     };
 
     logger.info('Data composer initialized with all repositories');

--- a/packages/api/src/data/repositories/artifact-search.repository.test.ts
+++ b/packages/api/src/data/repositories/artifact-search.repository.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ArtifactSearchRepository } from './artifact-search.repository';
+import { createMockSupabaseClient, type MockSupabaseClient } from '../../test/mocks/supabase.mock';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+describe('ArtifactSearchRepository', () => {
+  let mockSupabase: MockSupabaseClient;
+  let repo: ArtifactSearchRepository;
+
+  const disableEmbeddings = () => {
+    (repo as any).embeddingRouter = {
+      isEnabled: vi.fn().mockReturnValue(false),
+      getRuntimeConfig: vi.fn().mockReturnValue({
+        enabled: false,
+        queryThreshold: 0.2,
+        matchCountMultiplier: 1,
+      }),
+      embedQuery: vi.fn().mockResolvedValue(null),
+    };
+  };
+
+  const mockArtifactRow = {
+    id: 'art-1',
+    uri: 'ink://specs/test',
+    user_id: 'user-1',
+    workspace_id: 'ws-1',
+    title: 'Test Spec',
+    content: 'This is a test specification document about authentication.',
+    content_type: 'text/markdown',
+    artifact_type: 'spec',
+    collaborators: [],
+    visibility: 'private',
+    version: 1,
+    tags: ['auth', 'security'],
+    metadata: {},
+    created_at: '2026-05-11T10:00:00Z',
+    updated_at: '2026-05-11T12:00:00Z',
+    created_by_sb_id: null,
+    edit_mode: 'workspace',
+    embedding: null,
+  };
+
+  beforeEach(() => {
+    mockSupabase = createMockSupabaseClient();
+    repo = new ArtifactSearchRepository(mockSupabase as unknown as SupabaseClient);
+    disableEmbeddings();
+  });
+
+  describe('search', () => {
+    it('should perform text search when mode is text', async () => {
+      mockSupabase._setArrayData([mockArtifactRow]);
+
+      const results = await repo.search('user-1', 'authentication', 'text');
+
+      expect(results).toHaveLength(1);
+      expect(results[0].uri).toBe('ink://specs/test');
+      expect(results[0].title).toBe('Test Spec');
+      expect(results[0].artifactType).toBe('spec');
+      expect(results[0].textScore).toBeGreaterThan(0);
+    });
+
+    it('should fall back to text when mode is auto and embeddings disabled', async () => {
+      mockSupabase._setArrayData([mockArtifactRow]);
+
+      const results = await repo.search('user-1', 'test', 'auto');
+
+      expect(results).toHaveLength(1);
+      expect(mockSupabase.from).toHaveBeenCalledWith('artifacts');
+    });
+
+    it('should return empty array for empty query in semantic mode', async () => {
+      const results = await repo.search('user-1', '', 'semantic');
+
+      expect(results).toHaveLength(0);
+    });
+
+    it('should compute text scores correctly', async () => {
+      mockSupabase._setArrayData([mockArtifactRow]);
+
+      const results = await repo.search('user-1', 'authentication', 'text');
+
+      expect(results[0].textScore).toBeGreaterThan(0);
+      expect(results[0].finalScore).toBe(results[0].textScore);
+    });
+
+    it('should boost exact title matches', async () => {
+      mockSupabase._setArrayData([mockArtifactRow]);
+
+      const results = await repo.search('user-1', 'Test Spec', 'text');
+
+      expect(results[0].textScore).toBeGreaterThan(0.3);
+    });
+  });
+
+  describe('filters', () => {
+    it('should apply artifactType filter', async () => {
+      mockSupabase._setArrayData([mockArtifactRow]);
+
+      await repo.search('user-1', 'test', 'text', { artifactType: 'spec' });
+
+      expect(mockSupabase._queryBuilder.eq).toHaveBeenCalledWith('artifact_type', 'spec');
+    });
+
+    it('should apply tags filter', async () => {
+      mockSupabase._setArrayData([mockArtifactRow]);
+
+      await repo.search('user-1', 'test', 'text', { tags: ['auth'] });
+
+      expect(mockSupabase._queryBuilder.overlaps).toHaveBeenCalledWith('tags', ['auth']);
+    });
+
+    it('should apply workspace filter', async () => {
+      mockSupabase._setArrayData([mockArtifactRow]);
+
+      await repo.search('user-1', 'test', 'text', { workspaceId: 'ws-1' });
+
+      expect(mockSupabase._queryBuilder.eq).toHaveBeenCalledWith('workspace_id', 'ws-1');
+    });
+  });
+
+  describe('semantic fallback', () => {
+    it('should fall back to text search when embedding fails', async () => {
+      mockSupabase._setArrayData([mockArtifactRow]);
+      (repo as any).embeddingRouter = {
+        isEnabled: vi.fn().mockReturnValue(true),
+        getRuntimeConfig: vi.fn().mockReturnValue({
+          enabled: true,
+          queryThreshold: 0.2,
+          matchCountMultiplier: 1,
+        }),
+        embedQuery: vi.fn().mockResolvedValue(null),
+      };
+
+      const results = await repo.search('user-1', 'test', 'semantic');
+
+      expect(results).toHaveLength(1);
+      expect(results[0].textScore).toBeDefined();
+    });
+  });
+});

--- a/packages/api/src/data/repositories/artifact-search.repository.ts
+++ b/packages/api/src/data/repositories/artifact-search.repository.ts
@@ -1,0 +1,285 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { Database } from '../supabase/types';
+import { EmbeddingRouter } from '../../services/embeddings/router';
+import { formatVectorLiteral } from '../../services/embeddings/memory-chunks';
+import { logger } from '../../utils/logger';
+
+type ArtifactRow = Database['public']['Tables']['artifacts']['Row'];
+
+export interface ArtifactSearchOptions {
+  artifactType?: string;
+  tags?: string[];
+  visibility?: string;
+  workspaceId?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export type ArtifactSearchMode = 'text' | 'semantic' | 'hybrid' | 'auto';
+
+export interface ArtifactSearchResult {
+  id: string;
+  uri: string;
+  title: string;
+  content: string;
+  artifactType: string;
+  tags: string[];
+  version: number;
+  updatedAt: string;
+  workspaceId: string | null;
+  textScore?: number;
+  semanticScore?: number;
+  finalScore: number;
+}
+
+interface MatchArtifactsArgs {
+  query_embedding: string;
+  match_threshold: number;
+  match_count: number;
+  p_user_id: string;
+  p_workspace_id?: string;
+  p_artifact_type?: string;
+  p_tags?: string[];
+  p_visibility?: string;
+}
+
+interface MatchArtifactsRpcClient {
+  rpc(
+    fn: 'match_artifacts',
+    args: MatchArtifactsArgs
+  ): { data: SemanticMatchRow[] | null; error: { message: string } | null };
+}
+
+interface SemanticMatchRow extends ArtifactRow {
+  similarity: number;
+}
+
+export class ArtifactSearchRepository {
+  private embeddingRouter: EmbeddingRouter;
+
+  constructor(private supabase: SupabaseClient<Database>) {
+    this.embeddingRouter = new EmbeddingRouter();
+  }
+
+  async search(
+    userId: string,
+    query: string,
+    mode: ArtifactSearchMode,
+    options: ArtifactSearchOptions = {}
+  ): Promise<ArtifactSearchResult[]> {
+    const limit = options.limit || 20;
+    const offset = options.offset || 0;
+    const effectiveMode =
+      mode === 'auto' ? (this.embeddingRouter.isEnabled() ? 'hybrid' : 'text') : mode;
+
+    switch (effectiveMode) {
+      case 'text':
+        return this.textSearch(userId, query, options, limit, offset);
+      case 'semantic':
+        return this.semanticSearch(userId, query, options, limit, offset);
+      case 'hybrid':
+        return this.hybridSearch(userId, query, options, limit, offset);
+      default:
+        return this.textSearch(userId, query, options, limit, offset);
+    }
+  }
+
+  private async textSearch(
+    userId: string,
+    query: string,
+    options: ArtifactSearchOptions,
+    limit: number,
+    offset: number
+  ): Promise<ArtifactSearchResult[]> {
+    let queryBuilder = this.supabase
+      .from('artifacts')
+      .select('*')
+      .eq('user_id', userId)
+      .order('updated_at', { ascending: false });
+
+    queryBuilder = this.applyFilters(queryBuilder, options);
+
+    if (query) {
+      const terms = this.buildSearchTerms(query);
+      if (terms.length > 0) {
+        const clauses = terms.flatMap((term) => [
+          `title.ilike.%${term}%`,
+          `content.ilike.%${term}%`,
+        ]);
+        queryBuilder = queryBuilder.or(clauses.join(','));
+      }
+    }
+
+    queryBuilder = queryBuilder.range(offset, offset + limit - 1);
+
+    const { data, error } = await queryBuilder;
+
+    if (error) {
+      logger.error('Artifact text search failed', { error: error.message });
+      throw new Error(`Artifact text search failed: ${error.message}`);
+    }
+
+    return (data || []).map((row) => {
+      const textScore = query ? this.computeTextScore(query, row) : 0;
+      return this.rowToResult(row, { textScore, finalScore: textScore });
+    });
+  }
+
+  private async semanticSearch(
+    userId: string,
+    query: string,
+    options: ArtifactSearchOptions,
+    limit: number,
+    offset: number
+  ): Promise<ArtifactSearchResult[]> {
+    if (!query) return [];
+
+    const queryEmbedding = await this.embeddingRouter.embedQuery(query);
+    if (!queryEmbedding) {
+      logger.warn('Artifact semantic search: embedding generation failed, falling back to text');
+      return this.textSearch(userId, query, options, limit, offset);
+    }
+
+    const config = this.embeddingRouter.getRuntimeConfig();
+    const matchCount = Math.max(
+      limit,
+      (offset + limit) * Math.max(1, config.matchCountMultiplier || 1)
+    );
+
+    const rpcArgs: MatchArtifactsArgs = {
+      query_embedding: formatVectorLiteral(queryEmbedding.vector),
+      match_threshold: config.queryThreshold,
+      match_count: matchCount,
+      p_user_id: userId,
+      p_workspace_id: options.workspaceId,
+      p_artifact_type: options.artifactType,
+      p_tags: options.tags && options.tags.length > 0 ? options.tags : undefined,
+      p_visibility: options.visibility,
+    };
+
+    const rpcClient = this.supabase as unknown as MatchArtifactsRpcClient;
+    const { data, error } = await rpcClient.rpc('match_artifacts', rpcArgs);
+
+    if (error) {
+      logger.warn('Artifact semantic search RPC failed, falling back to text', {
+        error: error.message,
+      });
+      return this.textSearch(userId, query, options, limit, offset);
+    }
+
+    const rows = ((data || []) as SemanticMatchRow[]).slice(offset, offset + limit);
+    return rows.map((row) => {
+      const semanticScore = Math.max(0, Math.min(1, row.similarity ?? 0));
+      return this.rowToResult(row, { semanticScore, finalScore: semanticScore });
+    });
+  }
+
+  private async hybridSearch(
+    userId: string,
+    query: string,
+    options: ArtifactSearchOptions,
+    limit: number,
+    offset: number
+  ): Promise<ArtifactSearchResult[]> {
+    const config = this.embeddingRouter.getRuntimeConfig();
+    const candidatePool = Math.max(
+      limit,
+      (offset + limit) * Math.max(1, config.matchCountMultiplier)
+    );
+
+    const [semanticResults, textResults] = await Promise.all([
+      this.semanticSearch(userId, query, options, limit, offset),
+      this.textSearch(userId, query, options, candidatePool, 0),
+    ]);
+
+    const byId = new Map<string, ArtifactSearchResult>();
+
+    for (const result of semanticResults) {
+      byId.set(result.id, result);
+    }
+
+    for (const result of textResults) {
+      const existing = byId.get(result.id);
+      if (existing) {
+        existing.textScore = result.textScore;
+      } else {
+        byId.set(result.id, result);
+      }
+    }
+
+    const merged = Array.from(byId.values()).map((result) => ({
+      ...result,
+      finalScore: (result.semanticScore ?? 0) * 0.7 + (result.textScore ?? 0) * 0.3,
+    }));
+
+    merged.sort((a, b) => b.finalScore - a.finalScore || b.updatedAt.localeCompare(a.updatedAt));
+
+    return merged.slice(offset, offset + limit);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private applyFilters(query: any, options: ArtifactSearchOptions) {
+    if (options.workspaceId) {
+      query = query.eq('workspace_id', options.workspaceId);
+    }
+    if (options.artifactType) {
+      query = query.eq('artifact_type', options.artifactType);
+    }
+    if (options.tags && options.tags.length > 0) {
+      query = query.overlaps('tags', options.tags);
+    }
+    if (options.visibility) {
+      query = query.eq('visibility', options.visibility);
+    }
+    return query;
+  }
+
+  private buildSearchTerms(query: string): string[] {
+    const full = query
+      .trim()
+      .replace(/[,%()]/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim();
+    const tokens = full
+      .split(' ')
+      .filter((t) => t.length > 2)
+      .sort((a, b) => b.length - a.length)
+      .slice(0, 3);
+    return Array.from(new Set([full, ...tokens].filter(Boolean)));
+  }
+
+  private computeTextScore(query: string, row: ArtifactRow): number {
+    const queryLower = query.toLowerCase();
+    const tokens = queryLower.split(/\s+/).filter((t) => t.length > 2);
+    if (tokens.length === 0) return 0;
+
+    const haystack = `${row.title} ${row.content} ${(row.tags || []).join(' ')}`.toLowerCase();
+    const overlapCount = tokens.filter((token) => haystack.includes(token)).length;
+    let score = overlapCount / tokens.length;
+
+    if (haystack.includes(queryLower)) score += 0.2;
+    if (row.title.toLowerCase().includes(queryLower)) score += 0.2;
+
+    return Math.min(1, score);
+  }
+
+  private rowToResult(
+    row: ArtifactRow,
+    scores: { textScore?: number; semanticScore?: number; finalScore: number }
+  ): ArtifactSearchResult {
+    return {
+      id: row.id,
+      uri: row.uri,
+      title: row.title,
+      content: row.content,
+      artifactType: row.artifact_type,
+      tags: row.tags || [],
+      version: row.version ?? 1,
+      updatedAt: row.updated_at ?? row.created_at ?? new Date().toISOString(),
+      workspaceId: row.workspace_id,
+      textScore: scores.textScore,
+      semanticScore: scores.semanticScore,
+      finalScore: scores.finalScore,
+    };
+  }
+}

--- a/packages/api/src/data/supabase/types.ts
+++ b/packages/api/src/data/supabase/types.ts
@@ -3831,6 +3831,38 @@ export type Database = {
       [_ in never]: never;
     };
     Functions: {
+      match_artifacts: {
+        Args: {
+          match_count?: number;
+          match_threshold?: number;
+          p_artifact_type?: string;
+          p_tags?: string[];
+          p_user_id?: string;
+          p_visibility?: string;
+          p_workspace_id?: string;
+          query_embedding: string;
+        };
+        Returns: {
+          artifact_type: string;
+          collaborators: string[];
+          content: string;
+          content_type: string;
+          created_at: string;
+          created_by_sb_id: string;
+          edit_mode: string;
+          id: string;
+          metadata: Json;
+          similarity: number;
+          tags: string[];
+          title: string;
+          updated_at: string;
+          uri: string;
+          user_id: string;
+          version: number;
+          visibility: string;
+          workspace_id: string;
+        }[];
+      };
       match_links: {
         Args: {
           match_count?: number;

--- a/packages/api/src/data/supabase/types.ts
+++ b/packages/api/src/data/supabase/types.ts
@@ -768,6 +768,7 @@ export type Database = {
           created_at: string | null;
           created_by_sb_id: string | null;
           edit_mode: string;
+          embedding: string | null;
           id: string;
           metadata: Json | null;
           tags: string[] | null;
@@ -787,6 +788,7 @@ export type Database = {
           created_at?: string | null;
           created_by_sb_id?: string | null;
           edit_mode?: string;
+          embedding?: string | null;
           id?: string;
           metadata?: Json | null;
           tags?: string[] | null;
@@ -806,6 +808,7 @@ export type Database = {
           created_at?: string | null;
           created_by_sb_id?: string | null;
           edit_mode?: string;
+          embedding?: string | null;
           id?: string;
           metadata?: Json | null;
           tags?: string[] | null;

--- a/packages/api/src/mcp/tools/artifact-handlers.ts
+++ b/packages/api/src/mcp/tools/artifact-handlers.ts
@@ -167,6 +167,23 @@ const listArtifactCommentsSchema = workspaceScopedUserIdentifierSchema.extend({
   limit: z.number().min(1).max(200).optional().default(100).describe('Max comments to return'),
 });
 
+const searchArtifactsSchema = workspaceScopedUserIdentifierSchema.extend({
+  query: z.string().describe('Search query text'),
+  mode: z
+    .enum(['text', 'semantic', 'hybrid', 'auto'])
+    .optional()
+    .default('auto')
+    .describe(
+      'Search mode: text (keyword/trigram), semantic (embedding similarity), hybrid (blended), auto (hybrid if embeddings enabled, else text)'
+    ),
+  artifactType: z
+    .enum(['spec', 'design', 'decision', 'document', 'note'])
+    .optional()
+    .describe('Filter by artifact type'),
+  tags: z.array(z.string()).optional().describe('Filter by tags (any match)'),
+  limit: z.number().min(1).max(50).optional().default(10).describe('Max results to return'),
+});
+
 // ============== Helpers ==============
 
 function withWorkspaceFilter<T>(query: T, workspaceId?: string): T {
@@ -1302,6 +1319,54 @@ export async function handleListArtifactComments(args: unknown, dataComposer: Da
   };
 }
 
+export async function handleSearchArtifacts(args: unknown, dataComposer: DataComposer) {
+  const parsed = parseWithContext(searchArtifactsSchema, args);
+  const resolved = await resolveUserOrThrow(parsed, dataComposer);
+
+  const { query, mode = 'auto', artifactType, tags, limit = 10, workspaceId } = parsed;
+
+  const results = await dataComposer.repositories.artifactSearch.search(
+    resolved.user.id,
+    query,
+    mode,
+    {
+      artifactType,
+      tags,
+      workspaceId,
+      limit,
+    }
+  );
+
+  const SNIPPET_LENGTH = 200;
+
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: JSON.stringify({
+          success: true,
+          query,
+          mode,
+          resultCount: results.length,
+          results: results.map((r) => ({
+            title: r.title,
+            uri: r.uri,
+            artifactType: r.artifactType,
+            snippet:
+              r.content.length > SNIPPET_LENGTH
+                ? r.content.slice(0, SNIPPET_LENGTH) + '...'
+                : r.content,
+            relevanceScore: Math.round(r.finalScore * 1000) / 1000,
+            tags: r.tags,
+            version: r.version,
+            updatedAt: r.updatedAt,
+          })),
+        }),
+      },
+    ],
+  };
+}
+
 // ============== Tool Registration ==============
 
 export const artifactToolDefinitions = [
@@ -1351,5 +1416,12 @@ export const artifactToolDefinitions = [
       'List comments for an artifact, including canonical identity UUID author metadata.',
     schema: listArtifactCommentsSchema,
     handler: handleListArtifactComments,
+  },
+  {
+    name: 'search_artifacts',
+    description:
+      'Search artifacts using text (keyword/trigram), semantic (embedding similarity), or hybrid (blended) modes. Returns matching artifacts with title, URI, snippet, relevance score, and metadata.',
+    schema: searchArtifactsSchema,
+    handler: handleSearchArtifacts,
   },
 ];

--- a/packages/api/src/mcp/tools/artifact-handlers.ts
+++ b/packages/api/src/mcp/tools/artifact-handlers.ts
@@ -19,6 +19,51 @@ import { getEffectiveAgentId } from '../../auth/enforce-identity';
 import type { Database, Json } from '../../data/supabase/types';
 import { mergeWithContext } from '../../utils/request-context';
 import { resolveWorkspaceScopeForWrite } from '../../utils/workspace-scope';
+import { EmbeddingRouter } from '../../services/embeddings/router';
+import { formatVectorLiteral } from '../../services/embeddings/memory-chunks';
+
+const embeddingRouter = new EmbeddingRouter();
+
+async function tryEmbedArtifact(
+  supabase: SupabaseClient<Database>,
+  artifactId: string,
+  title: string,
+  content: string,
+  existingMetadata: Record<string, unknown>
+): Promise<void> {
+  if (!embeddingRouter.isEnabled()) return;
+
+  try {
+    const textToEmbed = `${title}\n\n${content}`;
+    const result = await embeddingRouter.embedDocument(textToEmbed);
+    if (!result) return;
+
+    const { error } = await supabase
+      .from('artifacts')
+      .update({
+        embedding: formatVectorLiteral(result.vector),
+        metadata: {
+          ...existingMetadata,
+          embedding: {
+            provider: result.provider,
+            model: result.model,
+            dimensions: result.dimensions,
+            updatedAt: new Date().toISOString(),
+          },
+        } as Json,
+      })
+      .eq('id', artifactId);
+
+    if (error) {
+      logger.warn('Failed to persist artifact embedding', { artifactId, error: error.message });
+    }
+  } catch (err) {
+    logger.warn('Artifact embedding failed', {
+      artifactId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
 
 // ============== Schemas ==============
 
@@ -374,6 +419,15 @@ export async function handleCreateArtifact(args: unknown, dataComposer: DataComp
   });
 
   logger.info('Artifact created', { uri, type: artifactType, agentId });
+
+  // Best-effort embedding — don't block the response
+  tryEmbedArtifact(
+    supabase,
+    artifact.id,
+    title,
+    content,
+    (metadata || {}) as Record<string, unknown>
+  );
 
   return {
     content: [
@@ -841,6 +895,17 @@ export async function handleUpdateArtifact(args: unknown, dataComposer: DataComp
     agentId,
     mergePerformed,
   });
+
+  // Re-embed when content or title changed
+  if (finalContent !== undefined || title !== undefined) {
+    tryEmbedArtifact(
+      supabase,
+      updated.id,
+      updated.title,
+      updated.content,
+      (updated.metadata || {}) as Record<string, unknown>
+    );
+  }
 
   return {
     content: [

--- a/packages/api/src/mcp/tools/index.ts
+++ b/packages/api/src/mcp/tools/index.ts
@@ -162,6 +162,7 @@ import {
   handleGetArtifactHistory,
   handleAddArtifactComment,
   handleListArtifactComments,
+  handleSearchArtifacts,
   artifactToolDefinitions,
 } from './artifact-handlers';
 
@@ -3872,6 +3873,35 @@ User can be identified by ONE of: userId, email, phone, or platform + platformId
         return await handleListArtifactComments(args, dataComposer);
       } catch (error) {
         logger.error('Error in list_artifact_comments:', error);
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                success: false,
+                error: error instanceof Error ? error.message : 'Unknown error',
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  server.registerTool(
+    'search_artifacts',
+    {
+      description: `Search artifacts using text (keyword/trigram), semantic (embedding similarity), or hybrid (blended) modes. Returns matching artifacts with title, URI, snippet, relevance score, and metadata. Use mode "auto" (default) to automatically pick the best available mode.
+
+User can be identified by ONE of: userId, email, phone, or platform + platformId`,
+      inputSchema: getArtifactToolSchema('search_artifacts'),
+    },
+    async (args: Record<string, unknown>) => {
+      try {
+        return await handleSearchArtifacts(args, dataComposer);
+      } catch (error) {
+        logger.error('Error in search_artifacts:', error);
         return {
           content: [
             {

--- a/packages/api/src/scripts/backfill-artifact-embeddings.ts
+++ b/packages/api/src/scripts/backfill-artifact-embeddings.ts
@@ -46,6 +46,8 @@ async function main() {
   let updated = 0;
   let skipped = 0;
   let scanned = 0;
+  let cursorCreatedAt: string | null = null;
+  let cursorId: string | null = null;
 
   while (limit === null || scanned < limit) {
     const remaining = limit === null ? batchSize : Math.min(batchSize, limit - scanned);
@@ -53,14 +55,21 @@ async function main() {
 
     let query = supabase
       .from('artifacts')
-      .select('id,user_id,title,content,artifact_type,metadata,embedding')
+      .select('id,user_id,title,content,artifact_type,metadata,embedding,created_at')
       .eq('user_id', userId)
-      .is('embedding', null)
       .order('created_at', { ascending: true })
-      .range(0, remaining - 1);
+      .order('id', { ascending: true })
+      .limit(remaining);
 
     if (artifactType) {
       query = query.eq('artifact_type', artifactType);
+    }
+
+    // Keyset pagination: advance past last seen (created_at, id)
+    if (cursorCreatedAt && cursorId) {
+      query = query.or(
+        `created_at.gt.${cursorCreatedAt},and(created_at.eq.${cursorCreatedAt},id.gt.${cursorId})`
+      );
     }
 
     const { data, error } = await query;
@@ -68,13 +77,18 @@ async function main() {
       throw new Error(`Failed to fetch artifacts for backfill: ${error.message}`);
     }
 
-    const rows = (data || []) as Pick<
+    const rows = (data || []) as (Pick<
       ArtifactRow,
       'id' | 'user_id' | 'title' | 'content' | 'artifact_type' | 'metadata' | 'embedding'
-    >[];
+    > & { created_at: string })[];
 
     if (rows.length === 0) break;
     scanned += rows.length;
+
+    // Advance cursor to last row in batch
+    const lastRow = rows[rows.length - 1];
+    cursorCreatedAt = lastRow.created_at;
+    cursorId = lastRow.id;
 
     for (const row of rows) {
       processed += 1;

--- a/packages/api/src/scripts/backfill-artifact-embeddings.ts
+++ b/packages/api/src/scripts/backfill-artifact-embeddings.ts
@@ -1,0 +1,145 @@
+import { createSupabaseClient } from '../data/supabase/client';
+import type { Database } from '../data/supabase/types';
+import { formatVectorLiteral } from '../services/embeddings/memory-chunks';
+import { EmbeddingRouter } from '../services/embeddings/router';
+
+type ArtifactRow = Database['public']['Tables']['artifacts']['Row'];
+
+const DEFAULT_BATCH_SIZE = 50;
+
+function parseBoolean(raw: string | undefined, defaultValue: boolean): boolean {
+  if (raw === undefined) return defaultValue;
+  return ['1', 'true', 'yes', 'on'].includes(raw.toLowerCase());
+}
+
+function parsePositiveInt(raw: string | undefined, defaultValue: number): number {
+  if (!raw) return defaultValue;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : defaultValue;
+}
+
+async function main() {
+  const userId = process.env.BACKFILL_ARTIFACT_USER_ID;
+  if (!userId) {
+    throw new Error(
+      'BACKFILL_ARTIFACT_USER_ID is required. Example: BACKFILL_ARTIFACT_USER_ID=<uuid> yarn backfill:artifact-embeddings'
+    );
+  }
+
+  const artifactType = process.env.BACKFILL_ARTIFACT_TYPE;
+  const batchSize = parsePositiveInt(process.env.BACKFILL_ARTIFACT_BATCH_SIZE, DEFAULT_BATCH_SIZE);
+  const limit = process.env.BACKFILL_ARTIFACT_LIMIT
+    ? parsePositiveInt(process.env.BACKFILL_ARTIFACT_LIMIT, batchSize)
+    : null;
+  const dryRun = parseBoolean(process.env.BACKFILL_ARTIFACT_DRY_RUN, false);
+
+  const router = new EmbeddingRouter();
+  if (!router.isEnabled()) {
+    throw new Error(
+      'Embeddings are disabled. Set MEMORY_EMBEDDINGS_ENABLED=true before backfilling.'
+    );
+  }
+
+  const supabase = createSupabaseClient();
+
+  let processed = 0;
+  let updated = 0;
+  let skipped = 0;
+  let scanned = 0;
+
+  while (limit === null || scanned < limit) {
+    const remaining = limit === null ? batchSize : Math.min(batchSize, limit - scanned);
+    if (remaining <= 0) break;
+
+    let query = supabase
+      .from('artifacts')
+      .select('id,user_id,title,content,artifact_type,metadata,embedding')
+      .eq('user_id', userId)
+      .is('embedding', null)
+      .order('created_at', { ascending: true })
+      .range(0, remaining - 1);
+
+    if (artifactType) {
+      query = query.eq('artifact_type', artifactType);
+    }
+
+    const { data, error } = await query;
+    if (error) {
+      throw new Error(`Failed to fetch artifacts for backfill: ${error.message}`);
+    }
+
+    const rows = (data || []) as Pick<
+      ArtifactRow,
+      'id' | 'user_id' | 'title' | 'content' | 'artifact_type' | 'metadata' | 'embedding'
+    >[];
+
+    if (rows.length === 0) break;
+    scanned += rows.length;
+
+    for (const row of rows) {
+      processed += 1;
+
+      if (row.embedding) {
+        skipped += 1;
+        continue;
+      }
+
+      const textToEmbed = `${row.title}\n\n${row.content}`;
+      const result = await router.embedDocument(textToEmbed);
+      if (!result) {
+        console.error(`Failed to generate embedding for artifact ${row.id}, skipping`);
+        skipped += 1;
+        continue;
+      }
+
+      if (dryRun) {
+        console.log(
+          `DRY RUN would backfill artifact ${row.id} (${row.artifact_type}) via ${result.provider}:${result.model}`
+        );
+        updated += 1;
+        continue;
+      }
+
+      const existingMetadata = ((row.metadata as Record<string, unknown> | null) || {}) as Record<
+        string,
+        unknown
+      >;
+
+      const { error: updateError } = await supabase
+        .from('artifacts')
+        .update({
+          embedding: formatVectorLiteral(result.vector),
+          metadata: {
+            ...existingMetadata,
+            embedding: {
+              provider: result.provider,
+              model: result.model,
+              dimensions: result.dimensions,
+              updatedAt: new Date().toISOString(),
+              backfilled: true,
+            },
+          } as Database['public']['Tables']['artifacts']['Update']['metadata'],
+        })
+        .eq('id', row.id);
+
+      if (updateError) {
+        throw new Error(`Failed to update artifact ${row.id}: ${updateError.message}`);
+      }
+
+      updated += 1;
+      console.log(
+        `Backfilled artifact ${row.id} (${row.artifact_type}) via ${result.provider}:${result.model}`
+      );
+    }
+  }
+
+  console.log(
+    `Backfill complete. scanned=${scanned} processed=${processed} updated=${updated} skipped=${skipped} dryRun=${dryRun}`
+  );
+}
+
+main().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(message);
+  process.exit(1);
+});

--- a/supabase/migrations/20260511214200_artifact_search_indexes.sql
+++ b/supabase/migrations/20260511214200_artifact_search_indexes.sql
@@ -1,0 +1,27 @@
+-- Migration: add search indexes + embedding column to artifacts table
+-- Enables text search (trigram + FTS) and semantic search (pgvector) on artifacts.
+-- Extensions vector and pg_trgm are already enabled in the initial schema.
+
+-- 1. Embedding column for semantic search (nullable — existing rows backfilled later)
+ALTER TABLE public.artifacts
+  ADD COLUMN IF NOT EXISTS embedding vector(1024);
+
+-- 2. HNSW index for cosine similarity on embeddings
+CREATE INDEX IF NOT EXISTS idx_artifacts_embedding
+  ON public.artifacts
+  USING hnsw (embedding vector_cosine_ops);
+
+-- 3. GIN trigram index on title for ILIKE substring matching
+CREATE INDEX IF NOT EXISTS idx_artifacts_title_trgm
+  ON public.artifacts
+  USING gin (title gin_trgm_ops);
+
+-- 4. FTS index on content for full-text search
+CREATE INDEX IF NOT EXISTS idx_artifacts_content_fts
+  ON public.artifacts
+  USING gin (to_tsvector('english'::regconfig, content));
+
+-- 5. FTS index on title for full-text search
+CREATE INDEX IF NOT EXISTS idx_artifacts_title_fts
+  ON public.artifacts
+  USING gin (to_tsvector('english'::regconfig, title));

--- a/supabase/migrations/20260511214949_match_artifacts_rpc.sql
+++ b/supabase/migrations/20260511214949_match_artifacts_rpc.sql
@@ -1,0 +1,67 @@
+-- RPC function for semantic artifact search via pgvector cosine distance.
+-- Mirrors match_memories but for the artifacts table.
+
+CREATE OR REPLACE FUNCTION public.match_artifacts(
+  query_embedding vector,
+  match_threshold double precision DEFAULT 0.2,
+  match_count integer DEFAULT 20,
+  p_user_id uuid DEFAULT NULL,
+  p_workspace_id uuid DEFAULT NULL,
+  p_artifact_type text DEFAULT NULL,
+  p_tags text[] DEFAULT NULL,
+  p_visibility text DEFAULT NULL
+)
+RETURNS TABLE (
+  id uuid,
+  uri text,
+  user_id uuid,
+  workspace_id uuid,
+  title text,
+  content text,
+  content_type text,
+  artifact_type text,
+  collaborators text[],
+  visibility text,
+  version integer,
+  tags text[],
+  metadata jsonb,
+  created_at timestamptz,
+  updated_at timestamptz,
+  created_by_sb_id uuid,
+  edit_mode text,
+  similarity double precision
+)
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT
+    a.id,
+    a.uri,
+    a.user_id,
+    a.workspace_id,
+    a.title,
+    a.content,
+    a.content_type,
+    a.artifact_type,
+    a.collaborators,
+    a.visibility,
+    a.version,
+    a.tags,
+    a.metadata,
+    a.created_at,
+    a.updated_at,
+    a.created_by_sb_id,
+    a.edit_mode,
+    1 - (a.embedding <=> query_embedding) AS similarity
+  FROM public.artifacts a
+  WHERE
+    a.embedding IS NOT NULL
+    AND (p_user_id IS NULL OR a.user_id = p_user_id)
+    AND (p_workspace_id IS NULL OR a.workspace_id = p_workspace_id)
+    AND (p_artifact_type IS NULL OR a.artifact_type = p_artifact_type)
+    AND (p_tags IS NULL OR a.tags && p_tags)
+    AND (p_visibility IS NULL OR a.visibility = p_visibility)
+    AND 1 - (a.embedding <=> query_embedding) > match_threshold
+  ORDER BY a.embedding <=> query_embedding
+  LIMIT match_count;
+$$;

--- a/supabase/migrations/20260511220538_artifact_content_trgm_index.sql
+++ b/supabase/migrations/20260511220538_artifact_content_trgm_index.sql
@@ -1,0 +1,5 @@
+-- GIN trigram index on content for ILIKE substring matching.
+-- textSearch uses ILIKE on content, which benefits from trigram indexing.
+CREATE INDEX IF NOT EXISTS idx_artifacts_content_trgm
+  ON public.artifacts
+  USING gin (content gin_trgm_ops);


### PR DESCRIPTION
## Summary

- **Migration**: adds GIN trigram index on `title`, FTS indexes on `title`+`content`, HNSW vector index on new `embedding vector(1024)` column, and `match_artifacts` RPC function for pgvector cosine similarity search
- **Embedding pipeline**: `tryEmbedArtifact` fires on artifact create/update via `EmbeddingRouter`, stores vectors in `artifacts.embedding` with provider metadata — eventually consistent (never blocks the response)
- **Repository**: `ArtifactSearchRepository` with `textSearch` (ILIKE + trigram scoring), `semanticSearch` (via RPC, graceful fallback to text), and `hybridSearch` (0.7 semantic + 0.3 text blending) — registered in `DataComposer`
- **MCP tool**: `search_artifacts` with `auto`/`text`/`semantic`/`hybrid` modes, artifact type + tags filtering, returns snippets with relevance scores
- **Backfill script**: `yarn backfill:artifact-embeddings` batch-processes existing artifacts without embeddings

## Test plan

- [x] All 28 artifact handler unit tests pass
- [x] All 9 artifact search repository unit tests pass
- [x] Full test suite: 131/132 files pass (1 pre-existing CLI build failure)
- [x] Type-check: no new errors (6 pre-existing in gateway.ts/server.ts/admin.ts)
- [x] Migration applied successfully to remote Supabase
- [ ] Manual: create an artifact, verify embedding is generated
- [ ] Manual: search_artifacts returns relevant results for text queries
- [ ] Manual: run backfill script on test user

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Wren