### PR TITLE
feat: final approval gate for strategy completion (by Wren)

### DIFF
--- a/packages/api/src/data/repositories/task-groups.repository.ts
+++ b/packages/api/src/data/repositories/task-groups.repository.ts
@@ -77,6 +77,10 @@ export interface StrategyConfig {
   /** Automatically create an ephemeral git worktree + studio for sandbox work (default: false).
    *  When true + sandbox: true, strategy creates a fresh studio at startup and cleans it up on completion. */
   ephemeralStudio?: boolean;
+  /** Require human approval before finalizing a completed strategy. Pauses with the criteria checklist instead of auto-completing. */
+  requireFinalApproval?: boolean;
+  /** Human-readable acceptance criteria the approver should verify before approving. Sent in the approval message. */
+  approvalCriteria?: string[];
 }
 
 export interface CreateTaskGroupInput {

--- a/packages/api/src/mcp/tools/strategy-handlers.ts
+++ b/packages/api/src/mcp/tools/strategy-handlers.ts
@@ -120,6 +120,18 @@ export const startStrategySchema = z.object({
     .describe(
       'Auto-create an ephemeral git worktree + studio for sandbox work. Requires sandbox: true and repoRoot in group metadata.'
     ),
+  requireFinalApproval: z
+    .boolean()
+    .optional()
+    .describe(
+      'Require human approval before finalizing. Pauses when all tasks are done and sends approval criteria to the approver.'
+    ),
+  approvalCriteria: z
+    .array(z.string())
+    .optional()
+    .describe(
+      'Acceptance criteria the approver should verify (e.g., ["tests pass", "PR reviewed", "visual review via Playwright"])'
+    ),
 });
 
 export async function handleStartStrategy(
@@ -155,6 +167,8 @@ export async function handleStartStrategy(
         sandboxPolicy: args.sandboxPolicy,
         sandboxBackendAuth: args.sandboxBackendAuth,
         ephemeralStudio: args.ephemeralStudio,
+        requireFinalApproval: args.requireFinalApproval,
+        approvalCriteria: args.approvalCriteria,
       },
     });
 

--- a/packages/api/src/services/strategy.service.test.ts
+++ b/packages/api/src/services/strategy.service.test.ts
@@ -837,6 +837,7 @@ describe('StrategyService', () => {
           approvalNotify: 'myra',
         } as StrategyConfig,
       });
