### PR TITLE
feat: add runner-backed memory dream experiments (by Lumen)

### DIFF
--- a/packages/api/src/benchmarks.ts
+++ b/packages/api/src/benchmarks.ts
@@ -5,6 +5,8 @@ export {
   DEFAULT_MEMORY_LLM_MODEL,
   MEMORY_EXTRACTION_VERSION,
 } from './services/memory-llm-extraction';
+export { ClaudeRunner } from './services/sessions';
+export type { ClaudeRunnerConfig, IRunner } from './services/sessions';
 export type {
   MemoryHybridChunkStrategy,
   MemorySemanticQueryStrategy,

--- a/packages/benchmarks/src/benchmark-memory-dream.logic.test.ts
+++ b/packages/benchmarks/src/benchmark-memory-dream.logic.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from 'vitest';
 import { hasOptionalAnswer } from './benchmark-answer-coverage';
 import {
   applyLocalDreamUpdate,
+  buildBatchDreamPrompt,
   buildOnlineDreamPrompt,
   buildOrderedDreamSessions,
+  coerceDreamStateUpdate,
   createInitialDreamState,
   parseLongMemSessionId,
   renderDreamStateForAnswerCheck,
@@ -267,6 +269,163 @@ describe('benchmark-memory-dream logic', () => {
 
     expect(prompt.systemPrompt).toContain('one new chronological episode');
     expect(prompt.userPrompt).toContain('Previous compact dream state JSON');
-    expect(prompt.userPrompt).toContain('session s1');
+    expect(prompt.userPrompt).toContain('\"sessionId\": \"s1\"');
+    expect(prompt.userPrompt).toContain('No future evaluation question is available');
+    expect(prompt.userPrompt).not.toContain('question for later evaluation only');
+  });
+
+  it('coerces runner dream JSON into evidence-linked state without trusting metadata as answer text', () => {
+    const initial = createInitialDreamState('case-coin', 'online');
+    const [session] = buildOrderedDreamSessions(
+      {
+        id: 'case-coin',
+        query: 'How many pre-1920 coins do I have?',
+        answerSessionIds: ['s2'],
+        sessions: [
+          {
+            sessionId: 's2',
+            content: 'session s2\nuser: I added one more quarter after having 37 coins.',
+            hasAnswer: true,
+            isAnswerSession: true,
+            turnCount: 1,
+          },
+        ],
+      },
+      [
+        {
+          id: 'mem-s2',
+          content: 'session s2\nuser: I added one more quarter after having 37 coins.',
+          summary: null,
+          metadata: null,
+          created_at: '2026-01-02T00:00:00Z',
+        },
+      ]
+    ).sessions;
+
+    const updated = coerceDreamStateUpdate(
+      {
+        stateSummary: 'The user now has 38 pre-1920 American coins.',
+        durableFacts: [
+          {
+            key: 'coin-count',
+            fact: 'The user has 38 pre-1920 American coins.',
+            category: 'status',
+            subject: 'user',
+            object: 'pre-1920 American coin count',
+            evidence: '37 coins plus one more quarter.',
+            status: 'active',
+          },
+        ],
+        entities: [],
+        currentStates: [],
+        temporalEvents: [
+          {
+            sessionId: 's2',
+            memoryId: 'mem-s2',
+            summary: 'The user added one quarter.',
+          },
+        ],
+      },
+      {
+        previousState: initial,
+        currentSession: session,
+      }
+    );
+
+    expect(updated.sessionCount).toBe(1);
+    expect(updated.durableFacts[0]).toMatchObject({
+      key: 'coin-count',
+      status: 'active',
+      evidenceMemoryIds: ['mem-s2'],
+      evidenceSessionIds: ['s2'],
+    });
+    expect(renderDreamStateForAnswerCheck(updated)).toContain('38 pre-1920 American coins');
+  });
+
+  it('builds a batch dream prompt with chronological extracted views and clamped excerpts', () => {
+    const dreamCase = {
+      id: 'case-1',
+      query: 'What changed?',
+      answerSessionIds: ['s1'],
+      sessions: [
+        {
+          sessionId: 's1',
+          content: 'session s1\nuser: ' + 'hello '.repeat(100),
+          hasAnswer: true,
+          isAnswerSession: true,
+          turnCount: 1,
+        },
+      ],
+    };
+    const [session] = buildOrderedDreamSessions(dreamCase, [
+      {
+        id: 'mem-s1',
+        content: dreamCase.sessions[0].content,
+        summary: null,
+        metadata: null,
+        created_at: '2026-01-01T00:00:00Z',
+      },
+    ]).sessions;
+
+    const prompt = buildBatchDreamPrompt({
+      caseId: 'case-1',
+      question: 'What changed?',
+      sessions: [session],
+      mode: 'batch',
+      maxContentExcerptChars: 80,
+    });
+
+    expect(prompt.systemPrompt).toContain('batch memory-dream worker');
+    expect(prompt.userPrompt).toContain('Chronological episodes JSON');
+    expect(prompt.userPrompt).toContain('contentExcerpt');
+    expect(prompt.userPrompt).toContain('No future evaluation question is available');
+    expect(prompt.userPrompt.length).toBeLessThan(4000);
+  });
+
+  it('can build a query-hinted diagnostic batch prompt that selects relevant middle text', () => {
+    const middle = 'user: The coin collection currently has a total of 37 pre-1920 coins.';
+    const content = [
+      'session s1',
+      'user: irrelevant opening '.repeat(30),
+      middle,
+      'assistant: irrelevant ending '.repeat(30),
+    ].join('\n');
+    const [session] = buildOrderedDreamSessions(
+      {
+        id: 'case-coin',
+        query: 'How many pre-1920 coins?',
+        answerSessionIds: ['s1'],
+        sessions: [
+          {
+            sessionId: 's1',
+            content,
+            hasAnswer: true,
+            isAnswerSession: true,
+            turnCount: 3,
+          },
+        ],
+      },
+      [
+        {
+          id: 'mem-s1',
+          content,
+          summary: null,
+          metadata: null,
+          created_at: '2026-01-01T00:00:00Z',
+        },
+      ]
+    ).sessions;
+
+    const prompt = buildBatchDreamPrompt({
+      caseId: 'case-coin',
+      question: 'How many pre-1920 coins?',
+      sessions: [session],
+      mode: 'batch',
+      maxContentExcerptChars: 140,
+      useQuestionHints: true,
+    });
+
+    expect(prompt.userPrompt).toContain('question for later evaluation only');
+    expect(prompt.userPrompt).toContain('37 pre-1920 coins');
   });
 });

