### PR TITLE
refactor: remove owner_agent_id from task_groups (by Wren)

### DIFF
--- a/packages/api/src/auth/resolve-identity.ts
+++ b/packages/api/src/auth/resolve-identity.ts
@@ -51,3 +51,27 @@ export async function resolveIdentityId(
 
   return data[0]?.id ?? null;
 }
+
+/**
+ * Reverse lookup: resolve an agent slug from a canonical identity UUID.
+ */
+export async function resolveAgentSlug(
+  supabase: SupabaseClient<Database>,
+  sbId: string
+): Promise<string | null> {
+  const { data, error } = await supabase
+    .from('agent_identities')
+    .select('agent_id')
+    .eq('id', sbId)
+    .single();
+
+  if (error) {
+    logger.warn('Failed to resolve agent slug from identity UUID', {
+      sbId,
+      error: error.message,
+    });
+    return null;
+  }
+
+  return (data as { agent_id: string } | null)?.agent_id ?? null;
+}

--- a/packages/api/src/data/repositories/task-groups.repository.ts
+++ b/packages/api/src/data/repositories/task-groups.repository.ts
@@ -47,7 +47,6 @@ export interface TaskGroup {
   iterations_since_approval: number;
   strategy_started_at: string | null;
   strategy_paused_at: string | null;
-  owner_agent_id: string | null;
   group_number: number;
   slug: string | null;
   outcome: string | null;
@@ -105,7 +104,6 @@ export interface CreateTaskGroupInput {
   strategy_config?: StrategyConfig;
   verification_mode?: VerificationMode;
   plan_uri?: string;
-  owner_agent_id?: string;
 }
 
 export interface UpdateTaskGroupInput {
@@ -134,7 +132,6 @@ export interface UpdateTaskGroupInput {
   iterations_since_approval?: number;
   strategy_started_at?: string | null;
   strategy_paused_at?: string | null;
-  owner_agent_id?: string | null;
   outcome?: string | null;
   conclusion?: string | null;
 }
@@ -145,7 +142,6 @@ export interface ListTaskGroupsOptions {
   sbId?: string;
   autonomousOnly?: boolean;
   strategy?: StrategyPreset;
-  ownerAgentId?: string;
   limit?: number;
 }
 
@@ -177,7 +173,6 @@ export class TaskGroupsRepository {
         strategy_config: input.strategy_config ?? {},
         verification_mode: input.verification_mode ?? 'self',
         plan_uri: input.plan_uri ?? null,
-        owner_agent_id: input.owner_agent_id ?? null,
       } as never)
       .select()
       .single();
@@ -234,10 +229,6 @@ export class TaskGroupsRepository {
       query = query.eq('strategy', options.strategy);
     }
 
-    if (options?.ownerAgentId) {
-      query = query.eq('owner_agent_id', options.ownerAgentId);
-    }
-
     if (options?.limit) {
       query = query.limit(options.limit);
     }
@@ -282,7 +273,6 @@ export class TaskGroupsRepository {
       updates.strategy_started_at = input.strategy_started_at;
     if (input.strategy_paused_at !== undefined)
       updates.strategy_paused_at = input.strategy_paused_at;
-    if (input.owner_agent_id !== undefined) updates.owner_agent_id = input.owner_agent_id;
     if (input.outcome !== undefined) updates.outcome = input.outcome;
     if (input.conclusion !== undefined) updates.conclusion = input.conclusion;
 
@@ -318,7 +308,7 @@ export class TaskGroupsRepository {
   /**
    * Find active strategies for an agent — used by heartbeat recovery
    */
-  async findActiveStrategies(userId: string, ownerAgentId?: string): Promise<TaskGroup[]> {
+  async findActiveStrategies(userId: string, sbId?: string): Promise<TaskGroup[]> {
     let query = this.client
       .from('task_groups' as never)
       .select('*')
@@ -326,8 +316,8 @@ export class TaskGroupsRepository {
       .eq('status', 'active')
       .not('strategy', 'is', null);
 
-    if (ownerAgentId) {
-      query = query.eq('owner_agent_id', ownerAgentId);
+    if (sbId) {
+      query = query.eq('sb_id', sbId);
     }
 
     const { data, error } = await query;

--- a/packages/api/src/data/supabase/types.ts
+++ b/packages/api/src/data/supabase/types.ts
@@ -63,13 +63,13 @@ export type Database = {
           created_at: string;
           duration_ms: number | null;
           id: string;
-          sb_id: string | null;
           is_dm: boolean | null;
           parent_id: string | null;
           payload: Json;
           platform: string | null;
           platform_chat_id: string | null;
           platform_message_id: string | null;
+          sb_id: string | null;
           session_id: string | null;
           status: string | null;
           subtype: string | null;
@@ -88,13 +88,13 @@ export type Database = {
           created_at?: string;
           duration_ms?: number | null;
           id?: string;
-          sb_id?: string | null;
           is_dm?: boolean | null;
           parent_id?: string | null;
           payload?: Json;
           platform?: string | null;
           platform_chat_id?: string | null;
           platform_message_id?: string | null;
+          sb_id?: string | null;
           session_id?: string | null;
           status?: string | null;
           subtype?: string | null;
@@ -113,13 +113,13 @@ export type Database = {
           created_at?: string;
           duration_ms?: number | null;
           id?: string;
-          sb_id?: string | null;
           is_dm?: boolean | null;
           parent_id?: string | null;
           payload?: Json;
           platform?: string | null;
           platform_chat_id?: string | null;
           platform_message_id?: string | null;
+          sb_id?: string | null;
           session_id?: string | null;
           status?: string | null;
           subtype?: string | null;
@@ -135,15 +135,15 @@ export type Database = {
             referencedColumns: ['id'];
           },
           {
-            foreignKeyName: 'activity_stream_sb_id_fkey';
-            columns: ['sb_id'];
-            referencedRelation: 'agent_identities';
-            referencedColumns: ['id'];
-          },
-          {
             foreignKeyName: 'activity_stream_parent_id_fkey';
             columns: ['parent_id'];
             referencedRelation: 'activity_stream';
+            referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'activity_stream_sb_id_fkey';
+            columns: ['sb_id'];
+            referencedRelation: 'agent_identities';
             referencedColumns: ['id'];
           },
           {
@@ -172,6 +172,7 @@ export type Database = {
           backend: string | null;
           capabilities: Json | null;
           created_at: string | null;
+          default_session_id: string | null;
           description: string | null;
           heartbeat: string | null;
           id: string;
@@ -195,6 +196,7 @@ export type Database = {
           backend?: string | null;
           capabilities?: Json | null;
           created_at?: string | null;
+          default_session_id?: string | null;
           description?: string | null;
           heartbeat?: string | null;
           id?: string;
@@ -218,6 +220,7 @@ export type Database = {
           backend?: string | null;
           capabilities?: Json | null;
           created_at?: string | null;
+          default_session_id?: string | null;
           description?: string | null;
           heartbeat?: string | null;
           id?: string;
@@ -237,6 +240,12 @@ export type Database = {
           workspace_id?: string | null;
         };
         Relationships: [
+          {
+            foreignKeyName: 'agent_identities_default_session_id_fkey';
+            columns: ['default_session_id'];
+            referencedRelation: 'sessions';
+            referencedColumns: ['id'];
+          },
           {
             foreignKeyName: 'agent_identities_user_id_fkey';
             columns: ['user_id'];
@@ -262,12 +271,12 @@ export type Database = {
           description: string | null;
           heartbeat: string | null;
           id: string;
-          sb_id: string;
           metadata: Json | null;
           name: string;
           permissions: Json;
           relationships: Json | null;
           role: string;
+          sb_id: string;
           soul: string | null;
           user_id: string;
           values: Json | null;
@@ -284,12 +293,12 @@ export type Database = {
           description?: string | null;
           heartbeat?: string | null;
           id?: string;
-          sb_id: string;
           metadata?: Json | null;
           name: string;
           permissions?: Json;
           relationships?: Json | null;
           role: string;
+          sb_id: string;
           soul?: string | null;
           user_id: string;
           values?: Json | null;
@@ -306,12 +315,12 @@ export type Database = {
           description?: string | null;
           heartbeat?: string | null;
           id?: string;
-          sb_id?: string;
           metadata?: Json | null;
           name?: string;
           permissions?: Json;
           relationships?: Json | null;
           role?: string;
+          sb_id?: string;
           soul?: string | null;
           user_id?: string;
           values?: Json | null;
@@ -969,11 +978,11 @@ export type Database = {
           chat_id: string | null;
           created_at: string;
           id: string;
-          sb_id: string;
           is_active: boolean;
           metadata: Json;
           platform: string;
           platform_account_id: string | null;
+          sb_id: string;
           studio_hint: string | null;
           updated_at: string;
           user_id: string;
@@ -983,11 +992,11 @@ export type Database = {
           chat_id?: string | null;
           created_at?: string;
           id?: string;
-          sb_id: string;
           is_active?: boolean;
           metadata?: Json;
           platform: string;
           platform_account_id?: string | null;
+          sb_id: string;
           studio_hint?: string | null;
           updated_at?: string;
           user_id: string;
@@ -997,11 +1006,11 @@ export type Database = {
           chat_id?: string | null;
           created_at?: string;
           id?: string;
-          sb_id?: string;
           is_active?: boolean;
           metadata?: Json;
           platform?: string;
           platform_account_id?: string | null;
+          sb_id?: string;
           studio_hint?: string | null;
           updated_at?: string;
           user_id?: string;
@@ -1647,9 +1656,9 @@ export type Database = {
           created_at: string | null;
           expires_at: string;
           id: string;
-          sb_id: string | null;
           last_used_at: string | null;
           refresh_token: string;
+          sb_id: string | null;
           scopes: string[] | null;
           supabase_refresh_token: string | null;
           updated_at: string | null;
@@ -1661,9 +1670,9 @@ export type Database = {
           created_at?: string | null;
           expires_at: string;
           id?: string;
-          sb_id?: string | null;
           last_used_at?: string | null;
           refresh_token: string;
+          sb_id?: string | null;
           scopes?: string[] | null;
           supabase_refresh_token?: string | null;
           updated_at?: string | null;
@@ -1675,9 +1684,9 @@ export type Database = {
           created_at?: string | null;
           expires_at?: string;
           id?: string;
-          sb_id?: string | null;
           last_used_at?: string | null;
           refresh_token?: string;
+          sb_id?: string | null;
           scopes?: string[] | null;
           supabase_refresh_token?: string | null;
           updated_at?: string | null;
@@ -1709,9 +1718,9 @@ export type Database = {
           embedding_chunks_version: number | null;
           expires_at: string | null;
           id: string;
-          sb_id: string | null;
           metadata: Json | null;
           salience: string;
+          sb_id: string | null;
           source: string;
           summary: string | null;
           topic_key: string | null;
@@ -1729,9 +1738,9 @@ export type Database = {
           embedding_chunks_version?: number | null;
           expires_at?: string | null;
           id?: string;
-          sb_id?: string | null;
           metadata?: Json | null;
           salience?: string;
+          sb_id?: string | null;
           source?: string;
           summary?: string | null;
           topic_key?: string | null;
@@ -1749,9 +1758,9 @@ export type Database = {
           embedding_chunks_version?: number | null;
           expires_at?: string | null;
           id?: string;
-          sb_id?: string | null;
           metadata?: Json | null;
           salience?: string;
+          sb_id?: string | null;
           source?: string;
           summary?: string | null;
           topic_key?: string | null;
@@ -2491,12 +2500,12 @@ export type Database = {
           delivery_target: string | null;
           description: string | null;
           id: string;
-          sb_id: string | null;
           last_run_at: string | null;
           max_runs: number | null;
           metadata: Json | null;
           next_run_at: string;
           run_count: number | null;
+          sb_id: string | null;
           status: string;
           studio_hint: string | null;
           title: string;
@@ -2510,12 +2519,12 @@ export type Database = {
           delivery_target?: string | null;
           description?: string | null;
           id?: string;
-          sb_id?: string | null;
           last_run_at?: string | null;
           max_runs?: number | null;
           metadata?: Json | null;
           next_run_at: string;
           run_count?: number | null;
+          sb_id?: string | null;
           status?: string;
           studio_hint?: string | null;
           title: string;
@@ -2529,12 +2538,12 @@ export type Database = {
           delivery_target?: string | null;
           description?: string | null;
           id?: string;
-          sb_id?: string | null;
           last_run_at?: string | null;
           max_runs?: number | null;
           metadata?: Json | null;
           next_run_at?: string;
           run_count?: number | null;
+          sb_id?: string | null;
           status?: string;
           studio_hint?: string | null;
           title?: string;
@@ -2706,21 +2715,23 @@ export type Database = {
       sessions: {
         Row: {
           agent_id: string | null;
+          alias: string | null;
           backend: string | null;
           backend_session_id: string | null;
           claude_session_id: string | null;
           cli_attached: boolean | null;
+          cli_poll_at: string | null;
           compacting_since: string | null;
           contact_id: string | null;
           context: string | null;
           current_phase: string | null;
           ended_at: string | null;
           id: string;
-          sb_id: string | null;
           lifecycle: string | null;
           message_count: number | null;
           metadata: Json | null;
           model: string | null;
+          sb_id: string | null;
           started_at: string | null;
           status: string | null;
           studio_id: string | null;
@@ -2733,21 +2744,23 @@ export type Database = {
         };
         Insert: {
           agent_id?: string | null;
+          alias?: string | null;
           backend?: string | null;
           backend_session_id?: string | null;
           claude_session_id?: string | null;
           cli_attached?: boolean | null;
+          cli_poll_at?: string | null;
           compacting_since?: string | null;
           contact_id?: string | null;
           context?: string | null;
           current_phase?: string | null;
           ended_at?: string | null;
           id?: string;
-          sb_id?: string | null;
           lifecycle?: string | null;
           message_count?: number | null;
           metadata?: Json | null;
           model?: string | null;
+          sb_id?: string | null;
           started_at?: string | null;
           status?: string | null;
           studio_id?: string | null;
@@ -2760,21 +2773,23 @@ export type Database = {
         };
         Update: {
           agent_id?: string | null;
+          alias?: string | null;
           backend?: string | null;
           backend_session_id?: string | null;
           claude_session_id?: string | null;
           cli_attached?: boolean | null;
+          cli_poll_at?: string | null;
           compacting_since?: string | null;
           contact_id?: string | null;
           context?: string | null;
           current_phase?: string | null;
           ended_at?: string | null;
           id?: string;
-          sb_id?: string | null;
           lifecycle?: string | null;
           message_count?: number | null;
           metadata?: Json | null;
           model?: string | null;
+          sb_id?: string | null;
           started_at?: string | null;
           status?: string | null;
           studio_id?: string | null;
@@ -3034,7 +3049,6 @@ export type Database = {
           cleaned_at: string | null;
           created_at: string | null;
           id: string;
-          sb_id: string | null;
           metadata: Json | null;
           permissions: Json;
           purpose: string | null;
@@ -3042,6 +3056,7 @@ export type Database = {
           role_template: string | null;
           route_patterns: string[] | null;
           sandbox_bypass: boolean | null;
+          sb_id: string | null;
           session_id: string | null;
           slug: string | null;
           status: string;
@@ -3058,7 +3073,6 @@ export type Database = {
           cleaned_at?: string | null;
           created_at?: string | null;
           id?: string;
-          sb_id?: string | null;
           metadata?: Json | null;
           permissions?: Json;
           purpose?: string | null;
@@ -3066,6 +3080,7 @@ export type Database = {
           role_template?: string | null;
           route_patterns?: string[] | null;
           sandbox_bypass?: boolean | null;
+          sb_id?: string | null;
           session_id?: string | null;
           slug?: string | null;
           status?: string;
@@ -3082,7 +3097,6 @@ export type Database = {
           cleaned_at?: string | null;
           created_at?: string | null;
           id?: string;
-          sb_id?: string | null;
           metadata?: Json | null;
           permissions?: Json;
           purpose?: string | null;
@@ -3090,6 +3104,7 @@ export type Database = {
           role_template?: string | null;
           route_patterns?: string[] | null;
           sandbox_bypass?: boolean | null;
+          sb_id?: string | null;
           session_id?: string | null;
           slug?: string | null;
           status?: string;
@@ -3264,9 +3279,8 @@ export type Database = {
           created_at: string;
           current_task_index: number;
           description: string | null;
-          group_number: number;
+          group_number: number | null;
           id: string;
-          sb_id: string | null;
           instructions: string | null;
           iterations_since_approval: number;
           max_sessions: number | null;
@@ -3275,10 +3289,10 @@ export type Database = {
           outcome: string | null;
           output_status: string | null;
           output_target: string | null;
-          owner_agent_id: string | null;
           plan_uri: string | null;
           priority: string;
           project_id: string | null;
+          sb_id: string | null;
           sessions_used: number;
           slug: string | null;
           status: string;
@@ -3300,9 +3314,8 @@ export type Database = {
           created_at?: string;
           current_task_index?: number;
           description?: string | null;
-          group_number: number;
+          group_number?: number | null;
           id?: string;
-          sb_id?: string | null;
           instructions?: string | null;
           iterations_since_approval?: number;
           max_sessions?: number | null;
@@ -3311,10 +3324,10 @@ export type Database = {
           outcome?: string | null;
           output_status?: string | null;
           output_target?: string | null;
-          owner_agent_id?: string | null;
           plan_uri?: string | null;
           priority?: string;
           project_id?: string | null;
+          sb_id?: string | null;
           sessions_used?: number;
           slug?: string | null;
           status?: string;
@@ -3336,10 +3349,8 @@ export type Database = {
           created_at?: string;
           current_task_index?: number;
           description?: string | null;
-          group_number?: number;
-
+          group_number?: number | null;
           id?: string;
-          sb_id?: string | null;
           instructions?: string | null;
           iterations_since_approval?: number;
           max_sessions?: number | null;
@@ -3348,10 +3359,10 @@ export type Database = {
           outcome?: string | null;
           output_status?: string | null;
           output_target?: string | null;
-          owner_agent_id?: string | null;
           plan_uri?: string | null;
           priority?: string;
           project_id?: string | null;
+          sb_id?: string | null;
           sessions_used?: number;
           slug?: string | null;
           status?: string;
@@ -3368,15 +3379,15 @@ export type Database = {
         };
         Relationships: [
           {
-            foreignKeyName: 'task_groups_sb_id_fkey';
-            columns: ['sb_id'];
-            referencedRelation: 'agent_identities';
-            referencedColumns: ['id'];
-          },
-          {
             foreignKeyName: 'task_groups_project_id_fkey';
             columns: ['project_id'];
             referencedRelation: 'projects';
+            referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'task_groups_sb_id_fkey';
+            columns: ['sb_id'];
+            referencedRelation: 'agent_identities';
             referencedColumns: ['id'];
           },
           {
@@ -3899,9 +3910,9 @@ export type Database = {
           embedding: string;
           expires_at: string;
           id: string;
-          sb_id: string;
           metadata: Json;
           salience: string;
+          sb_id: string;
           similarity: number;
           source: string;
           summary: string;
@@ -3932,12 +3943,12 @@ export type Database = {
           embedding: string;
           expires_at: string;
           id: string;
-          sb_id: string;
           matched_chunk_index: number;
           matched_chunk_text: string;
           matched_chunk_type: string;
           metadata: Json;
           salience: string;
+          sb_id: string;
           similarity: number;
           source: string;
           summary: string;

--- a/packages/api/src/mcp/tools/index.ts
+++ b/packages/api/src/mcp/tools/index.ts
@@ -1218,7 +1218,7 @@ User can be identified by ONE of: userId, email, phone, or platform + platformId
   server.registerTool(
     'list_task_groups',
     {
-      description: `List task groups for a user with per-status task counts per group. Omit \`statuses\` (or pass an empty array) to include all statuses. Pass a multi-select array to narrow (e.g. statuses: ["active","paused"]). Also supports projectId, sbId, autonomousOnly, strategy, and ownerAgentId filters.
+      description: `List task groups for a user with per-status task counts per group. Omit \`statuses\` (or pass an empty array) to include all statuses. Pass a multi-select array to narrow (e.g. statuses: ["active","paused"]). Also supports projectId, sbId, autonomousOnly, and strategy filters.
 
 User can be identified by ONE of: userId, email, phone, or platform + platformId`,
       inputSchema: listTaskGroupsSchema.shape,

--- a/packages/api/src/mcp/tools/strategy-handlers.test.ts
+++ b/packages/api/src/mcp/tools/strategy-handlers.test.ts
@@ -54,6 +54,10 @@ vi.mock('../../auth/enforce-identity', () => ({
   getEffectiveAgentId: vi.fn().mockReturnValue('wren'),
 }));
 
+vi.mock('../../auth/resolve-identity', () => ({
+  resolveIdentityId: vi.fn().mockResolvedValue('sb-wren-uuid'),
+}));
+
 vi.mock('../../utils/logger', () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
 }));
@@ -127,6 +131,7 @@ describe('handleStartStrategy', () => {
         groupId: 'group-1',
         userId: 'user-123',
         strategy: 'persistence',
+        sbId: 'sb-wren-uuid',
       })
     );
   });

--- a/packages/api/src/mcp/tools/strategy-handlers.ts
+++ b/packages/api/src/mcp/tools/strategy-handlers.ts
@@ -16,6 +16,7 @@ import { StrategyService } from '../../services/strategy.service';
 import { getOrchestrator } from '../../services/sandbox/index.js';
 import { resolveUser, type UserIdentifier } from '../../services/user-resolver';
 import { getEffectiveAgentId } from '../../auth/enforce-identity';
+import { resolveIdentityId } from '../../auth/resolve-identity';
 
 const userIdentifierSchema = z.object({
   userId: z
@@ -60,10 +61,6 @@ export const startStrategySchema = z.object({
   strategy: z
     .enum(['persistence', 'review', 'architect', 'parallel', 'swarm'])
     .describe('Strategy preset to use'),
-  ownerAgentId: z
-    .string()
-    .optional()
-    .describe('Agent ID that will execute the strategy. Defaults to calling agent.'),
   planUri: z
     .string()
     .optional()
@@ -145,14 +142,28 @@ export async function handleStartStrategy(
       return mcpResponse({ success: false, error: 'User not found' }, true);
     }
 
-    const agentId = getEffectiveAgentId(args.ownerAgentId);
+    const agentId = getEffectiveAgentId();
+
+    const sbId = agentId
+      ? await resolveIdentityId(dataComposer.getClient(), resolved.user.id, agentId)
+      : null;
+    if (!sbId) {
+      return mcpResponse(
+        {
+          success: false,
+          error:
+            'Could not resolve agent identity — ensure the calling agent has an identity record.',
+        },
+        true
+      );
+    }
 
     const service = new StrategyService(dataComposer, getOrchestrator());
     const result = await service.startStrategy({
       groupId: args.groupId,
       userId: resolved.user.id,
       strategy: args.strategy as StrategyPreset,
-      ownerAgentId: agentId || args.ownerAgentId || 'unknown',
+      sbId,
       verificationMode: args.verificationMode as VerificationMode,
       planUri: args.planUri,
       config: {

--- a/packages/api/src/mcp/tools/task-handlers.test.ts
+++ b/packages/api/src/mcp/tools/task-handlers.test.ts
@@ -1362,7 +1362,6 @@ describe('handleUpdateTaskGroup', () => {
     output_target: null,
     output_status: null,
     thread_key: null,
-    owner_agent_id: null,
     created_at: '2026-04-18T10:00:00Z',
     updated_at: '2026-04-18T10:00:00Z',
   };

--- a/packages/api/src/mcp/tools/task-handlers.ts
+++ b/packages/api/src/mcp/tools/task-handlers.ts
@@ -1284,11 +1284,6 @@ export const updateTaskGroupSchema = z.object({
   outputTarget: taskGroupOutputTargetEnum.nullable().optional(),
   outputStatus: taskGroupOutputStatusEnum.nullable().optional(),
   threadKey: z.string().nullable().optional(),
-  ownerAgentId: z
-    .string()
-    .nullable()
-    .optional()
-    .describe('Agent slug owning this group (e.g. "wren"). Pass null to clear.'),
   sbId: z
     .string()
     .uuid()
@@ -1382,7 +1377,6 @@ export async function handleUpdateTaskGroup(
       output_target: args.outputTarget,
       output_status: args.outputStatus,
       thread_key: args.threadKey,
-      owner_agent_id: args.ownerAgentId,
       sb_id: nextSbId,
       autonomous: args.autonomous,
       max_sessions: args.maxSessions,
@@ -1400,7 +1394,6 @@ export async function handleUpdateTaskGroup(
         metadata: updated.metadata,
         projectId: updated.project_id,
         sbId: updated.sb_id,
-        ownerAgentId: updated.owner_agent_id,
         autonomous: updated.autonomous,
         maxSessions: updated.max_sessions,
         sessionsUsed: updated.sessions_used,
@@ -1433,11 +1426,6 @@ export const listTaskGroupsSchema = z.object({
     ),
   projectId: z.string().uuid().optional().describe('Filter by project'),
   sbId: z.string().uuid().optional().describe('Filter by agent identity UUID'),
-  ownerAgentId: z
-    .string()
-    .max(64)
-    .optional()
-    .describe('Filter by owner agent ID (e.g. "wren", "lumen")'),
   autonomousOnly: z.boolean().optional().default(false).describe('Only autonomous groups'),
   includeTaskCounts: z
     .boolean()
@@ -1464,7 +1452,6 @@ export async function handleListTaskGroups(
       status: statuses,
       projectId: args.projectId,
       sbId: args.sbId,
-      ownerAgentId: args.ownerAgentId,
       autonomousOnly: args.autonomousOnly,
       limit: args.limit,
     });
@@ -1514,7 +1501,6 @@ export async function handleListTaskGroups(
         sbId: g.sb_id,
         agentId: g.sb_id ? identityMap.get(g.sb_id)?.agentId || null : null,
         agentName: g.sb_id ? identityMap.get(g.sb_id)?.name || null : null,
-        ownerAgentId: g.owner_agent_id,
         autonomous: g.autonomous,
         maxSessions: g.max_sessions,
         sessionsUsed: g.sessions_used,

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -6357,28 +6357,6 @@ router.get('/task-groups', async (req: Request, res: Response) => {
       }
     }
 
-    // Resolve strategy owner display names (owner_agent_id may differ from creator)
-    const ownerAgentIds = [
-      ...new Set(groups.map((g) => g.owner_agent_id).filter(Boolean)),
-    ] as string[];
-    let ownerNameMap: Record<string, string> = {};
-
-    if (ownerAgentIds.length > 0) {
-      const { data: ownerData } = await supabase
-        .from('agent_identities')
-        .select('agent_id, name')
-        .eq('user_id', authReq.pcpUserId)
-        .in('agent_id', ownerAgentIds);
-
-      if (ownerData) {
-        for (const row of ownerData) {
-          if (row.agent_id && row.name) {
-            ownerNameMap[row.agent_id] = row.name;
-          }
-        }
-      }
-    }
-
     res.json({
       groups: groups.map((g) => ({
         id: g.id,
@@ -6403,8 +6381,6 @@ router.get('/task-groups', async (req: Request, res: Response) => {
         agentName: (g.agent_identities as { agent_id: string; name: string } | null)?.name ?? null,
         taskCount: taskCountMap[g.id] || 0,
         strategy: g.strategy ?? null,
-        ownerAgentId: g.owner_agent_id ?? null,
-        ownerAgentName: (g.owner_agent_id && ownerNameMap[g.owner_agent_id]) || null,
         currentTaskIndex: g.current_task_index ?? 0,
         strategyStartedAt: g.strategy_started_at ?? null,
         strategyPausedAt: g.strategy_paused_at ?? null,
@@ -6467,21 +6443,6 @@ router.get('/task-groups/:id', async (req: Request, res: Response) => {
       return;
     }
 
-    // Resolve owner agent name if owner_agent_id is set
-    let ownerAgentName: string | null = null;
-    if (group.owner_agent_id) {
-      const { data: ownerData } = await supabase
-        .from('agent_identities')
-        .select('name')
-        .eq('user_id', userId)
-        .eq('agent_id', group.owner_agent_id)
-        .single();
-
-      if (ownerData?.name) {
-        ownerAgentName = ownerData.name;
-      }
-    }
-
     const tasks = tasksData || [];
 
     res.json({
@@ -6509,8 +6470,6 @@ router.get('/task-groups/:id', async (req: Request, res: Response) => {
           (group.agent_identities as { agent_id: string; name: string } | null)?.name ?? null,
         taskCount: tasks.length,
         strategy: group.strategy ?? null,
-        ownerAgentId: group.owner_agent_id ?? null,
-        ownerAgentName,
         currentTaskIndex: group.current_task_index ?? 0,
         strategyStartedAt: group.strategy_started_at ?? null,
         strategyPausedAt: group.strategy_paused_at ?? null,

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -884,7 +884,7 @@ async function resolveWorkspaceIdentityScope(
       id: string;
       agent_id: string;
       name: string;
-      role: string | null;
+      role: string;
     } => Boolean(row.id) && Boolean(row.agent_id) && Boolean(row.name)
   );
 

--- a/packages/api/src/services/sessions/trigger-delivery.test.ts
+++ b/packages/api/src/services/sessions/trigger-delivery.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+import {
+  checkPollFreshness,
+  checkLegacyAttached,
+  shouldSkipSpawn,
+  type SessionPollRow,
+  type SessionAttachedRow,
+} from './trigger-delivery';
+
+const NOW = Date.now();
+
+function freshPollRow(sessionId: string): SessionPollRow {
+  return { id: sessionId, cli_poll_at: new Date(NOW - 5_000).toISOString(), studio_id: null };
+}
+
+function stalePollRow(sessionId: string): SessionPollRow {
+  return { id: sessionId, cli_poll_at: new Date(NOW - 60_000).toISOString(), studio_id: null };
+}
+
+function attachedRow(ageMs: number): SessionAttachedRow {
+  return { cli_attached: true, updated_at: new Date(NOW - ageMs).toISOString() };
+}
+
+describe('trigger-delivery', () => {
+  describe('checkPollFreshness', () => {
+    it('returns true when poll is fresh (< 30s)', () => {
+      expect(checkPollFreshness(freshPollRow('s1'), NOW)).toBe(true);
+    });
+
+    it('returns false when poll is stale (> 30s)', () => {
+      expect(checkPollFreshness(stalePollRow('s1'), NOW)).toBe(false);
+    });
+
+    it('returns false when poll row is null', () => {
+      expect(checkPollFreshness(null, NOW)).toBe(false);
+    });
+
+    it('returns false when cli_poll_at is null', () => {
+      expect(checkPollFreshness({ id: 's1', cli_poll_at: null, studio_id: null }, NOW)).toBe(false);
+    });
+  });
+
+  describe('checkLegacyAttached', () => {
+    it('returns attached=true, stale=false for recent session', () => {
+      const result = checkLegacyAttached(attachedRow(30_000), NOW);
+      expect(result).toEqual({ attached: true, stale: false });
+    });
+
+    it('returns attached=true, stale=true for old session (> 10min)', () => {
+      const result = checkLegacyAttached(attachedRow(11 * 60 * 1000), NOW);
+      expect(result).toEqual({ attached: true, stale: true });
+    });
+
+    it('returns attached=false for cli_attached=false', () => {
+      const result = checkLegacyAttached(
+        { cli_attached: false, updated_at: new Date(NOW).toISOString() },
+        NOW
+      );
+      expect(result).toEqual({ attached: false, stale: false });
+    });
+
+    it('returns attached=false for null row', () => {
+      expect(checkLegacyAttached(null, NOW)).toEqual({ attached: false, stale: false });
+    });
+  });
+
+  describe('shouldSkipSpawn', () => {
+    it('skips when routed session has fresh poll', () => {
+      const result = shouldSkipSpawn(freshPollRow('routed-session'), null, NOW);
+      expect(result).toEqual({
+        skip: true,
+        source: 'cli_poll_at',
+        sessionId: 'routed-session',
+      });
+    });
+
+    it('skips when routed session has legacy cli_attached', () => {
+      const result = shouldSkipSpawn(null, attachedRow(30_000), NOW);
+      expect(result).toEqual({ skip: true, source: 'cli_attached', sessionId: null });
+    });
+
+    it('does NOT skip when poll is stale and no legacy attached', () => {
+      const result = shouldSkipSpawn(stalePollRow('routed-session'), null, NOW);
+      expect(result).toEqual({ skip: false, source: null, sessionId: null });
+    });
+
+    it('does NOT skip when no poll data and no legacy attached', () => {
+      const result = shouldSkipSpawn(null, null, NOW);
+      expect(result).toEqual({ skip: false, source: null, sessionId: null });
+    });
+
+    it('does NOT skip when legacy attached is stale', () => {
+      const result = shouldSkipSpawn(null, attachedRow(11 * 60 * 1000), NOW);
+      expect(result).toEqual({ skip: false, source: null, sessionId: null });
+    });
+
+    // Regression: Lumen's PR #350 review — session A polling, thread routed to session B.
+    // The server should only check the ROUTED session's poll state.
+    // If session A (different session) is polling, the routed session's poll row
+    // will be null/stale → should NOT skip spawn.
+    it('does NOT skip when a DIFFERENT session is polling (regression: PR #350)', () => {
+      // Session B is the routed session — no fresh poll
+      const routedSessionPoll: SessionPollRow = {
+        id: 'session-B',
+        cli_poll_at: null,
+        studio_id: null,
+      };
+      // Session A is polling (fresh) but is NOT the routed session —
+      // it's irrelevant because the caller only passes the routed session's row.
+      // This test verifies the contract: only the routed session matters.
+      const result = shouldSkipSpawn(routedSessionPoll, null, NOW);
+      expect(result).toEqual({ skip: false, source: null, sessionId: null });
+    });
+  });
+});

--- a/packages/api/src/services/sessions/trigger-delivery.ts
+++ b/packages/api/src/services/sessions/trigger-delivery.ts
@@ -1,0 +1,60 @@
+/**
+ * Trigger delivery check — determines whether the server should skip spawning
+ * a new process because a CLI channel plugin is already polling the routed session.
+ */
+
+export interface SessionPollRow {
+  id: string;
+  cli_poll_at: string | null;
+  studio_id: string | null;
+}
+
+export interface SessionAttachedRow {
+  cli_attached: boolean;
+  updated_at: string;
+}
+
+export interface CliDeliveryCheck {
+  skip: boolean;
+  source: 'cli_poll_at' | 'cli_attached' | null;
+  sessionId: string | null;
+}
+
+const CLI_POLL_FRESH_MS = 30_000;
+const CLI_STALE_MS = 10 * 60 * 1000;
+
+export function checkPollFreshness(
+  pollRow: SessionPollRow | null,
+  now: number = Date.now()
+): boolean {
+  if (!pollRow?.cli_poll_at) return false;
+  return now - new Date(pollRow.cli_poll_at).getTime() < CLI_POLL_FRESH_MS;
+}
+
+export function checkLegacyAttached(
+  attachedRow: SessionAttachedRow | null,
+  now: number = Date.now()
+): { attached: boolean; stale: boolean } {
+  if (!attachedRow?.cli_attached) return { attached: false, stale: false };
+  const age = now - new Date(attachedRow.updated_at).getTime();
+  const stale = age > CLI_STALE_MS;
+  return { attached: true, stale };
+}
+
+export function shouldSkipSpawn(
+  pollRow: SessionPollRow | null,
+  attachedRow: SessionAttachedRow | null,
+  now: number = Date.now()
+): CliDeliveryCheck {
+  const hasFreshPoll = checkPollFreshness(pollRow, now);
+  if (hasFreshPoll) {
+    return { skip: true, source: 'cli_poll_at', sessionId: pollRow!.id };
+  }
+
+  const { attached, stale } = checkLegacyAttached(attachedRow, now);
+  if (attached && !stale) {
+    return { skip: true, source: 'cli_attached', sessionId: null };
+  }
+
+  return { skip: false, source: null, sessionId: null };
+}

--- a/packages/api/src/services/strategy-approval-gate.integration.test.ts
+++ b/packages/api/src/services/strategy-approval-gate.integration.test.ts
@@ -41,6 +41,8 @@ const configPath = resolve(process.env.HOME || '', '.ink/config.json');
 const inkConfig = existsSync(configPath) ? JSON.parse(readFileSync(configPath, 'utf-8')) : {};
 const TEST_USER_ID: string | undefined = inkConfig.userId;
 
+let TEST_SB_ID: string | undefined;
+
 const canRun = !!SUPABASE_URL && !!SUPABASE_KEY && !!TEST_USER_ID;
 
 vi.mock('../mcp/tools/inbox-handlers', () => ({
@@ -130,6 +132,14 @@ describe.skipIf(!canRun)('Strategy Final Approval Gate (integration)', () => {
       },
     };
 
+    const { data: identity } = await client
+      .from('agent_identities')
+      .select('id')
+      .eq('user_id', TEST_USER_ID!)
+      .limit(1)
+      .single();
+    TEST_SB_ID = identity?.id;
+
     const created = await createTestGroup(dc, 'final_review', {});
     groupId = created.groupId;
     taskIds = created.taskIds;
@@ -147,7 +157,7 @@ describe.skipIf(!canRun)('Strategy Final Approval Gate (integration)', () => {
       groupId,
       userId: TEST_USER_ID!,
       strategy: 'persistence',
-      ownerAgentId: 'integration-test',
+      sbId: TEST_SB_ID!,
       config: {
         requireFinalApproval: true,
         approvalCriteria: ['tests pass', 'visual review'],
@@ -251,6 +261,16 @@ describe.skipIf(!canRun)(
         },
       };
 
+      if (!TEST_SB_ID) {
+        const { data: identity } = await client
+          .from('agent_identities')
+          .select('id')
+          .eq('user_id', TEST_USER_ID!)
+          .limit(1)
+          .single();
+        TEST_SB_ID = identity?.id;
+      }
+
       // Create group with exactly 2 tasks + maxIterationsWithoutApproval=2
       // so the periodic gate would fire on task 2 if ordering were wrong
       const group = await dc.repositories.taskGroups.create({
@@ -289,7 +309,7 @@ describe.skipIf(!canRun)(
         groupId,
         userId: TEST_USER_ID!,
         strategy: 'persistence',
-        ownerAgentId: 'integration-test',
+        sbId: TEST_SB_ID!,
         config: {
           maxIterationsWithoutApproval: 2,
           watchdogIntervalMinutes: 60,
@@ -352,6 +372,16 @@ describe.skipIf(!canRun)('Strategy Both Gates on Final Task (integration)', () =
       },
     };
 
+    if (!TEST_SB_ID) {
+      const { data: identity } = await client
+        .from('agent_identities')
+        .select('id')
+        .eq('user_id', TEST_USER_ID!)
+        .limit(1)
+        .single();
+      TEST_SB_ID = identity?.id;
+    }
+
     const group = await dc.repositories.taskGroups.create({
       user_id: TEST_USER_ID,
       title: `__both_gates_test_${Date.now()}`,
@@ -387,7 +417,7 @@ describe.skipIf(!canRun)('Strategy Both Gates on Final Task (integration)', () =
       groupId,
       userId: TEST_USER_ID!,
       strategy: 'persistence',
-      ownerAgentId: 'integration-test',
+      sbId: TEST_SB_ID!,
       config: {
         maxIterationsWithoutApproval: 2,
         requireFinalApproval: true,

--- a/packages/api/src/services/strategy-approval-gate.live.integration.test.ts
+++ b/packages/api/src/services/strategy-approval-gate.live.integration.test.ts
@@ -101,6 +101,8 @@ function inkwellReachable(): boolean {
   }
 }
 
+let TEST_SB_ID: string | undefined;
+
 const canRun =
   process.env.INK_LIVE_TESTS === '1' &&
   !!SUPABASE_URL &&
@@ -226,6 +228,14 @@ describe.skipIf(!canRun)('Strategy Approval Gate — worker phase (LLM live)', (
       },
     };
 
+    const { data: identity } = await client
+      .from('agent_identities')
+      .select('id')
+      .eq('user_id', TEST_USER_ID!)
+      .limit(1)
+      .single();
+    TEST_SB_ID = identity?.id;
+
     const group = await dc.repositories.taskGroups.create({
       user_id: TEST_USER_ID,
       title: `__llm_approval_gate_live_${Date.now()}`,
@@ -255,7 +265,7 @@ describe.skipIf(!canRun)('Strategy Approval Gate — worker phase (LLM live)', (
       groupId,
       userId: TEST_USER_ID!,
       strategy: 'persistence',
-      ownerAgentId: 'live-test',
+      sbId: TEST_SB_ID!,
       config: {
         requireFinalApproval: true,
         approvalCriteria: ['all tasks completed', 'no errors during execution'],
@@ -351,6 +361,16 @@ describe.skipIf(!canRun)('Strategy Approval Gate — supervisor review (LLM live
       },
     };
 
+    if (!TEST_SB_ID) {
+      const { data: identity } = await client
+        .from('agent_identities')
+        .select('id')
+        .eq('user_id', TEST_USER_ID!)
+        .limit(1)
+        .single();
+      TEST_SB_ID = identity?.id;
+    }
+
     // Create group, complete all tasks, start strategy so it's already in final_review
     const group = await dc.repositories.taskGroups.create({
       user_id: TEST_USER_ID,
@@ -382,7 +402,7 @@ describe.skipIf(!canRun)('Strategy Approval Gate — supervisor review (LLM live
       groupId,
       userId: TEST_USER_ID!,
       strategy: 'persistence',
-      ownerAgentId: 'live-test',
+      sbId: TEST_SB_ID!,
       config: {
         requireFinalApproval: true,
         approvalCriteria: ['CI passes', 'no regressions in test suite', 'code review approved'],

--- a/packages/api/src/services/strategy-observability.integration.test.ts
+++ b/packages/api/src/services/strategy-observability.integration.test.ts
@@ -40,6 +40,8 @@ const configPath = resolve(process.env.HOME || '', '.ink/config.json');
 const inkConfig = existsSync(configPath) ? JSON.parse(readFileSync(configPath, 'utf-8')) : {};
 const TEST_USER_ID: string | undefined = inkConfig.userId;
 
+let TEST_SB_ID: string | undefined;
+
 const canRun = !!SUPABASE_URL && !!SUPABASE_KEY && !!TEST_USER_ID;
 
 // Mock inbox handlers — we don't want real triggers during tests
@@ -95,6 +97,14 @@ describe.skipIf(!canRun)('Watchdog wakeup/skip observability (integration)', () 
       },
     };
 
+    const { data: identity } = await client
+      .from('agent_identities')
+      .select('id')
+      .eq('user_id', TEST_USER_ID!)
+      .limit(1)
+      .single();
+    TEST_SB_ID = identity?.id;
+
     // Create test group + task
     const group = await dc.repositories.taskGroups.create({
       user_id: TEST_USER_ID,
@@ -139,7 +149,7 @@ describe.skipIf(!canRun)('Watchdog wakeup/skip observability (integration)', () 
       groupId,
       userId: TEST_USER_ID!,
       strategy: 'persistence',
-      ownerAgentId: 'integration-test',
+      sbId: TEST_SB_ID!,
     });
 
     // Trigger watchdog — should log watchdog_wakeup then attempt trigger
@@ -241,6 +251,16 @@ describe.skipIf(!canRun)('Approval gate pauseReason metadata (integration)', () 
       },
     };
 
+    if (!TEST_SB_ID) {
+      const { data: identity } = await client
+        .from('agent_identities')
+        .select('id')
+        .eq('user_id', TEST_USER_ID!)
+        .limit(1)
+        .single();
+      TEST_SB_ID = identity?.id;
+    }
+
     // Create group with approval gate at 1 task
     const group = await dc.repositories.taskGroups.create({
       user_id: TEST_USER_ID,
@@ -293,7 +313,7 @@ describe.skipIf(!canRun)('Approval gate pauseReason metadata (integration)', () 
       groupId,
       userId: TEST_USER_ID!,
       strategy: 'persistence',
-      ownerAgentId: 'integration-test',
+      sbId: TEST_SB_ID!,
       config: { maxIterationsWithoutApproval: 1 },
     });
 
@@ -403,6 +423,16 @@ describe.skipIf(!canRun)('strategy_trigger activity events (integration)', () =>
       },
     };
 
+    if (!TEST_SB_ID) {
+      const { data: identity } = await client
+        .from('agent_identities')
+        .select('id')
+        .eq('user_id', TEST_USER_ID!)
+        .limit(1)
+        .single();
+      TEST_SB_ID = identity?.id;
+    }
+
     const group = await dc.repositories.taskGroups.create({
       user_id: TEST_USER_ID,
       title: `__observability_trigger_test_${Date.now()}`,
@@ -445,7 +475,7 @@ describe.skipIf(!canRun)('strategy_trigger activity events (integration)', () =>
       groupId,
       userId: TEST_USER_ID!,
       strategy: 'persistence',
-      ownerAgentId: 'integration-test',
+      sbId: TEST_SB_ID!,
     });
 
     // Wait briefly for fire-and-forget logs
@@ -458,7 +488,7 @@ describe.skipIf(!canRun)('strategy_trigger activity events (integration)', () =>
     expect(triggerEvents[0].payload).toMatchObject({
       groupId,
       reason: 'strategy_kickoff',
-      ownerAgentId: 'integration-test',
+      sbId: TEST_SB_ID!,
     });
     expect(triggerEvents[0].payload).toHaveProperty('taskId');
     expect(triggerEvents[0].payload).toHaveProperty('taskTitle');
@@ -481,7 +511,7 @@ describe.skipIf(!canRun)('strategy_trigger activity events (integration)', () =>
     expect(watchdogTriggers[0].payload).toMatchObject({
       groupId,
       reason: 'watchdog',
-      ownerAgentId: 'integration-test',
+      sbId: TEST_SB_ID!,
     });
   });
 

--- a/packages/api/src/services/strategy-watchdog.integration.test.ts
+++ b/packages/api/src/services/strategy-watchdog.integration.test.ts
@@ -43,6 +43,8 @@ const configPath = resolve(process.env.HOME || '', '.ink/config.json');
 const inkConfig = existsSync(configPath) ? JSON.parse(readFileSync(configPath, 'utf-8')) : {};
 const TEST_USER_ID: string | undefined = inkConfig.userId;
 
+let TEST_SB_ID: string | undefined;
+
 const canRun = !!SUPABASE_URL && !!SUPABASE_KEY && !!TEST_USER_ID;
 
 // Mock notifications so we don't send real inbox messages
@@ -83,6 +85,14 @@ describe.skipIf(!canRun)('Strategy Watchdog (integration)', () => {
         activityStream: new ActivityStreamRepository(client),
       },
     };
+
+    const { data: identity } = await client
+      .from('agent_identities')
+      .select('id')
+      .eq('user_id', TEST_USER_ID!)
+      .limit(1)
+      .single();
+    TEST_SB_ID = identity?.id;
 
     // Create test task group
     const group = await dc.repositories.taskGroups.create({
@@ -169,7 +179,7 @@ describe.skipIf(!canRun)('Strategy Watchdog (integration)', () => {
       groupId,
       userId: TEST_USER_ID!,
       strategy: 'persistence',
-      ownerAgentId: 'integration-test',
+      sbId: TEST_SB_ID!,
       config: { watchdogIntervalMinutes: 1 },
     });
 
@@ -181,7 +191,7 @@ describe.skipIf(!canRun)('Strategy Watchdog (integration)', () => {
     expect(meta.strategyWatchdog).toBe(true);
     expect(meta.groupId).toBe(groupId);
     expect(meta.strategy).toBe('persistence');
-    expect(meta.ownerAgentId).toBe('integration-test');
+    expect(meta.sbId).toBe(TEST_SB_ID);
     expect(watchdog.cron_expression).toBe('*/1 * * * *');
     expect(watchdog.status).toBe('active');
 

--- a/packages/api/src/services/strategy.service.test.ts
+++ b/packages/api/src/services/strategy.service.test.ts
@@ -37,6 +37,16 @@ vi.mock('./studio-settings', () => ({
   ensureStudioSettings: vi.fn().mockResolvedValue(true),
 }));
 
+vi.mock('../auth/resolve-identity', () => ({
+  resolveAgentSlug: vi.fn().mockImplementation((_client: unknown, sbId: string) => {
+    if (sbId === 'sb-wren-uuid') return Promise.resolve('wren');
+    if (sbId === 'supervisor-uuid-123' || sbId === 'supervisor-uuid-456')
+      return Promise.resolve('lumen');
+    return Promise.resolve(null);
+  }),
+  resolveIdentityId: vi.fn().mockResolvedValue('sb-wren-uuid'),
+}));
+
 // ============================================================================
 // Mock Helpers
 // ============================================================================
@@ -69,7 +79,7 @@ function createMockGroup(overrides: Partial<TaskGroup> = {}): TaskGroup {
     iterations_since_approval: 0,
     strategy_started_at: null,
     strategy_paused_at: null,
-    owner_agent_id: 'wren',
+    sb_id: 'sb-wren-uuid',
     created_at: '2026-04-10T00:00:00Z',
     updated_at: '2026-04-10T00:00:00Z',
     ...overrides,
@@ -210,7 +220,7 @@ describe('StrategyService', () => {
         groupId: 'group-1',
         userId: 'user-123',
         strategy: 'persistence',
-        ownerAgentId: 'wren',
+        sbId: 'sb-wren-uuid',
       });
 
       expect(result.action).toBe('next_task');
@@ -222,7 +232,6 @@ describe('StrategyService', () => {
 
       // Verify task was started with assignment metadata
       expect(dc.repositories.tasks.startTask).toHaveBeenCalledWith('task-1', {
-        agentId: 'wren',
         studioId: undefined,
       });
 
@@ -245,7 +254,7 @@ describe('StrategyService', () => {
           groupId: 'group-1',
           userId: 'user-123',
           strategy: 'persistence',
-          ownerAgentId: 'wren',
+          sbId: 'sb-wren-uuid',
         })
       ).rejects.toThrow('already active');
     });
@@ -259,7 +268,7 @@ describe('StrategyService', () => {
           groupId: 'group-1',
           userId: 'user-123',
           strategy: 'persistence',
-          ownerAgentId: 'wren',
+          sbId: 'sb-wren-uuid',
         })
       ).rejects.toThrow('does not belong');
     });
@@ -305,7 +314,7 @@ describe('StrategyService', () => {
         groupId: 'group-1',
         userId: 'user-123',
         strategy: 'persistence',
-        ownerAgentId: 'wren',
+        sbId: 'sb-wren-uuid',
         planUri: 'ink://specs/test',
       });
 
@@ -493,7 +502,7 @@ describe('StrategyService', () => {
         groupId: 'group-1',
         userId: 'user-123',
         strategy: 'persistence',
-        ownerAgentId: 'wren',
+        sbId: 'sb-wren-uuid',
       });
 
       expect(result.prompt).toContain('CONTRIBUTING.md');
@@ -535,7 +544,7 @@ describe('StrategyService', () => {
         groupId: 'group-1',
         userId: 'user-123',
         strategy: 'persistence',
-        ownerAgentId: 'wren',
+        sbId: 'sb-wren-uuid',
         config: { verificationGates: ['tests', 'type-check'] },
       });
 
@@ -576,7 +585,7 @@ describe('StrategyService', () => {
         groupId: 'group-1',
         userId: 'user-123',
         strategy: 'persistence',
-        ownerAgentId: 'wren',
+        sbId: 'sb-wren-uuid',
         planUri: 'ink://specs/my-plan',
       });
 
@@ -731,7 +740,6 @@ describe('StrategyService', () => {
 
       // Verify task was started with assignment metadata
       expect(dc.repositories.tasks.startTask).toHaveBeenCalledWith('task-2', {
-        agentId: 'wren',
         studioId: undefined,
       });
 
@@ -804,12 +812,8 @@ describe('StrategyService', () => {
       dc.repositories.taskGroups.findById.mockResolvedValue(group);
       dc.repositories.taskGroups.update.mockResolvedValue(group);
 
-      // from() calls: getTaskByOrder, getGroupTasks, resolveAgentSlug
-      setupChains(dc, [
-        chainTaskFound(nextTask),
-        chainGroupTasks(groupTasks),
-        chainResolveSlug('lumen'),
-      ]);
+      // from() calls: getTaskByOrder, getGroupTasks
+      setupChains(dc, [chainTaskFound(nextTask), chainGroupTasks(groupTasks)]);
 
       const result = await service.advanceStrategy('group-1', 'task-3', 'user-123');
 
@@ -1005,7 +1009,6 @@ describe('StrategyService', () => {
         notFoundChain,
         chainGroupTasks(groupTasks),
         chainNoop(), // cancelWatchdog
-        chainResolveSlug('lumen'), // resolve supervisor UUID → slug
       ]);
 
       await service.advanceStrategy('group-1', 'task-2', 'user-123');
@@ -1308,7 +1311,6 @@ describe('StrategyService', () => {
 
       // Verify task was started with assignment metadata
       expect(dc.repositories.tasks.startTask).toHaveBeenCalledWith('task-3', {
-        agentId: 'wren',
         studioId: undefined,
       });
 
@@ -1554,8 +1556,7 @@ describe('StrategyService', () => {
       let idx = 0;
       const chains = [
         noopChain, // watchdog: sessions
-        noopChain, // watchdog: identity
-        noopChain, // watchdog: insert
+        noopChain, // watchdog: insert (sb_id resolved directly, no identity lookup)
         taskNotFoundChain, // getTaskByOrder: exact match (fails)
         taskNotFoundChain, // getTaskByOrder: fallback (empty)
         groupTasksChain, // getGroupTasks for finalization
@@ -1715,7 +1716,7 @@ describe('StrategyService', () => {
 
       const group = createMockGroup({
         strategy: null,
-        owner_agent_id: 'wren',
+        sb_id: 'sb-wren-uuid',
         thread_key: 'strategy:group-1',
         metadata: { studioId: 'studio-uuid-omega', studioSlug: 'wren-omega' },
       });
@@ -1737,7 +1738,7 @@ describe('StrategyService', () => {
         groupId: 'group-1',
         userId: 'user-123',
         strategy: 'persistence',
-        ownerAgentId: 'wren',
+        sbId: 'sb-wren-uuid',
       });
 
       expect(sendMock).toHaveBeenCalledTimes(1);
@@ -1761,7 +1762,7 @@ describe('StrategyService', () => {
 
       const group = createMockGroup({
         strategy: null,
-        owner_agent_id: 'wren',
+        sb_id: 'sb-wren-uuid',
         metadata: { studioSlug: 'wren-omega' },
       });
       const updatedGroup = { ...group, strategy: 'persistence', status: 'active' };
@@ -1778,7 +1779,7 @@ describe('StrategyService', () => {
         groupId: 'group-1',
         userId: 'user-123',
         strategy: 'persistence',
-        ownerAgentId: 'wren',
+        sbId: 'sb-wren-uuid',
       });
 
       const call = (sendMock as unknown as { mock: { calls: unknown[][] } }).mock.calls[0];
@@ -1787,18 +1788,18 @@ describe('StrategyService', () => {
       expect(payload.recipientStudioSlug).toBe('wren-omega');
     });
 
-    it('startStrategy skips trigger when group has no owner_agent_id', async () => {
+    it('startStrategy skips trigger when group has no sb_id', async () => {
       const { handleSendToInbox: sendMock } = await import('../mcp/tools/inbox-handlers');
 
-      const group = createMockGroup({ strategy: null, owner_agent_id: null });
+      const group = createMockGroup({ strategy: null, sb_id: null });
       const updatedGroup = {
         ...group,
         strategy: 'persistence',
-        // owner_agent_id stays null because startStrategy passes ownerAgentId but
+        // sb_id stays null because startStrategy passes sbId but
         // for this test we're validating the triggerOwnerAgent no-op path; the
-        // service writes owner_agent_id=input.ownerAgentId. Force it back to null
+        // service writes sb_id=input.sbId. Force it back to null
         // on the updated group to exercise the early-return.
-        owner_agent_id: null,
+        sb_id: null,
         status: 'active',
       };
       const task = createMockTask();
@@ -1814,7 +1815,7 @@ describe('StrategyService', () => {
         groupId: 'group-1',
         userId: 'user-123',
         strategy: 'persistence',
-        ownerAgentId: 'wren',
+        sbId: 'sb-wren-uuid',
       });
 
       expect(sendMock).not.toHaveBeenCalled();
@@ -1826,7 +1827,7 @@ describe('StrategyService', () => {
       const group = createMockGroup({
         strategy: 'persistence',
         status: 'active',
-        owner_agent_id: 'wren',
+        sb_id: 'sb-wren-uuid',
         metadata: { studioId: 'studio-uuid-omega' },
       });
       const tasks = [
@@ -1884,7 +1885,7 @@ describe('StrategyService', () => {
       const group = createMockGroup({
         strategy: 'persistence',
         status: 'active',
-        owner_agent_id: 'wren',
+        sb_id: 'sb-wren-uuid',
         current_task_index: 1,
       });
       const tasks = [
@@ -1945,7 +1946,7 @@ describe('StrategyService', () => {
         groupId: 'group-1',
         userId: 'user-123',
         strategy: 'persistence',
-        ownerAgentId: 'wren',
+        sbId: 'sb-wren-uuid',
       });
 
       expect(mockOrchestrator.spinUp).not.toHaveBeenCalled();
@@ -2008,7 +2009,7 @@ describe('StrategyService', () => {
         groupId: 'group-1',
         userId: 'user-123',
         strategy: 'persistence',
-        ownerAgentId: 'wren',
+        sbId: 'sb-wren-uuid',
       });
 
       expect(mockOrchestrator.spinUp).toHaveBeenCalledWith(
@@ -2081,7 +2082,7 @@ describe('StrategyService', () => {
         groupId: 'group-1',
         userId: 'user-123',
         strategy: 'persistence',
-        ownerAgentId: 'wren',
+        sbId: 'sb-wren-uuid',
       });
 
       // Fail-closed: strategy aborts, group is paused
@@ -2148,7 +2149,7 @@ describe('StrategyService', () => {
         groupId: 'group-1',
         userId: 'user-123',
         strategy: 'persistence',
-        ownerAgentId: 'wren',
+        sbId: 'sb-wren-uuid',
       });
 
       // Preferred: strategy continues on host despite sandbox failure
@@ -2198,7 +2199,7 @@ describe('StrategyService', () => {
         groupId: 'group-1',
         userId: 'user-123',
         strategy: 'persistence',
-        ownerAgentId: 'wren',
+        sbId: 'sb-wren-uuid',
       });
 
       // Fail-closed: no studioId means sandbox can't start
@@ -2286,7 +2287,7 @@ describe('StrategyService', () => {
         groupId: 'group-1',
         userId: 'user-123',
         strategy: 'persistence',
-        ownerAgentId: 'wren',
+        sbId: 'sb-wren-uuid',
         config: { sandbox: true, ephemeralStudio: true },
       });
 
@@ -2360,7 +2361,7 @@ describe('StrategyService', () => {
         groupId: 'group-1',
         userId: 'user-123',
         strategy: 'persistence',
-        ownerAgentId: 'wren',
+        sbId: 'sb-wren-uuid',
         config: { sandbox: true, ephemeralStudio: true },
       });
 

--- a/packages/api/src/services/strategy.service.ts
+++ b/packages/api/src/services/strategy.service.ts
@@ -26,6 +26,7 @@ import type {
 } from '../data/repositories/task-groups.repository';
 import type { ProjectTask, TaskAssignment } from '../data/repositories/project-tasks.repository';
 import { handleSendToInbox } from '../mcp/tools/inbox-handlers';
+import { resolveAgentSlug } from '../auth/resolve-identity';
 import { logger } from '../utils/logger';
 import { ensureStudioSettings } from './studio-settings';
 import type { SandboxOrchestrator, SandboxSpinUpResult } from './sandbox/orchestrator';
@@ -40,7 +41,7 @@ export interface StartStrategyInput {
   groupId: string;
   userId: string;
   strategy: StrategyPreset;
-  ownerAgentId: string;
+  sbId: string;
   config?: StrategyConfig;
   verificationMode?: VerificationMode;
   planUri?: string;
@@ -68,7 +69,7 @@ export interface StrategyStatus {
   title: string;
   strategy: StrategyPreset;
   status: string;
-  ownerAgentId: string | null;
+  sbId: string | null;
   planUri: string | null;
   verificationMode: VerificationMode;
   currentTaskIndex: number;
@@ -182,8 +183,12 @@ export class StrategyService {
     const meta = group.metadata as Record<string, unknown> | null;
     return {
       studioId: (meta?.studioId as string) || undefined,
-      agentId: group.owner_agent_id || undefined,
     };
+  }
+
+  private async resolveOwnerSlug(group: TaskGroup): Promise<string | null> {
+    if (!group.sb_id) return null;
+    return resolveAgentSlug(this.dataComposer.getClient(), group.sb_id);
   }
 
   /**
@@ -207,7 +212,7 @@ export class StrategyService {
       strategy_config: input.config || (group.strategy_config as StrategyConfig),
       verification_mode: input.verificationMode || group.verification_mode,
       plan_uri: input.planUri || group.plan_uri || undefined,
-      owner_agent_id: input.ownerAgentId,
+      sb_id: input.sbId,
       status: 'active',
       autonomous: true,
       current_task_index: 0,
@@ -405,7 +410,10 @@ export class StrategyService {
 
         // Notify supervisor too if configured
         if (config.supervisorId) {
-          const supervisorSlug = await this.resolveAgentSlug(config.supervisorId);
+          const supervisorSlug = await resolveAgentSlug(
+            this.dataComposer.getClient(),
+            config.supervisorId
+          );
           if (supervisorSlug) {
             await this.notifyDispatcher(
               group,
@@ -525,7 +533,10 @@ export class StrategyService {
 
       // Notify supervisor at check-in points too
       if (config.supervisorId) {
-        const supervisorSlug = await this.resolveAgentSlug(config.supervisorId);
+        const supervisorSlug = await resolveAgentSlug(
+          this.dataComposer.getClient(),
+          config.supervisorId
+        );
         if (supervisorSlug) {
           await this.notifyDispatcher(
             group,
@@ -791,7 +802,7 @@ export class StrategyService {
       title: group.title,
       strategy: group.strategy as StrategyPreset,
       status: group.status,
-      ownerAgentId: group.owner_agent_id,
+      sbId: group.sb_id,
       planUri: group.plan_uri,
       verificationMode: group.verification_mode,
       currentTaskIndex: group.current_task_index,
@@ -908,12 +919,13 @@ export class StrategyService {
 
     try {
       const threadKey = group.thread_key || `strategy:${group.id}`;
+      const senderSlug = (await this.resolveOwnerSlug(group)) || 'system';
 
       await handleSendToInbox(
         {
           userId,
           recipientAgentId: notifyAgentId,
-          senderAgentId: group.owner_agent_id || 'system',
+          senderAgentId: senderSlug,
           content: message,
           messageType: 'notification',
           priority: 'high',
@@ -945,7 +957,7 @@ export class StrategyService {
    *     starts working without the user having to manually attach)
    *   - watchdog re-triggers (wake a stuck session on the heartbeat)
    *
-   * No-ops with a warn log if the group has no owner_agent_id. Non-fatal on
+   * No-ops with a warn log if the group has no sb_id. Non-fatal on
    * send failure — returns false so callers can decide whether to escalate.
    */
   private async triggerOwnerAgent(
@@ -954,9 +966,9 @@ export class StrategyService {
     reason: 'strategy_kickoff' | 'watchdog' | 'manual_resume',
     sandboxContainerName?: string
   ): Promise<boolean> {
-    if (!group.owner_agent_id) {
+    if (!group.sb_id) {
       logger.warn(
-        `Strategy triggerOwnerAgent: group ${group.id} has no owner_agent_id — cannot route trigger`
+        `Strategy triggerOwnerAgent: group ${group.id} has no sb_id — cannot route trigger`
       );
       return false;
     }
@@ -968,6 +980,12 @@ export class StrategyService {
     }
 
     try {
+      const ownerSlug = await this.resolveOwnerSlug(group);
+      if (!ownerSlug) {
+        logger.warn(`Strategy triggerOwnerAgent: could not resolve slug for sb_id ${group.sb_id}`);
+        return false;
+      }
+
       const threadKey = group.thread_key || `strategy:${group.id}`;
       const metadata = (group.metadata || {}) as Record<string, unknown>;
       const rawStudioId = metadata.studioId;
@@ -979,8 +997,8 @@ export class StrategyService {
       await handleSendToInbox(
         {
           userId: group.user_id,
-          recipientAgentId: group.owner_agent_id,
-          senderAgentId: group.owner_agent_id,
+          recipientAgentId: ownerSlug,
+          senderAgentId: ownerSlug,
           // Prefer studioId (UUID); fall back to slug only when UUID is absent.
           recipientStudioId: studioId,
           recipientStudioSlug: studioId ? undefined : studioSlug,
@@ -1005,19 +1023,19 @@ export class StrategyService {
       );
 
       logger.info(
-        `Strategy trigger sent to ${group.owner_agent_id} for group ${group.id} (task ${task.id}, reason: ${reason}${studioId ? `, studio: ${studioId}` : studioSlug ? `, studioSlug: ${studioSlug}` : ''})`
+        `Strategy trigger sent to ${ownerSlug} for group ${group.id} (task ${task.id}, reason: ${reason}${studioId ? `, studio: ${studioId}` : studioSlug ? `, studioSlug: ${studioSlug}` : ''})`
       );
 
       await this.logStrategyEvent(
         group,
         'strategy_trigger',
-        `Triggered ${group.owner_agent_id} for task: ${task.title}`,
+        `Triggered ${ownerSlug} for task: ${task.title}`,
         {
           reason,
           taskId: task.id,
           taskTitle: task.title,
           studioId: studioId || studioSlug || null,
-          ownerAgentId: group.owner_agent_id,
+          sbId: group.sb_id,
         }
       );
 
@@ -1032,7 +1050,7 @@ export class StrategyService {
       this.logStrategyEvent(
         group,
         'strategy_trigger_failed',
-        `Failed to trigger ${group.owner_agent_id} for task: ${task.title}`,
+        `Failed to trigger ${group.sb_id} for task: ${task.title}`,
         {
           reason,
           taskId: task.id,
@@ -1052,7 +1070,7 @@ export class StrategyService {
     group: TaskGroup,
     repoRoot: string
   ): Promise<{ studioId: string; worktreePath: string; branch: string } | null> {
-    const agentId = group.owner_agent_id || 'agent';
+    const ownerSlug = (await this.resolveOwnerSlug(group)) || 'agent';
     const slugBase = (group.title || 'task')
       .toLowerCase()
       .replace(/[^a-z0-9]+/g, '-')
@@ -1060,7 +1078,7 @@ export class StrategyService {
       .slice(0, 30);
     const uniqueSuffix = Date.now().toString(36).slice(-6);
     const slug = `ephemeral-${slugBase}-${uniqueSuffix}`;
-    const branch = `${agentId}/sandbox/${slug}`;
+    const branch = `${ownerSlug}/sandbox/${slug}`;
 
     // Resolve to the main worktree root
     let mainRoot = repoRoot;
@@ -1114,7 +1132,7 @@ export class StrategyService {
     try {
       const studio = await this.dataComposer.repositories.studios.create({
         userId: group.user_id,
-        agentId,
+        agentId: ownerSlug,
         repoRoot: mainRoot,
         worktreePath,
         branch,
@@ -1283,9 +1301,10 @@ export class StrategyService {
       return { containerName: '', success: false, error: msg };
     }
 
+    const ownerSlug = (await this.resolveOwnerSlug(group)) || studio.agentId || 'unknown';
     const result = await this.sandboxOrchestrator.spinUp({
       userId: group.user_id,
-      agentId: group.owner_agent_id || studio.agentId || 'unknown',
+      agentId: ownerSlug,
       studioId: studio.id,
       studioSlug: studio.slug || undefined,
       worktreePath: studio.worktreePath,
@@ -1450,20 +1469,6 @@ export class StrategyService {
           backendSessionId = (session as { backend_session_id: string | null }).backend_session_id;
       }
 
-      // Resolve the owner agent's identity for reminder routing
-      let sbId: string | null = null;
-      if (group.owner_agent_id) {
-        const { data: identity } = await this.dataComposer
-          .getClient()
-          .from('agent_identities')
-          .select('id')
-          .eq('agent_id', group.owner_agent_id)
-          .eq('user_id', userId)
-          .limit(1)
-          .single();
-        if (identity) sbId = identity.id;
-      }
-
       await this.dataComposer
         .getClient()
         .from('scheduled_reminders')
@@ -1481,7 +1486,7 @@ export class StrategyService {
           ]
             .filter(Boolean)
             .join(' '),
-          sb_id: sbId,
+          sb_id: group.sb_id,
           cron_expression: `*/${intervalMinutes} * * * *`,
           next_run_at: nextRunAt.toISOString(),
           status: 'active',
@@ -1489,7 +1494,7 @@ export class StrategyService {
             strategyWatchdog: true,
             groupId: group.id,
             strategy: group.strategy,
-            ownerAgentId: group.owner_agent_id,
+            sbId: group.sb_id,
             threadKey: group.thread_key,
             inkSessionId,
             backendSessionId,
@@ -1548,7 +1553,10 @@ export class StrategyService {
     );
 
     if (config.supervisorId) {
-      const supervisorSlug = await this.resolveAgentSlug(config.supervisorId);
+      const supervisorSlug = await resolveAgentSlug(
+        this.dataComposer.getClient(),
+        config.supervisorId
+      );
       if (supervisorSlug) {
         await this.notifyDispatcher(
           group,
@@ -1595,24 +1603,6 @@ export class StrategyService {
   }
 
   /**
-   * Resolve an identity UUID to an agent_id slug for notification routing.
-   * notifyDispatcher/handleSendToInbox accept slugs, but we store identity UUIDs.
-   */
-  private async resolveAgentSlug(sbId: string): Promise<string | null> {
-    try {
-      const { data } = await this.dataComposer
-        .getClient()
-        .from('agent_identities')
-        .select('agent_id')
-        .eq('id', sbId)
-        .single();
-      return data ? (data as { agent_id: string }).agent_id : null;
-    } catch {
-      return null;
-    }
-  }
-
-  /**
    * Log a strategy event to the activity stream.
    * Links to the task group via task_group_id for dashboard correlation.
    */
@@ -1624,9 +1614,10 @@ export class StrategyService {
   ): Promise<void> {
     try {
       const reqCtx = getRequestContext();
+      const agentSlug = (await this.resolveOwnerSlug(group)) || 'system';
       await this.dataComposer.repositories.activityStream.logActivity({
         userId: group.user_id,
-        agentId: group.owner_agent_id || 'system',
+        agentId: agentSlug,
         type: 'state_change',
         subtype,
         content,
@@ -1636,6 +1627,7 @@ export class StrategyService {
           groupId: group.id,
           groupTitle: group.title,
           strategy: group.strategy,
+          sbId: group.sb_id || undefined,
           ...payload,
         } as unknown as import('../data/repositories/activity-stream.repository').Json,
         status: 'completed',

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -2868,13 +2868,13 @@ async function ensurePcpSessionContext(
         ),
         linkedLocalSession?.fileSizeBytes
       );
-      const ownerAgentId = session.agentId || null;
+      const sessionAgentId = session.agentId || null;
       const sortTimestamp = linkedLocalSession?.latestPromptAt || linkedLocalSession?.modified;
       const sortMs = toEpochMs(sortTimestamp || session.startedAt) ?? 0;
       return {
         type: 'pcp' as const,
         id: session.id,
-        ownerAgentId,
+        sessionAgentId,
         threadKey: session.threadKey || null,
         phase: getSessionPhaseLabel(session) || null,
         contextPreview: session.context || null,
@@ -2972,12 +2972,12 @@ async function ensurePcpSessionContext(
         ...interleavedCandidates.map((entry) => {
           if (entry.kind === 'pcp') {
             const session = entry.candidate;
-            const showOwner = Boolean(session.ownerAgentId && session.ownerAgentId !== agentId);
+            const showOwner = Boolean(session.sessionAgentId && session.sessionAgentId !== agentId);
             const ownerPhase = showOwner
-              ? `${session.ownerAgentId} · ${session.phase || '-'}`
+              ? `${session.sessionAgentId} · ${session.phase || '-'}`
               : session.phase || '-';
             return {
-              type: showOwner ? `pcp:${session.ownerAgentId}` : 'pcp',
+              type: showOwner ? `pcp:${session.sessionAgentId}` : 'pcp',
               choice: `pcp:${session.id.slice(0, 8)}`,
               updated: formatCandidateTimestamp(session.linkedLocalModified || session.startedAt),
               phase: ownerPhase,

--- a/packages/cli/src/commands/hooks.ts
+++ b/packages/cli/src/commands/hooks.ts
@@ -1865,7 +1865,7 @@ async function onSessionStartHandler(options?: { backend?: string }): Promise<vo
     hookBackendOverride: options?.backend || process.env.INK_HOOK_BACKEND || null,
   });
 
-  let { studioId, studioName, role } = getIdentitySessionContext(cwd);
+  let { studioId, sbId, studioName, role } = getIdentitySessionContext(cwd);
   const studioLine = studioName ? `Studio: ${studioName}` : '';
 
   let identityBlock = '';
@@ -1974,7 +1974,7 @@ async function onSessionStartHandler(options?: { backend?: string }): Promise<vo
       callPcpTool('list_task_groups', {
         email: config?.email,
         statuses: ['active', 'paused'],
-        ownerAgentId: agentId,
+        ...(sbId ? { sbId } : {}),
         includeTaskCounts: true,
       }),
       callPcpTool('list_tasks', {

--- a/packages/web/src/app/(dashboard)/missions/[groupId]/page.tsx
+++ b/packages/web/src/app/(dashboard)/missions/[groupId]/page.tsx
@@ -61,8 +61,6 @@ interface TaskGroupDetail {
   tags: string[];
   autonomous: boolean;
   strategy: string | null;
-  ownerAgentId: string | null;
-  ownerAgentName: string | null;
   agentName: string | null;
   projectName: string | null;
   currentTaskIndex: number;
@@ -664,7 +662,7 @@ export default function MissionDetailPage() {
   const isPaused = group.status === 'paused';
   const statusCfg =
     STATUS_CONFIG[group.status as keyof typeof STATUS_CONFIG] ?? STATUS_CONFIG.draft;
-  const ownerName = group.strategy ? group.ownerAgentName : group.agentName;
+  const ownerName = group.agentName;
   const elapsed = computeElapsed(group.strategyStartedAt);
   const completed = tasks.filter((t) => t.status === 'completed').length;
   const agentColors = ownerName ? (AGENT_COLORS[ownerName.toLowerCase()] ?? null) : null;

--- a/packages/web/src/app/(dashboard)/tasks/page.tsx
+++ b/packages/web/src/app/(dashboard)/tasks/page.tsx
@@ -83,8 +83,6 @@ interface TaskGroupData {
   outputStatus: string | null;
   threadKey: string | null;
   strategy: string | null;
-  ownerAgentId: string | null;
-  ownerAgentName: string | null;
   currentTaskIndex: number;
   strategyStartedAt: string | null;
   strategyPausedAt: string | null;
@@ -688,10 +686,10 @@ function TaskGroupSection({
             )}
           </div>
           <div className="flex items-center gap-2 mt-0.5 text-[11px] text-gray-400">
-            {(group.strategy ? group.ownerAgentName : group.agentName) && (
+            {group.agentName && (
               <span className="flex items-center gap-1">
                 <Bot className="h-3 w-3" />
-                {group.strategy ? group.ownerAgentName : group.agentName}
+                {group.agentName}
               </span>
             )}
             {group.projectName && (

--- a/packages/web/src/components/command/data-hooks.ts
+++ b/packages/web/src/components/command/data-hooks.ts
@@ -53,7 +53,8 @@ interface TaskItem {
 interface TaskGroupItem {
   id: string;
   title: string;
-  ownerAgentId: string | null;
+  agentId: string | null;
+  agentName: string | null;
 }
 
 interface TasksResponse {

--- a/supabase/migrations/20260513003917_drop_task_groups_owner_agent_id.sql
+++ b/supabase/migrations/20260513003917_drop_task_groups_owner_agent_id.sql
@@ -1,0 +1,14 @@
+-- Migrate owner_agent_id (slug) → sb_id (UUID) for any rows that have the slug but not the UUID,
+-- then drop the denormalized slug column.
+
+-- Step 1: Backfill sb_id from owner_agent_id where sb_id is null
+UPDATE task_groups tg
+SET sb_id = ai.id
+FROM agent_identities ai
+WHERE tg.owner_agent_id IS NOT NULL
+  AND tg.sb_id IS NULL
+  AND ai.agent_id = tg.owner_agent_id
+  AND ai.user_id = tg.user_id;
+
+-- Step 2: Drop the column
+ALTER TABLE task_groups DROP COLUMN IF EXISTS owner_agent_id;


### PR DESCRIPTION
## Summary

- **Remove denormalized `owner_agent_id` slug column** from `task_groups` in favor of the canonical `sb_id` UUID (from `agent_identities.id`)
- **Add `resolveAgentSlug()` reverse lookup** (UUID → slug) in `resolve-identity.ts` for display/routing boundaries
- **Add `resolveOwnerSlug()` helper** to `StrategyService` — resolves slug from `group.sb_id` only when needed for `send_to_inbox`, logging, and sandbox orchestration
- **Migration** backfills `sb_id` from `owner_agent_id` where missing, then drops the column

### What changed across the stack

| Layer | Change |
|-------|--------|
| **Repository** | Removed `owner_agent_id` from `TaskGroup`, `CreateTaskGroupInput`, `UpdateTaskGroupInput`, `ListTaskGroupsOptions`, `findActiveStrategies` |
| **Strategy service** | `StartStrategyInput.ownerAgentId` → `sbId`; all slug reads resolved dynamically from `sb_id` |
| **MCP tools** | Removed `ownerAgentId` from `update_task_group`, `list_task_groups`, `start_strategy` schemas |
| **Admin routes** | Removed owner name resolution block; agent names come from existing `sb_id` → `agent_identities` join |
| **CLI** | Session display renamed to `sessionAgentId`; hook filtering uses `sbId` from identity.json |
| **Web dashboard** | Removed `ownerAgentId`/`ownerAgentName` from task group interfaces and rendering |
| **Tests** | Updated 53 unit tests + 4 integration test files |

## Test plan

- [x] All 53 strategy service unit tests pass
- [x] All 86 task handler unit tests pass
- [x] No new type errors (6 pre-existing, unchanged)
- [ ] Integration tests pass against real DB (require running server)
- [ ] Migration applies cleanly (`supabase db push`)
- [ ] Verify task groups display correctly in web dashboard after migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)