+      const nextTask = createMockTask({ id: 'task-6', title: 'Sixth task', task_order: 5 });
       const groupTasks = [
         createMockTask({ status: 'completed', task_order: 0 }),
         createMockTask({ status: 'completed', task_order: 1 }),
@@ -852,8 +853,8 @@ describe('StrategyService', () => {
         status: 'paused',
       });
 
-      // from() calls: getGroupTasks (for buildProgressSummary in approval gate)
-      setupChains(dc, [chainGroupTasks(groupTasks)]);
+      // from() calls: getTaskByOrder (found — more tasks remain), getGroupTasks (for summary)
+      setupChains(dc, [chainTaskFound(nextTask), chainGroupTasks(groupTasks)]);
 
       const result = await service.advanceStrategy('group-1', 'task-5', 'user-123');
 
@@ -1101,6 +1102,106 @@ describe('StrategyService', () => {
         (c: unknown[]) => (c[1] as Record<string, unknown>).status === 'completed'
       );
       expect(completedCall).toBeUndefined();
+    });
+
+    it('should finalize (not pause for periodic approval) when final task hits approval boundary', async () => {
+      // Regression: when maxIterationsWithoutApproval and the last task land on
+      // the same boundary, final-task handling must win (Lumen review, PR #362)
+      const group = createMockGroup({
+        current_task_index: 4,
+        iterations_since_approval: 4,
+        strategy_config: {
+          maxIterationsWithoutApproval: 5,
+          approvalNotify: 'myra',
+        } as StrategyConfig,
+      });
+      const groupTasks = [
+        createMockTask({ status: 'completed', task_order: 0 }),
+        createMockTask({ status: 'completed', task_order: 1 }),
+        createMockTask({ status: 'completed', task_order: 2 }),
+        createMockTask({ status: 'completed', task_order: 3 }),
+        createMockTask({ status: 'completed', task_order: 4 }),
+      ];
+
+      dc.repositories.taskGroups.findById.mockResolvedValue(group);
+      dc.repositories.taskGroups.update.mockResolvedValue({
+        ...group,
+        status: 'completed',
+      });
+
+      // from() calls: getTaskByOrder not found (both paths), getGroupTasks, cancelWatchdog
+      const notFoundChain = chainTaskNotFound();
+      setupChains(dc, [notFoundChain, notFoundChain, chainGroupTasks(groupTasks), chainNoop()]);
+
+      const result = await service.advanceStrategy('group-1', 'task-5', 'user-123');
+
+      expect(result.action).toBe('group_complete');
+      expect(result.stats).toEqual({ total: 5, completed: 5 });
+
+      // Should NOT have paused for periodic approval
+      const pauseCall = dc.repositories.taskGroups.update.mock.calls.find(
+        (c: unknown[]) =>
+          (c[1] as Record<string, unknown>).status === 'paused' &&
+          ((c[1] as Record<string, unknown>).metadata as Record<string, unknown>)?.pauseReason ===
+            'approval_gate'
+      );
+      expect(pauseCall).toBeUndefined();
+
+      // Should be marked completed
+      expect(dc.repositories.taskGroups.update).toHaveBeenCalledWith(
+        'group-1',
+        expect.objectContaining({ status: 'completed' })
+      );
+    });
+
+    it('should pause for final review (not periodic approval) when final task hits approval boundary with requireFinalApproval', async () => {
+      const group = createMockGroup({
+        current_task_index: 4,
+        iterations_since_approval: 4,
+        strategy_config: {
+          maxIterationsWithoutApproval: 5,
+          requireFinalApproval: true,
+          approvalCriteria: ['tests pass'],
+          approvalNotify: 'myra',
+        } as StrategyConfig,
+      });
+      const groupTasks = [
+        createMockTask({ status: 'completed', task_order: 0 }),
+        createMockTask({ status: 'completed', task_order: 1 }),
+        createMockTask({ status: 'completed', task_order: 2 }),
+        createMockTask({ status: 'completed', task_order: 3 }),
+        createMockTask({ status: 'completed', task_order: 4 }),
+      ];
+
+      dc.repositories.taskGroups.findById.mockResolvedValue(group);
+      dc.repositories.taskGroups.update.mockResolvedValue({
+        ...group,
+        status: 'paused',
+      });
+
+      const notFoundChain = chainTaskNotFound();
+      setupChains(dc, [
+        notFoundChain,
+        notFoundChain,
+        chainGroupTasks(groupTasks),
+        chainGroupTasks(groupTasks),
+        chainNoop(),
+      ]);
+
+      const result = await service.advanceStrategy('group-1', 'task-5', 'user-123');
+
+      expect(result.action).toBe('approval_required');
+      expect(result.progressSummary).toContain('Awaiting final approval');
+      expect(result.progressSummary).toContain('tests pass');
+
+      // Should be paused with final_review, NOT approval_gate
+      expect(dc.repositories.taskGroups.update).toHaveBeenCalledWith(
+        'group-1',
+        expect.objectContaining({
+          status: 'paused',
+          metadata: expect.objectContaining({ pauseReason: 'final_review' }),
+        })
+      );
     });
 
     it('should auto-complete when requireFinalApproval is not set', async () => {
@@ -1363,6 +1464,119 @@ describe('StrategyService', () => {
 
       await expect(service.resumeStrategy('group-1', 'user-123')).rejects.toThrow(
         'does not belong'
+      );
+    });
+
+    it('should finalize strategy when resuming from approval_gate with no remaining tasks', async () => {
+      // Regression: periodic approval_gate fires on the final task (before the
+      // ordering fix). On resume, no tasks remain — must finalize, not return
+      // group_complete with 0/0 stats (Lumen review, PR #362)
+      const group = createMockGroup({
+        status: 'paused',
+        strategy: 'persistence',
+        current_task_index: 5,
+        iterations_since_approval: 5,
+        metadata: { pauseReason: 'approval_gate' },
+        strategy_paused_at: '2026-04-10T12:00:00Z',
+      });
+      const groupTasks = [
+        createMockTask({ status: 'completed', task_order: 0 }),
+        createMockTask({ status: 'completed', task_order: 1 }),
+        createMockTask({ status: 'completed', task_order: 2 }),
+        createMockTask({ status: 'completed', task_order: 3 }),
+        createMockTask({ status: 'completed', task_order: 4 }),
+      ];
+
+      dc.repositories.taskGroups.findById.mockResolvedValueOnce(group);
+      // cleanupStrategyResources re-reads group
+      dc.repositories.taskGroups.findById.mockResolvedValueOnce(group);
+      dc.repositories.taskGroups.update.mockResolvedValue({
+        ...group,
+        status: 'completed',
+      });
+
+      const mockClient = dc.getClient();
+
+      // Build chains for from() calls:
+      // 1. createWatchdogReminder (sessions, identity, insert) — various from() calls
+      // 2. getTaskByOrder — not found (exact match fails, fallback empty)
+      // 3. getGroupTasks (for finalization stats)
+      // 4. cancelWatchdog
+      const inChain = vi.fn().mockReturnValue({
+        limit: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({ data: null, error: { code: 'PGRST116' } }),
+        }),
+        order: vi.fn().mockReturnValue({
+          order: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue({ data: [], error: null }),
+          }),
+        }),
+      });
+      const taskNotFoundChain = {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({ in: inChain }),
+            in: inChain,
+          }),
+        }),
+        insert: vi.fn().mockResolvedValue({ data: null, error: null }),
+        update: vi.fn().mockReturnValue({
+          contains: vi.fn().mockResolvedValue({ data: null, error: null }),
+        }),
+      };
+      const groupTasksChain = {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            order: vi.fn().mockReturnValue({
+              order: vi.fn().mockResolvedValue({ data: groupTasks, error: null }),
+            }),
+          }),
+        }),
+      };
+      const noopChain = {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              limit: vi.fn().mockReturnValue({
+                single: vi.fn().mockResolvedValue({ data: null, error: null }),
+              }),
+            }),
+            single: vi.fn().mockResolvedValue({ data: null, error: null }),
+          }),
+        }),
+        insert: vi.fn().mockResolvedValue({ data: null, error: null }),
+        update: vi.fn().mockReturnValue({
+          contains: vi.fn().mockResolvedValue({ data: null, error: null }),
+        }),
+      };
+
+      // Watchdog chains, then getTaskByOrder (not found), getGroupTasks, cleanup
+      let idx = 0;
+      const chains = [
+        noopChain, // watchdog: sessions
+        noopChain, // watchdog: identity
+        noopChain, // watchdog: insert
+        taskNotFoundChain, // getTaskByOrder: exact match (fails)
+        taskNotFoundChain, // getTaskByOrder: fallback (empty)
+        groupTasksChain, // getGroupTasks for finalization
+        noopChain, // cancelWatchdog
+      ];
+      mockClient.from.mockImplementation(() => chains[idx++] || noopChain);
+
+      const result = await service.resumeStrategy('group-1', 'user-123');
+
+      expect(result.action).toBe('group_complete');
+      expect(result.stats).toEqual({ total: 5, completed: 5 });
+
+      // Should have been marked completed
+      expect(dc.repositories.taskGroups.update).toHaveBeenCalledWith(
+        'group-1',
+        expect.objectContaining({ status: 'completed' })
+      );
+
+      // Should log strategy_completed
+      expect(dc.repositories.activityStream.logActivity).toHaveBeenCalledWith(
+        expect.objectContaining({ subtype: 'strategy_completed' })
       );
     });
 

