### PR TITLE
feat: Command Center dashboard + context-based MCP auth (by Wren)

### DIFF
--- a/packages/api/src/mcp/server.test.ts
+++ b/packages/api/src/mcp/server.test.ts
@@ -465,7 +465,7 @@ describe('MCP StreamableHTTP Transport (stateless)', () => {
     if (serverUnavailableError) return;
     mockVerifyAccessToken.mockResolvedValue(null);
     mockGetSession.mockResolvedValue({
-      id: 'sess-active',
+      id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
       userId: 'user-456',
       agentId: 'wren',
       lifecycle: 'running',
@@ -480,7 +480,7 @@ describe('MCP StreamableHTTP Transport (stateless)', () => {
     };
 
     const contextHeader = encodeContextHeader({
-      sessionId: 'sess-active',
+      sessionId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
       studioId: 'studio-1',
       agentId: 'wren',
       cliAttached: true,
@@ -492,7 +492,7 @@ describe('MCP StreamableHTTP Transport (stateless)', () => {
     });
 
     expect(res.status).toBe(200);
-    expect(mockGetSession).toHaveBeenCalledWith('sess-active');
+    expect(mockGetSession).toHaveBeenCalledWith('a1b2c3d4-e5f6-7890-abcd-ef1234567890');
   });
 
   it('should reject forged context with no matching session', async () => {
@@ -517,12 +517,34 @@ describe('MCP StreamableHTTP Transport (stateless)', () => {
     (env as any).MCP_REQUIRE_OAUTH = false;
   });
 
+  it('should reject context with malformed (non-UUID) sessionId without hitting DB', async () => {
+    if (serverUnavailableError) return;
+    (env as any).MCP_REQUIRE_OAUTH = true;
+    mockVerifyAccessToken.mockResolvedValue(null);
+
+    const contextHeader = encodeContextHeader({
+      sessionId: 'not-a-uuid',
+      studioId: 'studio-1',
+      agentId: 'wren',
+      cliAttached: true,
+      runtime: 'claude',
+    });
+
+    const res = await mcpPost(baseUrl, INITIALIZE_REQUEST, {
+      'x-ink-context': contextHeader,
+    });
+
+    expect(res.status).toBe(401);
+    expect(mockGetSession).not.toHaveBeenCalled();
+    (env as any).MCP_REQUIRE_OAUTH = false;
+  });
+
   it('should reject context when session agentId does not match', async () => {
     if (serverUnavailableError) return;
     (env as any).MCP_REQUIRE_OAUTH = true;
     mockVerifyAccessToken.mockResolvedValue(null);
     mockGetSession.mockResolvedValue({
-      id: 'sess-other',
+      id: 'b2c3d4e5-f6a7-8901-bcde-f12345678901',
       userId: 'user-456',
       agentId: 'lumen',
       lifecycle: 'running',
@@ -532,7 +554,7 @@ describe('MCP StreamableHTTP Transport (stateless)', () => {
     });
 
     const contextHeader = encodeContextHeader({
-      sessionId: 'sess-other',
+      sessionId: 'b2c3d4e5-f6a7-8901-bcde-f12345678901',
       studioId: 'studio-1',
       agentId: 'wren',
       cliAttached: true,
@@ -552,7 +574,7 @@ describe('MCP StreamableHTTP Transport (stateless)', () => {
     (env as any).MCP_REQUIRE_OAUTH = true;
     mockVerifyAccessToken.mockResolvedValue(null);
     mockGetSession.mockResolvedValue({
-      id: 'sess-ended',
+      id: 'c3d4e5f6-a7b8-9012-cdef-123456789012',
       userId: 'user-456',
       agentId: 'wren',
       lifecycle: 'completed',
@@ -562,7 +584,7 @@ describe('MCP StreamableHTTP Transport (stateless)', () => {
     });
 
     const contextHeader = encodeContextHeader({
-      sessionId: 'sess-ended',
+      sessionId: 'c3d4e5f6-a7b8-9012-cdef-123456789012',
       studioId: 'studio-1',
       agentId: 'wren',
       cliAttached: true,
@@ -581,7 +603,7 @@ describe('MCP StreamableHTTP Transport (stateless)', () => {
     if (serverUnavailableError) return;
     mockVerifyAccessToken.mockResolvedValue(null);
     mockGetSession.mockResolvedValue({
-      id: 'sess-active',
+      id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
       userId: 'user-456',
       agentId: 'wren',
       lifecycle: 'running',
@@ -596,7 +618,7 @@ describe('MCP StreamableHTTP Transport (stateless)', () => {
     };
 
     const contextHeader = encodeContextHeader({
-      sessionId: 'sess-active',
+      sessionId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
       studioId: 'studio-1',
       agentId: 'wren',
       cliAttached: true,
@@ -624,7 +646,7 @@ describe('MCP StreamableHTTP Transport (stateless)', () => {
     });
 
     const contextHeader = encodeContextHeader({
-      sessionId: 'sess-1',
+      sessionId: 'd4e5f6a7-b8c9-0123-defa-234567890123',
       studioId: 'studio-1',
       agentId: 'wren',
       cliAttached: true,

--- a/packages/api/src/mcp/server.test.ts
+++ b/packages/api/src/mcp/server.test.ts
@@ -171,12 +171,15 @@ describe('MCP StreamableHTTP Transport (stateless)', () => {
   let serverUnavailableError: Error | null = null;
   let delegatedIdentity: { id: string; agent_id: string } | null = null;
 
-  // Identity resolved by context-based auth fallback (resolveUserFromAgentId)
+  // Identity record returned when session-validated context auth resolves
   let contextIdentity: {
     id: string;
     user_id: string;
     users: { email: string };
   } | null = null;
+
+  // Mock session returned by getSession (for context-based auth validation)
+  const mockGetSession = vi.fn(async () => null);
 
   // Minimal DataComposer stub
   const mockDataComposer = {
@@ -202,8 +205,14 @@ describe('MCP StreamableHTTP Transport (stateless)', () => {
               return { data: matches ? delegatedIdentity : null, error: null };
             },
             single: async () => {
-              // resolveUserFromAgentId joins users and filters by agent_id only
-              if (selectedColumns.includes('users') && filters.agent_id && contextIdentity) {
+              // resolveUserFromContextSession joins users and filters by agent_id + user_id
+              if (
+                selectedColumns.includes('users') &&
+                filters.agent_id &&
+                filters.user_id &&
+                contextIdentity &&
+                contextIdentity.user_id === filters.user_id
+              ) {
                 return { data: contextIdentity, error: null };
               }
               return { data: null, error: { message: 'not found' } };
@@ -221,7 +230,7 @@ describe('MCP StreamableHTTP Transport (stateless)', () => {
       },
     }),
     repositories: {
-      memory: { getSession: vi.fn(async () => null) },
+      memory: { getSession: mockGetSession },
       workspaces: { findById: vi.fn(async () => null) },
     },
   } as any;
@@ -259,6 +268,7 @@ describe('MCP StreamableHTTP Transport (stateless)', () => {
 
   beforeEach(() => {
     mockVerifyAccessToken.mockReset();
+    mockGetSession.mockReset().mockResolvedValue(null);
     delegatedIdentity = null;
     contextIdentity = null;
   });
@@ -448,12 +458,21 @@ describe('MCP StreamableHTTP Transport (stateless)', () => {
   });
 
   // =========================================================================
-  // Context-based auth fallback (x-ink-context without OAuth)
+  // Session-validated context auth (x-ink-context without OAuth)
   // =========================================================================
 
-  it('should resolve identity from x-ink-context when no OAuth token is present', async () => {
+  it('should resolve identity from verified session in x-ink-context', async () => {
     if (serverUnavailableError) return;
     mockVerifyAccessToken.mockResolvedValue(null);
+    mockGetSession.mockResolvedValue({
+      id: 'sess-active',
+      userId: 'user-456',
+      agentId: 'wren',
+      lifecycle: 'running',
+      startedAt: new Date(),
+      endedAt: undefined,
+      metadata: {},
+    });
     contextIdentity = {
       id: 'sb-uuid-123',
       user_id: 'user-456',
@@ -461,7 +480,7 @@ describe('MCP StreamableHTTP Transport (stateless)', () => {
     };
 
     const contextHeader = encodeContextHeader({
-      sessionId: 'sess-1',
+      sessionId: 'sess-active',
       studioId: 'studio-1',
       agentId: 'wren',
       cliAttached: true,
@@ -473,18 +492,19 @@ describe('MCP StreamableHTTP Transport (stateless)', () => {
     });
 
     expect(res.status).toBe(200);
+    expect(mockGetSession).toHaveBeenCalledWith('sess-active');
   });
 
-  it('should challenge when both OAuth and context-based auth fail and MCP_REQUIRE_OAUTH is true', async () => {
+  it('should reject forged context with no matching session', async () => {
     if (serverUnavailableError) return;
     (env as any).MCP_REQUIRE_OAUTH = true;
     mockVerifyAccessToken.mockResolvedValue(null);
-    contextIdentity = null;
+    mockGetSession.mockResolvedValue(null);
 
     const contextHeader = encodeContextHeader({
-      sessionId: 'sess-1',
+      sessionId: 'forged-session-id',
       studioId: 'studio-1',
-      agentId: 'unknown-agent',
+      agentId: 'wren',
       cliAttached: true,
       runtime: 'claude',
     });
@@ -497,6 +517,103 @@ describe('MCP StreamableHTTP Transport (stateless)', () => {
     (env as any).MCP_REQUIRE_OAUTH = false;
   });
 
+  it('should reject context when session agentId does not match', async () => {
+    if (serverUnavailableError) return;
+    (env as any).MCP_REQUIRE_OAUTH = true;
+    mockVerifyAccessToken.mockResolvedValue(null);
+    mockGetSession.mockResolvedValue({
+      id: 'sess-other',
+      userId: 'user-456',
+      agentId: 'lumen',
+      lifecycle: 'running',
+      startedAt: new Date(),
+      endedAt: undefined,
+      metadata: {},
+    });
+
+    const contextHeader = encodeContextHeader({
+      sessionId: 'sess-other',
+      studioId: 'studio-1',
+      agentId: 'wren',
+      cliAttached: true,
+      runtime: 'claude',
+    });
+
+    const res = await mcpPost(baseUrl, INITIALIZE_REQUEST, {
+      'x-ink-context': contextHeader,
+    });
+
+    expect(res.status).toBe(401);
+    (env as any).MCP_REQUIRE_OAUTH = false;
+  });
+
+  it('should reject context when session is already ended', async () => {
+    if (serverUnavailableError) return;
+    (env as any).MCP_REQUIRE_OAUTH = true;
+    mockVerifyAccessToken.mockResolvedValue(null);
+    mockGetSession.mockResolvedValue({
+      id: 'sess-ended',
+      userId: 'user-456',
+      agentId: 'wren',
+      lifecycle: 'completed',
+      startedAt: new Date('2026-01-01'),
+      endedAt: new Date('2026-01-02'),
+      metadata: {},
+    });
+
+    const contextHeader = encodeContextHeader({
+      sessionId: 'sess-ended',
+      studioId: 'studio-1',
+      agentId: 'wren',
+      cliAttached: true,
+      runtime: 'claude',
+    });
+
+    const res = await mcpPost(baseUrl, INITIALIZE_REQUEST, {
+      'x-ink-context': contextHeader,
+    });
+
+    expect(res.status).toBe(401);
+    (env as any).MCP_REQUIRE_OAUTH = false;
+  });
+
+  it('should NOT fall back to context auth when Authorization header is present but invalid', async () => {
+    if (serverUnavailableError) return;
+    mockVerifyAccessToken.mockResolvedValue(null);
+    mockGetSession.mockResolvedValue({
+      id: 'sess-active',
+      userId: 'user-456',
+      agentId: 'wren',
+      lifecycle: 'running',
+      startedAt: new Date(),
+      endedAt: undefined,
+      metadata: {},
+    });
+    contextIdentity = {
+      id: 'sb-uuid-123',
+      user_id: 'user-456',
+      users: { email: 'test@example.com' },
+    };
+
+    const contextHeader = encodeContextHeader({
+      sessionId: 'sess-active',
+      studioId: 'studio-1',
+      agentId: 'wren',
+      cliAttached: true,
+      runtime: 'claude',
+    });
+
+    const res = await mcpPost(baseUrl, INITIALIZE_REQUEST, {
+      Authorization: 'Bearer expired-or-invalid-token',
+      'x-ink-context': contextHeader,
+    });
+
+    // Invalid Authorization header = hard 401, context is not a fallback
+    expect(res.status).toBe(401);
+    const body = JSON.parse(res.body);
+    expect(body.error.message).toContain('Invalid or expired');
+  });
+
   it('should prefer OAuth identity over context-based fallback', async () => {
     if (serverUnavailableError) return;
     mockVerifyAccessToken.mockResolvedValue({
@@ -505,11 +622,6 @@ describe('MCP StreamableHTTP Transport (stateless)', () => {
       agentId: 'wren',
       sbId: 'oauth-sb',
     });
-    contextIdentity = {
-      id: 'context-sb',
-      user_id: 'context-user',
-      users: { email: 'context@example.com' },
-    };
 
     const contextHeader = encodeContextHeader({
       sessionId: 'sess-1',
@@ -525,5 +637,7 @@ describe('MCP StreamableHTTP Transport (stateless)', () => {
     });
 
     expect(res.status).toBe(200);
+    // Session lookup should NOT have been called — OAuth was sufficient
+    expect(mockGetSession).not.toHaveBeenCalled();
   });
 });

--- a/packages/api/src/mcp/server.test.ts
+++ b/packages/api/src/mcp/server.test.ts
@@ -150,6 +150,17 @@ function parseSSEResult(body: string): unknown {
   return JSON.parse(match[1]);
 }
 
+/** Encode a PCP context token as a base64url header value. */
+function encodeContextHeader(token: {
+  sessionId: string;
+  studioId: string;
+  agentId: string;
+  cliAttached: boolean;
+  runtime: string;
+}): string {
+  return Buffer.from(JSON.stringify(token)).toString('base64url');
+}
+
 // ---------------------------------------------------------------------------
 // Test suite
 // ---------------------------------------------------------------------------
@@ -160,14 +171,25 @@ describe('MCP StreamableHTTP Transport (stateless)', () => {
   let serverUnavailableError: Error | null = null;
   let delegatedIdentity: { id: string; agent_id: string } | null = null;
 
+  // Identity resolved by context-based auth fallback (resolveUserFromAgentId)
+  let contextIdentity: {
+    id: string;
+    user_id: string;
+    users: { email: string };
+  } | null = null;
+
   // Minimal DataComposer stub
   const mockDataComposer = {
     getClient: () => ({
       from: (table: string) => {
         if (table === 'agent_identities') {
           const filters: Record<string, string> = {};
+          let selectedColumns = '';
           const query = {
-            select: () => query,
+            select: (cols?: string) => {
+              if (cols) selectedColumns = cols;
+              return query;
+            },
             eq: (field: string, value: string) => {
               filters[field] = value;
               return query;
@@ -179,8 +201,14 @@ describe('MCP StreamableHTTP Transport (stateless)', () => {
                 filters.agent_id === delegatedIdentity.agent_id;
               return { data: matches ? delegatedIdentity : null, error: null };
             },
-            single: async () => ({ data: null, error: null }),
-            limit: () => ({ error: null }),
+            single: async () => {
+              // resolveUserFromAgentId joins users and filters by agent_id only
+              if (selectedColumns.includes('users') && filters.agent_id && contextIdentity) {
+                return { data: contextIdentity, error: null };
+              }
+              return { data: null, error: { message: 'not found' } };
+            },
+            limit: (_n: number) => query,
           };
           return query;
         }
@@ -192,6 +220,10 @@ describe('MCP StreamableHTTP Transport (stateless)', () => {
         };
       },
     }),
+    repositories: {
+      memory: { getSession: vi.fn(async () => null) },
+      workspaces: { findById: vi.fn(async () => null) },
+    },
   } as any;
 
   beforeAll(async () => {
@@ -228,6 +260,7 @@ describe('MCP StreamableHTTP Transport (stateless)', () => {
   beforeEach(() => {
     mockVerifyAccessToken.mockReset();
     delegatedIdentity = null;
+    contextIdentity = null;
   });
 
   // =========================================================================
@@ -412,5 +445,85 @@ describe('MCP StreamableHTTP Transport (stateless)', () => {
     });
 
     expect(res.status).toBe(403);
+  });
+
+  // =========================================================================
+  // Context-based auth fallback (x-ink-context without OAuth)
+  // =========================================================================
+
+  it('should resolve identity from x-ink-context when no OAuth token is present', async () => {
+    if (serverUnavailableError) return;
+    mockVerifyAccessToken.mockResolvedValue(null);
+    contextIdentity = {
+      id: 'sb-uuid-123',
+      user_id: 'user-456',
+      users: { email: 'test@example.com' },
+    };
+
+    const contextHeader = encodeContextHeader({
+      sessionId: 'sess-1',
+      studioId: 'studio-1',
+      agentId: 'wren',
+      cliAttached: true,
+      runtime: 'claude',
+    });
+
+    const res = await mcpPost(baseUrl, INITIALIZE_REQUEST, {
+      'x-ink-context': contextHeader,
+    });
+
+    expect(res.status).toBe(200);
+  });
+
+  it('should challenge when both OAuth and context-based auth fail and MCP_REQUIRE_OAUTH is true', async () => {
+    if (serverUnavailableError) return;
+    (env as any).MCP_REQUIRE_OAUTH = true;
+    mockVerifyAccessToken.mockResolvedValue(null);
+    contextIdentity = null;
+
+    const contextHeader = encodeContextHeader({
+      sessionId: 'sess-1',
+      studioId: 'studio-1',
+      agentId: 'unknown-agent',
+      cliAttached: true,
+      runtime: 'claude',
+    });
+
+    const res = await mcpPost(baseUrl, INITIALIZE_REQUEST, {
+      'x-ink-context': contextHeader,
+    });
+
+    expect(res.status).toBe(401);
+    (env as any).MCP_REQUIRE_OAUTH = false;
+  });
+
+  it('should prefer OAuth identity over context-based fallback', async () => {
+    if (serverUnavailableError) return;
+    mockVerifyAccessToken.mockResolvedValue({
+      userId: 'oauth-user',
+      email: 'oauth@example.com',
+      agentId: 'wren',
+      sbId: 'oauth-sb',
+    });
+    contextIdentity = {
+      id: 'context-sb',
+      user_id: 'context-user',
+      users: { email: 'context@example.com' },
+    };
+
+    const contextHeader = encodeContextHeader({
+      sessionId: 'sess-1',
+      studioId: 'studio-1',
+      agentId: 'wren',
+      cliAttached: true,
+      runtime: 'claude',
+    });
+
+    const res = await mcpPost(baseUrl, INITIALIZE_REQUEST, {
+      Authorization: 'Bearer valid-token',
+      'x-ink-context': contextHeader,
+    });
+
+    expect(res.status).toBe(200);
   });
 });

--- a/packages/api/src/mcp/server.ts
+++ b/packages/api/src/mcp/server.ts
@@ -96,7 +96,22 @@ export class MCPServer {
     sessionId: string,
     agentId: string
   ): Promise<{ userId: string; email: string; agentId: string; sbId: string } | null> {
-    const session = await this.dataComposer.repositories.memory.getSession(sessionId);
+    const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    if (!UUID_RE.test(sessionId)) {
+      logger.debug('Context-based auth: malformed sessionId', { sessionId });
+      return null;
+    }
+
+    let session;
+    try {
+      session = await this.dataComposer.repositories.memory.getSession(sessionId);
+    } catch (error) {
+      logger.debug('Context-based auth: session lookup failed', {
+        sessionId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return null;
+    }
     if (!session) {
       logger.debug('Context-based auth: session not found', { sessionId });
       return null;

--- a/packages/api/src/mcp/server.ts
+++ b/packages/api/src/mcp/server.ts
@@ -86,6 +86,31 @@ export class MCPServer {
     logger.info('MCP Server initialized');
   }
 
+  private async resolveUserFromAgentId(
+    agentId: string
+  ): Promise<{ userId: string; email: string; agentId: string; sbId: string } | null> {
+    const { data, error } = await this.dataComposer
+      .getClient()
+      .from('agent_identities')
+      .select('id, user_id, users!inner(email)')
+      .eq('agent_id', agentId)
+      .limit(1)
+      .single();
+
+    if (error || !data) {
+      logger.debug('Context-based auth: no identity found for agentId', { agentId });
+      return null;
+    }
+
+    const email = (data.users as unknown as { email: string })?.email ?? '';
+    return {
+      userId: data.user_id,
+      email,
+      agentId,
+      sbId: data.id,
+    };
+  }
+
   private async deriveWorkspaceIdFromAgent(
     userId: string,
     agentId: string
@@ -237,10 +262,31 @@ export class MCPServer {
     // ============================================================================
     const handleMcpRequest = async (req: express.Request, res: express.Response) => {
       const authHeader = req.headers.authorization;
-      const userData = await this.authProvider.verifyAccessToken(authHeader);
+      let userData = await this.authProvider.verifyAccessToken(authHeader);
+
+      // Parse x-ink-context early so we can use it for auth fallback.
+      const contextHeader = req.header('x-ink-context')?.trim();
+      let contextToken: import('@inklabs/shared').PcpContextToken | null = null;
+      if (contextHeader) {
+        const { decodeContextToken } = await import('@inklabs/shared');
+        contextToken = decodeContextToken(contextHeader);
+      }
+
+      // Context-based auth fallback: when no OAuth token is present but the
+      // request carries an x-ink-context header with an agentId (injected by
+      // the `ink` CLI wrapper), resolve identity from agent_identities.
+      if (!userData && contextToken?.agentId) {
+        userData = await this.resolveUserFromAgentId(contextToken.agentId);
+        if (userData) {
+          logger.debug('Context-based auth: resolved identity from x-ink-context', {
+            agentId: contextToken.agentId,
+            userId: userData.userId,
+          });
+        }
+      }
 
       // OAuth challenge for MCP clients (e.g. Gemini) when auth is required.
-      const isMissingAuth = !authHeader;
+      const isMissingAuth = !authHeader && !userData;
       const isInvalidAuth = !!authHeader && !userData;
       const shouldChallenge = isInvalidAuth || (env.MCP_REQUIRE_OAUTH && isMissingAuth);
 
@@ -283,20 +329,6 @@ export class MCPServer {
           }
         : {};
       const callerProfileHeader = req.header('x-ink-caller-profile')?.trim().toLowerCase();
-      // Trust boundary note:
-      // `x-ink-caller-profile`, `x-ink-session-id`, and `x-ink-studio-id` are only consumed
-      // on the MCP transport entrypoint. Supported MCP clients in our stack do not expose
-      // arbitrary header injection to model prompts, so these remain runtime/server-controlled
-      // signals rather than LLM-controlled parameters.
-      // Parse consolidated context token first (Phase 1 — preferred source).
-      // Falls back to individual headers for backward compat.
-      const contextHeader = req.header('x-ink-context')?.trim();
-      let contextToken: import('@inklabs/shared').PcpContextToken | null = null;
-      if (contextHeader) {
-        const { decodeContextToken } = await import('@inklabs/shared');
-        contextToken = decodeContextToken(contextHeader);
-      }
-
       const callerProfile: 'agent' | 'runtime' =
         callerProfileHeader === 'runtime' ? 'runtime' : 'agent';
       const sessionIdHeader = contextToken?.sessionId || req.header('x-ink-session-id')?.trim();

--- a/packages/api/src/mcp/server.ts
+++ b/packages/api/src/mcp/server.ts
@@ -86,25 +86,55 @@ export class MCPServer {
     logger.info('MCP Server initialized');
   }
 
-  private async resolveUserFromAgentId(
+  /**
+   * Validate a context token by verifying the sessionId against the database.
+   * The session was created via an authenticated start_session call, so a
+   * matching active session proves the caller owns the identity. We also
+   * verify the agentId matches to prevent session-id reuse across agents.
+   */
+  private async resolveUserFromContextSession(
+    sessionId: string,
     agentId: string
   ): Promise<{ userId: string; email: string; agentId: string; sbId: string } | null> {
+    const session = await this.dataComposer.repositories.memory.getSession(sessionId);
+    if (!session) {
+      logger.debug('Context-based auth: session not found', { sessionId });
+      return null;
+    }
+
+    if (session.endedAt) {
+      logger.debug('Context-based auth: session already ended', { sessionId });
+      return null;
+    }
+
+    if (session.agentId !== agentId) {
+      logger.warn('Context-based auth: agentId mismatch', {
+        sessionId,
+        sessionAgentId: session.agentId,
+        contextAgentId: agentId,
+      });
+      return null;
+    }
+
     const { data, error } = await this.dataComposer
       .getClient()
       .from('agent_identities')
       .select('id, user_id, users!inner(email)')
       .eq('agent_id', agentId)
-      .limit(1)
+      .eq('user_id', session.userId)
       .single();
 
     if (error || !data) {
-      logger.debug('Context-based auth: no identity found for agentId', { agentId });
+      logger.debug('Context-based auth: no identity found for session user+agent', {
+        agentId,
+        userId: session.userId,
+      });
       return null;
     }
 
     const email = (data.users as unknown as { email: string })?.email ?? '';
     return {
-      userId: data.user_id,
+      userId: session.userId,
       email,
       agentId,
       sbId: data.id,
@@ -272,13 +302,22 @@ export class MCPServer {
         contextToken = decodeContextToken(contextHeader);
       }
 
-      // Context-based auth fallback: when no OAuth token is present but the
-      // request carries an x-ink-context header with an agentId (injected by
-      // the `ink` CLI wrapper), resolve identity from agent_identities.
-      if (!userData && contextToken?.agentId) {
-        userData = await this.resolveUserFromAgentId(contextToken.agentId);
+      // Session-validated context auth: when NO Authorization header is present
+      // but the request carries an x-ink-context with a sessionId + agentId,
+      // verify the session exists and is active in the database. The session was
+      // created through an authenticated start_session call, so a matching
+      // active session proves the caller owns the identity.
+      //
+      // This is NOT attempted when an Authorization header IS present but
+      // invalid — that's a hard auth failure, not a fallback scenario.
+      if (!userData && !authHeader && contextToken?.sessionId && contextToken?.agentId) {
+        userData = await this.resolveUserFromContextSession(
+          contextToken.sessionId,
+          contextToken.agentId
+        );
         if (userData) {
-          logger.debug('Context-based auth: resolved identity from x-ink-context', {
+          logger.debug('Context-based auth: resolved identity from verified session', {
+            sessionId: contextToken.sessionId,
             agentId: contextToken.agentId,
             userId: userData.userId,
           });

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -18,6 +18,7 @@
     "@mantine/core": "^8.2.4",
     "@mantine/hooks": "^8.2.4",
     "@mantine/tiptap": "^8.2.4",
+    "@pixi/react": "^8.0.5",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-slot": "^1.1.1",
     "@radix-ui/react-tabs": "^1.1.13",
@@ -32,6 +33,7 @@
     "@tiptap/pm": "^3.2.0",
     "@tiptap/react": "^3.2.0",
     "@tiptap/starter-kit": "^3.2.0",
+    "@xyflow/react": "^12.10.2",
     "axios": "^1.15.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
@@ -39,12 +41,14 @@
     "lucide-react": "^0.469.0",
     "markdown-it": "^14.1.1",
     "next": "^16.2.3",
+    "pixi.js": "^8.18.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-markdown": "^9.0.1",
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^2.6.0",
-    "tiptap-markdown": "^0.9.0"
+    "tiptap-markdown": "^0.9.0",
+    "zustand": "^5.0.13"
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.15",

--- a/packages/web/src/app/(dashboard)/command/page.tsx
+++ b/packages/web/src/app/(dashboard)/command/page.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+
+const CommandCenter = dynamic(
+  () => import('@/components/command/command-center').then((m) => m.CommandCenter),
+  { ssr: false }
+);
+
+export default function CommandPage() {
+  return (
+    <div className="-m-8 h-[calc(100vh)]">
+      <CommandCenter />
+    </div>
+  );
+}

--- a/packages/web/src/components/command/activity-log.tsx
+++ b/packages/web/src/components/command/activity-log.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { useCommandStore } from './store';
+import { getSkin } from './skins';
+
+const AGENT_COLORS: Record<string, string> = {
+  wren: '#e94560',
+  lumen: '#0abde3',
+  aster: '#f9ca24',
+  myra: '#6c5ce7',
+  benson: '#00b894',
+};
+
+function formatTime(ts: string): string {
+  const d = new Date(ts);
+  return d.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+}
+
+export function ActivityLog() {
+  const skin = getSkin(useCommandStore((s) => s.skin));
+  const agents = useCommandStore((s) => s.agents);
+
+  return (
+    <div
+      className="h-full overflow-y-auto p-3 space-y-1"
+      style={{ backgroundColor: skin.colors.surface, color: skin.colors.text }}
+    >
+      <div
+        className="text-xs font-bold mb-2 tracking-wider uppercase"
+        style={{ fontFamily: skin.fonts.heading, color: skin.colors.accent, fontSize: '10px' }}
+      >
+        Activity Log
+      </div>
+
+      {agents.length === 0 ? (
+        <div className="text-xs" style={{ color: skin.colors.textMuted }}>
+          Waiting for data...
+        </div>
+      ) : (
+        agents.map((agent) => {
+          const color = AGENT_COLORS[agent.agentId] ?? '#888';
+          const phase = agent.phase ?? 'idle';
+          const updated = agent.updatedAt ? formatTime(agent.updatedAt) : '--:--';
+
+          return (
+            <div
+              key={agent.agentId}
+              className="flex items-center gap-2 py-1 px-2 rounded text-xs"
+              style={{
+                fontFamily: skin.fonts.mono,
+                backgroundColor: skin.colors.bg + '80',
+              }}
+            >
+              <span style={{ color: skin.colors.textMuted }}>{updated}</span>
+              <span className="font-bold" style={{ color }}>
+                {agent.name}
+              </span>
+              <span style={{ color: skin.colors.textMuted }}>→</span>
+              <span style={{ color: skin.colors.text }} className="truncate flex-1">
+                {phase}
+              </span>
+              {agent.lifecycle === 'running' && (
+                <span
+                  className="inline-block w-2 h-2 rounded-full animate-pulse"
+                  style={{ backgroundColor: skin.colors.agentActive }}
+                />
+              )}
+            </div>
+          );
+        })
+      )}
+
+      <div
+        className="text-xs mt-3 pt-2 border-t"
+        style={{
+          color: skin.colors.textMuted,
+          borderColor: skin.colors.border,
+          fontFamily: skin.fonts.mono,
+        }}
+      >
+        {agents.filter((a) => a.lifecycle === 'running').length} active · {agents.length} total SBs
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/command/agent-panel.tsx
+++ b/packages/web/src/components/command/agent-panel.tsx
@@ -1,0 +1,156 @@
+'use client';
+
+import { useCommandStore } from './store';
+import { getSkin } from './skins';
+
+const AGENT_COLORS: Record<string, string> = {
+  wren: '#e94560',
+  lumen: '#0abde3',
+  aster: '#f9ca24',
+  myra: '#6c5ce7',
+  benson: '#00b894',
+};
+
+function formatBackend(b: string | null): string {
+  if (!b) return 'Unknown';
+  const map: Record<string, string> = {
+    'claude-code': 'Claude Code',
+    'codex-cli': 'Codex CLI',
+    gemini: 'Gemini',
+  };
+  return map[b] ?? b;
+}
+
+export function AgentPanel() {
+  const skin = getSkin(useCommandStore((s) => s.skin));
+  const selectedAgent = useCommandStore((s) => s.selectedAgent);
+  const agents = useCommandStore((s) => s.agents);
+  const studios = useCommandStore((s) => s.studios);
+  const selectAgent = useCommandStore((s) => s.selectAgent);
+
+  const agent = agents.find((a) => a.agentId === selectedAgent);
+  if (!agent) return null;
+
+  const agentStudios = studios.filter((s) => s.agentId === agent.agentId);
+  const color = AGENT_COLORS[agent.agentId] ?? '#888';
+
+  return (
+    <div
+      className="absolute top-4 right-4 w-72 rounded-lg shadow-xl border overflow-hidden z-10"
+      style={{
+        backgroundColor: skin.colors.surface,
+        borderColor: skin.colors.border,
+        fontFamily: skin.fonts.body,
+      }}
+    >
+      {/* Header */}
+      <div className="p-4 border-b" style={{ borderColor: skin.colors.border }}>
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <div
+              className="w-10 h-10 rounded-lg flex items-center justify-center text-white font-bold"
+              style={{ backgroundColor: color }}
+            >
+              {agent.name.charAt(0).toUpperCase()}
+            </div>
+            <div>
+              <div className="font-bold" style={{ color: skin.colors.text }}>
+                {agent.name}
+              </div>
+              <div className="text-xs" style={{ color: skin.colors.textMuted }}>
+                {formatBackend(agent.backend)}
+              </div>
+            </div>
+          </div>
+          <button
+            onClick={() => selectAgent(null)}
+            className="text-lg leading-none hover:opacity-70"
+            style={{ color: skin.colors.textMuted }}
+          >
+            ×
+          </button>
+        </div>
+      </div>
+
+      {/* Status */}
+      <div className="p-4 space-y-3">
+        <div>
+          <div
+            className="text-[10px] uppercase tracking-wider mb-1"
+            style={{ color: skin.colors.textMuted }}
+          >
+            Status
+          </div>
+          <div className="flex items-center gap-2">
+            <div
+              className="w-2 h-2 rounded-full"
+              style={{
+                backgroundColor:
+                  agent.lifecycle === 'running'
+                    ? skin.colors.agentActive
+                    : agent.phase?.startsWith('blocked')
+                      ? skin.colors.agentBlocked
+                      : skin.colors.agentIdle,
+              }}
+            />
+            <span className="text-sm" style={{ color: skin.colors.text }}>
+              {agent.lifecycle ?? 'idle'}
+              {agent.phase ? ` · ${agent.phase}` : ''}
+            </span>
+          </div>
+        </div>
+
+        {agent.role && (
+          <div>
+            <div
+              className="text-[10px] uppercase tracking-wider mb-1"
+              style={{ color: skin.colors.textMuted }}
+            >
+              Role
+            </div>
+            <div className="text-sm" style={{ color: skin.colors.text }}>
+              {agent.role}
+            </div>
+          </div>
+        )}
+
+        {/* Studios */}
+        <div>
+          <div
+            className="text-[10px] uppercase tracking-wider mb-1"
+            style={{ color: skin.colors.textMuted }}
+          >
+            Studios ({agentStudios.length})
+          </div>
+          <div className="space-y-1">
+            {agentStudios.map((studio) => (
+              <div
+                key={studio.id}
+                className="flex items-center gap-2 px-2 py-1 rounded text-xs"
+                style={{ backgroundColor: skin.colors.bg }}
+              >
+                <div
+                  className="w-1.5 h-1.5 rounded-full shrink-0"
+                  style={{
+                    backgroundColor:
+                      studio.status === 'active'
+                        ? skin.colors.studioActive
+                        : skin.colors.studioIdle,
+                  }}
+                />
+                <span style={{ color: skin.colors.text }} className="truncate">
+                  {studio.slug ?? studio.branch}
+                </span>
+                {studio.workType && (
+                  <span style={{ color: skin.colors.textMuted }} className="shrink-0">
+                    {studio.workType}
+                  </span>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/command/command-center.tsx
+++ b/packages/web/src/components/command/command-center.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { useState } from 'react';
+import { useCommandStore } from './store';
+import { getSkin } from './skins';
+import { useCommandData } from './data-hooks';
+import { SpatialMap } from './spatial-map';
+import { TaskGraph } from './task-graph';
+import { ActivityLog } from './activity-log';
+import { AgentPanel } from './agent-panel';
+import { SkinPicker } from './skin-picker';
+
+type ViewMode = 'split' | 'map' | 'graph';
+
+export function CommandCenter() {
+  useCommandData();
+
+  const skin = getSkin(useCommandStore((s) => s.skin));
+  const [viewMode, setViewMode] = useState<ViewMode>('map');
+
+  return (
+    <div
+      className="h-screen flex flex-col overflow-hidden"
+      style={{ backgroundColor: skin.colors.bg, color: skin.colors.text }}
+    >
+      {/* Top bar */}
+      <div
+        className="flex items-center justify-between px-4 py-1.5 border-b shrink-0"
+        style={{
+          backgroundColor: skin.colors.surface,
+          borderColor: skin.colors.border,
+        }}
+      >
+        <div className="flex items-center gap-4">
+          <h1
+            className="text-xs font-bold tracking-wider"
+            style={{ fontFamily: skin.fonts.heading, color: skin.colors.accent }}
+          >
+            COMMAND CENTER
+          </h1>
+          <div className="flex items-center gap-1">
+            {(['split', 'map', 'graph'] as ViewMode[]).map((mode) => (
+              <button
+                key={mode}
+                onClick={() => setViewMode(mode)}
+                className="px-2 py-0.5 rounded text-xs transition-all"
+                style={{
+                  backgroundColor: viewMode === mode ? skin.colors.accent + '20' : 'transparent',
+                  color: viewMode === mode ? skin.colors.accent : skin.colors.textMuted,
+                  fontFamily: skin.fonts.mono,
+                  fontSize: '11px',
+                }}
+              >
+                {mode === 'split' ? 'SPLIT' : mode === 'map' ? 'MAP' : 'TASKS'}
+              </button>
+            ))}
+          </div>
+        </div>
+        <SkinPicker />
+      </div>
+
+      {/* Main content */}
+      <div className="flex-1 flex overflow-hidden">
+        {/* Left panel: spatial map + task graph */}
+        <div className="flex-1 flex flex-col relative">
+          {viewMode === 'split' ? (
+            <>
+              <div className="relative" style={{ height: '60%' }}>
+                <SpatialMap />
+                <AgentPanel />
+              </div>
+              <div className="border-t" style={{ borderColor: skin.colors.border, height: '40%' }}>
+                <TaskGraph />
+              </div>
+            </>
+          ) : viewMode === 'map' ? (
+            <div className="flex-1 relative">
+              <SpatialMap />
+              <AgentPanel />
+            </div>
+          ) : (
+            <div className="flex-1">
+              <TaskGraph />
+            </div>
+          )}
+        </div>
+
+        {/* Right panel: activity log */}
+        <div className="w-64 border-l shrink-0" style={{ borderColor: skin.colors.border }}>
+          <ActivityLog />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/command/data-hooks.ts
+++ b/packages/web/src/components/command/data-hooks.ts
@@ -1,0 +1,193 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useApiQuery } from '@/lib/api';
+import { useCommandStore } from './store';
+import type { AgentState, StudioNode, TaskNode, ActivityEvent } from './store';
+
+// ─── Types matching API responses ───
+
+interface StudioInfo {
+  id: string;
+  branch: string;
+  purpose: string | null;
+  workType: string | null;
+  worktreePath: string | null;
+  slug: string | null;
+  status: string;
+  updatedAt: string;
+}
+
+interface AgentLatestSession {
+  lifecycle: string | null;
+  currentPhase: string | null;
+  status: string | null;
+  updatedAt: string;
+  studioId: string | null;
+}
+
+interface AgentWithStudios {
+  agentId: string;
+  agentName: string;
+  agentRole: string | null;
+  backend: string | null;
+  sbId: string;
+  latestSession: AgentLatestSession | null;
+  studios: StudioInfo[];
+}
+
+interface StudiosResponse {
+  agents: AgentWithStudios[];
+}
+
+interface TaskItem {
+  id: string;
+  title: string;
+  status: string;
+  priority: string;
+  taskGroupId: string | null;
+  taskOrder: number | null;
+  createdBy: string | null;
+}
+
+interface TaskGroupItem {
+  id: string;
+  title: string;
+  ownerAgentId: string | null;
+}
+
+interface TasksResponse {
+  tasks: TaskItem[];
+  stats: Record<string, number>;
+}
+
+interface TaskGroupsResponse {
+  taskGroups: TaskGroupItem[];
+}
+
+// ─── Layout helpers ───
+
+function arrangeStudiosInCircle(
+  studios: StudioInfo[],
+  agentId: string,
+  centerX: number,
+  centerY: number,
+  radius: number
+): StudioNode[] {
+  return studios.map((s, i) => {
+    const angle = (2 * Math.PI * i) / Math.max(studios.length, 1) - Math.PI / 2;
+    return {
+      id: s.id,
+      slug: s.slug,
+      branch: s.branch,
+      purpose: s.purpose,
+      workType: s.workType,
+      status: s.status,
+      agentId,
+      position: {
+        x: centerX + radius * Math.cos(angle),
+        y: centerY + radius * Math.sin(angle),
+      },
+    };
+  });
+}
+
+// ─── Hooks ───
+
+export function useCommandData() {
+  const setAgents = useCommandStore((s) => s.setAgents);
+  const setStudios = useCommandStore((s) => s.setStudios);
+  const setTasks = useCommandStore((s) => s.setTasks);
+  const setActivity = useCommandStore((s) => s.setActivity);
+
+  const { data: studiosData } = useApiQuery<StudiosResponse>(
+    ['command-studios'],
+    '/api/admin/studios',
+    { refetchInterval: 5000 }
+  );
+
+  const { data: tasksData } = useApiQuery<TasksResponse>(
+    ['command-tasks'],
+    '/api/admin/tasks?activeOnly=true',
+    { refetchInterval: 10000 }
+  );
+
+  const { data: groupsData } = useApiQuery<TaskGroupsResponse>(
+    ['command-task-groups'],
+    '/api/admin/task-groups',
+    { refetchInterval: 10000 }
+  );
+
+  // Transform studios data into agent + studio state
+  useEffect(() => {
+    if (!studiosData?.agents) return;
+
+    const agentStates: AgentState[] = [];
+    const studioNodes: StudioNode[] = [];
+
+    const cols = Math.min(3, studiosData.agents.length);
+    const colSpacing = 200;
+    const rowSpacing = 200;
+
+    studiosData.agents.forEach((agent, agentIdx) => {
+      const col = agentIdx % cols;
+      const row = Math.floor(agentIdx / cols);
+      const rowCount = Math.min(cols, studiosData.agents.length - row * cols);
+      const centerX = (col - (rowCount - 1) / 2) * colSpacing;
+      const centerY = (row - Math.floor((studiosData.agents.length - 1) / cols) / 2) * rowSpacing;
+
+      const activeStudio = agent.studios.find((s) => s.status === 'active');
+
+      agentStates.push({
+        agentId: agent.agentId,
+        name: agent.agentName,
+        role: agent.agentRole,
+        backend: agent.backend,
+        studioId: activeStudio?.id ?? null,
+        studioSlug: activeStudio?.slug ?? null,
+        lifecycle: agent.latestSession?.lifecycle ?? null,
+        phase: agent.latestSession?.currentPhase ?? null,
+        updatedAt: agent.latestSession?.updatedAt ?? null,
+        position: { x: centerX, y: centerY },
+        targetPosition: null,
+      });
+
+      const arranged = arrangeStudiosInCircle(
+        agent.studios.filter((s) => s.status !== 'cleaned'),
+        agent.agentId,
+        centerX,
+        centerY,
+        65
+      );
+      studioNodes.push(...arranged);
+    });
+
+    setAgents(agentStates);
+    setStudios(studioNodes);
+  }, [studiosData, setAgents, setStudios]);
+
+  // Transform tasks
+  useEffect(() => {
+    if (!tasksData?.tasks) return;
+
+    const groupMap = new Map<string, string>();
+    if (groupsData?.taskGroups) {
+      for (const g of groupsData.taskGroups) {
+        groupMap.set(g.id, g.title);
+      }
+    }
+
+    const taskNodes: TaskNode[] = tasksData.tasks.map((t) => ({
+      id: t.id,
+      title: t.title,
+      status: t.status,
+      priority: t.priority,
+      groupId: t.taskGroupId,
+      groupTitle: t.taskGroupId ? (groupMap.get(t.taskGroupId) ?? null) : null,
+      taskOrder: t.taskOrder,
+      agentId: t.createdBy,
+    }));
+
+    setTasks(taskNodes);
+  }, [tasksData, groupsData, setTasks]);
+}

--- a/packages/web/src/components/command/skin-picker.tsx
+++ b/packages/web/src/components/command/skin-picker.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { useCommandStore, type SkinId } from './store';
+import { SKINS, getSkin } from './skins';
+
+export function SkinPicker() {
+  const currentSkin = useCommandStore((s) => s.skin);
+  const setSkin = useCommandStore((s) => s.setSkin);
+  const skin = getSkin(currentSkin);
+
+  return (
+    <div className="flex items-center gap-1">
+      {(Object.keys(SKINS) as SkinId[]).map((id) => {
+        const s = SKINS[id];
+        const isActive = id === currentSkin;
+        return (
+          <button
+            key={id}
+            onClick={() => setSkin(id)}
+            className="px-2 py-1 rounded text-xs transition-all"
+            style={{
+              backgroundColor: isActive ? skin.colors.accent + '30' : 'transparent',
+              color: isActive ? skin.colors.accent : skin.colors.textMuted,
+              border: isActive ? `1px solid ${skin.colors.accent}60` : '1px solid transparent',
+              fontFamily: skin.fonts.body,
+            }}
+          >
+            {s.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/web/src/components/command/skins.ts
+++ b/packages/web/src/components/command/skins.ts
@@ -1,0 +1,131 @@
+import type { SkinId } from './store';
+
+export interface SkinConfig {
+  id: SkinId;
+  label: string;
+  colors: {
+    bg: string;
+    surface: string;
+    border: string;
+    text: string;
+    textMuted: string;
+    accent: string;
+    agentIdle: string;
+    agentActive: string;
+    agentBlocked: string;
+    studioActive: string;
+    studioIdle: string;
+    taskPending: string;
+    taskInProgress: string;
+    taskCompleted: string;
+    taskBlocked: string;
+  };
+  fonts: {
+    heading: string;
+    body: string;
+    mono: string;
+  };
+  avatarStyle: 'pixel' | 'circle' | 'hex';
+  studioShape: 'rounded' | 'sharp' | 'hex';
+  animationSpeed: number;
+}
+
+const PIXEL_SKIN: SkinConfig = {
+  id: 'pixel',
+  label: '🎮 Pixel RPG',
+  colors: {
+    bg: '#1a1a2e',
+    surface: '#16213e',
+    border: '#0f3460',
+    text: '#e8e8e8',
+    textMuted: '#8888aa',
+    accent: '#e94560',
+    agentIdle: '#4ecca3',
+    agentActive: '#00d2ff',
+    agentBlocked: '#ff6b6b',
+    studioActive: '#4ecca3',
+    studioIdle: '#444466',
+    taskPending: '#8888aa',
+    taskInProgress: '#00d2ff',
+    taskCompleted: '#4ecca3',
+    taskBlocked: '#ff6b6b',
+  },
+  fonts: {
+    heading: '"Press Start 2P", monospace',
+    body: '"Courier New", monospace',
+    mono: '"Courier New", monospace',
+  },
+  avatarStyle: 'pixel',
+  studioShape: 'sharp',
+  animationSpeed: 1,
+};
+
+const SCIFI_SKIN: SkinConfig = {
+  id: 'scifi',
+  label: '🚀 Sci-Fi',
+  colors: {
+    bg: '#0a0a0f',
+    surface: '#111122',
+    border: '#1a1a3e',
+    text: '#c8d6e5',
+    textMuted: '#576574',
+    accent: '#0abde3',
+    agentIdle: '#10ac84',
+    agentActive: '#0abde3',
+    agentBlocked: '#ee5a24',
+    studioActive: '#10ac84',
+    studioIdle: '#333355',
+    taskPending: '#576574',
+    taskInProgress: '#0abde3',
+    taskCompleted: '#10ac84',
+    taskBlocked: '#ee5a24',
+  },
+  fonts: {
+    heading: '"Orbitron", sans-serif',
+    body: '"Rajdhani", sans-serif',
+    mono: '"Fira Code", monospace',
+  },
+  avatarStyle: 'hex',
+  studioShape: 'hex',
+  animationSpeed: 0.8,
+};
+
+const MINIMAL_SKIN: SkinConfig = {
+  id: 'minimal',
+  label: '📋 Minimal',
+  colors: {
+    bg: '#fafafa',
+    surface: '#ffffff',
+    border: '#e5e7eb',
+    text: '#111827',
+    textMuted: '#6b7280',
+    accent: '#3b82f6',
+    agentIdle: '#10b981',
+    agentActive: '#3b82f6',
+    agentBlocked: '#ef4444',
+    studioActive: '#10b981',
+    studioIdle: '#d1d5db',
+    taskPending: '#9ca3af',
+    taskInProgress: '#3b82f6',
+    taskCompleted: '#10b981',
+    taskBlocked: '#ef4444',
+  },
+  fonts: {
+    heading: '"Inter", sans-serif',
+    body: '"Inter", sans-serif',
+    mono: '"JetBrains Mono", monospace',
+  },
+  avatarStyle: 'circle',
+  studioShape: 'rounded',
+  animationSpeed: 0.6,
+};
+
+export const SKINS: Record<SkinId, SkinConfig> = {
+  pixel: PIXEL_SKIN,
+  scifi: SCIFI_SKIN,
+  minimal: MINIMAL_SKIN,
+};
+
+export function getSkin(id: SkinId): SkinConfig {
+  return SKINS[id];
+}

--- a/packages/web/src/components/command/spatial-map.tsx
+++ b/packages/web/src/components/command/spatial-map.tsx
@@ -1,0 +1,663 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCommandStore } from './store';
+import { getSkin } from './skins';
+import type { SkinConfig } from './skins';
+import type { AgentState, StudioNode } from './store';
+
+const AGENT_COLORS: Record<string, string> = {
+  wren: '#e94560',
+  lumen: '#0abde3',
+  aster: '#f9ca24',
+  myra: '#6c5ce7',
+  benson: '#00b894',
+  echo: '#ff9ff3',
+};
+
+function getAgentColor(agentId: string): string {
+  return AGENT_COLORS[agentId] ?? '#888888';
+}
+
+function getPhaseLabel(phase: string | null): string {
+  if (!phase) return 'idle';
+  if (phase.startsWith('active:')) return phase.slice(7);
+  if (phase.startsWith('blocked:')) return 'BLOCKED';
+  if (phase.startsWith('waiting:')) return phase.split(':').slice(1).join(':');
+  return phase;
+}
+
+function getLifecycleIcon(lifecycle: string | null, phase: string | null): string {
+  if (phase?.startsWith('blocked')) return '!!';
+  if (lifecycle === 'running') return '>>';
+  if (lifecycle === 'failed') return 'XX';
+  if (lifecycle === 'completed') return 'OK';
+  return 'zz';
+}
+
+function hexPath(ctx: CanvasRenderingContext2D, cx: number, cy: number, r: number) {
+  ctx.beginPath();
+  for (let i = 0; i < 6; i++) {
+    const angle = (Math.PI / 3) * i - Math.PI / 6;
+    const x = cx + r * Math.cos(angle);
+    const y = cy + r * Math.sin(angle);
+    if (i === 0) ctx.moveTo(x, y);
+    else ctx.lineTo(x, y);
+  }
+  ctx.closePath();
+}
+
+function drawPixelChar(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  size: number,
+  color: string,
+  isRunning: boolean
+) {
+  const s = size / 8;
+  ctx.fillStyle = color;
+
+  // Body (wider rectangle)
+  ctx.fillRect(x - 3 * s, y - 3 * s, 6 * s, 7 * s);
+  // Head (top block)
+  ctx.fillRect(x - 2.5 * s, y - 4.5 * s, 5 * s, 2 * s);
+
+  // Eyes
+  ctx.fillStyle = '#ffffff';
+  ctx.fillRect(x - 2 * s, y - 3.5 * s, 1.5 * s, 1.5 * s);
+  ctx.fillRect(x + 0.5 * s, y - 3.5 * s, 1.5 * s, 1.5 * s);
+
+  // Pupils
+  ctx.fillStyle = '#000000';
+  ctx.fillRect(x - 1.5 * s, y - 3 * s, s, s);
+  ctx.fillRect(x + 1 * s, y - 3 * s, s, s);
+
+  // Mouth (changes with state)
+  ctx.fillStyle = '#ffffff';
+  if (isRunning) {
+    ctx.fillRect(x - 1.5 * s, y + 0.5 * s, 3 * s, s);
+  } else {
+    ctx.fillRect(x - s, y + 0.5 * s, 2 * s, 0.5 * s);
+  }
+
+  // Arms
+  ctx.fillStyle = color;
+  ctx.fillRect(x - 4.5 * s, y - 2 * s, 1.5 * s, 4 * s);
+  ctx.fillRect(x + 3 * s, y - 2 * s, 1.5 * s, 4 * s);
+
+  // Legs
+  ctx.fillRect(x - 2.5 * s, y + 4 * s, 2 * s, 2 * s);
+  ctx.fillRect(x + 0.5 * s, y + 4 * s, 2 * s, 2 * s);
+}
+
+function drawStatusBar(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  fillPct: number,
+  fillColor: string,
+  bgColor: string
+) {
+  ctx.fillStyle = bgColor;
+  ctx.fillRect(x, y, width, height);
+  ctx.fillStyle = fillColor;
+  ctx.fillRect(x, y, width * Math.max(0, Math.min(1, fillPct)), height);
+  ctx.strokeStyle = fillColor + '80';
+  ctx.lineWidth = 1;
+  ctx.strokeRect(x, y, width, height);
+}
+
+function drawStudio(
+  ctx: CanvasRenderingContext2D,
+  skin: SkinConfig,
+  studio: StudioNode,
+  pos: { x: number; y: number },
+  z: number,
+  timestamp: number
+) {
+  const isActive = studio.status === 'active';
+  const baseColor = isActive ? skin.colors.studioActive : skin.colors.studioIdle;
+  const radius = 28 * z;
+
+  if (skin.studioShape === 'hex') {
+    hexPath(ctx, pos.x, pos.y, radius);
+    ctx.fillStyle = baseColor + '18';
+    ctx.fill();
+    ctx.strokeStyle = baseColor + '50';
+    ctx.lineWidth = 1.5;
+    ctx.stroke();
+  } else if (skin.studioShape === 'sharp') {
+    const r = radius * 0.85;
+    ctx.fillStyle = baseColor + '18';
+    ctx.fillRect(pos.x - r, pos.y - r, r * 2, r * 2);
+    ctx.strokeStyle = baseColor + '50';
+    ctx.lineWidth = 1.5;
+    ctx.strokeRect(pos.x - r, pos.y - r, r * 2, r * 2);
+
+    // Corner ticks for pixel style
+    const tickLen = 5 * z;
+    ctx.strokeStyle = baseColor + '70';
+    ctx.lineWidth = 2;
+    const corners = [
+      [pos.x - r, pos.y - r],
+      [pos.x + r, pos.y - r],
+      [pos.x - r, pos.y + r],
+      [pos.x + r, pos.y + r],
+    ];
+    for (const [cx, cy] of corners) {
+      ctx.beginPath();
+      ctx.moveTo(cx, cy);
+      ctx.lineTo(cx + (cx < pos.x ? tickLen : -tickLen), cy);
+      ctx.stroke();
+      ctx.beginPath();
+      ctx.moveTo(cx, cy);
+      ctx.lineTo(cx, cy + (cy < pos.y ? tickLen : -tickLen));
+      ctx.stroke();
+    }
+  } else {
+    ctx.beginPath();
+    ctx.arc(pos.x, pos.y, radius, 0, Math.PI * 2);
+    ctx.fillStyle = baseColor + '18';
+    ctx.fill();
+    ctx.strokeStyle = baseColor + '50';
+    ctx.lineWidth = 1.5;
+    ctx.stroke();
+  }
+
+  // Active studio pulse
+  if (isActive) {
+    const pulse = Math.sin(timestamp / 1200) * 0.15 + 0.85;
+    ctx.strokeStyle =
+      baseColor +
+      Math.round(pulse * 40)
+        .toString(16)
+        .padStart(2, '0');
+    ctx.lineWidth = 1;
+    if (skin.studioShape === 'hex') {
+      hexPath(ctx, pos.x, pos.y, radius + 4 * z * pulse);
+      ctx.stroke();
+    } else if (skin.studioShape === 'sharp') {
+      const r2 = radius * 0.85 + 4 * z * pulse;
+      ctx.strokeRect(pos.x - r2, pos.y - r2, r2 * 2, r2 * 2);
+    } else {
+      ctx.beginPath();
+      ctx.arc(pos.x, pos.y, radius + 4 * z * pulse, 0, Math.PI * 2);
+      ctx.stroke();
+    }
+  }
+
+  // Label
+  const label = studio.slug ?? studio.branch.split('/').pop() ?? '?';
+  ctx.fillStyle = skin.colors.textMuted + 'cc';
+  ctx.font = `${Math.max(8, 9 * z)}px ${skin.fonts.mono}`;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'top';
+  ctx.fillText(label, pos.x, pos.y + radius + 4 * z);
+}
+
+function drawAgent(
+  ctx: CanvasRenderingContext2D,
+  skin: SkinConfig,
+  agent: AgentState,
+  pos: { x: number; y: number },
+  z: number,
+  timestamp: number,
+  isSelected: boolean
+) {
+  const color = getAgentColor(agent.agentId);
+  const agentRadius = 26 * z;
+  const isRunning = agent.lifecycle === 'running';
+
+  // Pulse ring for running agents
+  if (isRunning) {
+    const pulse = Math.sin(timestamp / 400) * 0.4 + 0.6;
+    const alpha = Math.round(pulse * 60)
+      .toString(16)
+      .padStart(2, '0');
+    ctx.strokeStyle = color + alpha;
+    ctx.lineWidth = 2 * z;
+
+    if (skin.avatarStyle === 'hex') {
+      hexPath(ctx, pos.x, pos.y, agentRadius + 10 * z * pulse);
+      ctx.stroke();
+    } else {
+      ctx.beginPath();
+      ctx.arc(pos.x, pos.y, agentRadius + 10 * z * pulse, 0, Math.PI * 2);
+      ctx.stroke();
+    }
+  }
+
+  // Selection ring
+  if (isSelected) {
+    ctx.strokeStyle = skin.colors.accent;
+    ctx.lineWidth = 2.5 * z;
+    ctx.setLineDash([4 * z, 3 * z]);
+    if (skin.avatarStyle === 'hex') {
+      hexPath(ctx, pos.x, pos.y, agentRadius + 6 * z);
+      ctx.stroke();
+    } else {
+      ctx.beginPath();
+      ctx.arc(pos.x, pos.y, agentRadius + 6 * z, 0, Math.PI * 2);
+      ctx.stroke();
+    }
+    ctx.setLineDash([]);
+  }
+
+  // Agent body
+  if (skin.avatarStyle === 'pixel') {
+    // Background square
+    ctx.fillStyle = color + '30';
+    ctx.fillRect(pos.x - agentRadius, pos.y - agentRadius, agentRadius * 2, agentRadius * 2);
+    ctx.strokeStyle = color + '60';
+    ctx.lineWidth = 2;
+    ctx.strokeRect(pos.x - agentRadius, pos.y - agentRadius, agentRadius * 2, agentRadius * 2);
+    drawPixelChar(ctx, pos.x, pos.y - 2 * z, agentRadius * 1.6, color, isRunning);
+  } else if (skin.avatarStyle === 'hex') {
+    // Hex avatar
+    hexPath(ctx, pos.x, pos.y, agentRadius);
+    const grad = ctx.createRadialGradient(pos.x, pos.y, 0, pos.x, pos.y, agentRadius);
+    grad.addColorStop(0, color);
+    grad.addColorStop(1, color + 'aa');
+    ctx.fillStyle = grad;
+    ctx.fill();
+    ctx.strokeStyle = color;
+    ctx.lineWidth = 2;
+    ctx.stroke();
+
+    // Initial letter
+    ctx.fillStyle = '#ffffff';
+    ctx.font = `bold ${16 * z}px ${skin.fonts.body}`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText(agent.name.charAt(0).toUpperCase(), pos.x, pos.y);
+  } else {
+    // Circle avatar with gradient
+    ctx.beginPath();
+    ctx.arc(pos.x, pos.y, agentRadius, 0, Math.PI * 2);
+    const grad = ctx.createRadialGradient(
+      pos.x - agentRadius * 0.3,
+      pos.y - agentRadius * 0.3,
+      0,
+      pos.x,
+      pos.y,
+      agentRadius
+    );
+    grad.addColorStop(0, color + 'ff');
+    grad.addColorStop(1, color + 'cc');
+    ctx.fillStyle = grad;
+    ctx.fill();
+
+    // Subtle border
+    ctx.strokeStyle = color;
+    ctx.lineWidth = 1.5;
+    ctx.stroke();
+
+    // Initial
+    ctx.fillStyle = '#ffffff';
+    ctx.font = `bold ${16 * z}px ${skin.fonts.body}`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText(agent.name.charAt(0).toUpperCase(), pos.x, pos.y);
+  }
+
+  // Name label
+  ctx.fillStyle = skin.colors.text;
+  ctx.font = `bold ${Math.max(10, 13 * z)}px ${skin.fonts.body}`;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'top';
+  ctx.fillText(agent.name, pos.x, pos.y + agentRadius + 6 * z);
+
+  // Status bar (HP-bar style)
+  const barWidth = 50 * z;
+  const barHeight = 4 * z;
+  const barY = pos.y + agentRadius + 22 * z;
+  const statusPct = isRunning
+    ? 1.0
+    : agent.lifecycle === 'completed'
+      ? 1.0
+      : agent.phase?.startsWith('blocked')
+        ? 0.3
+        : 0.5;
+  const barColor = isRunning
+    ? skin.colors.agentActive
+    : agent.phase?.startsWith('blocked')
+      ? skin.colors.agentBlocked
+      : skin.colors.agentIdle;
+  drawStatusBar(
+    ctx,
+    pos.x - barWidth / 2,
+    barY,
+    barWidth,
+    barHeight,
+    statusPct,
+    barColor,
+    skin.colors.bg + 'cc'
+  );
+
+  // Phase text
+  const icon = getLifecycleIcon(agent.lifecycle, agent.phase);
+  const phaseText = `[${icon}] ${getPhaseLabel(agent.phase)}`;
+  ctx.fillStyle = skin.colors.textMuted;
+  ctx.font = `${Math.max(8, 10 * z)}px ${skin.fonts.mono}`;
+  ctx.textAlign = 'center';
+  ctx.fillText(phaseText, pos.x, barY + barHeight + 6 * z);
+}
+
+export function SpatialMap() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const animFrameRef = useRef<number>(0);
+  const timeRef = useRef(0);
+
+  const skin = useCommandStore((s) => getSkin(s.skin));
+  const agents = useCommandStore((s) => s.agents);
+  const studios = useCommandStore((s) => s.studios);
+  const selectedAgent = useCommandStore((s) => s.selectedAgent);
+  const selectAgent = useCommandStore((s) => s.selectAgent);
+
+  const [camera, setCamera] = useState({ x: 0, y: 0, zoom: 0.7 });
+  const hasAutoFit = useRef(false);
+  const [isDragging, setIsDragging] = useState(false);
+  const dragStart = useRef({ x: 0, y: 0, camX: 0, camY: 0 });
+
+  // Auto-fit camera on first data load (deferred to ensure layout is ready)
+  useEffect(() => {
+    if (hasAutoFit.current || agents.length === 0) return;
+
+    const fitCamera = () => {
+      const container = containerRef.current;
+      if (!container || container.clientWidth === 0) {
+        requestAnimationFrame(fitCamera);
+        return;
+      }
+      hasAutoFit.current = true;
+
+      const allPositions = [...agents.map((a) => a.position), ...studios.map((s) => s.position)];
+      if (allPositions.length === 0) return;
+
+      const pad = 120;
+      const minX = Math.min(...allPositions.map((p) => p.x)) - pad;
+      const maxX = Math.max(...allPositions.map((p) => p.x)) + pad;
+      const minY = Math.min(...allPositions.map((p) => p.y)) - pad;
+      const maxY = Math.max(...allPositions.map((p) => p.y)) + pad;
+
+      const cw = container.clientWidth;
+      const ch = container.clientHeight;
+
+      const worldW = maxX - minX;
+      const worldH = maxY - minY;
+      const zoom = Math.min(cw / worldW, ch / worldH, 1.5) * 0.85;
+
+      setCamera({
+        x: -(minX + maxX) / 2,
+        y: -(minY + maxY) / 2,
+        zoom,
+      });
+    };
+
+    requestAnimationFrame(fitCamera);
+  }, [agents, studios]);
+
+  // Handle canvas resize
+  useEffect(() => {
+    const container = containerRef.current;
+    const canvas = canvasRef.current;
+    if (!container || !canvas) return;
+
+    const observer = new ResizeObserver(() => {
+      canvas.width = container.clientWidth * window.devicePixelRatio;
+      canvas.height = container.clientHeight * window.devicePixelRatio;
+      canvas.style.width = `${container.clientWidth}px`;
+      canvas.style.height = `${container.clientHeight}px`;
+    });
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, []);
+
+  // Mouse handlers for pan
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      setIsDragging(true);
+      dragStart.current = {
+        x: e.clientX,
+        y: e.clientY,
+        camX: camera.x,
+        camY: camera.y,
+      };
+    },
+    [camera]
+  );
+
+  const handleMouseMove = useCallback(
+    (e: React.MouseEvent) => {
+      if (!isDragging) return;
+      const dx = e.clientX - dragStart.current.x;
+      const dy = e.clientY - dragStart.current.y;
+      setCamera((c) => ({
+        ...c,
+        x: dragStart.current.camX + dx,
+        y: dragStart.current.camY + dy,
+      }));
+    },
+    [isDragging]
+  );
+
+  const handleMouseUp = useCallback(() => setIsDragging(false), []);
+
+  const handleWheel = useCallback((e: React.WheelEvent) => {
+    e.preventDefault();
+    const delta = e.deltaY > 0 ? 0.9 : 1.1;
+    setCamera((c) => ({
+      ...c,
+      zoom: Math.max(0.2, Math.min(3, c.zoom * delta)),
+    }));
+  }, []);
+
+  // Click handler for selecting agents
+  const handleClick = useCallback(
+    (e: React.MouseEvent) => {
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+      const rect = canvas.getBoundingClientRect();
+      const dpr = window.devicePixelRatio;
+      const mx = (e.clientX - rect.left) * dpr;
+      const my = (e.clientY - rect.top) * dpr;
+
+      const z = camera.zoom * dpr;
+      for (const agent of agents) {
+        const sx = (agent.position.x + camera.x) * z + canvas.width / 2;
+        const sy = (agent.position.y + camera.y) * z + canvas.height / 2;
+        const dist = Math.sqrt((mx - sx) ** 2 + (my - sy) ** 2);
+        if (dist < 35 * z) {
+          selectAgent(selectedAgent === agent.agentId ? null : agent.agentId);
+          return;
+        }
+      }
+      selectAgent(null);
+    },
+    [agents, camera, selectedAgent, selectAgent]
+  );
+
+  // Main render loop
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    function draw(timestamp: number) {
+      timeRef.current = timestamp;
+      const dpr = window.devicePixelRatio;
+      const w = canvas!.width;
+      const h = canvas!.height;
+      const z = camera.zoom * dpr;
+
+      ctx!.clearRect(0, 0, w, h);
+
+      // Background gradient
+      const bgGrad = ctx!.createLinearGradient(0, 0, 0, h);
+      bgGrad.addColorStop(0, skin.colors.bg);
+      bgGrad.addColorStop(1, skin.colors.surface);
+      ctx!.fillStyle = bgGrad;
+      ctx!.fillRect(0, 0, w, h);
+
+      // Grid
+      ctx!.strokeStyle = skin.colors.border + '25';
+      ctx!.lineWidth = 1;
+      const gridSize = 50 * z;
+      const offsetX = ((((camera.x * z) % gridSize) + gridSize) % gridSize) + ((w / 2) % gridSize);
+      const offsetY = ((((camera.y * z) % gridSize) + gridSize) % gridSize) + ((h / 2) % gridSize);
+      for (let x = offsetX - gridSize; x < w + gridSize; x += gridSize) {
+        ctx!.beginPath();
+        ctx!.moveTo(x, 0);
+        ctx!.lineTo(x, h);
+        ctx!.stroke();
+      }
+      for (let y = offsetY - gridSize; y < h + gridSize; y += gridSize) {
+        ctx!.beginPath();
+        ctx!.moveTo(0, y);
+        ctx!.lineTo(w, y);
+        ctx!.stroke();
+      }
+
+      // Major grid lines (every 4th)
+      ctx!.strokeStyle = skin.colors.border + '10';
+      ctx!.lineWidth = 2;
+      const majorGrid = gridSize * 4;
+      const majorOffX =
+        ((((camera.x * z) % majorGrid) + majorGrid) % majorGrid) + ((w / 2) % majorGrid);
+      const majorOffY =
+        ((((camera.y * z) % majorGrid) + majorGrid) % majorGrid) + ((h / 2) % majorGrid);
+      for (let x = majorOffX - majorGrid; x < w + majorGrid; x += majorGrid) {
+        ctx!.beginPath();
+        ctx!.moveTo(x, 0);
+        ctx!.lineTo(x, h);
+        ctx!.stroke();
+      }
+      for (let y = majorOffY - majorGrid; y < h + majorGrid; y += majorGrid) {
+        ctx!.beginPath();
+        ctx!.moveTo(0, y);
+        ctx!.lineTo(w, y);
+        ctx!.stroke();
+      }
+
+      const toScreen = (px: number, py: number) => ({
+        x: (px + camera.x) * z + w / 2,
+        y: (py + camera.y) * z + h / 2,
+      });
+
+      // Draw agent territory zones (subtle colored regions)
+      for (const agent of agents) {
+        const pos = toScreen(agent.position.x, agent.position.y);
+        const color = getAgentColor(agent.agentId);
+        const territoryRadius = 140 * z;
+
+        const grad = ctx!.createRadialGradient(pos.x, pos.y, 0, pos.x, pos.y, territoryRadius);
+        grad.addColorStop(0, color + '0a');
+        grad.addColorStop(0.7, color + '04');
+        grad.addColorStop(1, color + '00');
+        ctx!.fillStyle = grad;
+        ctx!.beginPath();
+        ctx!.arc(pos.x, pos.y, territoryRadius, 0, Math.PI * 2);
+        ctx!.fill();
+      }
+
+      // Draw studios
+      for (const studio of studios) {
+        const pos = toScreen(studio.position.x, studio.position.y);
+        drawStudio(ctx!, skin, studio, pos, z, timestamp);
+      }
+
+      // Draw connections from agents to studios
+      for (const agent of agents) {
+        const agentStudios = studios.filter((s) => s.agentId === agent.agentId);
+        for (const studio of agentStudios) {
+          const from = toScreen(agent.position.x, agent.position.y);
+          const to = toScreen(studio.position.x, studio.position.y);
+          const color = getAgentColor(agent.agentId);
+          const isActive = studio.id === agent.studioId;
+
+          ctx!.strokeStyle = isActive ? color + '50' : color + '20';
+          ctx!.lineWidth = isActive ? 2 * z : 1 * z;
+          ctx!.setLineDash(isActive ? [] : [3 * z, 3 * z]);
+          ctx!.beginPath();
+          ctx!.moveTo(from.x, from.y);
+          ctx!.lineTo(to.x, to.y);
+          ctx!.stroke();
+          ctx!.setLineDash([]);
+
+          // Arrow head for active connection
+          if (isActive) {
+            const angle = Math.atan2(to.y - from.y, to.x - from.x);
+            const arrowLen = 8 * z;
+            const midX = (from.x + to.x) / 2;
+            const midY = (from.y + to.y) / 2;
+            ctx!.fillStyle = color + '50';
+            ctx!.beginPath();
+            ctx!.moveTo(midX + arrowLen * Math.cos(angle), midY + arrowLen * Math.sin(angle));
+            ctx!.lineTo(
+              midX + arrowLen * Math.cos(angle + 2.5),
+              midY + arrowLen * Math.sin(angle + 2.5)
+            );
+            ctx!.lineTo(
+              midX + arrowLen * Math.cos(angle - 2.5),
+              midY + arrowLen * Math.sin(angle - 2.5)
+            );
+            ctx!.fill();
+          }
+        }
+      }
+
+      // Draw agents (on top of everything)
+      for (const agent of agents) {
+        const pos = toScreen(agent.position.x, agent.position.y);
+        const isSelected = selectedAgent === agent.agentId;
+        drawAgent(ctx!, skin, agent, pos, z, timestamp, isSelected);
+      }
+
+      // HUD: title
+      ctx!.fillStyle = skin.colors.text + 'cc';
+      ctx!.font = `bold ${12 * dpr}px ${skin.fonts.heading}`;
+      ctx!.textAlign = 'left';
+      ctx!.textBaseline = 'top';
+      ctx!.fillText('COMMAND CENTER', 14 * dpr, 12 * dpr);
+
+      // HUD: agent count
+      const running = agents.filter((a) => a.lifecycle === 'running').length;
+      ctx!.fillStyle = skin.colors.textMuted;
+      ctx!.font = `${10 * dpr}px ${skin.fonts.mono}`;
+      ctx!.fillText(
+        `${running} active / ${agents.length} agents · ${studios.length} studios`,
+        14 * dpr,
+        28 * dpr
+      );
+
+      // HUD: zoom indicator
+      ctx!.textAlign = 'right';
+      ctx!.fillText(`${Math.round(camera.zoom * 100)}%`, w - 14 * dpr, 12 * dpr);
+
+      animFrameRef.current = requestAnimationFrame(draw);
+    }
+
+    animFrameRef.current = requestAnimationFrame(draw);
+    return () => cancelAnimationFrame(animFrameRef.current);
+  }, [agents, studios, camera, skin, selectedAgent]);
+
+  return (
+    <div
+      ref={containerRef}
+      className="relative w-full h-full cursor-grab active:cursor-grabbing"
+      onMouseDown={handleMouseDown}
+      onMouseMove={handleMouseMove}
+      onMouseUp={handleMouseUp}
+      onMouseLeave={handleMouseUp}
+      onWheel={handleWheel}
+      onClick={handleClick}
+    >
+      <canvas ref={canvasRef} className="block w-full h-full" />
+    </div>
+  );
+}

--- a/packages/web/src/components/command/store.ts
+++ b/packages/web/src/components/command/store.ts
@@ -1,0 +1,114 @@
+import { create } from 'zustand';
+
+// ─── Types ───
+
+export type SkinId = 'pixel' | 'scifi' | 'minimal';
+
+export interface AgentState {
+  agentId: string;
+  name: string;
+  role: string | null;
+  backend: string | null;
+  studioId: string | null;
+  studioSlug: string | null;
+  lifecycle: string | null;
+  phase: string | null;
+  updatedAt: string | null;
+  position: { x: number; y: number };
+  targetPosition: { x: number; y: number } | null;
+}
+
+export interface StudioNode {
+  id: string;
+  slug: string | null;
+  branch: string;
+  purpose: string | null;
+  workType: string | null;
+  status: string;
+  agentId: string;
+  position: { x: number; y: number };
+}
+
+export interface TaskNode {
+  id: string;
+  title: string;
+  status: string;
+  priority: string;
+  groupId: string | null;
+  groupTitle: string | null;
+  taskOrder: number | null;
+  agentId: string | null;
+}
+
+export interface ActivityEvent {
+  id: string;
+  type: string;
+  agentId: string | null;
+  content: string;
+  timestamp: string;
+}
+
+export interface ChatMessage {
+  id: string;
+  from: string;
+  to: string | null;
+  content: string;
+  timestamp: string;
+  threadKey: string | null;
+}
+
+// ─── Store ───
+
+interface CommandStore {
+  skin: SkinId;
+  setSkin: (skin: SkinId) => void;
+
+  agents: AgentState[];
+  setAgents: (agents: AgentState[]) => void;
+
+  studios: StudioNode[];
+  setStudios: (studios: StudioNode[]) => void;
+
+  tasks: TaskNode[];
+  setTasks: (tasks: TaskNode[]) => void;
+
+  activity: ActivityEvent[];
+  addActivity: (event: ActivityEvent) => void;
+  setActivity: (events: ActivityEvent[]) => void;
+
+  selectedAgent: string | null;
+  selectAgent: (agentId: string | null) => void;
+
+  selectedStudio: string | null;
+  selectStudio: (studioId: string | null) => void;
+
+  showTaskGraph: boolean;
+  toggleTaskGraph: () => void;
+}
+
+export const useCommandStore = create<CommandStore>((set) => ({
+  skin: 'pixel',
+  setSkin: (skin) => set({ skin }),
+
+  agents: [],
+  setAgents: (agents) => set({ agents }),
+
+  studios: [],
+  setStudios: (studios) => set({ studios }),
+
+  tasks: [],
+  setTasks: (tasks) => set({ tasks }),
+
+  activity: [],
+  addActivity: (event) => set((s) => ({ activity: [event, ...s.activity].slice(0, 100) })),
+  setActivity: (events) => set({ activity: events }),
+
+  selectedAgent: null,
+  selectAgent: (agentId) => set({ selectedAgent: agentId }),
+
+  selectedStudio: null,
+  selectStudio: (studioId) => set({ selectedStudio: studioId }),
+
+  showTaskGraph: true,
+  toggleTaskGraph: () => set((s) => ({ showTaskGraph: !s.showTaskGraph })),
+}));

--- a/packages/web/src/components/command/task-graph.tsx
+++ b/packages/web/src/components/command/task-graph.tsx
@@ -1,0 +1,240 @@
+'use client';
+
+import { useMemo } from 'react';
+import {
+  ReactFlow,
+  Background,
+  Controls,
+  MiniMap,
+  type Node,
+  type Edge,
+  type NodeTypes,
+  Handle,
+  Position,
+} from '@xyflow/react';
+import '@xyflow/react/dist/style.css';
+import { useCommandStore } from './store';
+import { getSkin } from './skins';
+
+// ─── Custom Task Node ───
+
+function TaskNodeComponent({ data }: { data: Record<string, unknown> }) {
+  const skin = getSkin(useCommandStore((s) => s.skin));
+  const status = data.status as string;
+  const title = data.label as string;
+  const priority = data.priority as string;
+
+  const statusColor =
+    status === 'completed'
+      ? skin.colors.taskCompleted
+      : status === 'in_progress'
+        ? skin.colors.taskInProgress
+        : status === 'blocked'
+          ? skin.colors.taskBlocked
+          : skin.colors.taskPending;
+
+  const priorityBadge =
+    priority === 'critical' ? '🔴' : priority === 'high' ? '🟠' : priority === 'medium' ? '🟡' : '';
+
+  return (
+    <div
+      className="px-3 py-2 rounded shadow-lg border-2 min-w-[140px] max-w-[200px]"
+      style={{
+        backgroundColor: skin.colors.surface,
+        borderColor: statusColor,
+        fontFamily: skin.fonts.body,
+      }}
+    >
+      <Handle type="target" position={Position.Left} className="!bg-gray-400" />
+      <div className="flex items-center gap-1.5">
+        <div className="w-2 h-2 rounded-full shrink-0" style={{ backgroundColor: statusColor }} />
+        <span className="text-xs font-medium truncate" style={{ color: skin.colors.text }}>
+          {priorityBadge} {title}
+        </span>
+      </div>
+      <div className="text-[10px] mt-1" style={{ color: skin.colors.textMuted }}>
+        {status}
+        {data.agentId ? ` · ${data.agentId}` : ''}
+      </div>
+      <Handle type="source" position={Position.Right} className="!bg-gray-400" />
+    </div>
+  );
+}
+
+function GroupHeaderNode({ data }: { data: Record<string, unknown> }) {
+  const skin = getSkin(useCommandStore((s) => s.skin));
+
+  return (
+    <div
+      className="px-4 py-2 rounded-lg border"
+      style={{
+        backgroundColor: skin.colors.accent + '15',
+        borderColor: skin.colors.accent + '40',
+        fontFamily: skin.fonts.heading,
+      }}
+    >
+      <span className="text-xs font-bold" style={{ color: skin.colors.accent }}>
+        📋 {data.label as string}
+      </span>
+      <Handle type="source" position={Position.Right} className="!bg-gray-400" />
+    </div>
+  );
+}
+
+const nodeTypes: NodeTypes = {
+  taskNode: TaskNodeComponent,
+  groupHeader: GroupHeaderNode,
+};
+
+// ─── Task Graph Component ───
+
+export function TaskGraph() {
+  const skin = getSkin(useCommandStore((s) => s.skin));
+  const tasks = useCommandStore((s) => s.tasks);
+
+  const { nodes, edges } = useMemo(() => {
+    const n: Node[] = [];
+    const e: Edge[] = [];
+
+    // Group tasks by groupId
+    const groups = new Map<string, typeof tasks>();
+    const ungrouped: typeof tasks = [];
+
+    for (const task of tasks) {
+      if (task.groupId) {
+        const group = groups.get(task.groupId) ?? [];
+        group.push(task);
+        groups.set(task.groupId, group);
+      } else {
+        ungrouped.push(task);
+      }
+    }
+
+    let yOffset = 0;
+
+    // Render grouped tasks
+    for (const [groupId, groupTasks] of groups) {
+      const sorted = [...groupTasks].sort((a, b) => (a.taskOrder ?? 0) - (b.taskOrder ?? 0));
+      const groupTitle = sorted[0]?.groupTitle ?? 'Task Group';
+
+      n.push({
+        id: `group-${groupId}`,
+        type: 'groupHeader',
+        position: { x: 0, y: yOffset },
+        data: { label: groupTitle },
+      });
+
+      sorted.forEach((task, i) => {
+        const nodeId = `task-${task.id}`;
+        n.push({
+          id: nodeId,
+          type: 'taskNode',
+          position: { x: 200 + i * 220, y: yOffset },
+          data: {
+            label: task.title,
+            status: task.status,
+            priority: task.priority,
+            agentId: task.agentId,
+          },
+        });
+
+        // Edge from group header to first task
+        if (i === 0) {
+          e.push({
+            id: `e-group-${groupId}-${nodeId}`,
+            source: `group-${groupId}`,
+            target: nodeId,
+            animated: task.status === 'in_progress',
+            style: { stroke: skin.colors.accent + '60' },
+          });
+        }
+
+        // Chain edges between sequential tasks
+        if (i > 0) {
+          const prevId = `task-${sorted[i - 1].id}`;
+          e.push({
+            id: `e-${prevId}-${nodeId}`,
+            source: prevId,
+            target: nodeId,
+            animated: task.status === 'in_progress',
+            style: {
+              stroke:
+                sorted[i - 1].status === 'completed'
+                  ? skin.colors.taskCompleted + '80'
+                  : skin.colors.border,
+            },
+          });
+        }
+      });
+
+      yOffset += 100;
+    }
+
+    // Ungrouped tasks
+    ungrouped.forEach((task, i) => {
+      n.push({
+        id: `task-${task.id}`,
+        type: 'taskNode',
+        position: { x: 50 + (i % 4) * 220, y: yOffset + Math.floor(i / 4) * 80 },
+        data: {
+          label: task.title,
+          status: task.status,
+          priority: task.priority,
+          agentId: task.agentId,
+        },
+      });
+    });
+
+    return { nodes: n, edges: e };
+  }, [tasks, skin]);
+
+  if (tasks.length === 0) {
+    return (
+      <div
+        className="flex items-center justify-center h-full"
+        style={{ backgroundColor: skin.colors.surface, color: skin.colors.textMuted }}
+      >
+        <div className="text-center">
+          <div className="text-2xl mb-2">📋</div>
+          <div className="text-sm" style={{ fontFamily: skin.fonts.body }}>
+            No active tasks
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full w-full" style={{ backgroundColor: skin.colors.surface }}>
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        nodeTypes={nodeTypes}
+        fitView
+        proOptions={{ hideAttribution: true }}
+        style={{ backgroundColor: skin.colors.bg }}
+      >
+        <Background color={skin.colors.border} gap={20} />
+        <Controls
+          style={{
+            backgroundColor: skin.colors.surface,
+            borderColor: skin.colors.border,
+          }}
+        />
+        <MiniMap
+          style={{
+            backgroundColor: skin.colors.bg,
+            border: `1px solid ${skin.colors.border}`,
+          }}
+          nodeColor={(node) => {
+            const status = node.data?.status as string;
+            if (status === 'completed') return skin.colors.taskCompleted;
+            if (status === 'in_progress') return skin.colors.taskInProgress;
+            if (status === 'blocked') return skin.colors.taskBlocked;
+            return skin.colors.taskPending;
+          }}
+        />
+      </ReactFlow>
+    </div>
+  );
+}

--- a/packages/web/src/components/layout/sidebar.tsx
+++ b/packages/web/src/components/layout/sidebar.tsx
@@ -21,6 +21,7 @@ import {
   Route,
   MessageSquare,
   ListTodo,
+  Swords,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useRouter } from 'next/navigation';
@@ -52,7 +53,10 @@ interface NavGroup {
 
 const mainNav: NavGroup[] = [
   {
-    items: [{ name: 'Dashboard', href: '/', icon: Home }],
+    items: [
+      { name: 'Dashboard', href: '/', icon: Home },
+      { name: 'Command', href: '/command', icon: Swords },
+    ],
   },
   {
     label: 'Team',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1984,6 +1984,7 @@ __metadata:
     "@mantine/core": "npm:^8.2.4"
     "@mantine/hooks": "npm:^8.2.4"
     "@mantine/tiptap": "npm:^8.2.4"
+    "@pixi/react": "npm:^8.0.5"
     "@radix-ui/react-dialog": "npm:^1.1.15"
     "@radix-ui/react-slot": "npm:^1.1.1"
     "@radix-ui/react-tabs": "npm:^1.1.13"
@@ -2005,6 +2006,7 @@ __metadata:
     "@types/react": "npm:^19.0.0"
     "@types/react-dom": "npm:^19.0.0"
     "@vitejs/plugin-react": "npm:^5.1.4"
+    "@xyflow/react": "npm:^12.10.2"
     autoprefixer: "npm:^10.4.20"
     axios: "npm:^1.15.2"
     class-variance-authority: "npm:^0.7.1"
@@ -2014,6 +2016,7 @@ __metadata:
     lucide-react: "npm:^0.469.0"
     markdown-it: "npm:^14.1.1"
     next: "npm:^16.2.3"
+    pixi.js: "npm:^8.18.1"
     postcss: "npm:^8.4.49"
     react: "npm:^19.0.0"
     react-dom: "npm:^19.0.0"
@@ -2025,6 +2028,7 @@ __metadata:
     typescript: "npm:^5.3.3"
     vite: "npm:^8.0.9"
     vitest: "npm:^4.0.18"
+    zustand: "npm:^5.0.13"
   languageName: unknown
   linkType: soft
 
@@ -3054,6 +3058,26 @@ __metadata:
   version: 0.4.0
   resolution: "@pinojs/redact@npm:0.4.0"
   checksum: 10/2210ffb6b38357853d47239fd0532cc9edb406325270a81c440a35cece22090127c30c2ead3eefa3e608f2244087485308e515c431f4f69b6bd2e16cbd32812b
+  languageName: node
+  linkType: hard
+
+"@pixi/colord@npm:^2.9.6":
+  version: 2.9.6
+  resolution: "@pixi/colord@npm:2.9.6"
+  checksum: 10/62f56fa1dd881f30091973465046b7a50466923f42d8a1af33ccf06a13fbad3f68499ac025c6984b50f8913ac2f5cb8f4e4d2c96ce18c87637d54f1edcb3738b
+  languageName: node
+  linkType: hard
+
+"@pixi/react@npm:^8.0.5":
+  version: 8.0.5
+  resolution: "@pixi/react@npm:8.0.5"
+  dependencies:
+    its-fine: "npm:^2.0.0"
+    react-reconciler: "npm:0.31.0"
+  peerDependencies:
+    pixi.js: ^8.2.6
+    react: ">=19.0.0"
+  checksum: 10/61136f830413b9c6e3de37800e21817c90283aba5a672f2a58bc53bc42170a7c35b209226588d7df786856b36a7d09772b5bee097c580009b88ac21b91af92eb
   languageName: node
   linkType: hard
 
@@ -5083,6 +5107,57 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/d3-color@npm:*":
+  version: 3.1.3
+  resolution: "@types/d3-color@npm:3.1.3"
+  checksum: 10/1cf0f512c09357b25d644ab01b54200be7c9b15c808333b0ccacf767fff36f17520b2fcde9dad45e1bd7ce84befad39b43da42b4fded57680fa2127006ca3ece
+  languageName: node
+  linkType: hard
+
+"@types/d3-drag@npm:^3.0.7":
+  version: 3.0.7
+  resolution: "@types/d3-drag@npm:3.0.7"
+  dependencies:
+    "@types/d3-selection": "npm:*"
+  checksum: 10/93aba299c3a8d41ee326c5304ab694ceea135ed115c3b2ccab727a5d9bfc935f7f36d3fc416c013010eb755ac536c52adfcb15c195f241dc61f62650cc95088e
+  languageName: node
+  linkType: hard
+
+"@types/d3-interpolate@npm:*, @types/d3-interpolate@npm:^3.0.4":
+  version: 3.0.4
+  resolution: "@types/d3-interpolate@npm:3.0.4"
+  dependencies:
+    "@types/d3-color": "npm:*"
+  checksum: 10/72a883afd52c91132598b02a8cdfced9e783c54ca7e4459f9e29d5f45d11fb33f2cabc844e42fd65ba6e28f2a931dcce1add8607d2f02ef6fb8ea5b83ae84127
+  languageName: node
+  linkType: hard
+
+"@types/d3-selection@npm:*, @types/d3-selection@npm:^3.0.10":
+  version: 3.0.11
+  resolution: "@types/d3-selection@npm:3.0.11"
+  checksum: 10/2d2d993b9e9553d066566cb22916c632e5911090db99e247bd8c32855a344e6b7c25b674f3c27956c367a6b3b1214b09931ce854788c3be2072003e01f2c75d7
+  languageName: node
+  linkType: hard
+
+"@types/d3-transition@npm:^3.0.8":
+  version: 3.0.9
+  resolution: "@types/d3-transition@npm:3.0.9"
+  dependencies:
+    "@types/d3-selection": "npm:*"
+  checksum: 10/dad647c485440f176117e8a45f31aee9427d8d4dfa174eaa2f01e702641db53ad0f752a144b20987c7189723c4f0afe0bf0f16d95b2a91aa28937eee4339c161
+  languageName: node
+  linkType: hard
+
+"@types/d3-zoom@npm:^3.0.8":
+  version: 3.0.8
+  resolution: "@types/d3-zoom@npm:3.0.8"
+  dependencies:
+    "@types/d3-interpolate": "npm:*"
+    "@types/d3-selection": "npm:*"
+  checksum: 10/cc6ba975cf4f55f94933413954d81b87feb1ee8b8cee8f2202cf526f218dcb3ba240cbeb04ed80522416201c4a7394b37de3eb695d840a36d190dfb2d3e62cb5
+  languageName: node
+  linkType: hard
+
 "@types/debug@npm:^4.0.0":
   version: 4.1.12
   resolution: "@types/debug@npm:4.1.12"
@@ -5103,6 +5178,13 @@ __metadata:
   version: 1.0.36
   resolution: "@types/diff-match-patch@npm:1.0.36"
   checksum: 10/7d7ce03422fcc3e79d0cda26e4748aeb176b75ca4b4e5f38459b112bf24660d628424bdb08d330faefa69039d19a5316e7a102a8ab68b8e294c8346790e55113
+  languageName: node
+  linkType: hard
+
+"@types/earcut@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@types/earcut@npm:3.0.0"
+  checksum: 10/f36a07fe004b38116078a8548e43cf56b56d92e61af4c20cd7f95952ed18313eca9035ddf86bdce2945d8b58c4969182e47ae2196cac5ac4b5d752d094370060
   languageName: node
   linkType: hard
 
@@ -5408,6 +5490,15 @@ __metadata:
   peerDependencies:
     "@types/react": ^19.2.0
   checksum: 10/616c4a8aee250ea05fb1e7b98e7e00475dd3a6c1c30d7be18b4b93caba832f4203106b3a496a6b147e5acc2da14575eca47bce234c633bca1f8430ef8ffb234a
+  languageName: node
+  linkType: hard
+
+"@types/react-reconciler@npm:^0.28.9":
+  version: 0.28.9
+  resolution: "@types/react-reconciler@npm:0.28.9"
+  peerDependencies:
+    "@types/react": "*"
+  checksum: 10/2450e3df6169fb887591f2a949ca8f08439ac76c756124feeee7370f1a79b5060ba8e5f612302dc70169433e043da7f617dd7ea3b14a3c2bb39559d66b7a0986
   languageName: node
   linkType: hard
 
@@ -5802,6 +5893,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@webgpu/types@npm:^0.1.69":
+  version: 0.1.70
+  resolution: "@webgpu/types@npm:0.1.70"
+  checksum: 10/2cd8e3755eb118f0cf841fd95912d540c5cb1914d5dea3bfcecc40d989c33f7863621aa29874806394a0774e558e22c7d95d06a8f387b9630c1eac4e98953d93
+  languageName: node
+  linkType: hard
+
 "@whiskeysockets/baileys@npm:^7.0.0-rc.9":
   version: 7.0.0-rc.9
   resolution: "@whiskeysockets/baileys@npm:7.0.0-rc.9"
@@ -5829,6 +5927,44 @@ __metadata:
     link-preview-js:
       optional: true
   checksum: 10/98bf0eb86aa8861d9a7d5da62cd5edaf8c3ac830ad6cdf311d2fd9fd7c0773981a130872b73cb19e5742d479b4896f0815f3202bc20fdd4ddb5d8c37eb568236
+  languageName: node
+  linkType: hard
+
+"@xmldom/xmldom@npm:^0.8.12":
+  version: 0.8.13
+  resolution: "@xmldom/xmldom@npm:0.8.13"
+  checksum: 10/f8f3d56fa91d5026885c0c5c00b07eae47647bda0d742ecbf8e51e06bb287ab30222977b20529ee15c364031606225ebca58907a8ecc76a3add6b3f10e6ddfc6
+  languageName: node
+  linkType: hard
+
+"@xyflow/react@npm:^12.10.2":
+  version: 12.10.2
+  resolution: "@xyflow/react@npm:12.10.2"
+  dependencies:
+    "@xyflow/system": "npm:0.0.76"
+    classcat: "npm:^5.0.3"
+    zustand: "npm:^4.4.0"
+  peerDependencies:
+    react: ">=17"
+    react-dom: ">=17"
+  checksum: 10/92f341f31d50ca1c4886811fca4c1e41e3ce1ebb4f8abf3e7a75af91228866af4ffab7c36d15937fdbd046a5662e4b2e6d6773ef9be977b95074a568bafb0fcf
+  languageName: node
+  linkType: hard
+
+"@xyflow/system@npm:0.0.76":
+  version: 0.0.76
+  resolution: "@xyflow/system@npm:0.0.76"
+  dependencies:
+    "@types/d3-drag": "npm:^3.0.7"
+    "@types/d3-interpolate": "npm:^3.0.4"
+    "@types/d3-selection": "npm:^3.0.10"
+    "@types/d3-transition": "npm:^3.0.8"
+    "@types/d3-zoom": "npm:^3.0.8"
+    d3-drag: "npm:^3.0.0"
+    d3-interpolate: "npm:^3.0.1"
+    d3-selection: "npm:^3.0.0"
+    d3-zoom: "npm:^3.0.0"
+  checksum: 10/6fada3ea584b41007a8f10160046665a940a4302b85f7ccbd2169bf1109a2e070ddbededd3f4f4e2479234e9bb0a500406c7718f6d4b5328575be59bc6655a84
   languageName: node
   linkType: hard
 
@@ -6751,6 +6887,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"classcat@npm:^5.0.3":
+  version: 5.0.5
+  resolution: "classcat@npm:5.0.5"
+  checksum: 10/19bdeb99b8923b47f9df978b6ef2c5a4cc3bcaa8fb6be16244e31fad619b291b366429747331903ac2ea27560ffd6066d14089a99c95535ce0f1e897525fa63d
+  languageName: node
+  linkType: hard
+
 "cli-boxes@npm:^3.0.0":
   version: 3.0.0
   resolution: "cli-boxes@npm:3.0.0"
@@ -7204,6 +7347,88 @@ __metadata:
   languageName: node
   linkType: hard
 
+"d3-color@npm:1 - 3":
+  version: 3.1.0
+  resolution: "d3-color@npm:3.1.0"
+  checksum: 10/536ba05bfd9f4fcd6fa289b5974f5c846b21d186875684637e22bf6855e6aba93e24a2eb3712985c6af3f502fbbfa03708edb72f58142f626241a8a17258e545
+  languageName: node
+  linkType: hard
+
+"d3-dispatch@npm:1 - 3":
+  version: 3.0.1
+  resolution: "d3-dispatch@npm:3.0.1"
+  checksum: 10/2b82f41bf4ef88c2f9033dfe32815b67e2ef1c5754a74137a74c7d44d6f0d6ecfa934ac56ed8afe358f6c1f06462e8aa42ca0a388397b5b77a42721570e80487
+  languageName: node
+  linkType: hard
+
+"d3-drag@npm:2 - 3, d3-drag@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "d3-drag@npm:3.0.0"
+  dependencies:
+    d3-dispatch: "npm:1 - 3"
+    d3-selection: "npm:3"
+  checksum: 10/80bc689935e5a46ee92b2d7f71e1c792279382affed9fbcf46034bff3ff7d3f50cf61a874da4bdf331037292b9e7dca5c6401a605d4bb699fdcb4e0c87e176ec
+  languageName: node
+  linkType: hard
+
+"d3-ease@npm:1 - 3":
+  version: 3.0.1
+  resolution: "d3-ease@npm:3.0.1"
+  checksum: 10/985d46e868494e9e6806fedd20bad712a50dcf98f357bf604a843a9f6bc17714a657c83dd762f183173dcde983a3570fa679b2bc40017d40b24163cdc4167796
+  languageName: node
+  linkType: hard
+
+"d3-interpolate@npm:1 - 3, d3-interpolate@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "d3-interpolate@npm:3.0.1"
+  dependencies:
+    d3-color: "npm:1 - 3"
+  checksum: 10/988d66497ef5c190cf64f8c80cd66e1e9a58c4d1f8932d776a8e3ae59330291795d5a342f5a97602782ccbef21a5df73bc7faf1f0dc46a5145ba6243a82a0f0e
+  languageName: node
+  linkType: hard
+
+"d3-selection@npm:2 - 3, d3-selection@npm:3, d3-selection@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "d3-selection@npm:3.0.0"
+  checksum: 10/0e5acfd305b31628b7be5009ba7303d84bb34817a88ed4dde9c8bd9c23528573fc5272f89fc04e5be03d2cbf5441a248d7274aaf55a8ef3dad46e16333d72298
+  languageName: node
+  linkType: hard
+
+"d3-timer@npm:1 - 3":
+  version: 3.0.1
+  resolution: "d3-timer@npm:3.0.1"
+  checksum: 10/004128602bb187948d72c7dc153f0f063f38ac7a584171de0b45e3a841ad2e17f1e40ad396a4af9cce5551b6ab4a838d5246d23492553843d9da4a4050a911e2
+  languageName: node
+  linkType: hard
+
+"d3-transition@npm:2 - 3":
+  version: 3.0.1
+  resolution: "d3-transition@npm:3.0.1"
+  dependencies:
+    d3-color: "npm:1 - 3"
+    d3-dispatch: "npm:1 - 3"
+    d3-ease: "npm:1 - 3"
+    d3-interpolate: "npm:1 - 3"
+    d3-timer: "npm:1 - 3"
+  peerDependencies:
+    d3-selection: 2 - 3
+  checksum: 10/02571636acb82f5532117928a87fe25de68f088c38ab4a8b16e495f0f2d08a3fd2937eaebdefdfcf7f1461545524927d2632d795839b88d2e4c71e387aaaffac
+  languageName: node
+  linkType: hard
+
+"d3-zoom@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "d3-zoom@npm:3.0.0"
+  dependencies:
+    d3-dispatch: "npm:1 - 3"
+    d3-drag: "npm:2 - 3"
+    d3-interpolate: "npm:1 - 3"
+    d3-selection: "npm:2 - 3"
+    d3-transition: "npm:2 - 3"
+  checksum: 10/0e6e5c14e33c4ecdff311a900dd037dea407734f2dd2818988ed6eae342c1799e8605824523678bd404f81e37824cc588f62dbde46912444c89acc7888036c6b
+  languageName: node
+  linkType: hard
+
 "data-uri-to-buffer@npm:^4.0.0":
   version: 4.0.1
   resolution: "data-uri-to-buffer@npm:4.0.1"
@@ -7498,6 +7723,13 @@ __metadata:
     es-errors: "npm:^1.3.0"
     gopd: "npm:^1.2.0"
   checksum: 10/5add88a3d68d42d6e6130a0cac450b7c2edbe73364bbd2fc334564418569bea97c6943a8fcd70e27130bf32afc236f30982fc4905039b703f23e9e0433c29934
+  languageName: node
+  linkType: hard
+
+"earcut@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "earcut@npm:3.0.2"
+  checksum: 10/08374619e9510f3d669438c292153ec5c31a0ebac058bd03dab04c5b341e0fd2d91794681a1128321a49651ee55822ebb7bda5f8a35de636c4e3b0b27fa39a84
   languageName: node
   linkType: hard
 
@@ -8660,6 +8892,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"gifuct-js@npm:^2.1.2":
+  version: 2.1.2
+  resolution: "gifuct-js@npm:2.1.2"
+  dependencies:
+    js-binary-schema-parser: "npm:^2.0.3"
+  checksum: 10/e08b3acaf04a426f7104bc14bbc0831e0d86cf0822d8f4ad095c31d63b15cba2dd379eb975baf7cb7871db4354c216b8912ae81087b6918c972560c881ae35a8
+  languageName: node
+  linkType: hard
+
 "glob-parent@npm:^5.1.2, glob-parent@npm:~5.1.2":
   version: 5.1.2
   resolution: "glob-parent@npm:5.1.2"
@@ -9408,6 +9649,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ismobilejs@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "ismobilejs@npm:1.1.1"
+  checksum: 10/02db92559e85544fa5353894aede9a778c0a29d2e22db39db29eb9e4665f95fba90ee53b7105a31c2a8e8eabc63824303f6e3edbe73508ebdab6870a2b83904c
+  languageName: node
+  linkType: hard
+
 "istanbul-lib-coverage@npm:^3.0.0, istanbul-lib-coverage@npm:^3.2.0, istanbul-lib-coverage@npm:^3.2.2":
   version: 3.2.2
   resolution: "istanbul-lib-coverage@npm:3.2.2"
@@ -9470,6 +9718,17 @@ __metadata:
     html-escaper: "npm:^2.0.0"
     istanbul-lib-report: "npm:^3.0.0"
   checksum: 10/6773a1d5c7d47eeec75b317144fe2a3b1da84a44b6282bebdc856e09667865e58c9b025b75b3d87f5bc62939126cbba4c871ee84254537d934ba5da5d4c4ec4e
+  languageName: node
+  linkType: hard
+
+"its-fine@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "its-fine@npm:2.0.0"
+  dependencies:
+    "@types/react-reconciler": "npm:^0.28.9"
+  peerDependencies:
+    react: ^19.0.0
+  checksum: 10/26a6005615e31a8c5cec64ea66d4357bfa274616ed3e8224dd118e14c3f16aaa5a6c9454ae92a7bde687a4af80b5cfe7681f7ecc44edc3e64ee603a16550c8ea
   languageName: node
   linkType: hard
 
@@ -9925,6 +10184,13 @@ __metadata:
   version: 6.2.1
   resolution: "jose@npm:6.2.1"
   checksum: 10/12f06a76ac743eb48314e662e02b141f6e4644dbcbdb1cd083c3867b1f72f1e148a67ebf4978d0d5adeb62f4be1572feee76f1849cbc32f8af1457ec9f788299
+  languageName: node
+  linkType: hard
+
+"js-binary-schema-parser@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "js-binary-schema-parser@npm:2.0.3"
+  checksum: 10/40494a1ac114a41c9601d8289428282816179be2cff7001e9a4c8a577704c522e46b33c917f73a369612a01eeb66b5602f33c1d78afba9e9b9680f5c8794c498
   languageName: node
   linkType: hard
 
@@ -12254,6 +12520,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"parse-svg-path@npm:^0.1.2":
+  version: 0.1.2
+  resolution: "parse-svg-path@npm:0.1.2"
+  checksum: 10/bba7d4b4207fcc9eaf553b0d34db96ea8a1173635bc94528b5b66e1581902d4792d8d6229103764f01af4d839274234e97a4fa1c6f0fe7dcce195383848cec56
+  languageName: node
+  linkType: hard
+
 "parse5-htmlparser2-tree-adapter@npm:^6.0.0":
   version: 6.0.1
   resolution: "parse5-htmlparser2-tree-adapter@npm:6.0.1"
@@ -12480,6 +12753,24 @@ __metadata:
   version: 4.0.7
   resolution: "pirates@npm:4.0.7"
   checksum: 10/2427f371366081ae42feb58214f04805d6b41d6b84d74480ebcc9e0ddbd7105a139f7c653daeaf83ad8a1a77214cf07f64178e76de048128fec501eab3305a96
+  languageName: node
+  linkType: hard
+
+"pixi.js@npm:^8.18.1":
+  version: 8.18.1
+  resolution: "pixi.js@npm:8.18.1"
+  dependencies:
+    "@pixi/colord": "npm:^2.9.6"
+    "@types/earcut": "npm:^3.0.0"
+    "@webgpu/types": "npm:^0.1.69"
+    "@xmldom/xmldom": "npm:^0.8.12"
+    earcut: "npm:^3.0.2"
+    eventemitter3: "npm:^5.0.1"
+    gifuct-js: "npm:^2.1.2"
+    ismobilejs: "npm:^1.1.1"
+    parse-svg-path: "npm:^0.1.2"
+    tiny-lru: "npm:^11.4.7"
+  checksum: 10/c368d8e2b36773eb15265ecec7eeae0365c4dfb7d8b6daf158e12eda5780ad0259a438e47aba981f68b4b9afc67281d0602860cbfb1bf9b113d47c94d4a95593
   languageName: node
   linkType: hard
 
@@ -13166,6 +13457,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-reconciler@npm:0.31.0":
+  version: 0.31.0
+  resolution: "react-reconciler@npm:0.31.0"
+  dependencies:
+    scheduler: "npm:^0.25.0"
+  peerDependencies:
+    react: ^19.0.0
+  checksum: 10/e7235fa08947296c2084a89dc264651fd7cb9dc3a26c3b132b84ecf2a30c46b9b98cd004c30adfe2a24741cd1e49a618858a48080008ce2b4e964a2c4233041e
+  languageName: node
+  linkType: hard
+
 "react-reconciler@npm:^0.32.0":
   version: 0.32.0
   resolution: "react-reconciler@npm:0.32.0"
@@ -13717,6 +14019,13 @@ __metadata:
   version: 2.0.2
   resolution: "sandwich-stream@npm:2.0.2"
   checksum: 10/04fd8bc1f380fbb96b11ea6d555531069f7972a4fcb01e48b4207264bd96178763b8abb485e2f8824fcfdef4b630f5262cc83dc6873a16d44fb1551746fd0176
+  languageName: node
+  linkType: hard
+
+"scheduler@npm:^0.25.0":
+  version: 0.25.0
+  resolution: "scheduler@npm:0.25.0"
+  checksum: 10/e661e38503ab29a153429a99203fefa764f28b35c079719eb5efdd2c1c1086522f6653d8ffce388209682c23891a6d1d32fa6badf53c35fb5b9cd0c55ace42de
   languageName: node
   linkType: hard
 
@@ -14539,6 +14848,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tiny-lru@npm:^11.4.7":
+  version: 11.4.7
+  resolution: "tiny-lru@npm:11.4.7"
+  checksum: 10/34756e8f243b02d71b03a8147d4b71136d1fa92397b945c3db6ac4d9b1895e27c9cc064972a4dbe92f923ada95d8d4f9bdd2e1d177d23f050f169d3194bc4b5f
+  languageName: node
+  linkType: hard
+
 "tinybench@npm:^2.9.0":
   version: 2.9.0
   resolution: "tinybench@npm:2.9.0"
@@ -15130,7 +15446,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"use-sync-external-store@npm:^1.4.0":
+"use-sync-external-store@npm:^1.2.2, use-sync-external-store@npm:^1.4.0":
   version: 1.6.0
   resolution: "use-sync-external-store@npm:1.6.0"
   peerDependencies:
@@ -15780,6 +16096,47 @@ __metadata:
   version: 4.4.3
   resolution: "zod@npm:4.4.3"
   checksum: 10/804b9a42aa8f35f2b3c5a8dff906291cb749115f83ee2afe3576d70b5b5c53c965365c7f4967690647a9c54af9838ff232a85ff9577a0a36c44b68bc6cdefe36
+  languageName: node
+  linkType: hard
+
+"zustand@npm:^4.4.0":
+  version: 4.5.7
+  resolution: "zustand@npm:4.5.7"
+  dependencies:
+    use-sync-external-store: "npm:^1.2.2"
+  peerDependencies:
+    "@types/react": ">=16.8"
+    immer: ">=9.0.6"
+    react: ">=16.8"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    immer:
+      optional: true
+    react:
+      optional: true
+  checksum: 10/21c47ea1c9bb0363b714a7e371a91b9afaeabc5c9c2f522803a0fb412605b1e037c4f975a7377529de8f2857e60d1f4586e7ade18444168ecc492e38779e605d
+  languageName: node
+  linkType: hard
+
+"zustand@npm:^5.0.13":
+  version: 5.0.13
+  resolution: "zustand@npm:5.0.13"
+  peerDependencies:
+    "@types/react": ">=18.0.0"
+    immer: ">=9.0.6"
+    react: ">=18.0.0"
+    use-sync-external-store: ">=1.2.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    immer:
+      optional: true
+    react:
+      optional: true
+    use-sync-external-store:
+      optional: true
+  checksum: 10/161ad29b185f2278d64f60ae9230e7309d912511f758fbbd9bfef433021f3d5ecb1b3cb37dfbd3c0cd8b412d4fd71d7de7bc700ccf497d24c8c04ea2da6275dc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- **Command Center dashboard** (`/command`): Canvas-based spatial map with pixel-art agent characters, hex shapes, territory zones, and status bars. Task graph view using React Flow. Three skinnable themes (Pixel RPG, Sci-Fi, Minimal). Zustand state management with live polling.
- **Context-based MCP auth fallback**: When no OAuth token is present but the request carries an `x-ink-context` header with an agentId (injected by the `ink` CLI wrapper), the server resolves identity from `agent_identities` instead of challenging with 401. Eliminates token expiry friction for CLI sessions.
- **Memory/benchmark cleanup**: Removed the standalone benchmarks package and dead memory-dreaming/LLM-extraction services that were superseded by the recall pipeline refactor.

## Test plan

- [x] MCP server tests pass (15/15) including 3 new context-based auth tests
- [ ] Manual test: `ink`-wrapped session makes MCP tool calls without OAuth token
- [ ] Manual test: OAuth-authenticated requests still work as before
- [ ] Manual test: Command Center renders at `/command` with all three skins

🤖 Generated with [Claude Code](https://claude.com/claude-code)