### PR TITLE
test: approval gate integration tests (by Wren)

### DIFF
--- a/packages/api/src/services/strategy-approval-gate.integration.test.ts
+++ b/packages/api/src/services/strategy-approval-gate.integration.test.ts
@@ -1,0 +1,438 @@
+/**
+ * Strategy Approval Gate — Integration Tests
+ *
+ * Exercises the final approval gate and periodic-approval-on-final-task
+ * flows against the real Supabase database. Covers PR #362 features:
+ *
+ * 1. requireFinalApproval pauses with final_review when all tasks done
+ * 2. resume from final_review calls finalizeStrategy (status → completed)
+ * 3. maxIterationsWithoutApproval on the final task → completes (not approval_gate)
+ * 4. Both gates together: final task on periodic boundary → final_review wins
+ * 5. Activity stream has the correct event trail
+ *
+ * Run: PCP_PORT_BASE=9998 npx vitest run packages/api/src/services/strategy-approval-gate.integration.test.ts
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import dotenv from 'dotenv';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import { readFileSync, existsSync } from 'fs';
+import { resolve } from 'path';
+
+// ============================================================================
+// Environment setup
+// ============================================================================
+
+const projectRoot = resolve(__dirname, '../../../../');
+const envLocalPath = resolve(projectRoot, '.env.local');
+if (existsSync(envLocalPath)) {
+  const parsed = dotenv.parse(readFileSync(envLocalPath));
+  for (const [key, value] of Object.entries(parsed)) {
+    if (!process.env[key]) process.env[key] = value;
+  }
+}
+
+if (!process.env.PCP_PORT_BASE) process.env.PCP_PORT_BASE = '9998';
+
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_SECRET_KEY || process.env.SUPABASE_SERVICE_KEY;
+
+const configPath = resolve(process.env.HOME || '', '.ink/config.json');
+const inkConfig = existsSync(configPath) ? JSON.parse(readFileSync(configPath, 'utf-8')) : {};
+const TEST_USER_ID: string | undefined = inkConfig.userId;
+
+const canRun = !!SUPABASE_URL && !!SUPABASE_KEY && !!TEST_USER_ID;
+
+vi.mock('../mcp/tools/inbox-handlers', () => ({
+  handleSendToInbox: vi.fn().mockResolvedValue(undefined),
+}));
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+async function getActivitySubtypes(client: SupabaseClient, groupId: string): Promise<string[]> {
+  const { data } = await client
+    .from('activity_stream')
+    .select('subtype')
+    .eq('task_group_id', groupId)
+    .order('created_at', { ascending: true });
+
+  return (data || []).map((e: { subtype: string | null }) => e.subtype).filter(Boolean) as string[];
+}
+
+async function createTestGroup(
+  dc: any,
+  suffix: string,
+  config: Record<string, unknown>
+): Promise<{ groupId: string; taskIds: string[] }> {
+  const group = await dc.repositories.taskGroups.create({
+    user_id: TEST_USER_ID,
+    title: `__approval_gate_test_${suffix}_${Date.now()}`,
+    description: 'Integration test — safe to delete',
+    priority: 'low',
+    tags: ['__test'],
+  });
+
+  const taskIds: string[] = [];
+  for (let i = 0; i < 3; i++) {
+    const task = await dc.repositories.tasks.create({
+      user_id: TEST_USER_ID,
+      title: `Approval gate test task ${i + 1}`,
+      task_group_id: group.id,
+      task_order: i,
+      priority: 'low',
+      created_by: 'integration-test',
+    });
+    taskIds.push(task.id);
+  }
+
+  return { groupId: group.id, taskIds };
+}
+
+async function cleanup(client: SupabaseClient, groupId: string, taskIds: string[]): Promise<void> {
+  await client.from('tasks').delete().in('id', taskIds);
+  await client
+    .from('scheduled_reminders')
+    .delete()
+    .contains('metadata' as any, { groupId } as any);
+  await client.from('activity_stream').delete().eq('task_group_id', groupId);
+  await client.from('task_groups').delete().eq('id', groupId);
+}
+
+// ============================================================================
+// Test: requireFinalApproval lifecycle
+// ============================================================================
+
+describe.skipIf(!canRun)('Strategy Final Approval Gate (integration)', () => {
+  let client: SupabaseClient;
+  let dc: any;
+  let groupId: string;
+  let taskIds: string[];
+
+  beforeAll(async () => {
+    client = createClient(SUPABASE_URL!, SUPABASE_KEY!, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+
+    const { TaskGroupsRepository } = await import('../data/repositories/task-groups.repository');
+    const { ProjectTasksRepository } =
+      await import('../data/repositories/project-tasks.repository');
+    const { ActivityStreamRepository } =
+      await import('../data/repositories/activity-stream.repository');
+
+    dc = {
+      getClient: () => client,
+      repositories: {
+        taskGroups: new TaskGroupsRepository(client),
+        tasks: new ProjectTasksRepository(client),
+        activityStream: new ActivityStreamRepository(client),
+      },
+    };
+
+    const created = await createTestGroup(dc, 'final_review', {});
+    groupId = created.groupId;
+    taskIds = created.taskIds;
+  }, 15_000);
+
+  afterAll(async () => {
+    if (client && groupId) await cleanup(client, groupId, taskIds);
+  }, 10_000);
+
+  it('should start strategy with requireFinalApproval', async () => {
+    const { StrategyService } = await import('./strategy.service');
+    const service = new StrategyService(dc);
+
+    const result = await service.startStrategy({
+      groupId,
+      userId: TEST_USER_ID!,
+      strategy: 'persistence',
+      ownerAgentId: 'integration-test',
+      config: {
+        requireFinalApproval: true,
+        approvalCriteria: ['tests pass', 'visual review'],
+        watchdogIntervalMinutes: 60,
+      },
+    });
+
+    expect(result.action).toBe('next_task');
+    expect(result.nextTask).toBeDefined();
+  });
+
+  it('should advance through tasks without pausing (no periodic gate)', async () => {
+    const { StrategyService } = await import('./strategy.service');
+    const service = new StrategyService(dc);
+
+    // Complete task 1
+    await dc.repositories.tasks.completeTask(taskIds[0]);
+    const advance1 = await service.advanceStrategy(groupId, taskIds[0], TEST_USER_ID!);
+    expect(advance1.action).toBe('next_task');
+
+    // Complete task 2
+    await dc.repositories.tasks.completeTask(taskIds[1]);
+    const advance2 = await service.advanceStrategy(groupId, taskIds[1], TEST_USER_ID!);
+    expect(advance2.action).toBe('next_task');
+  });
+
+  it('should pause for final_review when last task completes', async () => {
+    const { StrategyService } = await import('./strategy.service');
+    const service = new StrategyService(dc);
+
+    // Complete task 3 (the last one)
+    await dc.repositories.tasks.completeTask(taskIds[2]);
+    const advance3 = await service.advanceStrategy(groupId, taskIds[2], TEST_USER_ID!);
+
+    expect(advance3.action).toBe('approval_required');
+    expect(advance3.progressSummary).toContain('Awaiting final approval');
+    expect(advance3.progressSummary).toContain('tests pass');
+    expect(advance3.progressSummary).toContain('visual review');
+
+    // Verify DB state
+    const group = await dc.repositories.taskGroups.findById(groupId);
+    expect(group.status).toBe('paused');
+    expect((group.metadata as Record<string, unknown>).pauseReason).toBe('final_review');
+  });
+
+  it('should finalize strategy when resuming from final_review', async () => {
+    const { StrategyService } = await import('./strategy.service');
+    const service = new StrategyService(dc);
+
+    const result = await service.resumeStrategy(groupId, TEST_USER_ID!);
+
+    expect(result.action).toBe('group_complete');
+    expect(result.stats).toEqual({ total: 3, completed: 3 });
+
+    // Verify DB state
+    const group = await dc.repositories.taskGroups.findById(groupId);
+    expect(group.status).toBe('completed');
+    expect((group.metadata as Record<string, unknown>).pauseReason).toBeUndefined();
+  });
+
+  it('should have correct activity stream trail', async () => {
+    const subtypes = await getActivitySubtypes(client, groupId);
+
+    expect(subtypes).toContain('strategy_started');
+    expect(subtypes).toContain('task_advanced');
+    expect(subtypes).toContain('final_review_requested');
+    expect(subtypes).toContain('final_review_approved');
+    expect(subtypes).toContain('strategy_completed');
+  });
+});
+
+// ============================================================================
+// Test: periodic approval gate on final task (regression, Lumen PR #362)
+// ============================================================================
+
+describe.skipIf(!canRun)(
+  'Strategy Periodic Approval on Final Task (integration regression)',
+  () => {
+    let client: SupabaseClient;
+    let dc: any;
+    let groupId: string;
+    let taskIds: string[];
+
+    beforeAll(async () => {
+      client = createClient(SUPABASE_URL!, SUPABASE_KEY!, {
+        auth: { autoRefreshToken: false, persistSession: false },
+      });
+
+      const { TaskGroupsRepository } = await import('../data/repositories/task-groups.repository');
+      const { ProjectTasksRepository } =
+        await import('../data/repositories/project-tasks.repository');
+      const { ActivityStreamRepository } =
+        await import('../data/repositories/activity-stream.repository');
+
+      dc = {
+        getClient: () => client,
+        repositories: {
+          taskGroups: new TaskGroupsRepository(client),
+          tasks: new ProjectTasksRepository(client),
+          activityStream: new ActivityStreamRepository(client),
+        },
+      };
+
+      // Create group with exactly 2 tasks + maxIterationsWithoutApproval=2
+      // so the periodic gate would fire on task 2 if ordering were wrong
+      const group = await dc.repositories.taskGroups.create({
+        user_id: TEST_USER_ID,
+        title: `__periodic_boundary_regression_${Date.now()}`,
+        description: 'Integration test — safe to delete',
+        priority: 'low',
+        tags: ['__test'],
+      });
+      groupId = group.id;
+
+      taskIds = [];
+      for (let i = 0; i < 2; i++) {
+        const task = await dc.repositories.tasks.create({
+          user_id: TEST_USER_ID,
+          title: `Boundary test task ${i + 1}`,
+          task_group_id: groupId,
+          task_order: i,
+          priority: 'low',
+          created_by: 'integration-test',
+        });
+        taskIds.push(task.id);
+      }
+    }, 15_000);
+
+    afterAll(async () => {
+      if (client && groupId) await cleanup(client, groupId, taskIds);
+    }, 10_000);
+
+    it('should complete (not pause for periodic approval) when final task hits approval boundary', async () => {
+      const { StrategyService } = await import('./strategy.service');
+      const service = new StrategyService(dc);
+
+      // Start with maxIterationsWithoutApproval=2 and NO requireFinalApproval
+      await service.startStrategy({
+        groupId,
+        userId: TEST_USER_ID!,
+        strategy: 'persistence',
+        ownerAgentId: 'integration-test',
+        config: {
+          maxIterationsWithoutApproval: 2,
+          watchdogIntervalMinutes: 60,
+        },
+      });
+
+      // Complete both tasks
+      await dc.repositories.tasks.completeTask(taskIds[0]);
+      const advance1 = await service.advanceStrategy(groupId, taskIds[0], TEST_USER_ID!);
+      expect(advance1.action).toBe('next_task');
+
+      await dc.repositories.tasks.completeTask(taskIds[1]);
+      const advance2 = await service.advanceStrategy(groupId, taskIds[1], TEST_USER_ID!);
+
+      // Should complete, NOT pause for periodic approval
+      expect(advance2.action).toBe('group_complete');
+      expect(advance2.stats).toEqual({ total: 2, completed: 2 });
+
+      const group = await dc.repositories.taskGroups.findById(groupId);
+      expect(group.status).toBe('completed');
+    });
+
+    it('should have strategy_completed in activity (not approval_required)', async () => {
+      const subtypes = await getActivitySubtypes(client, groupId);
+
+      expect(subtypes).toContain('strategy_completed');
+      // The periodic approval gate should NOT have fired
+      expect(subtypes).not.toContain('approval_required');
+    });
+  }
+);
+
+// ============================================================================
+// Test: both gates — final task on periodic boundary with requireFinalApproval
+// ============================================================================
+
+describe.skipIf(!canRun)('Strategy Both Gates on Final Task (integration)', () => {
+  let client: SupabaseClient;
+  let dc: any;
+  let groupId: string;
+  let taskIds: string[];
+
+  beforeAll(async () => {
+    client = createClient(SUPABASE_URL!, SUPABASE_KEY!, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+
+    const { TaskGroupsRepository } = await import('../data/repositories/task-groups.repository');
+    const { ProjectTasksRepository } =
+      await import('../data/repositories/project-tasks.repository');
+    const { ActivityStreamRepository } =
+      await import('../data/repositories/activity-stream.repository');
+
+    dc = {
+      getClient: () => client,
+      repositories: {
+        taskGroups: new TaskGroupsRepository(client),
+        tasks: new ProjectTasksRepository(client),
+        activityStream: new ActivityStreamRepository(client),
+      },
+    };
+
+    const group = await dc.repositories.taskGroups.create({
+      user_id: TEST_USER_ID,
+      title: `__both_gates_test_${Date.now()}`,
+      description: 'Integration test — safe to delete',
+      priority: 'low',
+      tags: ['__test'],
+    });
+    groupId = group.id;
+
+    taskIds = [];
+    for (let i = 0; i < 2; i++) {
+      const task = await dc.repositories.tasks.create({
+        user_id: TEST_USER_ID,
+        title: `Both gates test task ${i + 1}`,
+        task_group_id: groupId,
+        task_order: i,
+        priority: 'low',
+        created_by: 'integration-test',
+      });
+      taskIds.push(task.id);
+    }
+  }, 15_000);
+
+  afterAll(async () => {
+    if (client && groupId) await cleanup(client, groupId, taskIds);
+  }, 10_000);
+
+  it('should pause for final_review (not periodic approval) when both gates coincide', async () => {
+    const { StrategyService } = await import('./strategy.service');
+    const service = new StrategyService(dc);
+
+    await service.startStrategy({
+      groupId,
+      userId: TEST_USER_ID!,
+      strategy: 'persistence',
+      ownerAgentId: 'integration-test',
+      config: {
+        maxIterationsWithoutApproval: 2,
+        requireFinalApproval: true,
+        approvalCriteria: ['CI green'],
+        watchdogIntervalMinutes: 60,
+      },
+    });
+
+    await dc.repositories.tasks.completeTask(taskIds[0]);
+    const advance1 = await service.advanceStrategy(groupId, taskIds[0], TEST_USER_ID!);
+    expect(advance1.action).toBe('next_task');
+
+    await dc.repositories.tasks.completeTask(taskIds[1]);
+    const advance2 = await service.advanceStrategy(groupId, taskIds[1], TEST_USER_ID!);
+
+    // Should be final_review, not approval_gate
+    expect(advance2.action).toBe('approval_required');
+    expect(advance2.progressSummary).toContain('Awaiting final approval');
+    expect(advance2.progressSummary).toContain('CI green');
+
+    const group = await dc.repositories.taskGroups.findById(groupId);
+    expect(group.status).toBe('paused');
+    expect((group.metadata as Record<string, unknown>).pauseReason).toBe('final_review');
+  });
+
+  it('should finalize after resuming from final_review', async () => {
+    const { StrategyService } = await import('./strategy.service');
+    const service = new StrategyService(dc);
+
+    const result = await service.resumeStrategy(groupId, TEST_USER_ID!);
+
+    expect(result.action).toBe('group_complete');
+    expect(result.stats).toEqual({ total: 2, completed: 2 });
+
+    const group = await dc.repositories.taskGroups.findById(groupId);
+    expect(group.status).toBe('completed');
+  });
+
+  it('should have final_review events (not approval_required from periodic gate)', async () => {
+    const subtypes = await getActivitySubtypes(client, groupId);
+
+    expect(subtypes).toContain('final_review_requested');
+    expect(subtypes).toContain('final_review_approved');
+    expect(subtypes).toContain('strategy_completed');
+    // The periodic approval gate should NOT have fired
+    expect(subtypes).not.toContain('approval_required');
+  });
+});

--- a/packages/api/src/services/strategy-approval-gate.live.integration.test.ts
+++ b/packages/api/src/services/strategy-approval-gate.live.integration.test.ts
@@ -58,6 +58,8 @@ const accessToken: string | null = existsSync(authPath)
   ? JSON.parse(readFileSync(authPath, 'utf-8')).access_token
   : null;
 
+const INKWELL_URL = process.env.PCP_SERVER_URL || 'http://localhost:3001';
+
 // ============================================================================
 // Prerequisite checks (same pattern as sandbox live test)
 // ============================================================================
@@ -87,7 +89,7 @@ function claudeCredentialsAvailable(): boolean {
 
 function inkwellReachable(): boolean {
   try {
-    execFileSync('curl', ['-sf', '-o', '/dev/null', 'http://localhost:3001/health'], {
+    execFileSync('curl', ['-sf', '-o', '/dev/null', `${INKWELL_URL}/health`], {
       timeout: 3_000,
     });
     return true;
@@ -214,7 +216,7 @@ describe.skipIf(!canRun)('Strategy Approval Gate — LLM live test', () => {
         mcpServers: {
           inkwell: {
             type: 'http',
-            url: 'http://localhost:3001/mcp',
+            url: `${INKWELL_URL}/mcp`,
             headers: {
               Authorization: `Bearer ${accessToken}`,
             },

--- a/packages/api/src/services/strategy-approval-gate.live.integration.test.ts
+++ b/packages/api/src/services/strategy-approval-gate.live.integration.test.ts
@@ -1,13 +1,19 @@
 /**
  * Strategy Approval Gate — Live LLM Tests
  *
- * End-to-end test with a real LLM (Haiku) completing tasks and hitting
- * the approval gate. Uses the Anthropic API directly with custom tools
- * (list_tasks, complete_task) wired to StrategyService.
+ * End-to-end test with a real LLM (Haiku via Claude Code) completing tasks
+ * via MCP tools on the running Inkwell server, exercising the full approval
+ * gate lifecycle.
+ *
+ * Uses ClaudeRunner (the same infra as production strategy execution) — no
+ * separate ANTHROPIC_API_KEY required. Claude Code's existing OAuth
+ * credentials handle LLM auth.
  *
  * Requires:
  * - INK_LIVE_TESTS=1
- * - ANTHROPIC_API_KEY set
+ * - claude CLI installed with valid credentials
+ * - Inkwell server running on localhost:3001
+ * - Valid access token in ~/.ink/auth.json
  * - Supabase credentials (.env.local or env vars)
  *
  * Run:
@@ -18,11 +24,12 @@
  */
 
 import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