--- a/packages/api/src/services/strategy.service.test.ts
+++ b/packages/api/src/services/strategy.service.test.ts
@@ -1046,6 +1046,91 @@ describe('StrategyService', () => {
       expect(result.action).toBe('group_complete');
       expect(dc.repositories.taskGroups.update).not.toHaveBeenCalled();
     });
+
+    it('should pause for final approval when requireFinalApproval is set', async () => {
+      const group = createMockGroup({
+        current_task_index: 2,
+        iterations_since_approval: 2,
+        strategy_config: {
+          requireFinalApproval: true,
+          approvalCriteria: ['tests pass', 'PR reviewed by Lumen'],
+          checkInNotify: 'myra',
+        },
+      });
+      const groupTasks = [
+        createMockTask({ status: 'completed', task_order: 0 }),
+        createMockTask({ status: 'completed', task_order: 1 }),
+        createMockTask({ status: 'completed', task_order: 2 }),
+      ];
+
+      dc.repositories.taskGroups.findById.mockResolvedValue(group);
+      dc.repositories.taskGroups.update.mockResolvedValue({
+        ...group,
+        status: 'paused',
+      });
+
+      const notFoundChain = chainTaskNotFound();
+      // Chain: getTaskByOrder (not found), getGroupTasks (for stats), buildProgressSummary (getGroupTasks again), activity log
+      setupChains(dc, [
+        notFoundChain,
+        notFoundChain,
+        chainGroupTasks(groupTasks),
+        chainGroupTasks(groupTasks),
+        chainNoop(),
+      ]);
+
+      const result = await service.advanceStrategy('group-1', 'task-3', 'user-123');
+
+      expect(result.action).toBe('approval_required');
+      expect(result.progressSummary).toContain('tests pass');
+      expect(result.progressSummary).toContain('PR reviewed by Lumen');
+      expect(result.progressSummary).toContain('Awaiting final approval');
+
+      // Should pause, not complete
+      expect(dc.repositories.taskGroups.update).toHaveBeenCalledWith(
+        'group-1',
+        expect.objectContaining({
+          status: 'paused',
+          metadata: expect.objectContaining({ pauseReason: 'final_review' }),
+        })
+      );
+
+      // Should NOT have been marked completed
+      const updateCalls = dc.repositories.taskGroups.update.mock.calls;
+      const completedCall = updateCalls.find(
+        (c: unknown[]) => (c[1] as Record<string, unknown>).status === 'completed'
+      );
+      expect(completedCall).toBeUndefined();
+    });
+
+    it('should auto-complete when requireFinalApproval is not set', async () => {
+      const group = createMockGroup({
+        current_task_index: 2,
+        iterations_since_approval: 2,
+      });
+      const groupTasks = [
+        createMockTask({ status: 'completed', task_order: 0 }),
+        createMockTask({ status: 'completed', task_order: 1 }),
+        createMockTask({ status: 'completed', task_order: 2 }),
+      ];
+
+      dc.repositories.taskGroups.findById.mockResolvedValue(group);
+      dc.repositories.taskGroups.update.mockResolvedValue({
+        ...group,
+        status: 'completed',
+      });
+
+      const notFoundChain = chainTaskNotFound();
+      setupChains(dc, [notFoundChain, notFoundChain, chainGroupTasks(groupTasks), chainNoop()]);
+
+      const result = await service.advanceStrategy('group-1', 'task-3', 'user-123');
+
+      expect(result.action).toBe('group_complete');
+      expect(dc.repositories.taskGroups.update).toHaveBeenCalledWith(
+        'group-1',
+        expect.objectContaining({ status: 'completed' })
+      );
+    });
   });
 
   // ============================================================================
