### PR TITLE
refactor: trigger delivery extraction + rename update_session_state (by Wren)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,10 +62,10 @@ To find your session from bootstrap's `activeSessions` array, match by `studioId
 const mySession = activeSessions.find((s) => s.studioId === identityJson.studioId);
 ```
 
-Throughout the session, use `update_session_phase` for structural status changes:
+Throughout the session, use `update_session_state` for structural status changes:
 
 ```
-update_session_phase(userId: "...", phase: "active:implementing", studioId: "...")
+update_session_state(userId: "...", phase: "active:implementing", studioId: "...")
 ```
 
 Use `remember` for decisions, insights, and important events:
@@ -74,7 +74,7 @@ Use `remember` for decisions, insights, and important events:
 remember(userId: "...", content: "Decided to use X approach because...", agentId: "wren")
 ```
 
-**Note**: Session lifecycle (`start_session`, `end_session`) is managed automatically by hooks — SBs should not call these manually. Use `remember()` for important context and `update_session_phase()` for work status.
+**Note**: Session lifecycle (`start_session`, `end_session`) is managed automatically by hooks — SBs should not call these manually. Use `remember()` for important context and `update_session_state()` for work status.
 
 **Note**: Never commit PII (emails, user IDs) to the repository. Always read from config files.
 
@@ -490,7 +490,7 @@ The MCP server exposes 60+ tools. Key categories:
 
 - `bootstrap` - **Call first!** Loads identity, context, and recent memories
 - `start_session` / `end_session` - Managed automatically by hooks (do not call manually)
-- `update_session_phase` - Update work phase (investigating, implementing, reviewing, etc.)
+- `update_session_state` - Update work phase (investigating, implementing, reviewing, etc.)
 - `get_session` - Get session details and logs
 - `list_sessions` - List past sessions
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -166,9 +166,9 @@ Identity is resolved from: system prompt override → `$AGENT_ID` env var → `.
 
 | Domain                   | Tools                                                               |
 | ------------------------ | ------------------------------------------------------------------- |
-| **Bootstrap & Sessions** | `bootstrap`, `update_session_phase`, `get_session`, `list_sessions` |
+| **Bootstrap & Sessions** | `bootstrap`, `update_session_state`, `get_session`, `list_sessions` |
 | **Memory**               | `remember`, `recall`, `forget`, `update_memory`, history/restore    |
-| **Context & Projects**   | `save_context`, `get_context`, `save_project`, `set_focus`          |
+| **Context & Projects**   | `save_context`, `get_context`, `save_project`                       |
 | **Communication**        | `send_response`, `send_to_inbox`, `trigger_agent`                   |
 | **Data**                 | `save_link`, `create_task`, `create_reminder`, calendar, email      |
 | **Identity**             | `save_identity`, `get_identity`, permissions, audit log             |

--- a/packages/api/src/config/constants.ts
+++ b/packages/api/src/config/constants.ts
@@ -19,7 +19,7 @@ Most tools require identifying a user. You can use ANY ONE of these methods:
 
 ## Core Capabilities
 - **Memory**: remember, recall, forget - Long-term memory with semantic search
-- **Sessions**: update_session_phase, get_session, list_sessions - Track and inspect session state
+- **Sessions**: update_session_state, get_session, list_sessions - Track and inspect session state
 - **Bootstrap**: bootstrap - Initialize agent with user context, identity, and recent memories
 - **Gmail**: list_emails, get_email, send_email, modify_emails - Full Gmail integration
 - **Calendar**: list_calendars, list_calendar_events - Google Calendar access

--- a/packages/api/src/mcp/tools/index.test.ts
+++ b/packages/api/src/mcp/tools/index.test.ts
@@ -19,7 +19,7 @@ describe('registerAllTools lifecycle visibility', () => {
 
     expect(server.registeredTools).not.toContain('start_session');
     expect(server.registeredTools).not.toContain('end_session');
-    expect(server.registeredTools).toContain('update_session_phase');
+    expect(server.registeredTools).toContain('update_session_state');
   });
 
   it('includes lifecycle tools when includeInternalLifecycleTools=true', () => {
@@ -32,7 +32,7 @@ describe('registerAllTools lifecycle visibility', () => {
     expect(server.registeredTools).toContain('start_session');
     expect(server.registeredTools).toContain('end_session');
     expect(server.registeredTools).not.toContain('log_session');
-    expect(server.registeredTools).toContain('update_session_phase');
+    expect(server.registeredTools).toContain('update_session_state');
     expect(server.registeredTools).toContain('get_agent_summaries');
   });
 });

--- a/packages/api/src/mcp/tools/index.ts
+++ b/packages/api/src/mcp/tools/index.ts
@@ -12,8 +12,6 @@ import {
   handleSaveProject,
   handleListProjects,
   handleGetProject,
-  handleSetFocus,
-  handleGetFocus,
 } from './context-handlers';
 
 import {
@@ -51,7 +49,7 @@ import {
   handleEndSession,
   handleGetSession,
   handleListSessions,
-  handleUpdateSessionPhase,
+  handleUpdateSessionState,
   handleGetMemoryHistory,
   handleGetUserHistory,
   handleRestoreMemory,
@@ -721,76 +719,6 @@ User can be identified by ONE of: userId, email, phone, or platform + platformId
   // =====================================================
   // SESSION FOCUS TOOLS
   // =====================================================
-
-  // Register set_focus tool
-  server.registerTool(
-    'set_focus',
-    {
-      description: `Set the current focus/context for a session. Tracks what project and task we're working on.
-
-User can be identified by ONE of: userId, email, phone, or platform + platformId`,
-      inputSchema: {
-        ...userIdentifierFields,
-        sessionId: z.string().optional().describe('Session ID'),
-        projectName: z.string().optional().describe('Project name to focus on'),
-        projectId: z.string().uuid().optional().describe('Project UUID to focus on'),
-        focusSummary: z.string().optional().describe('What we are currently working on'),
-        contextSnapshot: z.record(z.unknown()).optional().describe('Context snapshot'),
-      },
-    },
-    async (args) => {
-      try {
-        return await handleSetFocus(args, dataComposer);
-      } catch (error) {
-        logger.error('Error in set_focus:', error);
-        return {
-          content: [
-            {
-              type: 'text' as const,
-              text: JSON.stringify({
-                success: false,
-                error: error instanceof Error ? error.message : 'Unknown error',
-              }),
-            },
-          ],
-          isError: true,
-        };
-      }
-    }
-  );
-
-  // Register get_focus tool
-  server.registerTool(
-    'get_focus',
-    {
-      description: `Get the current focus/context for a session or the user's most recent focus.
-
-User can be identified by ONE of: userId, email, phone, or platform + platformId`,
-      inputSchema: {
-        ...userIdentifierFields,
-        sessionId: z.string().optional().describe('Specific session ID'),
-      },
-    },
-    async (args) => {
-      try {
-        return await handleGetFocus(args, dataComposer);
-      } catch (error) {
-        logger.error('Error in get_focus:', error);
-        return {
-          content: [
-            {
-              type: 'text' as const,
-              text: JSON.stringify({
-                success: false,
-                error: error instanceof Error ? error.message : 'Unknown error',
-              }),
-            },
-          ],
-          isError: true,
-        };
-      }
-    }
-  );
 
   // =====================================================
   // PROJECT TASK TOOLS
@@ -2075,9 +2003,9 @@ User can be identified by ONE of: userId, email, phone, or platform + platformId
     }
   );
 
-  // Register update_session_phase tool
+  // Register update_session_state tool
   server.registerTool(
-    'update_session_phase',
+    'update_session_state',
     {
       description: `Update your session state — work phase, status, backend session ID, context. This is the primary tool for managing session state.
 