--- a/packages/benchmarks/src/benchmark-memory-dream.logic.ts
+++ b/packages/benchmarks/src/benchmark-memory-dream.logic.ts
@@ -135,7 +135,7 @@ export interface DreamLimits {
   maxStateSummaryChars: number;
 }
 
-const DEFAULT_LIMITS: DreamLimits = {
+export const DEFAULT_DREAM_LIMITS: DreamLimits = {
   maxEntities: 80,
   maxDurableFacts: 160,
   maxCurrentStates: 60,
@@ -167,8 +167,90 @@ function clampText(text: string, maxChars: number): string {
   return `${compacted.slice(0, Math.max(0, maxChars - 1)).trimEnd()}…`;
 }
 
+const QUERY_STOPWORDS = new Set([
+  'about',
+  'after',
+  'again',
+  'does',
+  'have',
+  'how',
+  'many',
+  'much',
+  'what',
+  'when',
+  'where',
+  'which',
+  'while',
+  'with',
+  'your',
+]);
+
 function stripSessionHeader(content: string): string {
   return content.replace(/^session\s+[^\r\n]+[\r\n]+/i, '');
+}
+
+function queryTokens(query: string): string[] {
+  return uniqueStrings(
+    query
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, ' ')
+      .split(/\s+/)
+      .filter((token) => token.length >= 3 || /^\d+$/.test(token))
+      .filter((token) => !QUERY_STOPWORDS.has(token))
+  );
+}
+
+function paragraphScore(paragraph: string, tokens: string[]): number {
+  const normalized = paragraph.toLowerCase().replace(/[^a-z0-9]+/g, ' ');
+  const tokenScore = tokens.filter((token) => normalized.includes(token)).length;
+  const numberScore = /\d/.test(paragraph) ? 1 : 0;
+  return tokenScore * 3 + numberScore;
+}
+
+function buildContentEdgeExcerpt(content: string, maxChars: number): string {
+  const stripped = stripSessionHeader(content).trim();
+  if (stripped.length <= maxChars) return stripped;
+  const edgeChars = Math.max(200, Math.floor((maxChars - 20) / 2));
+  return `${stripped.slice(0, edgeChars).trimEnd()}\n...\n${stripped.slice(-edgeChars).trimStart()}`;
+}
+
+function buildRelevantContentExcerpt(
+  content: string,
+  query: string | null,
+  maxChars: number
+): string {
+  const stripped = stripSessionHeader(content).trim();
+  if (stripped.length <= maxChars) return stripped;
+  if (!query?.trim()) return buildContentEdgeExcerpt(content, maxChars);
+
+  const tokens = queryTokens(query);
+  const paragraphs = stripped
+    .split(/\n(?=(?:user|assistant):)|\n{2,}/i)
+    .map((paragraph) => paragraph.trim())
+    .filter(Boolean);
+  const scored = paragraphs
+    .map((paragraph, index) => ({
+      paragraph,
+      index,
+      score: paragraphScore(paragraph, tokens),
+    }))
+    .filter((entry) => entry.score > 0)
+    .sort((a, b) => b.score - a.score || a.index - b.index);
+
+  if (scored.length === 0) {
+    return buildContentEdgeExcerpt(content, maxChars);
+  }
+
+  const selected = scored.slice(0, 4).sort((a, b) => a.index - b.index);
+  const separatorBudget = Math.max(0, selected.length - 1) * 5;
+  const perParagraphChars = Math.max(
+    120,
+    Math.floor((maxChars - separatorBudget) / Math.max(1, selected.length))
+  );
+  return (
+    selected.map((entry) => clampText(entry.paragraph, perParagraphChars)).join('\n...\n') ||
+    clampText(stripped, maxChars)
+  );
 }
 
 function normalizeKey(text: string): string {
@@ -381,7 +463,7 @@ export function applyLocalDreamUpdate(
   session: OrderedDreamSession,
   limits: Partial<DreamLimits> = {}
 ): DreamState {
-  const resolvedLimits = { ...DEFAULT_LIMITS, ...limits };
+  const resolvedLimits = { ...DEFAULT_DREAM_LIMITS, ...limits };
   const entityMap = new Map(state.entities.map((entity) => [normalizeKey(entity.name), entity]));
   const factMap = new Map(state.durableFacts.map((fact) => [fact.key, fact]));
   const currentStateMap = new Map(state.currentStates.map((item) => [item.key, item]));
@@ -500,21 +582,28 @@ export function buildOnlineDreamPrompt(params: {
   question: string;
   previousState: DreamState;
   nextSession: OrderedDreamSession;
+  maxContentExcerptChars?: number;
+  useQuestionHints?: boolean;
 }): { systemPrompt: string; userPrompt: string; schemaDescription: string } {
+  const questionHint = params.useQuestionHints
+    ? `question for later evaluation only, not a label: ${params.question}`
+    : 'No future evaluation question is available to the dream worker.';
   return {
     systemPrompt:
       'You are an online memory-dream worker. Integrate one new chronological episode into a compact, evidence-grounded state ledger. Return strict JSON only. Do not use benchmark answer labels. Do not review all past raw episodes; use the prior compact state plus this one new episode.',
     schemaDescription:
-      'JSON schema: {"stateSummary": string, "entities": [{"name": string, "entityType"?: string, "description": string, "aliases": string[], "evidenceMemoryIds": string[], "evidenceSessionIds": string[]}], "durableFacts": [{"key": string, "fact": string, "category": string, "subject"?: string, "object"?: string, "status": "active"|"superseded"|"uncertain", "evidenceMemoryIds": string[], "evidenceSessionIds": string[]}], "currentStates": [{"key": string, "state": string, "scope": string, "status": string, "volatility": string, "evidenceMemoryIds": string[], "evidenceSessionIds": string[]}], "temporalEvents": [{"sessionId": string, "memoryId": string, "date"?: string, "summary": string}], "notes": string[]}',
+      'JSON schema: {"stateSummary": string, "entities": [{"name": string, "entityType"?: string, "description": string, "aliases": string[], "evidence": string, "evidenceMemoryIds": string[], "evidenceSessionIds": string[]}], "durableFacts": [{"key": string, "fact": string, "category": string, "subject"?: string, "object"?: string, "evidence": string, "status": "active"|"superseded"|"uncertain", "evidenceMemoryIds": string[], "evidenceSessionIds": string[]}], "currentStates": [{"key": string, "state": string, "scope": string, "status": string, "volatility": string, "evidence": string, "evidenceMemoryIds": string[], "evidenceSessionIds": string[]}], "temporalEvents": [{"sessionId": string, "memoryId": string, "date"?: string, "summary": string}], "notes": string[]}',
     userPrompt: [
       `caseId: ${params.caseId}`,
-      `question for later evaluation only, not a label: ${params.question}`,
+      questionHint,
       '',
       'Integration rules:',
       '- Treat episodes as chronological within this case.',
       '- Preserve current state updates, quantities, decisions, constraints, process rules, list/table mappings, and exact values when evidence supports them.',
       '- If a new episode updates an old value, mark the old fact superseded and write the new active value with evidence links.',
       '- If a value requires arithmetic or accumulation, perform the update and keep both evidence session ids.',
+      '- Explicit aggregate/count statements are authoritative state. Do not replace an explicit total with a smaller count of named examples.',
+      '- If an earlier episode says a collection has total N and a later episode adds one item to that collection, write the active total as N+1 with both evidence links.',
       '- Keep the ledger compact. Do not copy the full transcript.',
       '- Keep cases isolated: never infer from other cases.',
       '',
@@ -528,9 +617,267 @@ export function buildOnlineDreamPrompt(params: {
           memoryId: params.nextSession.memoryId,
           date: params.nextSession.date || null,
           sourceSummary: params.nextSession.sourceSummary,
-          extractedViews: params.nextSession.extractions,
-          content: params.nextSession.content,
+          extractedViews: compactDreamExtractionViews(params.nextSession.extractions),
+          contentExcerpt: buildRelevantContentExcerpt(
+            params.nextSession.content,
+            params.useQuestionHints ? params.question : null,
+            params.maxContentExcerptChars || 4000
+          ),
         },
+        null,
+        2
+      ),
+    ].join('\n'),
+  };
+}
+
+function compactDreamExtractionViews(views: DreamExtractionViews): DreamExtractionViews {
+  return {
+    entities: views.entities.slice(0, 6).map((entity) => ({
+      ...entity,
+      description: clampText(entity.description, 220),
+      evidence: clampText(entity.evidence, 180),
+    })),
+    durableFacts: views.durableFacts.slice(0, 8).map((fact) => ({
+      ...fact,
+      fact: clampText(fact.fact, 260),
+      evidence: clampText(fact.evidence, 180),
+    })),
+    summary: views.summary
+      ? {
+          summary: clampText(views.summary.summary, 500),
+          keyPoints: views.summary.keyPoints.slice(0, 6).map((point) => clampText(point, 220)),
+          actionRelevance: clampText(views.summary.actionRelevance, 260),
+        }
+      : null,
+    currentState: views.currentState
+      ? {
+          ...views.currentState,
+          state: clampText(views.currentState.state, 240),
+          evidence: clampText(views.currentState.evidence, 180),
+        }
+      : null,
+  };
+}
+
+function statusFromRaw(raw: unknown): DreamDurableFact['status'] {
+  const status = asString(raw);
+  return status === 'active' || status === 'superseded' || status === 'uncertain'
+    ? status
+    : 'active';
+}
+
+function evidenceIdsFromRaw(raw: unknown, fallback: string): string[] {
+  const ids = asArray(raw)
+    .map(asString)
+    .filter((id): id is string => Boolean(id));
+  return uniqueStrings(ids.length > 0 ? ids : [fallback]);
+}
+
+function clampDreamState(state: DreamState, limits: DreamLimits): DreamState {
+  return {
+    ...state,
+    stateSummary: clampText(state.stateSummary, limits.maxStateSummaryChars),
+    entities: state.entities.slice(-limits.maxEntities),
+    durableFacts: state.durableFacts.slice(-limits.maxDurableFacts),
+    currentStates: state.currentStates.slice(-limits.maxCurrentStates),
+    temporalEvents: state.temporalEvents.slice(-limits.maxTemporalEvents),
+  };
+}
+
+export function coerceDreamStateUpdate(
+  raw: unknown,
+  params: {
+    previousState: DreamState;
+    currentSession: OrderedDreamSession;
+    limits?: Partial<DreamLimits>;
+  }
+): DreamState {
+  const record = asRecord(raw);
+  if (!record) {
+    throw new Error('Dream update response must be a JSON object.');
+  }
+
+  const limits = { ...DEFAULT_DREAM_LIMITS, ...params.limits };
+  const currentSessionId = params.currentSession.sessionId;
+  const currentMemoryId = params.currentSession.memoryId;
+  const stateSummary = asString(record.stateSummary) || params.previousState.stateSummary;
+
+  const entities = asArray(record.entities)
+    .map((item) => {
+      const entity = asRecord(item);
+      const name = asString(entity?.name);
+      const description = asString(entity?.description);
+      if (!name || !description) return null;
+      const evidenceMemoryIds = evidenceIdsFromRaw(entity?.evidenceMemoryIds, currentMemoryId);
+      const evidenceSessionIds = evidenceIdsFromRaw(entity?.evidenceSessionIds, currentSessionId);
+      return {
+        name,
+        entityType: asString(entity?.entityType) || undefined,
+        description,
+        aliases: asArray(entity?.aliases)
+          .map(asString)
+          .filter((alias): alias is string => Boolean(alias)),
+        evidence: asString(entity?.evidence) || description,
+        evidenceMemoryIds,
+        evidenceSessionIds,
+        firstSeenSessionId: evidenceSessionIds[0] || currentSessionId,
+        lastSeenSessionId: evidenceSessionIds[evidenceSessionIds.length - 1] || currentSessionId,
+      };
+    })
+    .filter((entity): entity is DreamEntity => Boolean(entity));
+
+  const durableFacts = asArray(record.durableFacts)
+    .map((item) => {
+      const fact = asRecord(item);
+      const factText = asString(fact?.fact);
+      if (!factText) return null;
+      const category = asString(fact?.category) || 'other';
+      const subject = asString(fact?.subject) || undefined;
+      const object = asString(fact?.object) || undefined;
+      const key =
+        asString(fact?.key) || normalizeKey([category, subject, object, factText].join('|'));
+      const evidenceMemoryIds = evidenceIdsFromRaw(fact?.evidenceMemoryIds, currentMemoryId);
+      const evidenceSessionIds = evidenceIdsFromRaw(fact?.evidenceSessionIds, currentSessionId);
+      return {
+        key,
+        fact: factText,
+        category,
+        subject,
+        object,
+        evidence: asString(fact?.evidence) || factText,
+        status: statusFromRaw(fact?.status),
+        evidenceMemoryIds,
+        evidenceSessionIds,
+        firstSeenSessionId: evidenceSessionIds[0] || currentSessionId,
+        lastSeenSessionId: evidenceSessionIds[evidenceSessionIds.length - 1] || currentSessionId,
+      };
+    })
+    .filter((fact): fact is DreamDurableFact => Boolean(fact));
+
+  const currentStates = asArray(record.currentStates)
+    .map((item) => {
+      const state = asRecord(item);
+      const stateText = asString(state?.state);
+      const scope = asString(state?.scope);
+      const status = asString(state?.status);
+      if (!stateText || !scope || !status) return null;
+      const key = asString(state?.key) || normalizeKey([scope, status, stateText].join('|'));
+      const evidenceMemoryIds = evidenceIdsFromRaw(state?.evidenceMemoryIds, currentMemoryId);
+      const evidenceSessionIds = evidenceIdsFromRaw(state?.evidenceSessionIds, currentSessionId);
+      return {
+        key,
+        state: stateText,
+        scope,
+        status,
+        volatility: asString(state?.volatility) || 'semi-stable',
+        evidence: asString(state?.evidence) || stateText,
+        evidenceMemoryIds,
+        evidenceSessionIds,
+        lastSeenSessionId: evidenceSessionIds[evidenceSessionIds.length - 1] || currentSessionId,
+      };
+    })
+    .filter((state): state is DreamCurrentState => Boolean(state));
+
+  const temporalEvents = asArray(record.temporalEvents)
+    .map((item, index) => {
+      const event = asRecord(item);
+      const sessionId = asString(event?.sessionId);
+      const memoryId = asString(event?.memoryId);
+      const summary = asString(event?.summary);
+      if (!sessionId || !memoryId || !summary) return null;
+      const rawOrderIndex = typeof event?.orderIndex === 'number' ? event.orderIndex : index;
+      return {
+        sessionId,
+        memoryId,
+        date: asString(event?.date) || undefined,
+        orderIndex: rawOrderIndex,
+        summary,
+        isAnswerSession: Boolean(event?.isAnswerSession),
+      };
+    })
+    .filter((event): event is DreamTemporalEvent => Boolean(event));
+
+  const evidenceMemoryIds = uniqueStrings([
+    ...params.previousState.evidenceMemoryIds,
+    ...entities.flatMap((entity) => entity.evidenceMemoryIds),
+    ...durableFacts.flatMap((fact) => fact.evidenceMemoryIds),
+    ...currentStates.flatMap((state) => state.evidenceMemoryIds),
+    ...temporalEvents.map((event) => event.memoryId),
+    currentMemoryId,
+  ]);
+  const evidenceSessionIds = uniqueStrings([
+    ...params.previousState.evidenceSessionIds,
+    ...entities.flatMap((entity) => entity.evidenceSessionIds),
+    ...durableFacts.flatMap((fact) => fact.evidenceSessionIds),
+    ...currentStates.flatMap((state) => state.evidenceSessionIds),
+    ...temporalEvents.map((event) => event.sessionId),
+    currentSessionId,
+  ]);
+
+  return clampDreamState(
+    {
+      caseId: params.previousState.caseId,
+      mode: params.previousState.mode,
+      sessionCount: Math.max(params.previousState.sessionCount + 1, temporalEvents.length),
+      stateSummary,
+      entities,
+      durableFacts,
+      currentStates,
+      temporalEvents,
+      evidenceMemoryIds,
+      evidenceSessionIds,
+      updatedAt: new Date().toISOString(),
+    },
+    limits
+  );
+}
+
+export function buildBatchDreamPrompt(params: {
+  caseId: string;
+  question: string;
+  sessions: OrderedDreamSession[];
+  mode: DreamMode;
+  maxContentExcerptChars: number;
+  useQuestionHints?: boolean;
+}): { systemPrompt: string; userPrompt: string; schemaDescription: string } {
+  const questionHint = params.useQuestionHints
+    ? `question for later evaluation only, not a label: ${params.question}`
+    : 'No future evaluation question is available to the dream worker.';
+  return {
+    systemPrompt:
+      'You are a batch memory-dream worker. Reconcile a chronological case history into a compact, evidence-grounded state ledger. Return strict JSON only. Do not use benchmark answer labels. Keep cases isolated.',
+    schemaDescription:
+      'JSON schema: {"stateSummary": string, "entities": [{"name": string, "entityType"?: string, "description": string, "aliases": string[], "evidence": string, "evidenceMemoryIds": string[], "evidenceSessionIds": string[]}], "durableFacts": [{"key": string, "fact": string, "category": string, "subject"?: string, "object"?: string, "evidence": string, "status": "active"|"superseded"|"uncertain", "evidenceMemoryIds": string[], "evidenceSessionIds": string[]}], "currentStates": [{"key": string, "state": string, "scope": string, "status": string, "volatility": string, "evidence": string, "evidenceMemoryIds": string[], "evidenceSessionIds": string[]}], "temporalEvents": [{"sessionId": string, "memoryId": string, "date"?: string, "summary": string}], "notes": string[]}',
+    userPrompt: [
+      `caseId: ${params.caseId}`,
+      questionHint,
+      `dream mode: ${params.mode}`,
+      '',
+      'Reconciliation rules:',
+      '- Treat episodes as chronological within this case.',
+      '- Preserve current state updates, quantities, decisions, constraints, process rules, list/table mappings, and exact values when evidence supports them.',
+      '- If a later episode updates an earlier value, mark the older fact superseded and keep the latest active value with evidence links.',
+      '- If a value requires arithmetic or accumulation, perform the update and keep all supporting evidence session ids.',
+      '- Explicit aggregate/count statements are authoritative state. Do not replace an explicit total with a smaller count of named examples.',
+      '- If an earlier episode says a collection has total N and a later episode adds one item to that collection, write the active total as N+1 with both evidence links.',
+      '- Keep the ledger compact. Do not copy full transcripts.',
+      '- Use memoryId/sessionId exactly as supplied for evidence links.',
+      '',
+      'Chronological episodes JSON:',
+      JSON.stringify(
+        params.sessions.map((session) => ({
+          sessionId: session.sessionId,
+          memoryId: session.memoryId,
+          date: session.date || null,
+          sourceSummary: session.sourceSummary,
+          extractedViews: compactDreamExtractionViews(session.extractions),
+          contentExcerpt: buildRelevantContentExcerpt(
+            session.content,
+            params.useQuestionHints ? params.question : null,
+            params.maxContentExcerptChars
+          ),
+        })),
         null,
         2
       ),

--- a/packages/benchmarks/src/benchmark-memory-dream.ts
+++ b/packages/benchmarks/src/benchmark-memory-dream.ts
@@ -1,22 +1,35 @@
-import { mkdir, writeFile } from 'node:fs/promises';
-import { dirname, resolve } from 'node:path';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
 import { randomUUID } from 'node:crypto';
-import { createSupabaseClient } from '@inklabs/api/benchmarks';
+import { tmpdir } from 'node:os';
+import { spawn } from 'node:child_process';
+import {
+  ClaudeRunner,
+  createSupabaseClient,
+  type ClaudeRunnerConfig,
+  type IRunner,
+} from '@inklabs/api/benchmarks';
 import { loadLongMemEvalDreamDataset } from './benchmark-data/longmemeval-loader';
 import { hasOptionalAnswer } from './benchmark-answer-coverage';
 import { loadBenchmarkSeedState } from './benchmark-memory-recall.state';
 import {
   applyLocalDreamUpdate,
+  buildBatchDreamPrompt,
+  buildOnlineDreamPrompt,
   buildOrderedDreamSessions,
+  coerceDreamStateUpdate,
   createInitialDreamState,
   renderDreamStateForAnswerCheck,
   type DreamMemoryRow,
   type DreamMode,
   type DreamState,
+  type OrderedDreamSession,
 } from './benchmark-memory-dream.logic';
 
 const BENCHMARK_TOPIC = 'benchmark:memory-recall';
 const DEFAULT_PROGRESS_EVERY = 5;
+const DEFAULT_BATCH_CONTENT_EXCERPT_CHARS = 1200;
+const DEFAULT_ONLINE_CONTENT_EXCERPT_CHARS = 4000;
 
 interface DreamCaseResult {
   caseId: string;
@@ -26,6 +39,7 @@ interface DreamCaseResult {
   questionDate?: string;
   answerSessionIds: string[];
   sessionCount: number;
+  availableMemorySessionCount: number;
   processedSessionCount: number;
   missingSessionIds: string[];
   extraMemoryIds: string[];
@@ -33,6 +47,9 @@ interface DreamCaseResult {
   answerInSource: boolean | null;
   finalState: DreamState;
   steps: DreamStepSummary[];
+  runnerFailureCount: number;
+  runnerCallCount: number;
+  truncatedSessionCount: number;
 }
 
 interface DreamStepSummary {
@@ -45,7 +62,12 @@ interface DreamStepSummary {
   durableFactCount: number;
   currentStateCount: number;
   temporalEventCount: number;
+  updateStatus: DreamUpdateStatus;
 }
+
+type DreamUpdaterKind = 'local' | 'runner';
+type DreamBackend = 'codex' | 'claude';
+type DreamUpdateStatus = 'local' | 'runner' | 'runner-failed-local-fallback';
 
 function parseBoolean(raw: string | undefined, defaultValue: boolean): boolean {
   if (raw === undefined) return defaultValue;
@@ -63,6 +85,35 @@ function parseDreamMode(raw: string | undefined): DreamMode {
   if (normalized === 'online' || normalized === 'batch') return normalized;
   console.warn(`[memory-dream] unknown MEMORY_DREAM_MODE=${raw}; falling back to online`);
   return 'online';
+}
+
+function parseDreamUpdater(raw: string | undefined): DreamUpdaterKind {
+  const normalized = (raw || 'local').trim().toLowerCase();
+  if (normalized === 'local' || normalized === 'runner') return normalized;
+  console.warn(`[memory-dream] unknown MEMORY_DREAM_UPDATER=${raw}; falling back to local`);
+  return 'local';
+}
+
+function parseDreamBackend(raw: string | undefined): DreamBackend {
+  const normalized = (raw || 'codex').trim().toLowerCase();
+  if (normalized === 'codex' || normalized === 'claude') return normalized;
+  console.warn(`[memory-dream] unknown MEMORY_DREAM_BACKEND=${raw}; falling back to codex`);
+  return 'codex';
+}
+
+function parseOptionalPositiveInt(raw: string | undefined): number | null {
+  if (!raw) return null;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : null;
+}
+
+function parseCaseIdFilter(raw: string | undefined): Set<string> | null {
+  if (!raw?.trim()) return null;
+  const ids = raw
+    .split(',')
+    .map((id) => id.trim())
+    .filter(Boolean);
+  return ids.length > 0 ? new Set(ids) : null;
 }
 
 async function writeJsonOutput(outputPath: string, payload: unknown): Promise<void> {
@@ -100,11 +151,228 @@ function logProgress(params: {
   processedSessions: number;
   lastCaseId: string;
   lastMs: number;
+  runnerCalls: number;
+  runnerFailures: number;
 }) {
   console.log(
     `[memory-dream] progress cases=${params.completedCases}/${params.totalCases} ` +
-      `sessions=${params.processedSessions} lastCase=${params.lastCaseId} lastMs=${params.lastMs}`
+      `sessions=${params.processedSessions} runnerCalls=${params.runnerCalls} ` +
+      `runnerFailures=${params.runnerFailures} lastCase=${params.lastCaseId} lastMs=${params.lastMs}`
   );
+}
+
+function extractJsonObject(text: string): string {
+  const trimmed = text.trim();
+  if (trimmed.startsWith('{') && trimmed.endsWith('}')) return trimmed;
+  const fencedJson = trimmed.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  if (fencedJson?.[1]?.trim()) return extractJsonObject(fencedJson[1]);
+  const firstBrace = trimmed.indexOf('{');
+  const lastBrace = trimmed.lastIndexOf('}');
+  if (firstBrace === -1 || lastBrace === -1 || lastBrace <= firstBrace) {
+    throw new Error('Dream runner response did not contain a JSON object');
+  }
+  return trimmed.slice(firstBrace, lastBrace + 1);
+}
+
+function compactError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.replace(/\s+/g, ' ').trim().slice(0, 700);
+}
+
+class RunnerDreamUpdater {
+  private readonly runner: IRunner;
+  private readonly config: ClaudeRunnerConfig;
+  private callCount = 0;
+  private failureCount = 0;
+
+  constructor(private readonly backend: DreamBackend) {
+    this.runner = new ClaudeRunner();
+    this.config = {
+      workingDirectory: process.env.MEMORY_DREAM_WORKING_DIRECTORY || process.cwd(),
+      mcpConfigPath: process.env.MEMORY_DREAM_MCP_CONFIG_PATH || '',
+      ...(process.env.MEMORY_DREAM_MODEL && backend === 'claude'
+        ? { model: process.env.MEMORY_DREAM_MODEL }
+        : {}),
+      systemPrompt:
+        'You are a deterministic memory dream worker. Do not use tools. Return only strict JSON matching the requested schema.',
+      sandboxBypass: false,
+    };
+  }
+
+  getCallCount(): number {
+    return this.callCount;
+  }
+
+  getFailureCount(): number {
+    return this.failureCount;
+  }
+
+  async updateOnline(params: {
+    caseId: string;
+    question: string;
+    previousState: DreamState;
+    nextSession: OrderedDreamSession;
+    maxContentExcerptChars: number;
+    useQuestionHints: boolean;
+  }): Promise<DreamState> {
+    const prompt = buildOnlineDreamPrompt(params);
+    const raw = await this.runPrompt(prompt);
+    return coerceDreamStateUpdate(raw, {
+      previousState: params.previousState,
+      currentSession: params.nextSession,
+    });
+  }
+
+  async updateBatch(params: {
+    caseId: string;
+    question: string;
+    initialState: DreamState;
+    sessions: OrderedDreamSession[];
+    maxContentExcerptChars: number;
+    useQuestionHints: boolean;
+  }): Promise<DreamState> {
+    if (params.sessions.length === 0) return params.initialState;
+    const prompt = buildBatchDreamPrompt({
+      caseId: params.caseId,
+      question: params.question,
+      sessions: params.sessions,
+      mode: params.initialState.mode,
+      maxContentExcerptChars: params.maxContentExcerptChars,
+      useQuestionHints: params.useQuestionHints,
+    });
+    const raw = await this.runPrompt(prompt);
+    return coerceDreamStateUpdate(raw, {
+      previousState: {
+        ...params.initialState,
+        sessionCount: Math.max(0, params.sessions.length - 1),
+      },
+      currentSession: params.sessions[params.sessions.length - 1],
+    });
+  }
+
+  private async runPrompt(prompt: {
+    systemPrompt: string;
+    schemaDescription: string;
+    userPrompt: string;
+  }): Promise<unknown> {
+    this.callCount += 1;
+    const message = [
+      prompt.systemPrompt,
+      prompt.schemaDescription,
+      '',
+      'Return only the JSON object. Do not wrap it in Markdown. Do not call tools.',
+      '',
+      prompt.userPrompt,
+    ].join('\n');
+
+    if (this.backend === 'codex') {
+      const content = await runCodexExecNoMcp(message);
+      try {
+        return JSON.parse(extractJsonObject(content));
+      } catch (error) {
+        this.failureCount += 1;
+        throw error;
+      }
+    }
+
+    const result = await this.runner.run(message, { config: this.config });
+    if (!result.success) {
+      this.failureCount += 1;
+      throw new Error(result.error || `${this.backend} dream runner failed`);
+    }
+
+    const content =
+      result.finalTextResponse ||
+      result.responses
+        .map((response) => response.content)
+        .filter(Boolean)
+        .join('\n');
+    if (!content.trim()) {
+      this.failureCount += 1;
+      throw new Error(`${this.backend} dream runner returned no text`);
+    }
+
+    try {
+      return JSON.parse(extractJsonObject(content));
+    } catch (error) {
+      this.failureCount += 1;
+      throw error;
+    }
+  }
+}
+
+async function runCodexExecNoMcp(message: string): Promise<string> {
+  const scratchDir = await mkdtemp(join(tmpdir(), 'ink-memory-dream-codex-'));
+  const outputPath = join(scratchDir, 'last-message.txt');
+  const codexBin = process.env.MEMORY_DREAM_CODEX_BIN || 'codex';
+  const model = process.env.MEMORY_DREAM_MODEL || 'gpt-5.5';
+  const timeoutMs = parsePositiveInt(process.env.MEMORY_DREAM_CODEX_TIMEOUT_MS, 10 * 60 * 1000);
+  const args = [
+    'exec',
+    '--ignore-user-config',
+    '--ignore-rules',
+    '--skip-git-repo-check',
+    '--ephemeral',
+    '--json',
+    '-C',
+    process.env.MEMORY_DREAM_WORKING_DIRECTORY || '/tmp',
+    '-m',
+    model,
+    '-o',
+    outputPath,
+    '-',
+  ];
+
+  try {
+    return await new Promise<string>((resolvePromise, rejectPromise) => {
+      const proc = spawn(codexBin, args, {
+        cwd: process.env.MEMORY_DREAM_WORKING_DIRECTORY || '/tmp',
+        env: process.env,
+        stdio: ['pipe', 'ignore', 'pipe'],
+      });
+      let stderr = '';
+      let settled = false;
+      const timeout = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        proc.kill('SIGTERM');
+        rejectPromise(new Error(`Codex dream runner timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+
+      proc.stderr.on('data', (chunk) => {
+        stderr += chunk.toString();
+      });
+      proc.on('error', (error) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeout);
+        rejectPromise(error);
+      });
+      proc.on('close', async (code, signal) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeout);
+        if (code !== 0) {
+          rejectPromise(
+            new Error(
+              `Codex dream runner exited with code ${code} signal=${signal || 'none'}: ${stderr.slice(
+                -2000
+              )}`
+            )
+          );
+          return;
+        }
+        try {
+          resolvePromise(await readFile(outputPath, 'utf-8'));
+        } catch (error) {
+          rejectPromise(error);
+        }
+      });
+      proc.stdin.end(message);
+    });
+  } finally {
+    await rm(scratchDir, { recursive: true, force: true });
+  }
 }
 
 async function main() {
@@ -114,14 +382,24 @@ async function main() {
   }
 
   const mode = parseDreamMode(process.env.MEMORY_DREAM_MODE);
-  if (mode === 'batch') {
-    console.warn(
-      '[memory-dream] MEMORY_DREAM_MODE=batch is reserved for a future batch reducer; current runner still applies the online local reducer'
-    );
-  }
+  const updaterKind = parseDreamUpdater(process.env.MEMORY_DREAM_UPDATER);
+  const backend = parseDreamBackend(process.env.MEMORY_DREAM_BACKEND);
   const strictSeed = parseBoolean(process.env.MEMORY_DREAM_STRICT_SEED, true);
   const writeSteps = parseBoolean(process.env.MEMORY_DREAM_WRITE_STEPS, true);
   const memoryLoadLimit = parsePositiveInt(process.env.MEMORY_DREAM_MEMORY_LOAD_LIMIT, 1000);
+  const maxSessionsPerCase = parseOptionalPositiveInt(
+    process.env.MEMORY_DREAM_MAX_SESSIONS_PER_CASE
+  );
+  const batchContentExcerptChars = parsePositiveInt(
+    process.env.MEMORY_DREAM_BATCH_CONTENT_EXCERPT_CHARS,
+    DEFAULT_BATCH_CONTENT_EXCERPT_CHARS
+  );
+  const onlineContentExcerptChars = parsePositiveInt(
+    process.env.MEMORY_DREAM_ONLINE_CONTENT_EXCERPT_CHARS,
+    DEFAULT_ONLINE_CONTENT_EXCERPT_CHARS
+  );
+  const caseIdFilter = parseCaseIdFilter(process.env.MEMORY_DREAM_CASE_IDS);
+  const useQuestionHints = parseBoolean(process.env.MEMORY_DREAM_USE_QUERY_HINTS, false);
   const progressEvery = parsePositiveInt(
     process.env.MEMORY_DREAM_PROGRESS_EVERY,
     DEFAULT_PROGRESS_EVERY
@@ -141,17 +419,32 @@ async function main() {
   ]);
   if (!seedState) throw new Error(`Missing seed state at ${seedPath}`);
 
+  const selectedCases = caseIdFilter
+    ? cases.filter((benchmarkCase) => caseIdFilter.has(benchmarkCase.id))
+    : cases;
+  if (selectedCases.length === 0) {
+    throw new Error(
+      `No LongMemEval cases matched MEMORY_DREAM_CASE_IDS=${process.env.MEMORY_DREAM_CASE_IDS}`
+    );
+  }
+
   const supabase = createSupabaseClient();
+  const runnerUpdater = updaterKind === 'runner' ? new RunnerDreamUpdater(backend) : null;
   const results: DreamCaseResult[] = [];
   let processedSessions = 0;
+  let runnerFailures = 0;
+  let runnerCalls = 0;
 
   console.log(
-    `[memory-dream] start mode=${mode} cases=${cases.length} seedId=${seedState.seedId} seedPath=${seedPath}`
+    `[memory-dream] start mode=${mode} updater=${updaterKind} backend=${backend} ` +
+      `cases=${selectedCases.length}/${cases.length} seedId=${seedState.seedId} seedPath=${seedPath}`
   );
   console.log(`[memory-dream] source=${source} outputPath=${outputPath} writeSteps=${writeSteps}`);
 
-  for (const [caseIndex, dreamCase] of cases.entries()) {
+  for (const [caseIndex, dreamCase] of selectedCases.entries()) {
     const startedAt = Date.now();
+    const caseRunnerCallsStart = runnerCalls;
+    const caseRunnerFailuresStart = runnerFailures;
     const seededCase = seedState.seededCases[dreamCase.id];
     if (!seededCase) {
       const message = `Seed state does not include case ${dreamCase.id}`;
@@ -175,22 +468,89 @@ async function main() {
 
     let state = createInitialDreamState(dreamCase.id, mode);
     const steps: DreamStepSummary[] = [];
+    const sessions = maxSessionsPerCase
+      ? ordered.sessions.slice(0, maxSessionsPerCase)
+      : ordered.sessions;
+    const truncatedSessionCount = ordered.sessions.length - sessions.length;
 
-    for (const [sessionIndex, session] of ordered.sessions.entries()) {
-      state = applyLocalDreamUpdate(state, session);
-      processedSessions += 1;
-      if (writeSteps) {
-        steps.push({
-          sessionId: session.sessionId,
-          memoryId: session.memoryId,
-          index: sessionIndex,
-          hasAnswer: session.hasAnswer,
-          isAnswerSession: session.isAnswerSession,
-          entityCount: state.entities.length,
-          durableFactCount: state.durableFacts.length,
-          currentStateCount: state.currentStates.length,
-          temporalEventCount: state.temporalEvents.length,
+    if (runnerUpdater && mode === 'batch') {
+      let updateStatus: DreamUpdateStatus = 'runner';
+      try {
+        state = await runnerUpdater.updateBatch({
+          caseId: dreamCase.id,
+          question: dreamCase.query,
+          initialState: state,
+          sessions,
+          maxContentExcerptChars: batchContentExcerptChars,
+          useQuestionHints,
         });
+      } catch (error) {
+        updateStatus = 'runner-failed-local-fallback';
+        console.warn(
+          `[memory-dream] runner batch failed case=${dreamCase.id}; falling back to local reducer: ${compactError(error)}`
+        );
+        for (const session of sessions) state = applyLocalDreamUpdate(state, session);
+      }
+      processedSessions += sessions.length;
+      runnerCalls = runnerUpdater.getCallCount();
+      runnerFailures = runnerUpdater.getFailureCount();
+      if (writeSteps) {
+        for (const [sessionIndex, session] of sessions.entries()) {
+          steps.push({
+            sessionId: session.sessionId,
+            memoryId: session.memoryId,
+            index: sessionIndex,
+            hasAnswer: session.hasAnswer,
+            isAnswerSession: session.isAnswerSession,
+            entityCount: state.entities.length,
+            durableFactCount: state.durableFacts.length,
+            currentStateCount: state.currentStates.length,
+            temporalEventCount: state.temporalEvents.length,
+            updateStatus,
+          });
+        }
+      }
+    } else {
+      for (const [sessionIndex, session] of sessions.entries()) {
+        let updateStatus: DreamUpdateStatus = 'local';
+        if (runnerUpdater) {
+          try {
+            state = await runnerUpdater.updateOnline({
+              caseId: dreamCase.id,
+              question: dreamCase.query,
+              previousState: state,
+              nextSession: session,
+              maxContentExcerptChars: onlineContentExcerptChars,
+              useQuestionHints,
+            });
+            updateStatus = 'runner';
+          } catch (error) {
+            updateStatus = 'runner-failed-local-fallback';
+            console.warn(
+              `[memory-dream] runner online update failed case=${dreamCase.id} session=${session.sessionId}; falling back to local reducer: ${compactError(error)}`
+            );
+            state = applyLocalDreamUpdate(state, session);
+          }
+          runnerCalls = runnerUpdater.getCallCount();
+          runnerFailures = runnerUpdater.getFailureCount();
+        } else {
+          state = applyLocalDreamUpdate(state, session);
+        }
+        processedSessions += 1;
+        if (writeSteps) {
+          steps.push({
+            sessionId: session.sessionId,
+            memoryId: session.memoryId,
+            index: sessionIndex,
+            hasAnswer: session.hasAnswer,
+            isAnswerSession: session.isAnswerSession,
+            entityCount: state.entities.length,
+            durableFactCount: state.durableFacts.length,
+            currentStateCount: state.currentStates.length,
+            temporalEventCount: state.temporalEvents.length,
+            updateStatus,
+          });
+        }
       }
     }
 
@@ -204,22 +564,28 @@ async function main() {
       questionDate: dreamCase.questionDate,
       answerSessionIds: dreamCase.answerSessionIds,
       sessionCount: dreamCase.sessions.length,
-      processedSessionCount: ordered.sessions.length,
+      availableMemorySessionCount: ordered.sessions.length,
+      processedSessionCount: sessions.length,
       missingSessionIds: ordered.missingSessionIds,
       extraMemoryIds: ordered.extraMemoryIds,
       answerInDream: hasOptionalAnswer(renderedDream, dreamCase.answer),
       answerInSource: hasOptionalAnswer(sourceText, dreamCase.answer),
       finalState: state,
       steps,
+      runnerFailureCount: runnerFailures - caseRunnerFailuresStart,
+      runnerCallCount: runnerCalls - caseRunnerCallsStart,
+      truncatedSessionCount,
     });
 
-    if ((caseIndex + 1) % progressEvery === 0 || caseIndex === cases.length - 1) {
+    if ((caseIndex + 1) % progressEvery === 0 || caseIndex === selectedCases.length - 1) {
       logProgress({
         completedCases: caseIndex + 1,
-        totalCases: cases.length,
+        totalCases: selectedCases.length,
         processedSessions,
         lastCaseId: dreamCase.id,
         lastMs: Date.now() - startedAt,
+        runnerCalls,
+        runnerFailures,
       });
     }
   }
@@ -234,15 +600,29 @@ async function main() {
       seedId: seedState.seedId,
       seedPath,
       outputPath,
-      caseCount: cases.length,
+      caseCount: selectedCases.length,
+      totalLoadedCases: cases.length,
+      updater: updaterKind,
+      backend: updaterKind === 'runner' ? backend : null,
       strictSeed,
       writeSteps,
       memoryLoadLimit,
-      note: 'First-pass dream run uses existing per-memory LLM extraction views and a local online reducer. It does not write new DB memories or embeddings. Batch mode is accepted for future experiments but currently uses the same online reducer.',
+      maxSessionsPerCase,
+      batchContentExcerptChars,
+      onlineContentExcerptChars,
+      useQuestionHints,
+      caseIdFilter: caseIdFilter ? Array.from(caseIdFilter) : null,
+      note:
+        updaterKind === 'runner'
+          ? 'Runner dream pass writes local JSON only. Online mode updates prior compact state plus one episode; batch mode reconciles a chronological case slice in one runner call. Neither mode writes DB memories or embeddings. By default the dream worker is not shown the future evaluation query; MEMORY_DREAM_USE_QUERY_HINTS=true enables query-hinted diagnostic runs.'
+          : 'Local dream run uses existing per-memory LLM extraction views and a deterministic online reducer. It does not write new DB memories or embeddings.',
     },
     summary: {
       cases: results.length,
       processedSessions,
+      runnerCalls,
+      runnerFailures,
+      truncatedSessionCount: results.reduce((sum, result) => sum + result.truncatedSessionCount, 0),
       missingSessionCount: results.reduce(
         (sum, result) => sum + result.missingSessionIds.length,
         0


### PR DESCRIPTION
## Summary

Adds a runner-backed LongMem dream benchmark path so we can test dream/reconciliation behavior with real Claude/Codex calls, while keeping it isolated from production memory writes.

Key details:
- Adds `MEMORY_DREAM_UPDATER=local|runner` and `MEMORY_DREAM_BACKEND=codex|claude`.
- Supports both `online` mode (prior compact state + one new episode) and `batch` mode (one chronological case slice per runner call).
- Writes local JSON only; it does **not** create DB memories or embeddings.
- Tracks runner calls/failures/truncated sessions in output.
- Coerces runner JSON into evidence-linked dream state without using benchmark metadata as answer text.
- Adds `MEMORY_DREAM_USE_QUERY_HINTS=false` by default so fair dream runs do not see the future evaluation query. Query-hinted mode is retained only as a diagnostic span-surfacing experiment.

## Runs

- `yarn workspace @inklabs/benchmarks test` ✅ — 36 tests passing.
- `yarn workspace @inklabs/api type-check` ⚠️ — fails on pre-existing unrelated errors in `src/channels/gateway.ts`, `src/mcp/server.ts`, and `src/routes/admin.ts`.

Benchmark smoke/diagnostic outputs written locally:
- `packages/benchmarks/output/memory-dreams/longmem-69fee5aa-batch-codex-direct-dream-query-hinted-20260512.json`
  - 1 case, 49 sessions, 1 runner call, 0 failures, answerInDream=1; correctly derives current total 38 coins.
- `packages/benchmarks/output/memory-dreams/longmem-69fee5aa-batch-codex-direct-dream-no-query-20260512.json`
  - 1 case, 49 sessions, 1 runner call, 0 failures, answerInDream=0; fair no-query dream preserved coin entities but dropped the prior aggregate count of 37.
- `packages/benchmarks/output/memory-dreams/longmem-curated-11-batch-codex-direct-dream-20260512.json`
  - 11 curated known-miss cases, 545 sessions, 11 runner calls, 0 failures, answerInSource=10, answerInDream=6.

## Interpretation

The query-hinted diagnostic proves the model can reconcile chronology when the answer-bearing raw span is visible. The fair no-query failure is the more important scientific result: current dream compression/excerpting still loses small aggregate/count facts. That supports the architecture we discussed: raw episodic memory remains ground truth; dream outputs are auxiliary overlays that need better question-independent exact-value/count/state/list preservation.

— Lumen