@@ -1278,6 +1363,72 @@ describe('StrategyService', () => {
 
       await expect(service.resumeStrategy('group-1', 'user-123')).rejects.toThrow(
         'does not belong'
+      );
+    });
+
+    it('should finalize strategy when resuming from final_review pause', async () => {
+      const group = createMockGroup({
+        status: 'paused',
+        strategy: 'persistence',
+        current_task_index: 3,
+        metadata: { pauseReason: 'final_review' },
+        strategy_paused_at: '2026-04-10T12:00:00Z',
+        strategy_config: { requireFinalApproval: true, approvalCriteria: ['tests pass'] },
+      });
+      const groupTasks = [
+        createMockTask({ status: 'completed', task_order: 0 }),
+        createMockTask({ status: 'completed', task_order: 1 }),
+        createMockTask({ status: 'completed', task_order: 2 }),
+      ];
+
+      dc.repositories.taskGroups.findById.mockResolvedValueOnce(group);
+      // Second findById call from cleanupStrategyResources
+      dc.repositories.taskGroups.findById.mockResolvedValueOnce(group);
+      dc.repositories.taskGroups.update.mockResolvedValue({
+        ...group,
+        status: 'completed',
+      });
+
+      const mockClient = dc.getClient();
+      const groupTasksChain = {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            order: vi.fn().mockReturnValue({
+              order: vi.fn().mockResolvedValue({ data: groupTasks, error: null }),
+            }),
+          }),
+        }),
+      };
+      const noopChain = {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              in: vi.fn().mockReturnValue({
+                limit: vi.fn().mockReturnValue({
+                  single: vi.fn().mockResolvedValue({ data: null, error: null }),
+                }),
+              }),
+            }),
+            single: vi.fn().mockResolvedValue({ data: null, error: null }),
+          }),
+        }),
+        insert: vi.fn().mockResolvedValue({ data: null, error: null }),
+        update: vi.fn().mockReturnValue({
+          contains: vi.fn().mockResolvedValue({ data: null, error: null }),
+        }),
+      };
+      mockClient.from.mockReturnValueOnce(groupTasksChain).mockReturnValue(noopChain);
+
+      const result = await service.resumeStrategy('group-1', 'user-123');
+
+      expect(result.action).toBe('group_complete');
+      expect(result.stats).toEqual({ total: 3, completed: 3 });
+
+      expect(dc.repositories.activityStream.logActivity).toHaveBeenCalledWith(
+        expect.objectContaining({ subtype: 'final_review_approved' })
+      );
+      expect(dc.repositories.activityStream.logActivity).toHaveBeenCalledWith(
+        expect.objectContaining({ subtype: 'strategy_completed' })
       );
     });
   });