@@ -2147,9 +2075,9 @@ User can be identified by ONE of: userId, email, phone, or platform + platformId
     },
     async (args) => {
       try {
-        return await handleUpdateSessionPhase(args, dataComposer);
+        return await handleUpdateSessionState(args, dataComposer);
       } catch (error) {
-        logger.error('Error in update_session_phase:', error);
+        logger.error('Error in update_session_state:', error);
         return {
           content: [
             {
@@ -2283,7 +2211,7 @@ User can be identified by ONE of: userId, email, phone, or platform + platformId
 Returns:
 - Identity Files: shared values/user/process docs and agent-specific identity docs from ~/.pcp
 - Identity Core: user profile, assistant role, relationship context from DB
-- Active Context: current projects, focus, project-specific context
+- Active Context: current projects, session context, project-specific context
 - Active Session: current session if any
 - Recent Memories: high-salience memories (filtered by agent if provided)
 

--- a/packages/api/src/mcp/tools/memory-handlers.test.ts
+++ b/packages/api/src/mcp/tools/memory-handlers.test.ts
@@ -2,15 +2,15 @@
  * Memory Handler Tests
  *
  * Tests for MCP tool schemas and handlers related to sessions,
- * session phases, and the unified update_session_phase tool.
+ * session phases, and the unified update_session_state tool.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   startSessionSchema,
   listSessionsSchema,
-  updateSessionPhaseSchema,
-  handleUpdateSessionPhase,
+  updateSessionStateSchema,
+  handleUpdateSessionState,
   handleStartSession,
   curateRecallSchema,
   handleCurateRecall,
@@ -237,9 +237,9 @@ describe('listSessionsSchema', () => {
   });
 });
 
-describe('updateSessionPhaseSchema', () => {
+describe('updateSessionStateSchema', () => {
   it('should accept phase only', () => {
-    const result = updateSessionPhaseSchema.safeParse({
+    const result = updateSessionStateSchema.safeParse({
       email: 'test@test.com',
       phase: 'implementing',
     });
@@ -251,7 +251,7 @@ describe('updateSessionPhaseSchema', () => {
   });
 
   it('should accept blocked phase with note', () => {
-    const result = updateSessionPhaseSchema.safeParse({
+    const result = updateSessionStateSchema.safeParse({
       email: 'test@test.com',
       phase: 'blocked:awaiting-user-approval',
       note: 'Need approval on approach C before proceeding',
@@ -267,7 +267,7 @@ describe('updateSessionPhaseSchema', () => {
   });
 
   it('should accept backendSessionId without phase (metadata-only update)', () => {
-    const result = updateSessionPhaseSchema.safeParse({
+    const result = updateSessionStateSchema.safeParse({
       email: 'test@test.com',
       backendSessionId: 'claude-session-abc123',
     });
@@ -280,7 +280,7 @@ describe('updateSessionPhaseSchema', () => {
   });
 
   it('should accept all unified fields together', () => {
-    const result = updateSessionPhaseSchema.safeParse({
+    const result = updateSessionStateSchema.safeParse({
       email: 'test@test.com',
       phase: 'implementing',
       backendSessionId: 'claude-session-abc123',
@@ -303,7 +303,7 @@ describe('updateSessionPhaseSchema', () => {
 
   it('should accept status enum values', () => {
     for (const status of ['active', 'paused', 'resumable', 'completed']) {
-      const result = updateSessionPhaseSchema.safeParse({
+      const result = updateSessionStateSchema.safeParse({
         email: 'test@test.com',
         status,
       });
@@ -312,7 +312,7 @@ describe('updateSessionPhaseSchema', () => {
   });
 
   it('should reject invalid status enum values', () => {
-    const result = updateSessionPhaseSchema.safeParse({
+    const result = updateSessionStateSchema.safeParse({
       email: 'test@test.com',
       status: 'invalid-status',
     });
@@ -320,7 +320,7 @@ describe('updateSessionPhaseSchema', () => {
   });
 
   it('should accept sessionId as optional UUID', () => {
-    const result = updateSessionPhaseSchema.safeParse({
+    const result = updateSessionStateSchema.safeParse({
       email: 'test@test.com',
       sessionId: '550e8400-e29b-41d4-a716-446655440000',
       phase: 'reviewing',
@@ -333,7 +333,7 @@ describe('updateSessionPhaseSchema', () => {
   });
 
   it('should reject non-UUID sessionId', () => {
-    const result = updateSessionPhaseSchema.safeParse({
+    const result = updateSessionStateSchema.safeParse({
       email: 'test@test.com',
       sessionId: 'not-a-uuid',
       phase: 'implementing',
@@ -342,7 +342,7 @@ describe('updateSessionPhaseSchema', () => {
   });
 
   it('should accept free-text phase values (extensible)', () => {
-    const result = updateSessionPhaseSchema.safeParse({
+    const result = updateSessionStateSchema.safeParse({
       email: 'test@test.com',
       phase: 'waiting:ci-pipeline-completion',
     });
@@ -358,7 +358,7 @@ describe('updateSessionPhaseSchema', () => {
 // HANDLER TESTS
 // =====================================================
 
-describe('handleUpdateSessionPhase', () => {
+describe('handleUpdateSessionState', () => {
   let mockDataComposer: ReturnType<typeof createMockDataComposer>;
 
   const mockSession = {
@@ -392,7 +392,7 @@ describe('handleUpdateSessionPhase', () => {
       mockDataComposer.repositories.memory.getActiveSession.mockResolvedValue(mockSession);
       mockDataComposer.repositories.memory.updateSession.mockResolvedValue(mockUpdatedSession);
 
-      const result = await handleUpdateSessionPhase(
+      const result = await handleUpdateSessionState(
         { email: 'test@test.com', phase: 'implementing' },
         mockDataComposer as never
       );
@@ -417,7 +417,7 @@ describe('handleUpdateSessionPhase', () => {
     it('should update phase on explicitly specified session', async () => {
       mockDataComposer.repositories.memory.updateSession.mockResolvedValue(mockUpdatedSession);
 
-      const result = await handleUpdateSessionPhase(
+      const result = await handleUpdateSessionState(
         {
           email: 'test@test.com',
           sessionId: '550e8400-e29b-41d4-a716-446655440000',
@@ -437,7 +437,7 @@ describe('handleUpdateSessionPhase', () => {
       mockDataComposer.repositories.memory.getActiveSession.mockResolvedValue(mockSession);
       mockDataComposer.repositories.memory.updateSession.mockResolvedValue(mockUpdatedSession);
 
-      await handleUpdateSessionPhase(
+      await handleUpdateSessionState(
         { email: 'test@test.com', phase: 'investigating', agentId: 'wren' },
         mockDataComposer as never
       );
@@ -468,7 +468,7 @@ describe('handleUpdateSessionPhase', () => {
       mockDataComposer.repositories.memory.getSession.mockResolvedValue(before);
       mockDataComposer.repositories.memory.updateSession.mockResolvedValue(after);
 
-      const result = await handleUpdateSessionPhase(
+      const result = await handleUpdateSessionState(
         {
           email: 'test@test.com',
           phase: 'implementing',
@@ -501,7 +501,7 @@ describe('handleUpdateSessionPhase', () => {
       mockDataComposer.repositories.memory.updateSession.mockResolvedValue(mockUpdatedSession);
 
       const studioId = '550e8400-e29b-41d4-a716-446655440099';
-      await handleUpdateSessionPhase(
+      await handleUpdateSessionState(
         { email: 'test@test.com', phase: 'implementing', agentId: 'wren', studioId },
         mockDataComposer as never
       );
@@ -518,7 +518,7 @@ describe('handleUpdateSessionPhase', () => {
 
       const sessionId = '550e8400-e29b-41d4-a716-446655440000';
       const studioId = '550e8400-e29b-41d4-a716-446655440099';
-      await handleUpdateSessionPhase(
+      await handleUpdateSessionState(
         { email: 'test@test.com', phase: 'reviewing', sessionId, studioId },
         mockDataComposer as never
       );
@@ -536,7 +536,7 @@ describe('handleUpdateSessionPhase', () => {
       mockDataComposer.repositories.memory.updateSession.mockResolvedValue(mockUpdatedSession);
 
       const studioId = '550e8400-e29b-41d4-a716-446655440099';
-      await handleUpdateSessionPhase(
+      await handleUpdateSessionState(
         { email: 'test@test.com', phase: 'implementing', agentId: 'wren', studioId },
         mockDataComposer as never
       );
@@ -559,7 +559,7 @@ describe('handleUpdateSessionPhase', () => {
       mockDataComposer.repositories.memory.listSessions.mockResolvedValue([mockSession]);
       mockDataComposer.repositories.memory.updateSession.mockResolvedValue(mockSession);
 
-      const result = await handleUpdateSessionPhase(
+      const result = await handleUpdateSessionState(
         { email: 'test@test.com', backendSessionId: 'claude-abc123' },
         mockDataComposer as never
       );
@@ -591,7 +591,7 @@ describe('handleUpdateSessionPhase', () => {
         backendSessionId: 'claude-abc123',
       });
 
-      const result = await handleUpdateSessionPhase(
+      const result = await handleUpdateSessionState(
         { email: 'test@test.com', backendSessionId: 'claude-abc123', agentId: 'wren' },
         mockDataComposer as never
       );
@@ -618,7 +618,7 @@ describe('handleUpdateSessionPhase', () => {
       mockDataComposer.repositories.memory.getActiveSession.mockResolvedValue(mockSession);
       mockDataComposer.repositories.memory.updateSession.mockResolvedValue(mockSession);
 
-      const result = await handleUpdateSessionPhase(
+      const result = await handleUpdateSessionState(
         { email: 'test@test.com', status: 'resumable' },
         mockDataComposer as never
       );
@@ -632,7 +632,7 @@ describe('handleUpdateSessionPhase', () => {
       mockDataComposer.repositories.memory.getActiveSession.mockResolvedValue(mockSession);
       mockDataComposer.repositories.memory.updateSession.mockResolvedValue(mockSession);
 
-      const result = await handleUpdateSessionPhase(
+      const result = await handleUpdateSessionState(
         {
           email: 'test@test.com',
           context: 'Writing tests for session phase',
@@ -654,7 +654,7 @@ describe('handleUpdateSessionPhase', () => {
         currentPhase: 'implementing',
       });
 
-      const result = await handleUpdateSessionPhase(
+      const result = await handleUpdateSessionState(
         {
           email: 'test@test.com',
           phase: 'implementing',
@@ -696,7 +696,7 @@ describe('handleUpdateSessionPhase', () => {
         content: '[blocked:awaiting-approval] Need user approval on design',
       });
 
-      const result = await handleUpdateSessionPhase(
+      const result = await handleUpdateSessionState(
         {
           email: 'test@test.com',
           phase: 'blocked:awaiting-approval',
@@ -736,7 +736,7 @@ describe('handleUpdateSessionPhase', () => {
         content: '[waiting:ci-pipeline] CI pipeline running for PR #42',
       });
 
-      const result = await handleUpdateSessionPhase(
+      const result = await handleUpdateSessionState(
         {
           email: 'test@test.com',
           phase: 'waiting:ci-pipeline',
@@ -764,7 +764,7 @@ describe('handleUpdateSessionPhase', () => {
         currentPhase: 'complete',
       });
 
-      const result = await handleUpdateSessionPhase(
+      const result = await handleUpdateSessionState(
         { email: 'test@test.com', phase: 'complete' },
         mockDataComposer as never
       );
@@ -785,7 +785,7 @@ describe('handleUpdateSessionPhase', () => {
         content: '[complete] Merged PR #214 after resolving sender-metadata propagation bug.',
       });
 
-      const result = await handleUpdateSessionPhase(
+      const result = await handleUpdateSessionState(
         {
           email: 'test@test.com',
           phase: 'complete',
@@ -810,7 +810,7 @@ describe('handleUpdateSessionPhase', () => {
         currentPhase: 'blocked:unknown-issue',
       });
 
-      await handleUpdateSessionPhase(
+      await handleUpdateSessionState(
         { email: 'test@test.com', phase: 'blocked:unknown-issue' },
         mockDataComposer as never
       );
@@ -830,7 +830,7 @@ describe('handleUpdateSessionPhase', () => {
           currentPhase: phase,
         });
 
-        const result = await handleUpdateSessionPhase(
+        const result = await handleUpdateSessionState(
           { email: 'test@test.com', phase },
           mockDataComposer as never
         );
@@ -845,7 +845,7 @@ describe('handleUpdateSessionPhase', () => {
       mockDataComposer.repositories.memory.getActiveSession.mockResolvedValue(mockSession);
       mockDataComposer.repositories.memory.updateSession.mockResolvedValue(mockSession);
 
-      const result = await handleUpdateSessionPhase(
+      const result = await handleUpdateSessionState(
         { email: 'test@test.com', backendSessionId: 'abc123', status: 'active' },
         mockDataComposer as never
       );
@@ -866,7 +866,7 @@ describe('handleUpdateSessionPhase', () => {
         content: '[blocked:test] Awaiting review from Wren.',
       });
 
-      await handleUpdateSessionPhase(
+      await handleUpdateSessionState(
         {
           email: 'test@test.com',
           phase: 'blocked:test',
@@ -907,7 +907,7 @@ describe('handleUpdateSessionPhase', () => {
         title: '[blocked:awaiting-input] Need user feedback',
       });
 
-      const result = await handleUpdateSessionPhase(
+      const result = await handleUpdateSessionState(
         {
           email: 'test@test.com',
           phase: 'blocked:awaiting-input',
@@ -952,7 +952,7 @@ describe('handleUpdateSessionPhase', () => {
         title: '[waiting:ci-build] CI running',
       });
 
-      const result = await handleUpdateSessionPhase(
+      const result = await handleUpdateSessionState(
         {
           email: 'test@test.com',
           phase: 'waiting:ci-build',
@@ -977,7 +977,7 @@ describe('handleUpdateSessionPhase', () => {
         content: 'test',
       });
 
-      await handleUpdateSessionPhase(
+      await handleUpdateSessionState(
         { email: 'test@test.com', phase: 'blocked:test', createTask: false },
         mockDataComposer as never
       );
@@ -990,7 +990,7 @@ describe('handleUpdateSessionPhase', () => {
       mockDataComposer.repositories.memory.getActiveSession.mockResolvedValue(mockSession);
       mockDataComposer.repositories.memory.updateSession.mockResolvedValue(mockUpdatedSession);
 
-      await handleUpdateSessionPhase(
+      await handleUpdateSessionState(
         { email: 'test@test.com', phase: 'implementing', createTask: true },
         mockDataComposer as never
       );
@@ -1015,7 +1015,7 @@ describe('handleUpdateSessionPhase', () => {
         new Error('Database constraint violation')
       );
 
-      const result = await handleUpdateSessionPhase(
+      const result = await handleUpdateSessionState(
         { email: 'test@test.com', phase: 'blocked:test', createTask: true },
         mockDataComposer as never
       );
@@ -1038,7 +1038,7 @@ describe('handleUpdateSessionPhase', () => {
       });
       mockDataComposer.repositories.projects.findAllByUser.mockResolvedValue([]);
 
-      const result = await handleUpdateSessionPhase(
+      const result = await handleUpdateSessionState(
         { email: 'test@test.com', phase: 'blocked:test', createTask: true },
         mockDataComposer as never
       );
@@ -1056,7 +1056,7 @@ describe('handleUpdateSessionPhase', () => {
 
   describe('error handling', () => {
     it('should error when no fields provided', async () => {
-      const result = await handleUpdateSessionPhase(
+      const result = await handleUpdateSessionState(
         { email: 'test@test.com' },
         mockDataComposer as never
       );
@@ -1069,7 +1069,7 @@ describe('handleUpdateSessionPhase', () => {
     it('should error when no active session found', async () => {
       mockDataComposer.repositories.memory.getActiveSession.mockResolvedValue(null);
 
-      const result = await handleUpdateSessionPhase(
+      const result = await handleUpdateSessionState(
         { email: 'test@test.com', phase: 'implementing' },
         mockDataComposer as never
       );
@@ -1082,7 +1082,7 @@ describe('handleUpdateSessionPhase', () => {
     it('should error when session not found by ID', async () => {
       mockDataComposer.repositories.memory.updateSession.mockResolvedValue(null);
 
-      const result = await handleUpdateSessionPhase(
+      const result = await handleUpdateSessionState(
         {
           email: 'test@test.com',
           sessionId: '00000000-0000-0000-0000-000000000000',
@@ -1109,7 +1109,7 @@ describe('handleUpdateSessionPhase', () => {
         currentPhase: 'reviewing',
       });
 
-      const result = await handleUpdateSessionPhase(
+      const result = await handleUpdateSessionState(
         {
           email: 'test@test.com',
           phase: 'reviewing',
@@ -1138,7 +1138,7 @@ describe('handleUpdateSessionPhase', () => {
       mockDataComposer.repositories.memory.getActiveSession.mockResolvedValue(mockSession);
       mockDataComposer.repositories.memory.updateSession.mockResolvedValue(sessionWithWorkspace);
 
-      const result = await handleUpdateSessionPhase(
+      const result = await handleUpdateSessionState(
         { email: 'test@test.com', phase: 'implementing' },
         mockDataComposer as never
       );

--- a/packages/api/src/mcp/tools/memory-handlers.ts
+++ b/packages/api/src/mcp/tools/memory-handlers.ts
@@ -498,9 +498,9 @@ export const listSessionsSchema = userIdentifierBaseSchema.extend({
   limit: z.number().min(1).max(100).optional().describe('Max results (default: 20)'),
 });
 
-// ==============================================// SESSION PHASE SCHEMA
+// ==============================================// SESSION STATE SCHEMA
 // ==============================================
-export const updateSessionPhaseSchema = userIdentifierBaseSchema.extend({
+export const updateSessionStateSchema = userIdentifierBaseSchema.extend({
   sessionId: z
     .string()
     .uuid()
@@ -1461,8 +1461,8 @@ function toJsonObject(value: Record<string, unknown>): Json {
   return value as Json;
 }
 
-export async function handleUpdateSessionPhase(args: unknown, dataComposer: DataComposer) {
-  const params = updateSessionPhaseSchema.parse(args);
+export async function handleUpdateSessionState(args: unknown, dataComposer: DataComposer) {
+  const params = updateSessionStateSchema.parse(args);
   const { user, resolvedBy } = await resolveUserOrThrow(params, dataComposer);
   const rawStudioId = resolveStudioId(params);
   const studioScope = resolveStudioScope(rawStudioId);

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -50,6 +50,11 @@ import { classifyError } from '@inklabs/shared';
 import { logger } from './utils/logger';
 import { getUserFromContext } from './utils/request-context';
 import { env } from './config/env';
+import {
+  shouldSkipSpawn,
+  type SessionPollRow,
+  type SessionAttachedRow,
+} from './services/sessions/trigger-delivery';
 
 // Server configuration
 interface ServerConfig {
@@ -955,68 +960,49 @@ When you complete a task_request, mark it as completed using update_inbox_messag
         }
       }
 
-      // Check if the routed session has a channel plugin actively polling.
-      // cli_poll_at is stamped by the channel plugin on every poll (~10s).
-      // Only skip spawn when the *routed* session is polling — if a different
-      // session is polling, it won't see threads stamped to this session
-      // (get_inbox channelPoll filters by session_id).
-      const CLI_POLL_FRESH_MS = 30_000; // 3 missed polls = stale
-      // cli_poll_at is not yet in generated Supabase types — cast result
+      // Check if the routed session has a CLI actively polling or attached.
+      // Only the routed session matters — a different session polling can't
+      // see threads stamped to this one (get_inbox channelPoll filters by session_id).
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const { data: routedSessionPoll } = (await (dataComposer!.getClient() as any)
+      const { data: pollRow } = (await (dataComposer!.getClient() as any)
         .from('sessions')
         .select('id, cli_poll_at, studio_id')
         .eq('id', routedSession.id)
-        .maybeSingle()) as {
-        data: { id: string; cli_poll_at: string; studio_id: string | null } | null;
-      };
+        .maybeSingle()) as { data: SessionPollRow | null };
 
-      const hasFreshPoll =
-        routedSessionPoll?.cli_poll_at &&
-        Date.now() - new Date(routedSessionPoll.cli_poll_at).getTime() < CLI_POLL_FRESH_MS;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { data: attachedRow } = (await (dataComposer!.getClient() as any)
+        .from('sessions')
+        .select('cli_attached, updated_at')
+        .eq('id', routedSession.id)
+        .maybeSingle()) as { data: SessionAttachedRow | null };
 
-      // Legacy fallback: check cli_attached on the routed session for
-      // backends without a channel plugin (Codex, Gemini) where on-prompt
-      // still sets cli_attached=true.
-      let isLegacyCliAttached = false;
-      if (!hasFreshPoll) {
-        const { data: sessionRow } = (await dataComposer!
+      // Clear stale cli_attached flag as a side effect (before the skip decision)
+      if (
+        attachedRow?.cli_attached &&
+        attachedRow.updated_at &&
+        Date.now() - new Date(attachedRow.updated_at).getTime() > 10 * 60 * 1000
+      ) {
+        logger.warn('[Trigger] CLI-attached session is stale, clearing flag', {
+          sessionId: routedSession.id,
+          updatedAt: attachedRow.updated_at,
+        });
+        await dataComposer!
           .getClient()
           .from('sessions')
-          .select('cli_attached, updated_at')
-          .eq('id', routedSession.id)
-          .single()) as { data: { cli_attached: boolean; updated_at: string } | null };
-
-        const CLI_STALE_MS = 10 * 60 * 1000;
-        const isCliAttached = sessionRow?.cli_attached === true;
-        const isCliStale =
-          isCliAttached &&
-          sessionRow?.updated_at &&
-          Date.now() - new Date(sessionRow.updated_at).getTime() > CLI_STALE_MS;
-
-        if (isCliStale) {
-          logger.warn('[Trigger] CLI-attached session is stale, clearing flag', {
-            sessionId: routedSession.id,
-            updatedAt: sessionRow?.updated_at,
-          });
-          await dataComposer!
-            .getClient()
-            .from('sessions')
-            .update({ cli_attached: false } as never)
-            .eq('id', routedSession.id);
-        }
-
-        isLegacyCliAttached = isCliAttached && !isCliStale;
+          .update({ cli_attached: false } as never)
+          .eq('id', routedSession.id);
+        attachedRow.cli_attached = false;
       }
 
-      if (hasFreshPoll || isLegacyCliAttached) {
-        const source = hasFreshPoll ? 'cli_poll_at' : 'cli_attached (legacy)';
-        const attachedSessionId = hasFreshPoll ? routedSessionPoll!.id : routedSession.id;
+      const delivery = shouldSkipSpawn(pollRow, attachedRow);
+
+      if (delivery.skip) {
         logger.info(
-          `[Trigger] CLI-attached (${source}) — skipping spawn, channel plugin will deliver`,
+          `[Trigger] CLI-attached (${delivery.source}) — skipping spawn, channel plugin will deliver`,
           {
             targetAgentId,
-            attachedSessionId,
+            attachedSessionId: delivery.sessionId || routedSession.id,
             routedSessionId: routedSession.id,
             studioId: routedSession.studioId,
             threadKey: payload.threadKey,

--- a/packages/api/src/services/sessions/trigger-delivery.test.ts
+++ b/packages/api/src/services/sessions/trigger-delivery.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+import {
+  checkPollFreshness,
+  checkLegacyAttached,
+  shouldSkipSpawn,
+  type SessionPollRow,
+  type SessionAttachedRow,
+} from './trigger-delivery';
+
+const NOW = Date.now();
+
+function freshPollRow(sessionId: string): SessionPollRow {
+  return { id: sessionId, cli_poll_at: new Date(NOW - 5_000).toISOString(), studio_id: null };
+}
+
+function stalePollRow(sessionId: string): SessionPollRow {
+  return { id: sessionId, cli_poll_at: new Date(NOW - 60_000).toISOString(), studio_id: null };
+}
+
+function attachedRow(ageMs: number): SessionAttachedRow {
+  return { cli_attached: true, updated_at: new Date(NOW - ageMs).toISOString() };
+}
+
+describe('trigger-delivery', () => {
+  describe('checkPollFreshness', () => {
+    it('returns true when poll is fresh (< 30s)', () => {
+      expect(checkPollFreshness(freshPollRow('s1'), NOW)).toBe(true);
+    });
+
+    it('returns false when poll is stale (> 30s)', () => {
+      expect(checkPollFreshness(stalePollRow('s1'), NOW)).toBe(false);
+    });
+
+    it('returns false when poll row is null', () => {
+      expect(checkPollFreshness(null, NOW)).toBe(false);
+    });
+
+    it('returns false when cli_poll_at is null', () => {
+      expect(checkPollFreshness({ id: 's1', cli_poll_at: null, studio_id: null }, NOW)).toBe(false);
+    });
+  });
+
+  describe('checkLegacyAttached', () => {
+    it('returns attached=true, stale=false for recent session', () => {
+      const result = checkLegacyAttached(attachedRow(30_000), NOW);
+      expect(result).toEqual({ attached: true, stale: false });
+    });
+
+    it('returns attached=true, stale=true for old session (> 10min)', () => {
+      const result = checkLegacyAttached(attachedRow(11 * 60 * 1000), NOW);
+      expect(result).toEqual({ attached: true, stale: true });
+    });
+
+    it('returns attached=false for cli_attached=false', () => {
+      const result = checkLegacyAttached(
+        { cli_attached: false, updated_at: new Date(NOW).toISOString() },
+        NOW
+      );
+      expect(result).toEqual({ attached: false, stale: false });
+    });
+
+    it('returns attached=false for null row', () => {
+      expect(checkLegacyAttached(null, NOW)).toEqual({ attached: false, stale: false });
+    });
+  });
+
+  describe('shouldSkipSpawn', () => {
+    it('skips when routed session has fresh poll', () => {
+      const result = shouldSkipSpawn(freshPollRow('routed-session'), null, NOW);
+      expect(result).toEqual({
+        skip: true,
+        source: 'cli_poll_at',
+        sessionId: 'routed-session',
+      });
+    });
+
+    it('skips when routed session has legacy cli_attached', () => {
+      const result = shouldSkipSpawn(null, attachedRow(30_000), NOW);
+      expect(result).toEqual({ skip: true, source: 'cli_attached', sessionId: null });
+    });
+
+    it('does NOT skip when poll is stale and no legacy attached', () => {
+      const result = shouldSkipSpawn(stalePollRow('routed-session'), null, NOW);
+      expect(result).toEqual({ skip: false, source: null, sessionId: null });
+    });
+
+    it('does NOT skip when no poll data and no legacy attached', () => {
+      const result = shouldSkipSpawn(null, null, NOW);
+      expect(result).toEqual({ skip: false, source: null, sessionId: null });
+    });
+
+    it('does NOT skip when legacy attached is stale', () => {
+      const result = shouldSkipSpawn(null, attachedRow(11 * 60 * 1000), NOW);
+      expect(result).toEqual({ skip: false, source: null, sessionId: null });
+    });
+
+    // Regression: Lumen's PR #350 review — session A polling, thread routed to session B.
+    // The server should only check the ROUTED session's poll state.
+    // If session A (different session) is polling, the routed session's poll row
+    // will be null/stale → should NOT skip spawn.
+    it('does NOT skip when a DIFFERENT session is polling (regression: PR #350)', () => {
+      // Session B is the routed session — no fresh poll
+      const routedSessionPoll: SessionPollRow = {
+        id: 'session-B',
+        cli_poll_at: null,
+        studio_id: null,
+      };
+      // Session A is polling (fresh) but is NOT the routed session —
+      // it's irrelevant because the caller only passes the routed session's row.
+      // This test verifies the contract: only the routed session matters.
+      const result = shouldSkipSpawn(routedSessionPoll, null, NOW);
+      expect(result).toEqual({ skip: false, source: null, sessionId: null });
+    });
+  });
+});

--- a/packages/api/src/services/sessions/trigger-delivery.ts
+++ b/packages/api/src/services/sessions/trigger-delivery.ts
@@ -1,0 +1,60 @@
+/**
+ * Trigger delivery check — determines whether the server should skip spawning
+ * a new process because a CLI channel plugin is already polling the routed session.
+ */
+
+export interface SessionPollRow {
+  id: string;
+  cli_poll_at: string | null;
+  studio_id: string | null;
+}
+
+export interface SessionAttachedRow {
+  cli_attached: boolean;
+  updated_at: string;
+}
+
+export interface CliDeliveryCheck {
+  skip: boolean;
+  source: 'cli_poll_at' | 'cli_attached' | null;
+  sessionId: string | null;
+}
+
+const CLI_POLL_FRESH_MS = 30_000;
+const CLI_STALE_MS = 10 * 60 * 1000;
+
+export function checkPollFreshness(
+  pollRow: SessionPollRow | null,
+  now: number = Date.now()
+): boolean {
+  if (!pollRow?.cli_poll_at) return false;
+  return now - new Date(pollRow.cli_poll_at).getTime() < CLI_POLL_FRESH_MS;
+}
+
+export function checkLegacyAttached(
+  attachedRow: SessionAttachedRow | null,
+  now: number = Date.now()
+): { attached: boolean; stale: boolean } {
+  if (!attachedRow?.cli_attached) return { attached: false, stale: false };
+  const age = now - new Date(attachedRow.updated_at).getTime();
+  const stale = age > CLI_STALE_MS;
+  return { attached: true, stale };
+}
+
+export function shouldSkipSpawn(
+  pollRow: SessionPollRow | null,
+  attachedRow: SessionAttachedRow | null,
+  now: number = Date.now()
+): CliDeliveryCheck {
+  const hasFreshPoll = checkPollFreshness(pollRow, now);
+  if (hasFreshPoll) {
+    return { skip: true, source: 'cli_poll_at', sessionId: pollRow!.id };
+  }
+
+  const { attached, stale } = checkLegacyAttached(attachedRow, now);
+  if (attached && !stale) {
+    return { skip: true, source: 'cli_attached', sessionId: null };
+  }
+
+  return { skip: false, source: null, sessionId: null };
+}

--- a/packages/api/src/skills/builtin/pcp/SKILL.md
+++ b/packages/api/src/skills/builtin/pcp/SKILL.md
@@ -112,7 +112,7 @@ Searches your memories. Returns matches sorted by relevance and salience.
 Sessions track what you're working on and in what phase:
 
 ```
-update_session_phase(phase: "implementing")
+update_session_state(phase: "implementing")
 ```
 
 Phases: `investigating`, `implementing`, `reviewing`, `blocked:<reason>`, `waiting:<reason>`.
@@ -179,7 +179,7 @@ Read: `get_identity(agentId, file: "identity")`. Write: `save_identity(descripti
 | `get_inbox`            | Check your inbox                                  |
 | `get_thread_messages`  | Read a conversation thread                        |
 | `mark_thread_read`     | Mark thread as read                               |
-| `update_session_phase` | Set work phase                                    |
+| `update_session_state` | Set work phase                                    |
 | `end_session`          | End session with summary                          |
 | `get_identity`         | Read identity documents                           |
 | `save_identity`        | Update identity documents                         |

--- a/packages/cli/HOOKS.md
+++ b/packages/cli/HOOKS.md
@@ -32,7 +32,7 @@ Inkwell hooks bridge coding agents (Claude Code, Codex, Gemini) with Inkwell's s
 5. Reconciles Inkwell/backend session linkage when backend session ID is available (prefers existing server-side backend-session match)
 6. Stores runtime session state in `.ink/runtime/sessions.json` (multi-session list + current pointer + correlation link)
 7. Stores backend session ID in `.ink/runtime/session-id` (legacy compatibility)
-8. Links backend session ID to Inkwell session via `update_session_phase(sessionId, backendSessionId)`
+8. Links backend session ID to Inkwell session via `update_session_state(sessionId, backendSessionId)`
 
 **Output:**
 
@@ -75,7 +75,7 @@ Context is about to be compacted. Before compaction completes:
 
 1. **Save critical decisions** — Use `mcp__inkwell__remember` to persist any
    important reasoning, decisions, or context that should survive compaction.
-2. **Note current task state** — Use `mcp__inkwell__update_session_phase` to record
+2. **Note current task state** — Use `mcp__inkwell__update_session_state` to record
    where you are in the current task so you can resume smoothly after compaction.
 
 This context will be lost after compaction unless you save it now.
@@ -115,7 +115,7 @@ Agent: {agentId}
 
 **What it does:**
 
-1. Marks runtime phase as `runtime:generating` via `update_session_phase(sessionId, phase)`
+1. Marks runtime phase as `runtime:generating` via `update_session_state(sessionId, phase)`
 2. Reconciles backend session ID linkage if the hook payload includes a session ID
    - short-circuits on local `sessions.json` if linkage is already known
 3. Checks if inbox was polled within the last 5 minutes — if so, exits silently
@@ -139,7 +139,7 @@ Agent: {agentId}
 
 **What it does:**
 
-1. Marks runtime phase as `runtime:idle` via `update_session_phase(sessionId, phase)`
+1. Marks runtime phase as `runtime:idle` via `update_session_state(sessionId, phase)`
 2. Reconciles backend session ID linkage if the hook payload includes a session ID
    - short-circuits on local `sessions.json` if linkage is already known
 3. Increments tool call counter in `.ink/runtime/tool-count`

--- a/packages/cli/src/backends/identity.ts
+++ b/packages/cli/src/backends/identity.ts
@@ -190,7 +190,7 @@ export function buildIdentityPrompt(agentId: string, startupContextBlock?: strin
 
 **You are ${agentId}. Your agent ID is \`${agentId}\`.**
 
-When calling PCP tools (bootstrap, remember, recall, update_session_phase, etc.), use \`agentId: "${agentId}"\`.
+When calling PCP tools (bootstrap, remember, recall, update_session_state, etc.), use \`agentId: "${agentId}"\`.
 Do NOT read \`.ink/identity.json\` — your identity is set by this system prompt.
 Do NOT run \`echo $AGENT_ID\` — use the agentId provided above.`;
 
@@ -200,7 +200,7 @@ Always use **PCP cloud tools** (mcp__inkwell__*) over file reads or Claude Code 
 - Identity: use mcp__inkwell__bootstrap, not file reads
 - Tasks: use mcp__inkwell__create_task, not TaskCreate
 - Memory: use mcp__inkwell__remember, not local notes
-- Sessions: use mcp__inkwell__update_session_phase/get_session/list_sessions
+- Sessions: use mcp__inkwell__update_session_state/get_session/list_sessions
 
 PCP tools persist across sessions and are shared with the user and other agents.`;
 

--- a/packages/cli/src/commands/chat.integration.test.ts
+++ b/packages/cli/src/commands/chat.integration.test.ts
@@ -104,7 +104,7 @@ describe('runChat integration', () => {
           return { session: { id: 'sess-1' } };
         case 'get_inbox':
           return { messages: [] };
-        case 'update_session_phase':
+        case 'update_session_state':
         case 'end_session':
           return { success: true };
         default:
@@ -191,8 +191,8 @@ describe('runChat integration', () => {
     };
     expect(backendRequest.backend).toBe('gemini');
     expect(backendRequest.prompt).toContain('Latest user message:\nheartbeat pulse');
-    // Non-interactive sessions are left resumable (update_session_phase, not end_session).
-    expect(testState.pcpCalls.some((call) => call.tool === 'update_session_phase')).toBe(true);
+    // Non-interactive sessions are left resumable (update_session_state, not end_session).
+    expect(testState.pcpCalls.some((call) => call.tool === 'update_session_state')).toBe(true);
   });
 
   it('attaches to provided session id and does not end attached session', async () => {
@@ -485,7 +485,7 @@ describe('runChat integration', () => {
           return { session: { id: 'sess-fallback' } };
         case 'get_inbox':
           return { messages: [] };
-        case 'update_session_phase':
+        case 'update_session_state':
         case 'end_session':
           return { success: true };
         default:
@@ -729,7 +729,7 @@ describe('runChat integration', () => {
             };
           }
           return { messages: [] };
-        case 'update_session_phase':
+        case 'update_session_state':
         case 'end_session':
           return { success: true };
         default:
@@ -780,7 +780,7 @@ describe('runChat integration', () => {
             };
           }
           return { messages: [] };
-        case 'update_session_phase':
+        case 'update_session_state':
         case 'end_session':
           return { success: true };
         default:
@@ -827,7 +827,7 @@ describe('runChat integration', () => {
             };
           }
           return { messages: [] };
-        case 'update_session_phase':
+        case 'update_session_state':
         case 'end_session':
           return { success: true };
         default:
@@ -897,7 +897,7 @@ describe('runChat integration', () => {
             };
           }
           return { messages: [] };
-        case 'update_session_phase':
+        case 'update_session_state':
         case 'end_session':
           return { success: true };
         default:
@@ -957,7 +957,7 @@ describe('runChat integration', () => {
             };
           }
           return { messages: [] };
-        case 'update_session_phase':
+        case 'update_session_state':
         case 'end_session':
           return { success: true };
         default:
@@ -1268,7 +1268,7 @@ describe('runChat integration', () => {
             return { session: { id: 'sess-1' } };
           case 'get_inbox':
             return { messages: [], echo: args || {} };
-          case 'update_session_phase':
+          case 'update_session_state':
           case 'end_session':
             return { success: true };
           default:
@@ -1317,7 +1317,7 @@ describe('runChat integration', () => {
             return { session: { id: 'sess-1' } };
           case 'get_inbox':
             return { messages: [], echo: args || {} };
-          case 'update_session_phase':
+          case 'update_session_state':
           case 'end_session':
             return { success: true };
           default:
@@ -1363,7 +1363,7 @@ describe('runChat integration', () => {
             return { session: { id: 'sess-1' } };
           case 'get_inbox':
             return { messages: [], echo: args || {} };
-          case 'update_session_phase':
+          case 'update_session_state':
           case 'end_session':
             return { success: true };
           default:
@@ -1480,7 +1480,7 @@ describe('runChat integration', () => {
             return { session: { id: 'sess-1' } };
           case 'get_inbox':
             return { messages: [{ from: 'myra', subject: 'test' }], echo: args || {} };
-          case 'update_session_phase':
+          case 'update_session_state':
           case 'end_session':
           case 'log_activity':
             return { success: true };
@@ -1535,7 +1535,7 @@ describe('runChat integration', () => {
             return { session: { id: 'sess-1' } };
           case 'get_inbox':
             return { messages: [], echo: args || {} };
-          case 'update_session_phase':
+          case 'update_session_state':
           case 'end_session':
           case 'log_activity':
             return { success: true };
@@ -1626,7 +1626,7 @@ describe('runChat integration', () => {
             return { session: { id: 'sess-1' } };
           case 'get_inbox':
             return { messages: [{ id: 'm1', content: 'test message' }], echo: args || {} };
-          case 'update_session_phase':
+          case 'update_session_state':
           case 'end_session':
           case 'log_activity':
             return { success: true };

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -2282,7 +2282,7 @@ export async function runChat(options: ChatOptions): Promise<void> {
 
   if (runtime.sessionId && !attachedToExistingSession) {
     await pcp
-      .callTool('update_session_phase', {
+      .callTool('update_session_state', {
         agentId,
         sessionId: runtime.sessionId,
         phase: 'investigating',
@@ -2702,7 +2702,7 @@ export async function runChat(options: ChatOptions): Promise<void> {
 
     if (runtime.sessionId) {
       await pcp
-        .callTool('update_session_phase', {
+        .callTool('update_session_state', {
           agentId,
           sessionId: runtime.sessionId,
           phase: 'implementing',
@@ -3417,7 +3417,7 @@ export async function runChat(options: ChatOptions): Promise<void> {
 
     if (runtime.sessionId) {
       await pcp
-        .callTool('update_session_phase', {
+        .callTool('update_session_state', {
           agentId,
           sessionId: runtime.sessionId,
           phase,

--- a/packages/cli/src/commands/claude.integration.test.ts
+++ b/packages/cli/src/commands/claude.integration.test.ts
@@ -191,7 +191,7 @@ console.log(JSON.stringify({ session_id: process.env.FAKE_CLAUDE_SESSION_ID || '
       expect(persistedBackendSessionId).toBe('claude-session-int-1');
 
       const phaseUpdatesWithBackendId = pcpToolCalls
-        .filter((call) => call.name === 'update_session_phase')
+        .filter((call) => call.name === 'update_session_state')
         .some((call) => call.args.backendSessionId === 'claude-session-int-1');
       expect(phaseUpdatesWithBackendId).toBe(true);
     } finally {
@@ -367,7 +367,7 @@ console.log('fake-claude-run-complete');
       expect(persistedBackendSessionId).toBe(delayedSessionId);
 
       const phaseUpdatesWithBackendId = pcpToolCalls
-        .filter((call) => call.name === 'update_session_phase')
+        .filter((call) => call.name === 'update_session_state')
         .some((call) => call.args.backendSessionId === delayedSessionId);
       expect(phaseUpdatesWithBackendId).toBe(true);
     } finally {
@@ -526,7 +526,7 @@ console.log(JSON.stringify({ session_id: process.env.FAKE_CODEX_SESSION_ID || 'c
       expect(persistedBackendSessionId).toBe('codex-session-int-1');
 
       const phaseUpdatesWithBackendId = pcpToolCalls
-        .filter((call) => call.name === 'update_session_phase')
+        .filter((call) => call.name === 'update_session_state')
         .some((call) => call.args.backendSessionId === 'codex-session-int-1');
       expect(phaseUpdatesWithBackendId).toBe(true);
     } finally {
@@ -677,7 +677,7 @@ console.log(JSON.stringify({ session_id: process.env.FAKE_GEMINI_SESSION_ID || '
       expect(persistedBackendSessionId).toBe('gemini-session-int-1');
 
       const phaseUpdatesWithBackendId = pcpToolCalls
-        .filter((call) => call.name === 'update_session_phase')
+        .filter((call) => call.name === 'update_session_state')
         .some((call) => call.args.backendSessionId === 'gemini-session-int-1');
       expect(phaseUpdatesWithBackendId).toBe(true);
     } finally {

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -2420,7 +2420,7 @@ async function persistBackendSessionLink(options: {
         conflictingAgentId?: string;
       };
       sessionTrace?: { changedFields?: string[] };
-    }>('update_session_phase', {
+    }>('update_session_state', {
       email: options.email,
       agentId: options.agentId,
       sessionId: options.pcpSessionId,
@@ -3371,7 +3371,7 @@ async function ensurePcpSessionContext(
 
   if (email) {
     try {
-      await callPcpTool('update_session_phase', {
+      await callPcpTool('update_session_state', {
         email,
         agentId,
         sessionId: chosen.id,

--- a/packages/cli/src/commands/hooks.ts
+++ b/packages/cli/src/commands/hooks.ts
@@ -2059,7 +2059,7 @@ async function onSessionStartHandler(options?: { backend?: string }): Promise<vo
         workingDir: cwd,
       };
       if (backendSessionId) updateArgs.backendSessionId = backendSessionId;
-      await callPcpTool('update_session_phase', updateArgs);
+      await callPcpTool('update_session_state', updateArgs);
     } catch {
       // Non-fatal; startup should continue even if linkage fails.
     }
@@ -2427,7 +2427,7 @@ async function onPromptHandler(options?: { backend?: string }): Promise<void> {
       '\n<ink-reminder>\n' +
         'If your runtime state has changed since your last context update ' +
         '(started/stopped a server, opened a PR, kicked off a build, changed ports, etc.), ' +
-        'update your session context via `update_session_phase(context: "...")` so it survives ' +
+        'update your session context via `update_session_state(context: "...")` so it survives ' +
         "compaction. Context is your scratch board for transient active state — what's running, " +
         "what's pending, what port you're on.\n" +
         '</ink-reminder>\n'

--- a/packages/cli/src/repl/tool-policy.ts
+++ b/packages/cli/src/repl/tool-policy.ts
@@ -166,7 +166,6 @@ export const DEFAULT_SAFE_PCP_TOOLS = new Set<string>([
   'get_workspace',
   'get_studio',
   'get_timezone',
-  'get_focus',
 ]);
 
 export const TOOL_GROUPS: ToolGroupMap = {
@@ -175,7 +174,7 @@ export const TOOL_GROUPS: ToolGroupMap = {
   'group:ink-memory': ['remember', 'recall', 'forget', 'update_memory', 'restore_memory'],
   'group:ink-session': [
     'start_session',
-    'update_session_phase',
+    'update_session_state',
     'get_session',
     'list_sessions',
     'end_session',

--- a/packages/openclaw-plugin/skills/SKILL.md
+++ b/packages/openclaw-plugin/skills/SKILL.md
@@ -112,7 +112,7 @@ Searches your memories. Returns matches sorted by relevance and salience.
 Sessions track what you're working on and in what phase:
 
 ```
-update_session_phase(phase: "implementing")
+update_session_state(phase: "implementing")
 ```
 
 Phases: `investigating`, `implementing`, `reviewing`, `blocked:<reason>`, `waiting:<reason>`.
@@ -179,7 +179,7 @@ Read: `get_identity(agentId, file: "identity")`. Write: `save_identity(descripti
 | `get_inbox`            | Check your inbox                                  |
 | `get_thread_messages`  | Read a conversation thread                        |
 | `mark_thread_read`     | Mark thread as read                               |
-| `update_session_phase` | Set work phase                                    |
+| `update_session_state` | Set work phase                                    |
 | `end_session`          | End session with summary                          |
 | `get_identity`         | Read identity documents                           |
 | `save_identity`        | Update identity documents                         |

--- a/packages/spec/protocol-v0.1.md
+++ b/packages/spec/protocol-v0.1.md
@@ -307,7 +307,7 @@ Implementations MUST ensure at most one active session exists per `(userId, agen
 
 When `start_session` is called with a `threadKey` that has no active match, implementations MUST create a new session (not silently route to a default session). This ensures threadKey isolation: work on `pr:42` never accidentally lands in a session tracking `pr:41`.
 
-**Phase Updates (`update_session_phase`)**
+**Phase Updates (`update_session_state`)**
 
 Phases describe the agent's current work state. Core phases:
 


### PR DESCRIPTION
## Summary

- **Extract trigger delivery check**: Moves inline `cli_poll_at` / `cli_attached` skip logic from `server.ts` into `trigger-delivery.ts` with pure functions (`checkPollFreshness`, `checkLegacyAttached`, `shouldSkipSpawn`). Includes 14 unit tests with the regression case from Lumen's PR #350 review (session A polling should not suppress spawn when thread routed to session B).

- **Rename `update_session_phase` → `update_session_state`**: The session context field replaces the old focus concept. The tool name now reflects that it manages session state broadly, not just phase.

- **Remove `set_focus` / `get_focus` MCP tools**: Superseded by the `context` field on `update_session_state`. The handler code remains in `context-handlers.ts` but is no longer registered as a tool.

## Changes

- `trigger-delivery.ts` + `trigger-delivery.test.ts`: New module with pure delivery-check functions and 14 tests
- `server.ts`: Uses extracted `shouldSkipSpawn` instead of inline logic
- `index.ts`: Tool renamed, focus tools removed
- `memory-handlers.ts`: Schema/handler renamed (`updateSessionStateSchema`, `handleUpdateSessionState`)
- `tool-policy.ts`, `chat.ts`, `identity.ts`: CLI references updated
- `AGENTS.md`, `SKILL.md`, `protocol-v0.1.md`, `constants.ts`: Docs updated

## Breaking change

**MCP tool rename**: `update_session_phase` → `update_session_state`. All agents will need their MCP servers reconnected after deploy.

## Test plan

- [x] 14 new trigger-delivery unit tests (including PR #350 regression)
- [x] Full test suite green (136 files, 2397 tests)
- [x] Grep confirms zero remaining references to old tool names

🤖 Generated with [Claude Code](https://claude.com/claude-code)