### PR TITLE
feat: add active_thread_key to sessions for live artifact tracking (by Wren)

### DIFF
--- a/packages/api/src/data/models/memory.ts
+++ b/packages/api/src/data/models/memory.ts
@@ -109,6 +109,7 @@ export interface Session {
   agentId?: string;
   studioId?: string;
   threadKey?: string;
+  activeThreadKey?: string;
   /** Runtime lifecycle state: running, idle, completed, failed */
   lifecycle?: SessionLifecycle;
   /** @deprecated Use lifecycle. Kept for backward compat. */
@@ -203,6 +204,7 @@ export interface SessionRow {
   agent_id: string | null;
   studio_id: string | null;
   thread_key: string | null;
+  active_thread_key?: string | null;
   lifecycle?: string | null;
   status?: string | null;
   current_phase: string | null;

--- a/packages/api/src/data/repositories/memory-repository.ts
+++ b/packages/api/src/data/repositories/memory-repository.ts
@@ -1493,6 +1493,7 @@ export class MemoryRepository {
       cliAttached?: boolean;
       cliPollAt?: string;
       alias?: string | null;
+      activeThreadKey?: string | null;
     }
   ): Promise<Session | null> {
     const dbUpdates: Record<string, unknown> = {};
@@ -1526,6 +1527,9 @@ export class MemoryRepository {
     }
     if (updates.alias !== undefined) {
       (dbUpdates as Record<string, unknown>).alias = updates.alias;
+    }
+    if (updates.activeThreadKey !== undefined) {
+      (dbUpdates as Record<string, unknown>).active_thread_key = updates.activeThreadKey;
     }
 
     const { data, error } = await this.supabase
@@ -2035,6 +2039,7 @@ export class MemoryRepository {
       agentId: row.agent_id || undefined,
       studioId,
       threadKey: row.thread_key || undefined,
+      activeThreadKey: row.active_thread_key || undefined,
       lifecycle: (row.lifecycle as Session['lifecycle']) || undefined,
       status: row.status || undefined,
       currentPhase: row.current_phase || undefined,

--- a/packages/api/src/data/supabase/types.ts
+++ b/packages/api/src/data/supabase/types.ts
@@ -2714,6 +2714,7 @@ export type Database = {
       };
       sessions: {
         Row: {
+          active_thread_key: string | null;
           agent_id: string | null;
           alias: string | null;
           backend: string | null;
@@ -2743,6 +2744,7 @@ export type Database = {
           working_dir: string | null;
         };
         Insert: {
+          active_thread_key?: string | null;
           agent_id?: string | null;
           alias?: string | null;
           backend?: string | null;
@@ -2772,6 +2774,7 @@ export type Database = {
           working_dir?: string | null;
         };
         Update: {
+          active_thread_key?: string | null;
           agent_id?: string | null;
           alias?: string | null;
           backend?: string | null;

--- a/packages/api/src/mcp/tools/index.ts
+++ b/packages/api/src/mcp/tools/index.ts
@@ -2071,6 +2071,12 @@ User can be identified by ONE of: userId, email, phone, or platform + platformId
             'Transient runtime state — active facts too ephemeral for a memory but important to preserve across compaction. E.g. "server on :4001", "waiting on PR #341 review", "vitest running in background". Use as a scratch board; memories handle durable decisions.'
           ),
         workingDir: z.string().optional().describe('Working directory'),
+        activeThreadKey: z
+          .string()
+          .optional()
+          .describe(
+            'The thread key the session is currently working on (e.g., "pr:350", "spec:auth-refactor"). Mutable — updates as the session shifts focus. The original thread_key (set at session creation) remains the immutable routing anchor. Set to empty string to clear.'
+          ),
       },
     },
     async (args) => {

--- a/packages/api/src/mcp/tools/memory-handlers.ts
+++ b/packages/api/src/mcp/tools/memory-handlers.ts
@@ -560,6 +560,12 @@ export const updateSessionStateSchema = userIdentifierBaseSchema.extend({
     .describe(
       'Human-readable session alias for explicit routing (e.g., "main", "review"). Unique per agent among active sessions. Use to name a session so messages can be routed to it by alias.'
     ),
+  activeThreadKey: z
+    .string()
+    .optional()
+    .describe(
+      'The thread key the session is currently working on (e.g., "pr:350", "spec:auth-refactor"). Mutable — updates as the session shifts focus. Set to empty string to clear.'
+    ),
 });
 
 // ==============================================// MEMORY HISTORY SCHEMAS
@@ -1407,7 +1413,8 @@ type SessionTraceField =
   | 'status'
   | 'backendSessionId'
   | 'workingDir'
-  | 'context';
+  | 'context'
+  | 'activeThreadKey';
 
 interface SessionTraceSnapshot {
   agentId: string | null;
@@ -1417,6 +1424,7 @@ interface SessionTraceSnapshot {
   backendSessionId: string | null;
   workingDir: string | null;
   context: string | null;
+  activeThreadKey: string | null;
 }
 
 const SESSION_TRACE_FIELDS: SessionTraceField[] = [
@@ -1427,6 +1435,7 @@ const SESSION_TRACE_FIELDS: SessionTraceField[] = [
   'backendSessionId',
   'workingDir',
   'context',
+  'activeThreadKey',
 ];
 
 function normalizeTraceString(value: string | null | undefined, truncateAt = 240): string | null {
@@ -1445,6 +1454,7 @@ function toSessionTraceSnapshot(session: Session | null | undefined): SessionTra
     backendSessionId: normalizeTraceString(session?.backendSessionId || session?.claudeSessionId),
     workingDir: normalizeTraceString(session?.workingDir),
     context: normalizeTraceString(session?.context),
+    activeThreadKey: normalizeTraceString(session?.activeThreadKey),
   };
 }
 
@@ -1476,7 +1486,8 @@ export async function handleUpdateSessionState(args: unknown, dataComposer: Data
     !params.context &&
     !params.workingDir &&
     params.cliAttached === undefined &&
-    params.alias === undefined
+    params.alias === undefined &&
+    params.activeThreadKey === undefined
   ) {
     return {
       content: [
@@ -1541,6 +1552,7 @@ export async function handleUpdateSessionState(args: unknown, dataComposer: Data
     workingDir?: string;
     cliAttached?: boolean;
     alias?: string | null;
+    activeThreadKey?: string | null;
   } = {};
 
   // Map runtime: prefix phases to lifecycle (backward compat for old callers)
@@ -1587,6 +1599,9 @@ export async function handleUpdateSessionState(args: unknown, dataComposer: Data
   if (params.alias !== undefined) {
     updates.alias = params.alias || null;
   }
+  if (params.activeThreadKey !== undefined) {
+    updates.activeThreadKey = params.activeThreadKey || null;
+  }
 
   const updated = await dataComposer.repositories.memory.updateSession(sessionId, updates);
 
@@ -1609,6 +1624,8 @@ export async function handleUpdateSessionState(args: unknown, dataComposer: Data
   if (params.context) messageParts.push('context updated');
   if (params.workingDir) messageParts.push('workingDir updated');
   if (params.alias !== undefined) messageParts.push(`alias → ${params.alias || '(cleared)'}`);
+  if (params.activeThreadKey !== undefined)
+    messageParts.push(`activeThreadKey → ${params.activeThreadKey || '(cleared)'}`);
 
   const result: Record<string, unknown> = {
     success: true,

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -5089,6 +5089,7 @@ router.get('/studios', async (req: Request, res: Response) => {
         lifecycle: string | null;
         currentPhase: string | null;
         status: string | null;
+        activeThreadKey: string | null;
         updatedAt: string;
       }
     >();
@@ -5096,7 +5097,7 @@ router.get('/studios', async (req: Request, res: Response) => {
     if (agentIds.length > 0) {
       const { data: sessions } = await supabase
         .from('sessions')
-        .select('agent_id, lifecycle, current_phase, status, updated_at')
+        .select('agent_id, lifecycle, current_phase, status, active_thread_key, updated_at')
         .eq('user_id', authReq.pcpUserId)
         .in('agent_id', agentIds)
         .is('ended_at', null)
@@ -5109,6 +5110,7 @@ router.get('/studios', async (req: Request, res: Response) => {
             lifecycle: session.lifecycle,
             currentPhase: session.current_phase,
             status: session.status,
+            activeThreadKey: session.active_thread_key,
             updatedAt: session.updated_at,
           });
         }
@@ -5139,6 +5141,7 @@ router.get('/studios', async (req: Request, res: Response) => {
               lifecycle: latestSession.lifecycle,
               currentPhase: latestSession.currentPhase,
               status: latestSession.status,
+              activeThreadKey: latestSession.activeThreadKey,
               updatedAt: latestSession.updatedAt,
             }
           : null,

--- a/packages/api/src/services/strategy.service.test.ts
+++ b/packages/api/src/services/strategy.service.test.ts
@@ -2493,7 +2493,7 @@ describe('StrategyService', () => {
         groupId: 'group-1',
         userId: 'user-123',
         strategy: 'persistence',
-        ownerAgentId: 'wren',
+        sbId: 'sb-wren-uuid',
         config: { studioSlug: 'auth-refactor' },
       });
 
@@ -2528,7 +2528,7 @@ describe('StrategyService', () => {
           groupId: 'group-1',
           userId: 'user-123',
           strategy: 'persistence',
-          ownerAgentId: 'wren',
+          sbId: 'sb-wren-uuid',
           config: { studioSlug: 'auth-refactor' },
         })
       ).rejects.toThrow('Failed to create persistent studio');
@@ -2552,7 +2552,7 @@ describe('StrategyService', () => {
           groupId: 'group-1',
           userId: 'user-123',
           strategy: 'persistence',
-          ownerAgentId: 'wren',
+          sbId: 'sb-wren-uuid',
           config: { studioSlug: 'auth-refactor', ephemeralStudio: true },
         })
       ).rejects.toThrow('mutually exclusive');
@@ -2615,7 +2615,7 @@ describe('StrategyService', () => {
         groupId: 'group-1',
         userId: 'user-123',
         strategy: 'persistence',
-        ownerAgentId: 'wren',
+        sbId: 'sb-wren-uuid',
         config: { studioSlug: 'auth-refactor' },
       });
 
@@ -2623,11 +2623,11 @@ describe('StrategyService', () => {
       expect(dc.repositories.studios.create).not.toHaveBeenCalled();
     });
 
-    it('uses input.ownerAgentId for branch/studio even when group.owner_agent_id is null', async () => {
+    it('uses input.sbId for branch/studio even when group.sb_id is null', async () => {
       const group = createMockGroup({
         strategy: null,
         status: 'active',
-        owner_agent_id: null,
+        sb_id: null,
         metadata: { repoRoot: '/repo' },
       });
       const task = createMockTask();
@@ -2679,7 +2679,7 @@ describe('StrategyService', () => {
         groupId: 'group-1',
         userId: 'user-123',
         strategy: 'persistence',
-        ownerAgentId: 'wren',
+        sbId: 'sb-wren-uuid',
         config: { studioSlug: 'auth-refactor' },
       });
 

--- a/packages/api/src/services/strategy.service.ts
+++ b/packages/api/src/services/strategy.service.ts
@@ -218,11 +218,13 @@ export class StrategyService {
     if (inputConfig?.studioSlug) {
       const metadata = (group.metadata || {}) as Record<string, unknown>;
       if (!metadata.studioId) {
-        const created = await this.createPersistentStudio(
-          group,
-          inputConfig.studioSlug,
-          input.ownerAgentId
-        );
+        const ownerSlug = input.sbId
+          ? await resolveAgentSlug(this.dataComposer.getClient(), input.sbId)
+          : null;
+        if (!ownerSlug) {
+          throw new Error('Could not resolve agent slug for persistent studio branch naming');
+        }
+        const created = await this.createPersistentStudio(group, inputConfig.studioSlug, ownerSlug);
         if (!created) {
           throw new Error(
             `Failed to create persistent studio "${inputConfig.studioSlug}" — check repoRoot in group metadata`

--- a/packages/web/src/components/command/data-hooks.ts
+++ b/packages/web/src/components/command/data-hooks.ts
@@ -22,6 +22,7 @@ interface AgentLatestSession {
   lifecycle: string | null;
   currentPhase: string | null;
   status: string | null;
+  activeThreadKey: string | null;
   updatedAt: string;
   studioId: string | null;
 }
@@ -148,6 +149,7 @@ export function useCommandData() {
         studioSlug: activeStudio?.slug ?? null,
         lifecycle: agent.latestSession?.lifecycle ?? null,
         phase: agent.latestSession?.currentPhase ?? null,
+        activeThreadKey: agent.latestSession?.activeThreadKey ?? null,
         updatedAt: agent.latestSession?.updatedAt ?? null,
         position: { x: centerX, y: centerY },
         targetPosition: null,

--- a/packages/web/src/components/command/store.ts
+++ b/packages/web/src/components/command/store.ts
@@ -13,6 +13,7 @@ export interface AgentState {
   studioSlug: string | null;
   lifecycle: string | null;
   phase: string | null;
+  activeThreadKey: string | null;
   updatedAt: string | null;
   position: { x: number; y: number };
   targetPosition: { x: number; y: number } | null;

--- a/supabase/migrations/20260513185053_add_active_thread_key_to_sessions.sql
+++ b/supabase/migrations/20260513185053_add_active_thread_key_to_sessions.sql
@@ -1,0 +1,9 @@
+-- Add active_thread_key to sessions for tracking what artifact/thread
+-- a session is currently working on (mutable, unlike thread_key which
+-- is the immutable routing anchor set at session creation).
+
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS active_thread_key text;
+
+CREATE INDEX IF NOT EXISTS idx_sessions_active_thread_key
+  ON sessions (user_id, active_thread_key)
+  WHERE active_thread_key IS NOT NULL AND ended_at IS NULL;


### PR DESCRIPTION
## Summary

- Adds a mutable `active_thread_key` column to sessions, distinct from the immutable `thread_key` routing anchor set at session creation
- Agents set it via `update_session_state(activeThreadKey: "pr:350")` to signal what artifact they're currently working on
- Changes flow through the existing session trace diff machinery, so thread key transitions are automatically captured in the `activity_stream` as `state_change` events — no separate history table needed
- Wired end-to-end: migration, model, repository, tool schema, trace diff, admin API, and Command Center store/data hooks
- Also fixes a leftover `ownerAgentId` reference in persistent studio creation from the PR #367 merge

## How it works

1. Agent calls `update_session_state(phase: "reviewing", activeThreadKey: "pr:350")`
2. `active_thread_key` is written to the session row
3. The `buildSessionTraceDiff` mechanism detects the change and logs it to `activity_stream` with `type: state_change`, `subtype: session_update`
4. Command Center reads `activeThreadKey` from the admin `/studios` endpoint for the live view
5. Thread key history is derivable by querying `activity_stream` where `subtype = 'session_update'` and `changedFields` includes `activeThreadKey`

## Test plan

- [x] All 2403 unit tests pass (including 59 strategy service, 13 strategy-handlers, 104 memory-handlers)
- [x] TypeScript type check passes (no new errors)
- [x] Migration applied to remote DB
- [ ] Verify `update_session_state(activeThreadKey: "pr:367")` persists and appears in session state
- [ ] Verify activity_stream captures the thread key transition in the before/after payload

— Wren