--- a/packages/api/src/services/strategy.service.ts
+++ b/packages/api/src/services/strategy.service.ts
@@ -345,48 +345,8 @@ export class StrategyService {
       iterations_since_approval: newIterations,
     });
 
-    // Check approval gate
-    const maxIterations = config.maxIterationsWithoutApproval;
-    if (maxIterations && newIterations >= maxIterations) {
-      const summary = await this.buildProgressSummary(group, newIndex);
-
-      // Pause for approval — set pauseReason so resumeStrategy can distinguish
-      // approval-gate pauses from manual pauses (Lumen review, PR #338)
-      await this.dataComposer.repositories.taskGroups.update(groupId, {
-        strategy_paused_at: new Date().toISOString(),
-        status: 'paused',
-        context_summary: summary,
-        metadata: { ...group.metadata, pauseReason: 'approval_gate' },
-      });
-
-      // Notify dispatcher
-      const notified = await this.notifyDispatcher(
-        group,
-        config.approvalNotify,
-        `Approval needed: completed ${newIterations} tasks in "${group.title}". ${summary}`,
-        userId
-      );
-
-      await this.logStrategyEvent(
-        group,
-        'approval_required',
-        `Approval gate: ${newIterations} tasks completed without approval`,
-        {
-          iterationsSinceApproval: newIterations,
-          progressSummary: summary,
-          routedTo: config.approvalNotify || null,
-          notified,
-        }
-      );
-
-      return {
-        action: 'approval_required',
-        progressSummary: summary,
-        notified,
-      };
-    }
-
-    // Get next task
+    // Check for completion BEFORE the periodic approval gate — final-task
+    // handling must win over maxIterationsWithoutApproval (Lumen review, PR #362)
     const nextTask = await this.getTaskByOrder(groupId, newIndex);
 
     if (!nextTask) {
@@ -487,6 +447,47 @@ export class StrategyService {
       return {
         action: 'group_complete',
         stats: { total: tasks.length, completed },
+      };
+    }
+
+    // Check periodic approval gate (only when there ARE more tasks to do)
+    const maxIterations = config.maxIterationsWithoutApproval;
+    if (maxIterations && newIterations >= maxIterations) {
+      const summary = await this.buildProgressSummary(group, newIndex);
+
+      // Pause for approval — set pauseReason so resumeStrategy can distinguish
+      // approval-gate pauses from manual pauses (Lumen review, PR #338)
+      await this.dataComposer.repositories.taskGroups.update(groupId, {
+        strategy_paused_at: new Date().toISOString(),
+        status: 'paused',
+        context_summary: summary,
+        metadata: { ...group.metadata, pauseReason: 'approval_gate' },
+      });
+
+      // Notify dispatcher
+      const notified = await this.notifyDispatcher(
+        group,
+        config.approvalNotify,
+        `Approval needed: completed ${newIterations} tasks in "${group.title}". ${summary}`,
+        userId
+      );
+
+      await this.logStrategyEvent(
+        group,
+        'approval_required',
+        `Approval gate: ${newIterations} tasks completed without approval`,
+        {
+          iterationsSinceApproval: newIterations,
+          progressSummary: summary,
+          routedTo: config.approvalNotify || null,
+          notified,
+        }
+      );
+
+      return {
+        action: 'approval_required',
+        progressSummary: summary,
+        notified,
       };
     }
 
@@ -653,7 +654,54 @@ export class StrategyService {
     const nextTask = await this.getTaskByOrder(groupId, group.current_task_index);
 
     if (!nextTask) {
-      return { action: 'group_complete', stats: { total: 0, completed: 0 } };
+      // No more tasks — finalize the strategy (handles the case where the
+      // periodic approval gate fired on the final task, Lumen review PR #362)
+      const config = group.strategy_config as StrategyConfig;
+      const tasks = await this.getGroupTasks(groupId);
+      const completed = tasks.filter((t) => t.status === 'completed').length;
+      const pending = tasks.filter((t) => t.status === 'pending').length;
+      const blocked = tasks.filter((t) => t.status === 'blocked').length;
+      const hasIncomplete = pending > 0 || blocked > 0;
+
+      if (config.requireFinalApproval) {
+        // Still need final review — re-pause with final_review reason
+        const summary = await this.buildProgressSummary(group, group.current_task_index);
+        const criteria = config.approvalCriteria || [];
+        const criteriaList =
+          criteria.length > 0
+            ? `\n\nAcceptance criteria:\n${criteria.map((c) => `• ${c}`).join('\n')}`
+            : '';
+
+        await this.dataComposer.repositories.taskGroups.update(groupId, {
+          strategy_paused_at: new Date().toISOString(),
+          status: 'paused',
+          context_summary: summary,
+          metadata: { ...cleanedMetadata, pauseReason: 'final_review' },
+        });
+
+        const approvalMessage =
+          `All tasks complete on "${group.title}" (${completed}/${tasks.length}).` +
+          `${hasIncomplete ? ` WARNING: ${pending} pending, ${blocked} blocked tasks remain.` : ''}` +
+          ` Awaiting final approval before closing.${criteriaList}\n\n${summary}`;
+
+        const notified = await this.notifyDispatcher(
+          group,
+          config.approvalNotify || config.checkInNotify,
+          approvalMessage,
+          group.user_id
+        );
+
+        return { action: 'approval_required', progressSummary: approvalMessage, notified };
+      }
+
+      await this.finalizeStrategy(
+        { ...group, metadata: cleanedMetadata },
+        { total: tasks.length, completed, pending, blocked, hasIncomplete },
+        config,
+        group.user_id
+      );
+
+      return { action: 'group_complete', stats: { total: tasks.length, completed } };
     }
 
     // Mark as in_progress if not already

--- a/packages/api/src/services/strategy.service.ts
+++ b/packages/api/src/services/strategy.service.ts
@@ -390,7 +390,7 @@ export class StrategyService {
     const nextTask = await this.getTaskByOrder(groupId, newIndex);
 
     if (!nextTask) {
-      // No more pending/in_progress tasks — strategy is done
+      // No more pending/in_progress tasks — strategy is done (or needs final approval)
       const tasks = await this.getGroupTasks(groupId);
       const completed = tasks.filter((t) => t.status === 'completed').length;
       const pending = tasks.filter((t) => t.status === 'pending').length;
@@ -415,49 +415,74 @@ export class StrategyService {
         );
       }
 
-      await this.dataComposer.repositories.taskGroups.update(groupId, {
-        status: 'completed',
-        context_summary: hasIncomplete
-          ? `Strategy complete with issues: ${completed}/${tasks.length} done, ${pending} pending, ${blocked} blocked.`
-          : `Strategy complete. ${completed}/${tasks.length} tasks done.`,
-      });
+      // Final approval gate — pause for human review instead of auto-completing
+      if (config.requireFinalApproval) {
+        const summary = await this.buildProgressSummary(group, newIndex);
+        const criteria = config.approvalCriteria || [];
+        const criteriaList =
+          criteria.length > 0
+            ? `\n\nAcceptance criteria:\n${criteria.map((c) => `• ${c}`).join('\n')}`
+            : '';
 
-      // Clean up strategy resources (watchdog, ephemeral studio, sandbox)
-      await this.cleanupStrategyResources(group.id);
+        await this.dataComposer.repositories.taskGroups.update(groupId, {
+          strategy_paused_at: new Date().toISOString(),
+          status: 'paused',
+          context_summary: summary,
+          metadata: { ...group.metadata, pauseReason: 'final_review' },
+        });
 
-      await this.logStrategyEvent(
-        group,
-        'strategy_completed',
-        `Strategy complete: ${completed}/${tasks.length} tasks done`,
-        {
-          totalTasks: tasks.length,
-          completedTasks: completed,
-          pendingTasks: pending,
-          blockedTasks: blocked,
-          hasIncomplete,
+        const approvalMessage =
+          `All tasks complete on "${group.title}" (${completed}/${tasks.length}).` +
+          `${hasIncomplete ? ` WARNING: ${pending} pending, ${blocked} blocked tasks remain.` : ''}` +
+          ` Awaiting final approval before closing.${criteriaList}\n\n${summary}`;
+
+        const notified = await this.notifyDispatcher(
+          group,
+          config.approvalNotify || config.checkInNotify,
+          approvalMessage,
+          userId
+        );
+
+        // Notify supervisor too if configured
+        if (config.supervisorId) {
+          const supervisorSlug = await this.resolveAgentSlug(config.supervisorId);
+          if (supervisorSlug) {
+            await this.notifyDispatcher(
+              group,
+              supervisorSlug,
+              `[Supervisor] Final review requested on "${group.title}". ${completed}/${tasks.length} tasks done.${criteriaList}`,
+              userId
+            );
+          }
         }
-      );
 
-      // Notify dispatcher of completion
-      await this.notifyDispatcher(
+        await this.logStrategyEvent(
+          group,
+          'final_review_requested',
+          `All tasks done — paused for final approval`,
+          {
+            totalTasks: tasks.length,
+            completedTasks: completed,
+            approvalCriteria: criteria,
+            notified,
+            routedTo: config.approvalNotify || config.checkInNotify || null,
+          }
+        );
+
+        return {
+          action: 'approval_required',
+          progressSummary: approvalMessage,
+          notified,
+        };
+      }
+
+      // No final approval needed — complete immediately
+      await this.finalizeStrategy(
         group,
-        config.checkInNotify || config.approvalNotify,
-        `Strategy "${group.strategy}" complete on "${group.title}": ${completed}/${tasks.length} tasks finished.${hasIncomplete ? ` WARNING: ${pending} pending, ${blocked} blocked tasks remain.` : ''}`,
+        { total: tasks.length, completed, pending, blocked, hasIncomplete },
+        config,
         userId
       );
-
-      // Notify supervisor for final audit (if configured)
-      if (config.supervisorId) {
-        const supervisorSlug = await this.resolveAgentSlug(config.supervisorId);
-        if (supervisorSlug) {
-          await this.notifyDispatcher(
-            group,
-            supervisorSlug,
-            `[Supervisor audit] Strategy "${group.strategy}" on "${group.title}" is complete. ${completed}/${tasks.length} tasks done.${hasIncomplete ? ` PROCESS VIOLATION: ${pending} pending, ${blocked} blocked tasks were not completed.` : ''} Review the activity stream for task_group_id ${group.id}.`,
-            userId
-          );
-        }
-      }
 
       return {
         action: 'group_complete',
@@ -565,11 +590,46 @@ export class StrategyService {
     if (group.status !== 'paused') throw new Error('Strategy is not paused');
     if (!group.strategy) throw new Error('No strategy set on this group');
 
-    const wasAwaitingApproval = group.metadata?.pauseReason === 'approval_gate';
+    const pauseReason = (group.metadata as Record<string, unknown>)?.pauseReason;
+    const wasAwaitingApproval = pauseReason === 'approval_gate';
+    const wasFinalReview = pauseReason === 'final_review';
 
     // Clear pauseReason on resume so it doesn't persist into the next pause cycle
-    const cleanedMetadata = { ...group.metadata };
+    const cleanedMetadata = { ...group.metadata } as Record<string, unknown>;
     delete cleanedMetadata.pauseReason;
+
+    // Final review approval — all tasks done, finalize the strategy
+    if (wasFinalReview) {
+      const config = group.strategy_config as StrategyConfig;
+      const tasks = await this.getGroupTasks(groupId);
+      const completed = tasks.filter((t) => t.status === 'completed').length;
+      const pending = tasks.filter((t) => t.status === 'pending').length;
+      const blocked = tasks.filter((t) => t.status === 'blocked').length;
+      const hasIncomplete = pending > 0 || blocked > 0;
+
+      await this.logStrategyEvent(
+        group,
+        'final_review_approved',
+        `Final review approved on "${group.title}" — finalizing strategy`,
+        { completedTasks: completed, totalTasks: tasks.length }
+      );
+
+      // Set back to active briefly so finalizeStrategy can complete it cleanly
+      await this.dataComposer.repositories.taskGroups.update(groupId, {
+        status: 'active',
+        strategy_paused_at: null,
+        metadata: cleanedMetadata,
+      });
+
+      await this.finalizeStrategy(
+        { ...group, metadata: cleanedMetadata },
+        { total: tasks.length, completed, pending, blocked, hasIncomplete },
+        config,
+        userId
+      );
+
+      return { action: 'group_complete', stats: { total: tasks.length, completed } };
+    }
 
     await this.dataComposer.repositories.taskGroups.update(groupId, {
       status: 'active',
@@ -1398,6 +1458,60 @@ export class StrategyService {
   /**
    * Cancel the watchdog reminder for a strategy (on pause/complete).
    */
+  private async finalizeStrategy(
+    group: TaskGroup,
+    stats: {
+      total: number;
+      completed: number;
+      pending: number;
+      blocked: number;
+      hasIncomplete: boolean;
+    },
+    config: StrategyConfig,
+    userId: string
+  ): Promise<void> {
+    await this.dataComposer.repositories.taskGroups.update(group.id, {
+      status: 'completed',
+      context_summary: stats.hasIncomplete
+        ? `Strategy complete with issues: ${stats.completed}/${stats.total} done, ${stats.pending} pending, ${stats.blocked} blocked.`
+        : `Strategy complete. ${stats.completed}/${stats.total} tasks done.`,
+    });
+
+    await this.cleanupStrategyResources(group.id);
+
+    await this.logStrategyEvent(
+      group,
+      'strategy_completed',
+      `Strategy complete: ${stats.completed}/${stats.total} tasks done`,
+      {
+        totalTasks: stats.total,
+        completedTasks: stats.completed,
+        pendingTasks: stats.pending,
+        blockedTasks: stats.blocked,
+        hasIncomplete: stats.hasIncomplete,
+      }
+    );
+
+    await this.notifyDispatcher(
+      group,
+      config.checkInNotify || config.approvalNotify,
+      `Strategy "${group.strategy}" complete on "${group.title}": ${stats.completed}/${stats.total} tasks finished.${stats.hasIncomplete ? ` WARNING: ${stats.pending} pending, ${stats.blocked} blocked tasks remain.` : ''}`,
+      userId
+    );
+
+    if (config.supervisorId) {
+      const supervisorSlug = await this.resolveAgentSlug(config.supervisorId);
+      if (supervisorSlug) {
+        await this.notifyDispatcher(
+          group,
+          supervisorSlug,
+          `[Supervisor audit] Strategy "${group.strategy}" on "${group.title}" is complete. ${stats.completed}/${stats.total} tasks done.${stats.hasIncomplete ? ` PROCESS VIOLATION: ${stats.pending} pending, ${stats.blocked} blocked tasks were not completed.` : ''} Review the activity stream for task_group_id ${group.id}.`,
+          userId
+        );
+      }
+    }
+  }
+
   /**
    * Clean up strategy resources (watchdog, etc.) without logging a
    * strategy_cancelled event or changing group status. Use this when


### PR DESCRIPTION
## Summary

- Adds `requireFinalApproval` and `approvalCriteria` to `StrategyConfig`
- When all tasks are done and `requireFinalApproval: true`, the strategy **pauses** with criteria checklist instead of auto-completing
- Approval message routed to `approvalNotify` / `checkInNotify` (e.g., Myra → Telegram)
- `resume_strategy` from a `final_review` pause triggers finalization (completion + cleanup + supervisor audit)
- Extracts `finalizeStrategy()` private method so both direct-complete and resume-after-approval share the same logic
- MCP `start_strategy` tool schema updated with both new params

## Example usage

```
start_strategy(groupId, 'persistence', {
  requireFinalApproval: true,
  approvalCriteria: ['tests pass', 'PR reviewed', 'visual review via Playwright'],
  approvalNotify: 'myra',
  supervisorId: '<lumen-uuid>'
})
```

When the agent finishes all tasks, Myra sends you:
> All tasks complete on "OAuth PKCE". Awaiting final approval.
> • tests pass
> • PR reviewed
> • visual review via Playwright

You respond, or call `resume_strategy` to finalize.

## Test plan

- [x] 63/63 strategy tests pass (50 service + 13 handler)
- [x] New test: pauses for approval when `requireFinalApproval` set
- [x] New test: auto-completes when `requireFinalApproval` not set  
- [x] New test: `resumeStrategy` from `final_review` finalizes correctly

— Wren