-import Anthropic from '@anthropic-ai/sdk';
 import dotenv from 'dotenv';
 import { createClient, type SupabaseClient } from '@supabase/supabase-js';
-import { readFileSync, existsSync } from 'fs';
-import { resolve } from 'path';
+import { execFileSync, spawnSync } from 'child_process';
+import { readFileSync, writeFileSync, mkdirSync, rmSync, existsSync } from 'fs';
+import { resolve, join } from 'path';
+import { homedir, tmpdir } from 'os';
 
 // ============================================================================
 // Environment setup
@@ -41,57 +48,67 @@ if (!process.env.PCP_PORT_BASE) process.env.PCP_PORT_BASE = '9998';
 
 const SUPABASE_URL = process.env.SUPABASE_URL;
 const SUPABASE_KEY = process.env.SUPABASE_SECRET_KEY || process.env.SUPABASE_SERVICE_KEY;
-const ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY;
 
-const configPath = resolve(process.env.HOME || '', '.ink/config.json');
+const configPath = resolve(homedir(), '.ink/config.json');
 const inkConfig = existsSync(configPath) ? JSON.parse(readFileSync(configPath, 'utf-8')) : {};
 const TEST_USER_ID: string | undefined = inkConfig.userId;
+
+const authPath = resolve(homedir(), '.ink/auth.json');
+const accessToken: string | null = existsSync(authPath)
+  ? JSON.parse(readFileSync(authPath, 'utf-8')).access_token
+  : null;
+
+// ============================================================================
+// Prerequisite checks (same pattern as sandbox live test)
+// ============================================================================
+
+function claudeAvailable(): boolean {
+  const result = spawnSync('which', ['claude'], { stdio: 'ignore', timeout: 5_000 });
+  return result.status === 0;
+}
+
+function claudeCredentialsAvailable(): boolean {
+  const credFile = join(homedir(), '.claude', '.credentials.json');
+  if (existsSync(credFile)) return true;
+  if (process.platform === 'darwin') {
+    try {
+      execFileSync('security', ['find-generic-password', '-s', 'Claude Code-credentials', '-w'], {
+        encoding: 'utf-8',
+        timeout: 5_000,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}
+
+function inkwellReachable(): boolean {
+  try {
+    execFileSync('curl', ['-sf', '-o', '/dev/null', 'http://localhost:3001/health'], {
+      timeout: 3_000,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 const canRun =
   process.env.INK_LIVE_TESTS === '1' &&
   !!SUPABASE_URL &&
   !!SUPABASE_KEY &&
-  !!ANTHROPIC_API_KEY &&
-  !!TEST_USER_ID;
+  !!TEST_USER_ID &&
+  !!accessToken &&
+  claudeAvailable() &&
+  claudeCredentialsAvailable() &&
+  inkwellReachable();
 
 vi.mock('../mcp/tools/inbox-handlers', () => ({
   handleSendToInbox: vi.fn().mockResolvedValue(undefined),
 }));
-
-// ============================================================================
-// Anthropic tool schemas for the LLM
-// ============================================================================
-
-const TOOL_SCHEMAS: Anthropic.Tool[] = [
-  {
-    name: 'list_tasks',
-    description:
-      'List all tasks in the strategy group with their IDs and statuses. Call this first to see what needs to be done.',
-    input_schema: {
-      type: 'object' as const,
-      properties: {},
-      required: [],
-    },
-  },
-  {
-    name: 'complete_task',
-    description:
-      'Mark a task as completed by its ID. This advances the strategy. Call this for each pending task.',
-    input_schema: {
-      type: 'object' as const,
-      properties: {
-        taskId: {
-          type: 'string',
-          description: 'The UUID of the task to complete',
-        },
-      },
-      required: ['taskId'],
-    },
-  },
-];
-
-const MODEL = 'claude-haiku-4-5-20251001';
-const MAX_ITERATIONS = 15;
 
 // ============================================================================
 // Helpers
@@ -118,21 +135,20 @@ async function getActivitySubtypes(client: SupabaseClient, groupId: string): Pro
 }
 
 // ============================================================================
-// Test: LLM-driven approval gate
+// Test: LLM-driven approval gate via ClaudeRunner + MCP
 // ============================================================================
 
 describe.skipIf(!canRun)('Strategy Approval Gate — LLM live test', () => {
   let client: SupabaseClient;
-  let anthropic: Anthropic;
   let dc: any;
   let groupId: string;
   let taskIds: string[];
+  let tmpDir: string;
 
   beforeAll(async () => {
     client = createClient(SUPABASE_URL!, SUPABASE_KEY!, {
       auth: { autoRefreshToken: false, persistSession: false },
     });
-    anthropic = new Anthropic({ apiKey: ANTHROPIC_API_KEY });
 
     const { TaskGroupsRepository } = await import('../data/repositories/task-groups.repository');
     const { ProjectTasksRepository } =
@@ -187,105 +203,54 @@ describe.skipIf(!canRun)('Strategy Approval Gate — LLM live test', () => {
         watchdogIntervalMinutes: 60,
       },
     });
+
+    // Write temp MCP config with inkwell server + auth
+    tmpDir = join(tmpdir(), `approval-gate-live-${Date.now()}`);
+    mkdirSync(tmpDir, { recursive: true });
+
+    writeFileSync(
+      join(tmpDir, '.mcp.json'),
+      JSON.stringify({
+        mcpServers: {
+          inkwell: {
+            type: 'http',
+            url: 'http://localhost:3001/mcp',
+            headers: {
+              Authorization: `Bearer ${accessToken}`,
+            },
+          },
+        },
+      })
+    );
   }, 30_000);
 
   afterAll(async () => {
     if (client && groupId) await cleanup(client, groupId, taskIds);
+    if (tmpDir && existsSync(tmpDir)) rmSync(tmpDir, { recursive: true, force: true });
   }, 10_000);
 
-  it('LLM completes all tasks and strategy pauses for final_review', async () => {
-    const { StrategyService } = await import('./strategy.service');
-    const service = new StrategyService(dc);
+  it('LLM completes all tasks via MCP and strategy pauses for final_review', async () => {
+    const { ClaudeRunner } = await import('./sessions/claude-runner');
+    const runner = new ClaudeRunner();
 
-    // Tool executors — called when the LLM uses tools
-    async function executeTool(name: string, input: Record<string, unknown>): Promise<string> {
-      if (name === 'list_tasks') {
-        const tasks = await dc.repositories.tasks.findByGroupId(groupId);
-        return JSON.stringify(
-          tasks.map((t: any) => ({
-            id: t.id,
-            title: t.title,
-            status: t.status,
-            taskOrder: t.task_order,
-          }))
-        );
-      }
-
-      if (name === 'complete_task') {
-        const taskId = input.taskId as string;
-        await dc.repositories.tasks.completeTask(taskId);
-        const result = await service.advanceStrategy(groupId, taskId, TEST_USER_ID!);
-        return JSON.stringify({
-          action: result.action,
-          progressSummary: result.progressSummary || null,
-          nextTask: result.nextTask
-            ? { id: result.nextTask.id, title: result.nextTask.title }
-            : null,
-        });
-      }
-
-      return `Error: Unknown tool "${name}"`;
-    }
-
-    // Agentic loop — LLM sees the tasks and completes them
-    const messages: Anthropic.MessageParam[] = [
+    const result = await runner.run(
+      `You have a task group with ID ${groupId}. ` +
+        `Use mcp__inkwell__list_tasks with groupId="${groupId}" to see the tasks, ` +
+        `then call mcp__inkwell__complete_task with each task's ID in task_order. ` +
+        `Do NOT write any code — just call the MCP tools. ` +
+        `Stop when all tasks are done or you receive an approval_required response.`,
       {
-        role: 'user',
-        content: [
-          {
-            type: 'text',
-            text: `You are completing tasks in a work strategy. Use list_tasks to see the tasks, then call complete_task for each pending task in order (by taskOrder). After each completion, check the response — if the action is "approval_required", stop. Do not write any code; just call the tools.`,
-          },
-        ],
-      },
-    ];
-
-    let lastStrategyAction: string | null = null;
-
-    for (let iteration = 0; iteration < MAX_ITERATIONS; iteration++) {
-      const response = await anthropic.messages.create({
-        model: MODEL,
-        max_tokens: 2048,
-        messages,
-        tools: TOOL_SCHEMAS,
-      });
-
-      const toolUseBlocks = response.content.filter(
-        (b): b is Anthropic.ToolUseBlock => b.type === 'tool_use'
-      );
-
-      if (toolUseBlocks.length === 0 || response.stop_reason === 'end_turn') {
-        break;
+        config: {
+          workingDirectory: tmpDir,
+          mcpConfigPath: join(tmpDir, '.mcp.json'),
+          model: 'claude-haiku-4-5-20251001',
+        },
       }
+    );
 
-      // Add assistant response
-      messages.push({ role: 'assistant', content: response.content });
-
-      // Execute tools
-      const toolResults: Anthropic.ToolResultBlockParam[] = [];
-      for (const toolUse of toolUseBlocks) {
-        const result = await executeTool(toolUse.name, toolUse.input as Record<string, unknown>);
-        toolResults.push({
-          type: 'tool_result',
-          tool_use_id: toolUse.id,
-          content: result,
-        });
-
-        // Track complete_task results
-        if (toolUse.name === 'complete_task') {
-          try {
-            const parsed = JSON.parse(result);
-            lastStrategyAction = parsed.action;
-          } catch {}
-        }
-      }
-
-      messages.push({ role: 'user', content: toolResults });
-    }
+    expect(result.success).toBe(true);
 
     // Verify: strategy should have paused for final_review
-    expect(lastStrategyAction).toBe('approval_required');
-
     const group = await dc.repositories.taskGroups.findById(groupId);
     expect(group.status).toBe('paused');
     expect((group.metadata as Record<string, unknown>).pauseReason).toBe('final_review');
@@ -295,7 +260,7 @@ describe.skipIf(!canRun)('Strategy Approval Gate — LLM live test', () => {
       const task = await dc.repositories.tasks.findById(taskId);
       expect(task.status).toBe('completed');
     }
-  }, 120_000);
+  }, 180_000);
 
   it('resume from final_review finalizes the strategy', async () => {
     const { StrategyService } = await import('./strategy.service');

--- a/packages/api/src/services/strategy-approval-gate.live.integration.test.ts
+++ b/packages/api/src/services/strategy-approval-gate.live.integration.test.ts
@@ -111,6 +111,9 @@ const canRun =
   claudeCredentialsAvailable() &&
   inkwellReachable();
 
+// Mock for in-process advanceStrategy calls (suite 2 setup). The external
+// MCP server has its own un-mocked handler — those side effects are cleaned
+// up in afterAll via the cleanup() helper.
 vi.mock('../mcp/tools/inbox-handlers', () => ({
   handleSendToInbox: vi.fn().mockResolvedValue(undefined),
 }));
@@ -137,12 +140,43 @@ function writeMcpConfig(dir: string): string {
 }
 
 async function cleanup(client: SupabaseClient, groupId: string, taskIds: string[]): Promise<void> {
+  // Core test data
   await client.from('tasks').delete().in('id', taskIds);
   await client
     .from('scheduled_reminders')
     .delete()
     .contains('metadata' as any, { groupId } as any);
   await client.from('activity_stream').delete().eq('task_group_id', groupId);
+
+  // Memories auto-created by handleCompleteTask (topics contain task:<id>)
+  for (const taskId of taskIds) {
+    await client
+      .from('memories')
+      .delete()
+      .contains('metadata' as any, { taskId } as any);
+  }
+
+  // Inbox/thread records created by notifyDispatcher (threadKey = strategy:<groupId>)
+  const threadKey = `strategy:${groupId}`;
+  const { data: thread } = await client
+    .from('inbox_threads')
+    .select('id')
+    .eq('thread_key', threadKey)
+    .maybeSingle();
+
+  if (thread) {
+    await client.from('inbox_thread_messages').delete().eq('thread_id', thread.id);
+    await client.from('agent_inbox_read_status').delete().eq('thread_id', thread.id);
+    await client.from('inbox_threads').delete().eq('id', thread.id);
+  }
+
+  // Legacy agent_inbox entries (if notifyDispatcher fell through to non-thread path)
+  await client
+    .from('agent_inbox')
+    .delete()
+    .contains('metadata' as any, { groupId } as any);
+
+  // Task group last (FK references)
   await client.from('task_groups').delete().eq('id', groupId);
 }
 

--- a/packages/api/src/services/strategy-approval-gate.live.integration.test.ts
+++ b/packages/api/src/services/strategy-approval-gate.live.integration.test.ts
@@ -3,21 +3,24 @@
  *
  * End-to-end test with a real LLM (Haiku via Claude Code) completing tasks
  * via MCP tools on the running Inkwell server, exercising the full approval
- * gate lifecycle.
+ * gate lifecycle including supervisor review.
  *
  * Uses ClaudeRunner (the same infra as production strategy execution) — no
  * separate ANTHROPIC_API_KEY required. Claude Code's existing OAuth
  * credentials handle LLM auth.
  *
+ * Suite 1: Worker completes tasks → final_review gate fires
+ * Suite 2: Supervisor reviews activity + criteria → approves → finalization
+ *
  * Requires:
  * - INK_LIVE_TESTS=1
  * - claude CLI installed with valid credentials
- * - Inkwell server running on localhost:3001
+ * - Inkwell server running (default localhost:3001, override via PCP_SERVER_URL)
  * - Valid access token in ~/.ink/auth.json
  * - Supabase credentials (.env.local or env vars)
  *
  * Run:
- *   INK_LIVE_TESTS=1 npx vitest run \
+ *   INK_LIVE_TESTS=1 PCP_SERVER_URL=http://localhost:4001 npx vitest run \
  *     --config vitest.integration.db.config.ts \
  *     --root packages/api \
  *     src/services/strategy-approval-gate.live.integration.test.ts
@@ -113,8 +116,25 @@ vi.mock('../mcp/tools/inbox-handlers', () => ({
 }));
 
 // ============================================================================
-// Helpers
+// Shared helpers
 // ============================================================================
+
+function writeMcpConfig(dir: string): string {
+  const configFile = join(dir, '.mcp.json');
+  writeFileSync(
+    configFile,
+    JSON.stringify({
+      mcpServers: {
+        inkwell: {
+          type: 'http',
+          url: `${INKWELL_URL}/mcp`,
+          headers: { Authorization: `Bearer ${accessToken}` },
+        },
+      },
+    })
+  );
+  return configFile;
+}
 
 async function cleanup(client: SupabaseClient, groupId: string, taskIds: string[]): Promise<void> {
   await client.from('tasks').delete().in('id', taskIds);
@@ -126,21 +146,26 @@ async function cleanup(client: SupabaseClient, groupId: string, taskIds: string[
   await client.from('task_groups').delete().eq('id', groupId);
 }
 
-async function getActivitySubtypes(client: SupabaseClient, groupId: string): Promise<string[]> {
+async function getActivityEvents(
+  client: SupabaseClient,
+  groupId: string
+): Promise<Array<{ subtype: string; payload: Record<string, unknown> }>> {
   const { data } = await client
     .from('activity_stream')
-    .select('subtype')
+    .select('subtype, payload')
     .eq('task_group_id', groupId)
     .order('created_at', { ascending: true });
 
-  return (data || []).map((e: { subtype: string | null }) => e.subtype).filter(Boolean) as string[];
+  return (data || [])
+    .filter((e: { subtype: string | null }) => e.subtype)
+    .map((e: any) => ({ subtype: e.subtype, payload: e.payload || {} }));
 }
 
 // ============================================================================
-// Test: LLM-driven approval gate via ClaudeRunner + MCP
+// Suite 1: Worker completes tasks → final_review gate fires
 // ============================================================================
 
-describe.skipIf(!canRun)('Strategy Approval Gate — LLM live test', () => {
+describe.skipIf(!canRun)('Strategy Approval Gate — worker phase (LLM live)', () => {
   let client: SupabaseClient;
   let dc: any;
   let groupId: string;
@@ -167,7 +192,6 @@ describe.skipIf(!canRun)('Strategy Approval Gate — LLM live test', () => {
       },
     };
 
-    // Create group with 3 tasks
     const group = await dc.repositories.taskGroups.create({
       user_id: TEST_USER_ID,
       title: `__llm_approval_gate_live_${Date.now()}`,
@@ -191,7 +215,6 @@ describe.skipIf(!canRun)('Strategy Approval Gate — LLM live test', () => {
       taskIds.push(task.id);
     }
 
-    // Start strategy with requireFinalApproval
     const { StrategyService } = await import('./strategy.service');
     const service = new StrategyService(dc);
     await service.startStrategy({
@@ -202,28 +225,14 @@ describe.skipIf(!canRun)('Strategy Approval Gate — LLM live test', () => {
       config: {
         requireFinalApproval: true,
         approvalCriteria: ['all tasks completed', 'no errors during execution'],
+        approvalNotify: 'lumen',
         watchdogIntervalMinutes: 60,
       },
     });
 
-    // Write temp MCP config with inkwell server + auth
     tmpDir = join(tmpdir(), `approval-gate-live-${Date.now()}`);
     mkdirSync(tmpDir, { recursive: true });
-
-    writeFileSync(
-      join(tmpDir, '.mcp.json'),
-      JSON.stringify({
-        mcpServers: {
-          inkwell: {
-            type: 'http',
-            url: `${INKWELL_URL}/mcp`,
-            headers: {
-              Authorization: `Bearer ${accessToken}`,
-            },
-          },
-        },
-      })
-    );
+    writeMcpConfig(tmpDir);
   }, 30_000);
 
   afterAll(async () => {
@@ -252,38 +261,172 @@ describe.skipIf(!canRun)('Strategy Approval Gate — LLM live test', () => {
 
     expect(result.success).toBe(true);
 
-    // Verify: strategy should have paused for final_review
     const group = await dc.repositories.taskGroups.findById(groupId);
     expect(group.status).toBe('paused');
     expect((group.metadata as Record<string, unknown>).pauseReason).toBe('final_review');
 
-    // All 3 tasks should be completed
     for (const taskId of taskIds) {
       const task = await dc.repositories.tasks.findById(taskId);
       expect(task.status).toBe('completed');
     }
   }, 180_000);
 
-  it('resume from final_review finalizes the strategy', async () => {
+  it('final_review_requested event has correct routing and criteria', async () => {
+    const events = await getActivityEvents(client, groupId);
+    const reviewEvent = events.find((e) => e.subtype === 'final_review_requested');
+
+    expect(reviewEvent).toBeDefined();
+    expect(reviewEvent!.payload.routedTo).toBe('lumen');
+    expect(reviewEvent!.payload.approvalCriteria).toEqual([
+      'all tasks completed',
+      'no errors during execution',
+    ]);
+    expect(reviewEvent!.payload.completedTasks).toBe(3);
+    expect(reviewEvent!.payload.totalTasks).toBe(3);
+  });
+});
+
+// ============================================================================
+// Suite 2: Supervisor reviews and approves via MCP
+// ============================================================================
+
+describe.skipIf(!canRun)('Strategy Approval Gate — supervisor review (LLM live)', () => {
+  let client: SupabaseClient;
+  let dc: any;
+  let groupId: string;
+  let taskIds: string[];
+  let tmpDir: string;
+
+  beforeAll(async () => {
+    client = createClient(SUPABASE_URL!, SUPABASE_KEY!, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+
+    const { TaskGroupsRepository } = await import('../data/repositories/task-groups.repository');
+    const { ProjectTasksRepository } =
+      await import('../data/repositories/project-tasks.repository');
+    const { ActivityStreamRepository } =
+      await import('../data/repositories/activity-stream.repository');
+
+    dc = {
+      getClient: () => client,
+      repositories: {
+        taskGroups: new TaskGroupsRepository(client),
+        tasks: new ProjectTasksRepository(client),
+        activityStream: new ActivityStreamRepository(client),
+      },
+    };
+
+    // Create group, complete all tasks, start strategy so it's already in final_review
+    const group = await dc.repositories.taskGroups.create({
+      user_id: TEST_USER_ID,
+      title: `__llm_supervisor_review_live_${Date.now()}`,
+      description: 'Live LLM supervisor test — safe to delete',
+      priority: 'low',
+      tags: ['__test'],
+    });
+    groupId = group.id;
+
+    taskIds = [];
+    const taskTitles = ['Implement auth flow', 'Add rate limiting', 'Write integration tests'];
+    for (let i = 0; i < taskTitles.length; i++) {
+      const task = await dc.repositories.tasks.create({
+        user_id: TEST_USER_ID,
+        title: taskTitles[i],
+        task_group_id: groupId,
+        task_order: i,
+        priority: 'low',
+        created_by: 'live-test',
+      });
+      taskIds.push(task.id);
+    }
+
+    // Start strategy, then complete all tasks so it enters final_review
     const { StrategyService } = await import('./strategy.service');
     const service = new StrategyService(dc);
+    await service.startStrategy({
+      groupId,
+      userId: TEST_USER_ID!,
+      strategy: 'persistence',
+      ownerAgentId: 'live-test',
+      config: {
+        requireFinalApproval: true,
+        approvalCriteria: ['CI passes', 'no regressions in test suite', 'code review approved'],
+        approvalNotify: 'lumen',
+        watchdogIntervalMinutes: 60,
+      },
+    });
 
-    const result = await service.resumeStrategy(groupId, TEST_USER_ID!);
+    // Worker completes tasks (direct DB calls — the worker LLM phase is tested in suite 1)
+    for (let i = 0; i < taskIds.length; i++) {
+      await dc.repositories.tasks.completeTask(taskIds[i]);
+      await service.advanceStrategy(groupId, taskIds[i], TEST_USER_ID!);
+    }
 
-    expect(result.action).toBe('group_complete');
-    expect(result.stats).toEqual({ total: 3, completed: 3 });
+    // Confirm we're in final_review before the supervisor test starts
+    const paused = await dc.repositories.taskGroups.findById(groupId);
+    if (paused.status !== 'paused' || (paused.metadata as any)?.pauseReason !== 'final_review') {
+      throw new Error(`Expected final_review state, got status=${paused.status}`);
+    }
 
+    tmpDir = join(tmpdir(), `supervisor-review-live-${Date.now()}`);
+    mkdirSync(tmpDir, { recursive: true });
+    writeMcpConfig(tmpDir);
+  }, 30_000);
+
+  afterAll(async () => {
+    if (client && groupId) await cleanup(client, groupId, taskIds);
+    if (tmpDir && existsSync(tmpDir)) rmSync(tmpDir, { recursive: true, force: true });
+  }, 10_000);
+
+  it('supervisor LLM reviews strategy status and approves via resume_strategy', async () => {
+    const { ClaudeRunner } = await import('./sessions/claude-runner');
+    const runner = new ClaudeRunner();
+
+    const result = await runner.run(
+      `You are a supervisor agent reviewing a completed strategy for approval.\n\n` +
+        `The task group ID is: ${groupId}\n\n` +
+        `Your review process:\n` +
+        `1. Call mcp__inkwell__get_strategy_status with groupId="${groupId}" to see the current state\n` +
+        `2. Call mcp__inkwell__get_activity with taskGroupId="${groupId}" and limit=20 to review the execution history\n` +
+        `3. Evaluate whether the approval criteria are met based on the activity stream\n` +
+        `4. If satisfied, call mcp__inkwell__resume_strategy with groupId="${groupId}" to approve\n\n` +
+        `The approval criteria are: CI passes, no regressions in test suite, code review approved.\n` +
+        `For this test, assume all criteria are met based on the successful task completions in the activity stream.\n\n` +
+        `Do NOT write any code. Just call the MCP tools in order.`,
+      {
+        config: {
+          workingDirectory: tmpDir,
+          mcpConfigPath: join(tmpDir, '.mcp.json'),
+          model: 'claude-haiku-4-5-20251001',
+        },
+      }
+    );
+
+    expect(result.success).toBe(true);
+
+    // Verify: strategy should be completed after supervisor approval
     const group = await dc.repositories.taskGroups.findById(groupId);
     expect(group.status).toBe('completed');
-  });
+  }, 180_000);
 
-  it('activity stream shows the full lifecycle', async () => {
-    const subtypes = await getActivitySubtypes(client, groupId);
+  it('activity stream shows supervisor approval trail', async () => {
+    const events = await getActivityEvents(client, groupId);
+    const subtypes = events.map((e) => e.subtype);
 
     expect(subtypes).toContain('strategy_started');
     expect(subtypes).toContain('task_advanced');
     expect(subtypes).toContain('final_review_requested');
     expect(subtypes).toContain('final_review_approved');
     expect(subtypes).toContain('strategy_completed');
+
+    // Verify the review event captured the right routing
+    const reviewEvent = events.find((e) => e.subtype === 'final_review_requested');
+    expect(reviewEvent!.payload.routedTo).toBe('lumen');
+    expect(reviewEvent!.payload.approvalCriteria).toEqual([
+      'CI passes',
+      'no regressions in test suite',
+      'code review approved',
+    ]);
   });
 });

--- a/packages/api/src/services/strategy-approval-gate.live.integration.test.ts
+++ b/packages/api/src/services/strategy-approval-gate.live.integration.test.ts
@@ -1,0 +1,322 @@
+/**
+ * Strategy Approval Gate — Live LLM Tests
+ *
+ * End-to-end test with a real LLM (Haiku) completing tasks and hitting
+ * the approval gate. Uses the Anthropic API directly with custom tools
+ * (list_tasks, complete_task) wired to StrategyService.
+ *
+ * Requires:
+ * - INK_LIVE_TESTS=1
+ * - ANTHROPIC_API_KEY set
+ * - Supabase credentials (.env.local or env vars)
+ *
+ * Run:
+ *   INK_LIVE_TESTS=1 npx vitest run \
+ *     --config vitest.integration.db.config.ts \
+ *     --root packages/api \
+ *     src/services/strategy-approval-gate.live.integration.test.ts
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import Anthropic from '@anthropic-ai/sdk';
+import dotenv from 'dotenv';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import { readFileSync, existsSync } from 'fs';
+import { resolve } from 'path';
+
+// ============================================================================
+// Environment setup
+// ============================================================================
+
+const projectRoot = resolve(__dirname, '../../../../');
+const envLocalPath = resolve(projectRoot, '.env.local');
+if (existsSync(envLocalPath)) {
+  const parsed = dotenv.parse(readFileSync(envLocalPath));
+  for (const [key, value] of Object.entries(parsed)) {
+    if (!process.env[key]) process.env[key] = value;
+  }
+}
+
+if (!process.env.PCP_PORT_BASE) process.env.PCP_PORT_BASE = '9998';
+
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_SECRET_KEY || process.env.SUPABASE_SERVICE_KEY;
+const ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY;
+
+const configPath = resolve(process.env.HOME || '', '.ink/config.json');
+const inkConfig = existsSync(configPath) ? JSON.parse(readFileSync(configPath, 'utf-8')) : {};
+const TEST_USER_ID: string | undefined = inkConfig.userId;
+
+const canRun =
+  process.env.INK_LIVE_TESTS === '1' &&
+  !!SUPABASE_URL &&
+  !!SUPABASE_KEY &&
+  !!ANTHROPIC_API_KEY &&
+  !!TEST_USER_ID;
+
+vi.mock('../mcp/tools/inbox-handlers', () => ({
+  handleSendToInbox: vi.fn().mockResolvedValue(undefined),
+}));
+
+// ============================================================================
+// Anthropic tool schemas for the LLM
+// ============================================================================
+
+const TOOL_SCHEMAS: Anthropic.Tool[] = [
+  {
+    name: 'list_tasks',
+    description:
+      'List all tasks in the strategy group with their IDs and statuses. Call this first to see what needs to be done.',
+    input_schema: {
+      type: 'object' as const,
+      properties: {},
+      required: [],
+    },
+  },
+  {
+    name: 'complete_task',
+    description:
+      'Mark a task as completed by its ID. This advances the strategy. Call this for each pending task.',
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        taskId: {
+          type: 'string',
+          description: 'The UUID of the task to complete',
+        },
+      },
+      required: ['taskId'],
+    },
+  },
+];
+
+const MODEL = 'claude-haiku-4-5-20251001';
+const MAX_ITERATIONS = 15;
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+async function cleanup(client: SupabaseClient, groupId: string, taskIds: string[]): Promise<void> {
+  await client.from('tasks').delete().in('id', taskIds);
+  await client
+    .from('scheduled_reminders')
+    .delete()
+    .contains('metadata' as any, { groupId } as any);
+  await client.from('activity_stream').delete().eq('task_group_id', groupId);
+  await client.from('task_groups').delete().eq('id', groupId);
+}
+
+async function getActivitySubtypes(client: SupabaseClient, groupId: string): Promise<string[]> {
+  const { data } = await client
+    .from('activity_stream')
+    .select('subtype')
+    .eq('task_group_id', groupId)
+    .order('created_at', { ascending: true });
+
+  return (data || []).map((e: { subtype: string | null }) => e.subtype).filter(Boolean) as string[];
+}
+
+// ============================================================================
+// Test: LLM-driven approval gate
+// ============================================================================
+
+describe.skipIf(!canRun)('Strategy Approval Gate — LLM live test', () => {
+  let client: SupabaseClient;
+  let anthropic: Anthropic;
+  let dc: any;
+  let groupId: string;
+  let taskIds: string[];
+
+  beforeAll(async () => {
+    client = createClient(SUPABASE_URL!, SUPABASE_KEY!, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+    anthropic = new Anthropic({ apiKey: ANTHROPIC_API_KEY });
+
+    const { TaskGroupsRepository } = await import('../data/repositories/task-groups.repository');
+    const { ProjectTasksRepository } =
+      await import('../data/repositories/project-tasks.repository');
+    const { ActivityStreamRepository } =
+      await import('../data/repositories/activity-stream.repository');
+
+    dc = {
+      getClient: () => client,
+      repositories: {
+        taskGroups: new TaskGroupsRepository(client),
+        tasks: new ProjectTasksRepository(client),
+        activityStream: new ActivityStreamRepository(client),
+      },
+    };
+
+    // Create group with 3 tasks
+    const group = await dc.repositories.taskGroups.create({
+      user_id: TEST_USER_ID,
+      title: `__llm_approval_gate_live_${Date.now()}`,
+      description: 'Live LLM test — safe to delete',
+      priority: 'low',
+      tags: ['__test'],
+    });
+    groupId = group.id;
+
+    taskIds = [];
+    const taskTitles = ['Write a greeting function', 'Add error handling', 'Write unit tests'];
+    for (let i = 0; i < taskTitles.length; i++) {
+      const task = await dc.repositories.tasks.create({
+        user_id: TEST_USER_ID,
+        title: taskTitles[i],
+        task_group_id: groupId,
+        task_order: i,
+        priority: 'low',
+        created_by: 'live-test',
+      });
+      taskIds.push(task.id);
+    }
+
+    // Start strategy with requireFinalApproval
+    const { StrategyService } = await import('./strategy.service');
+    const service = new StrategyService(dc);
+    await service.startStrategy({
+      groupId,
+      userId: TEST_USER_ID!,
+      strategy: 'persistence',
+      ownerAgentId: 'live-test',
+      config: {
+        requireFinalApproval: true,
+        approvalCriteria: ['all tasks completed', 'no errors during execution'],
+        watchdogIntervalMinutes: 60,
+      },
+    });
+  }, 30_000);
+
+  afterAll(async () => {
+    if (client && groupId) await cleanup(client, groupId, taskIds);
+  }, 10_000);
+
+  it('LLM completes all tasks and strategy pauses for final_review', async () => {
+    const { StrategyService } = await import('./strategy.service');
+    const service = new StrategyService(dc);
+
+    // Tool executors — called when the LLM uses tools
+    async function executeTool(name: string, input: Record<string, unknown>): Promise<string> {
+      if (name === 'list_tasks') {
+        const tasks = await dc.repositories.tasks.findByGroupId(groupId);
+        return JSON.stringify(
+          tasks.map((t: any) => ({
+            id: t.id,
+            title: t.title,
+            status: t.status,
+            taskOrder: t.task_order,
+          }))
+        );
+      }
+
+      if (name === 'complete_task') {
+        const taskId = input.taskId as string;
+        await dc.repositories.tasks.completeTask(taskId);
+        const result = await service.advanceStrategy(groupId, taskId, TEST_USER_ID!);
+        return JSON.stringify({
+          action: result.action,
+          progressSummary: result.progressSummary || null,
+          nextTask: result.nextTask
+            ? { id: result.nextTask.id, title: result.nextTask.title }
+            : null,
+        });
+      }
+
+      return `Error: Unknown tool "${name}"`;
+    }
+
+    // Agentic loop — LLM sees the tasks and completes them
+    const messages: Anthropic.MessageParam[] = [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: `You are completing tasks in a work strategy. Use list_tasks to see the tasks, then call complete_task for each pending task in order (by taskOrder). After each completion, check the response — if the action is "approval_required", stop. Do not write any code; just call the tools.`,
+          },
+        ],
+      },
+    ];
+
+    let lastStrategyAction: string | null = null;
+
+    for (let iteration = 0; iteration < MAX_ITERATIONS; iteration++) {
+      const response = await anthropic.messages.create({
+        model: MODEL,
+        max_tokens: 2048,
+        messages,
+        tools: TOOL_SCHEMAS,
+      });
+
+      const toolUseBlocks = response.content.filter(
+        (b): b is Anthropic.ToolUseBlock => b.type === 'tool_use'
+      );
+
+      if (toolUseBlocks.length === 0 || response.stop_reason === 'end_turn') {
+        break;
+      }
+
+      // Add assistant response
+      messages.push({ role: 'assistant', content: response.content });
+
+      // Execute tools
+      const toolResults: Anthropic.ToolResultBlockParam[] = [];
+      for (const toolUse of toolUseBlocks) {
+        const result = await executeTool(toolUse.name, toolUse.input as Record<string, unknown>);
+        toolResults.push({
+          type: 'tool_result',
+          tool_use_id: toolUse.id,
+          content: result,
+        });
+
+        // Track complete_task results
+        if (toolUse.name === 'complete_task') {
+          try {
+            const parsed = JSON.parse(result);
+            lastStrategyAction = parsed.action;
+          } catch {}
+        }
+      }
+
+      messages.push({ role: 'user', content: toolResults });
+    }
+
+    // Verify: strategy should have paused for final_review
+    expect(lastStrategyAction).toBe('approval_required');
+
+    const group = await dc.repositories.taskGroups.findById(groupId);
+    expect(group.status).toBe('paused');
+    expect((group.metadata as Record<string, unknown>).pauseReason).toBe('final_review');
+
+    // All 3 tasks should be completed
+    for (const taskId of taskIds) {
+      const task = await dc.repositories.tasks.findById(taskId);
+      expect(task.status).toBe('completed');
+    }
+  }, 120_000);
+
+  it('resume from final_review finalizes the strategy', async () => {
+    const { StrategyService } = await import('./strategy.service');
+    const service = new StrategyService(dc);
+
+    const result = await service.resumeStrategy(groupId, TEST_USER_ID!);
+
+    expect(result.action).toBe('group_complete');
+    expect(result.stats).toEqual({ total: 3, completed: 3 });
+
+    const group = await dc.repositories.taskGroups.findById(groupId);
+    expect(group.status).toBe('completed');
+  });
+
+  it('activity stream shows the full lifecycle', async () => {
+    const subtypes = await getActivitySubtypes(client, groupId);
+
+    expect(subtypes).toContain('strategy_started');
+    expect(subtypes).toContain('task_advanced');
+    expect(subtypes).toContain('final_review_requested');
+    expect(subtypes).toContain('final_review_approved');
+    expect(subtypes).toContain('strategy_completed');
+  });
+});


### PR DESCRIPTION
## Summary
- Integration tests for the final approval gate feature (PR #362) against real Supabase
- Three test suites covering the full strategy lifecycle with real DB round-trips
- 10 tests total, all exercising StrategyService directly against Supabase

## Test suites

1. **Final approval gate lifecycle** (5 tests): start → advance 3 tasks → pauses with `final_review` + criteria in summary → resume → `group_complete` → correct activity trail (`final_review_requested`, `final_review_approved`, `strategy_completed`)

2. **Periodic boundary regression** (2 tests): `maxIterationsWithoutApproval=2` with exactly 2 tasks → completes instead of pausing for periodic approval. Verifies `strategy_completed` in activity stream and NO `approval_required`.

3. **Both gates on final task** (3 tests): periodic + final approval coincide → `final_review` wins → resume → completed. Verifies the ordering fix from Lumen's PR #362 review.

## Run locally
```bash
PCP_PORT_BASE=9998 npx vitest run src/services/strategy-approval-gate.integration.test.ts \
  --config vitest.integration.db.config.ts --root packages/api
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)