### PR TITLE
feat: surface activeThreadKey across all read paths and Command Center (by Wren)

### DIFF
--- a/packages/api/src/mcp/tools/memory-handlers.ts
+++ b/packages/api/src/mcp/tools/memory-handlers.ts
@@ -133,6 +133,7 @@ export function mapSessionForBootstrap(
     agentId?: string;
     studioId?: string;
     threadKey?: string;
+    activeThreadKey?: string;
     lifecycle?: string;
     currentPhase?: string;
     context?: string;
@@ -145,6 +146,7 @@ export function mapSessionForBootstrap(
     agentId: s.agentId,
     studioId: s.studioId || null,
     threadKey: s.threadKey || null,
+    activeThreadKey: s.activeThreadKey || null,
     lifecycle: s.lifecycle || null,
     currentPhase: s.currentPhase || null,
     ...(callerSessionId && s.id === callerSessionId && s.context ? { context: s.context } : {}),
@@ -1289,6 +1291,7 @@ export async function handleGetSession(args: unknown, dataComposer: DataComposer
               studioId: session.studioId,
               lifecycle: session.lifecycle || null,
               currentPhase: session.currentPhase || null,
+              activeThreadKey: session.activeThreadKey || null,
               startedAt: session.startedAt.toISOString(),
               endedAt: session.endedAt?.toISOString(),
               summary: session.summary,
@@ -1359,6 +1362,7 @@ export async function handleListSessions(args: unknown, dataComposer: DataCompos
                 : null,
               lifecycle: s.lifecycle || null,
               currentPhase: s.currentPhase || null,
+              activeThreadKey: s.activeThreadKey || null,
               status: s.status || null,
               backend: s.backend || null,
               model: s.model || null,

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -5502,6 +5502,45 @@ router.get('/sessions/:id/conversation', async (req: Request, res: Response) => 
       }
     }
 
+    // For ink backend: query activity_stream for conversation messages
+    if (backend === 'ink') {
+      const { data: activities, error: actError } = await supabase
+        .from('activity_stream')
+        .select('id, type, direction, content, agent_id, platform, created_at, payload')
+        .eq('user_id', authReq.pcpUserId)
+        .eq('session_id', sessionId)
+        .in('type', [
+          'message_in',
+          'message_out',
+          'message',
+          'agent_spawn',
+          'agent_complete',
+          'error',
+        ])
+        .order('created_at', { ascending: true })
+        .limit(500);
+
+      if (!actError && activities && activities.length > 0) {
+        const events = activities.map((a) => ({
+          type: a.type,
+          direction: a.direction,
+          content: a.content,
+          agentId: a.agent_id,
+          platform: a.platform,
+          timestamp: a.created_at,
+          payload: a.payload,
+        }));
+        res.json({
+          session: sessionInfo,
+          source: 'cloud',
+          backend,
+          transcript: { events },
+          totalEvents: events.length,
+        });
+        return;
+      }
+    }
+
     res.json({
       session: sessionInfo,
       source: 'none',

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -5394,6 +5394,128 @@ router.get('/sessions/:id/transcript', async (req: Request, res: Response) => {
 });
 
 /**
+ * GET /api/admin/sessions/:id/conversation
+ * Returns raw transcript events for the conversation viewer.
+ * Tries synced transcript first, falls back to local.
+ */
+router.get('/sessions/:id/conversation', async (req: Request, res: Response) => {
+  try {
+    const sessionId = req.params.id;
+    const authReq = req as AdminAuthRequest;
+
+    const supabase = createClient(env.SUPABASE_URL, env.SUPABASE_SECRET_KEY, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+
+    const { scope, error: scopedIdentityError } = await resolveWorkspaceIdentityScope(
+      supabase,
+      authReq.pcpUserId,
+      authReq.pcpWorkspaceId
+    );
+
+    if (scopedIdentityError || !scope || scope.sbIds.length === 0) {
+      res.status(404).json({ error: 'Session not found' });
+      return;
+    }
+
+    const { data: session, error: sessionError } = await supabase
+      .from('sessions')
+      .select(
+        'id, sb_id, agent_id, backend, backend_session_id, lifecycle, current_phase, active_thread_key, started_at, updated_at, ended_at, studio_id'
+      )
+      .eq('id', sessionId)
+      .eq('user_id', authReq.pcpUserId)
+      .single();
+
+    if (sessionError || !session || !isSessionInWorkspace(session, scope)) {
+      res.status(404).json({ error: 'Session not found' });
+      return;
+    }
+
+    const identity = scope.rows.find(
+      (row) => row.id === session.sb_id || row.agent_id === session.agent_id
+    );
+
+    const sessionInfo = {
+      id: session.id,
+      agentId: identity?.agent_id ?? session.agent_id ?? 'unknown',
+      agentName: identity?.name ?? session.agent_id ?? 'Unknown',
+      backend: session.backend,
+      backendSessionId: session.backend_session_id,
+      lifecycle: session.lifecycle,
+      currentPhase: session.current_phase,
+      activeThreadKey: session.active_thread_key ?? null,
+      startedAt: session.started_at,
+      updatedAt: session.updated_at,
+      endedAt: session.ended_at,
+    };
+
+    const backend = session.backend ?? 'claude-code';
+
+    const { data: archive } = await supabase
+      .from('session_transcript_archives')
+      .select('payload')
+      .eq('user_id', authReq.pcpUserId)
+      .eq('session_id', sessionId)
+      .order('synced_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (archive?.payload && typeof archive.payload === 'object') {
+      const payload = archive.payload as Record<string, unknown>;
+      const events = Array.isArray(payload.events) ? payload.events : [];
+      res.json({
+        session: sessionInfo,
+        source: 'synced',
+        backend,
+        transcript: { events },
+        totalEvents: events.length,
+      });
+      return;
+    }
+
+    const localItems = await tryReadLocalTranscript({
+      sessionId: session.id,
+      backendSessionId: session.backend_session_id,
+      backend: session.backend,
+    });
+
+    if (localItems.length > 0) {
+      const descriptor = await resolveLocalTranscriptDescriptor({
+        sessionId: session.id,
+        backend: session.backend,
+        backendSessionId: session.backend_session_id,
+      });
+
+      if (descriptor) {
+        const parsed = await readTranscriptFromDescriptor(descriptor);
+        if (parsed) {
+          res.json({
+            session: sessionInfo,
+            source: 'local',
+            backend,
+            transcript: { events: parsed.events },
+            totalEvents: parsed.events.length,
+          });
+          return;
+        }
+      }
+    }
+
+    res.json({
+      session: sessionInfo,
+      source: 'none',
+      backend,
+      transcript: null,
+      totalEvents: 0,
+    });
+  } catch (error) {
+    logger.error('Failed to load conversation:', error);
+    res.status(500).json(errorJson('Failed to load conversation', error));
+  }
+});
+
+/**
  * POST /api/admin/sessions/:id/sync-transcript
  * Sync full local backend transcript into Postgres jsonb for cross-server portability.
  */

--- a/packages/cli/src/commands/hooks.ts
+++ b/packages/cli/src/commands/hooks.ts
@@ -2048,6 +2048,24 @@ async function onSessionStartHandler(options?: { backend?: string }): Promise<vo
   pcpThreadKey = reconciled.threadKey || pcpThreadKey;
   const backendSessionId = reconciled.backendSessionId;
 
+  // Hydrate threadKey from the server when we have a pre-created session
+  // (e.g., INK_SESSION_ID from trigger) but no local threadKey yet.
+  if (pcpSessionId && !pcpThreadKey) {
+    try {
+      const sessionResult = await callPcpTool('get_session', {
+        email: config?.email,
+        sessionId: pcpSessionId,
+      });
+      const session = sessionResult?.session as Record<string, unknown> | undefined;
+      if (session) {
+        if (typeof session.activeThreadKey === 'string') pcpThreadKey = session.activeThreadKey;
+        else if (typeof session.threadKey === 'string') pcpThreadKey = session.threadKey;
+      }
+    } catch {
+      // Non-fatal
+    }
+  }
+
   // Set lifecycle to idle on startup (ready for user input).
   if (pcpSessionId) {
     try {

--- a/packages/cli/src/commands/hooks.ts
+++ b/packages/cli/src/commands/hooks.ts
@@ -2059,6 +2059,7 @@ async function onSessionStartHandler(options?: { backend?: string }): Promise<vo
         workingDir: cwd,
       };
       if (backendSessionId) updateArgs.backendSessionId = backendSessionId;
+      if (pcpThreadKey) updateArgs.activeThreadKey = pcpThreadKey;
       await callPcpTool('update_session_state', updateArgs);
     } catch {
       // Non-fatal; startup should continue even if linkage fails.
@@ -2429,7 +2430,8 @@ async function onPromptHandler(options?: { backend?: string }): Promise<void> {
         '(started/stopped a server, opened a PR, kicked off a build, changed ports, etc.), ' +
         'update your session context via `update_session_state(context: "...")` so it survives ' +
         "compaction. Context is your scratch board for transient active state — what's running, " +
-        "what's pending, what port you're on.\n" +
+        "what's pending, what port you're on. If you're working on a specific artifact " +
+        '(PR, spec, thread), set `activeThreadKey` too (e.g., "pr:350", "spec:auth-refactor").\n' +
         '</ink-reminder>\n'
     );
     writeRuntimeFile(cwd, 'last-context-reminder', new Date().toISOString());

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -25,6 +25,7 @@
     "@supabase/ssr": "^0.5.2",
     "@supabase/supabase-js": "^2.39.3",
     "@tanstack/react-query": "^5.62.0",
+    "@tanstack/react-virtual": "^3.13.26",
     "@tiptap/core": "^3.2.0",
     "@tiptap/extension-highlight": "^3.2.0",
     "@tiptap/extension-link": "^3.2.0",

--- a/packages/web/src/app/(dashboard)/sessions/page.tsx
+++ b/packages/web/src/app/(dashboard)/sessions/page.tsx
@@ -298,11 +298,17 @@ function SessionCard({ session }: { session: Session }) {
           <div className="rounded-md bg-gray-50 p-3 text-xs space-y-3">
             <div>
               <Link
-                href={`/sessions/${session.id}`}
+                href={`/sessions/viewer?id=${session.id}`}
                 className="inline-flex items-center gap-1.5 rounded border border-gray-300 bg-white px-2 py-1 text-xs font-medium text-gray-700 hover:bg-gray-100"
               >
                 <MessageSquare className="h-3.5 w-3.5" />
-                View full log
+                View conversation
+              </Link>
+              <Link
+                href={`/sessions/${session.id}`}
+                className="inline-flex items-center gap-1.5 rounded border border-gray-300 bg-white px-2 py-1 text-xs font-medium text-gray-500 hover:bg-gray-100"
+              >
+                View raw log
               </Link>
             </div>
             {/* Session IDs */}

--- a/packages/web/src/app/(dashboard)/sessions/viewer/page.tsx
+++ b/packages/web/src/app/(dashboard)/sessions/viewer/page.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { SessionSidebar } from '@/components/session-viewer/session-sidebar';
+import { ConversationViewer } from '@/components/session-viewer/conversation-viewer';
+
+export default function SessionViewerPage() {
+  const searchParams = useSearchParams();
+  const initialSession = searchParams.get('id');
+  const [selectedId, setSelectedId] = useState<string | null>(initialSession);
+
+  return (
+    <div className="h-[calc(100vh-64px)] flex overflow-hidden -m-8">
+      <SessionSidebar selectedId={selectedId} onSelect={setSelectedId} />
+      <div className="flex-1 flex flex-col overflow-hidden bg-white">
+        {selectedId ? (
+          <ConversationViewer sessionId={selectedId} />
+        ) : (
+          <div className="flex-1 flex items-center justify-center text-gray-400">
+            <div className="text-center">
+              <p className="text-lg font-medium mb-1">Select a session</p>
+              <p className="text-sm">Choose a session from the sidebar to view the conversation.</p>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/command/activity-log.tsx
+++ b/packages/web/src/components/command/activity-log.tsx
@@ -56,9 +56,14 @@ export function ActivityLog() {
                 {agent.name}
               </span>
               <span style={{ color: skin.colors.textMuted }}>→</span>
-              <span style={{ color: skin.colors.text }} className="truncate flex-1">
+              <span style={{ color: skin.colors.text }} className="truncate">
                 {phase}
               </span>
+              {agent.activeThreadKey && (
+                <span style={{ color: skin.colors.accent }} className="truncate">
+                  {agent.activeThreadKey}
+                </span>
+              )}
               {agent.lifecycle === 'running' && (
                 <span
                   className="inline-block w-2 h-2 rounded-full animate-pulse"

--- a/packages/web/src/components/command/agent-cards.tsx
+++ b/packages/web/src/components/command/agent-cards.tsx
@@ -1,0 +1,304 @@
+'use client';
+
+import { useCommandStore } from './store';
+import { getSkin } from './skins';
+import type { SkinConfig } from './skins';
+import type { AgentState, StudioNode, TaskNode } from './store';
+
+const AGENT_COLORS: Record<string, string> = {
+  wren: '#e94560',
+  lumen: '#0abde3',
+  aster: '#f9ca24',
+  myra: '#6c5ce7',
+  benson: '#00b894',
+};
+
+function formatBackend(b: string | null): string {
+  if (!b) return 'Unknown';
+  const map: Record<string, string> = {
+    'claude-code': 'Claude Code',
+    claude: 'Claude',
+    'codex-cli': 'Codex CLI',
+    codex: 'Codex',
+    gemini: 'Gemini',
+  };
+  return map[b] ?? b;
+}
+
+function timeAgo(ts: string | null): string {
+  if (!ts) return 'never';
+  const diff = Date.now() - new Date(ts).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+function lifecycleColor(lifecycle: string | null, phase: string | null, skin: SkinConfig): string {
+  if (lifecycle === 'running') return skin.colors.agentActive;
+  if (phase?.startsWith('blocked')) return skin.colors.agentBlocked;
+  return skin.colors.agentIdle;
+}
+
+function lifecycleLabel(lifecycle: string | null, phase: string | null): string {
+  if (!lifecycle && !phase) return 'offline';
+  if (lifecycle === 'running') return phase ?? 'active';
+  if (lifecycle === 'idle') return phase ?? 'idle';
+  return phase ?? lifecycle ?? 'unknown';
+}
+
+interface TaskStats {
+  total: number;
+  completed: number;
+  inProgress: number;
+  blocked: number;
+}
+
+function computeTaskStats(agentId: string, tasks: TaskNode[]): TaskStats {
+  const agentTasks = tasks.filter((t) => t.agentId === agentId);
+  return {
+    total: agentTasks.length,
+    completed: agentTasks.filter((t) => t.status === 'completed' || t.status === 'done').length,
+    inProgress: agentTasks.filter((t) => t.status === 'in_progress').length,
+    blocked: agentTasks.filter((t) => t.status === 'blocked').length,
+  };
+}
+
+function ProgressBar({ stats, skin }: { stats: TaskStats; skin: SkinConfig }) {
+  if (stats.total === 0) return null;
+  const pct = (stats.completed / stats.total) * 100;
+  return (
+    <div className="flex items-center gap-2">
+      <div
+        className="flex-1 h-1.5 rounded-full overflow-hidden"
+        style={{ backgroundColor: skin.colors.border }}
+      >
+        <div
+          className="h-full rounded-full transition-all"
+          style={{
+            width: `${pct}%`,
+            backgroundColor: skin.colors.taskCompleted,
+          }}
+        />
+      </div>
+      <span className="text-[10px] shrink-0" style={{ color: skin.colors.textMuted }}>
+        {stats.completed}/{stats.total}
+      </span>
+    </div>
+  );
+}
+
+function AgentCard({
+  agent,
+  studios,
+  taskStats,
+  skin,
+  onSelect,
+}: {
+  agent: AgentState;
+  studios: StudioNode[];
+  taskStats: TaskStats;
+  skin: SkinConfig;
+  onSelect: () => void;
+}) {
+  const color = AGENT_COLORS[agent.agentId] ?? '#888';
+  const statusColor = lifecycleColor(agent.lifecycle, agent.phase, skin);
+  const statusLabel = lifecycleLabel(agent.lifecycle, agent.phase);
+  const isActive = agent.lifecycle === 'running';
+  const activeStudios = studios.filter((s) => s.status === 'active');
+
+  return (
+    <button
+      onClick={onSelect}
+      className="w-full text-left rounded-lg border transition-all hover:scale-[1.01]"
+      style={{
+        backgroundColor: skin.colors.surface,
+        borderColor: isActive ? statusColor + '60' : skin.colors.border,
+        boxShadow: isActive ? `0 0 12px ${statusColor}20` : 'none',
+      }}
+    >
+      {/* Header */}
+      <div className="p-3 pb-2 flex items-start gap-3">
+        <div
+          className="w-9 h-9 rounded-lg flex items-center justify-center text-white font-bold text-sm shrink-0"
+          style={{ backgroundColor: color }}
+        >
+          {agent.name.charAt(0).toUpperCase()}
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center justify-between gap-2">
+            <span className="font-semibold text-sm truncate" style={{ color: skin.colors.text }}>
+              {agent.name}
+            </span>
+            <div className="flex items-center gap-1.5 shrink-0">
+              <div
+                className="w-2 h-2 rounded-full"
+                style={{
+                  backgroundColor: statusColor,
+                  animation: isActive ? 'pulse 2s infinite' : 'none',
+                }}
+              />
+              <span className="text-[10px]" style={{ color: statusColor }}>
+                {statusLabel}
+              </span>
+            </div>
+          </div>
+          <span className="text-xs" style={{ color: skin.colors.textMuted }}>
+            {formatBackend(agent.backend)}
+          </span>
+        </div>
+      </div>
+
+      {/* Active context */}
+      {(agent.activeThreadKey || agent.phase) && (
+        <div className="px-3 pb-2 space-y-1">
+          {agent.activeThreadKey && (
+            <div
+              className="inline-block text-[11px] px-1.5 py-0.5 rounded"
+              style={{
+                backgroundColor: skin.colors.accent + '18',
+                color: skin.colors.accent,
+                fontFamily: skin.fonts.mono,
+              }}
+            >
+              {agent.activeThreadKey}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Studios */}
+      {activeStudios.length > 0 && (
+        <div className="px-3 pb-2">
+          <div className="flex flex-wrap gap-1">
+            {activeStudios.slice(0, 3).map((s) => (
+              <span
+                key={s.id}
+                className="text-[10px] px-1.5 py-0.5 rounded truncate max-w-[120px]"
+                style={{
+                  backgroundColor: skin.colors.bg,
+                  color: skin.colors.textMuted,
+                  fontFamily: skin.fonts.mono,
+                }}
+              >
+                {s.slug ?? s.branch}
+              </span>
+            ))}
+            {activeStudios.length > 3 && (
+              <span className="text-[10px] px-1" style={{ color: skin.colors.textMuted }}>
+                +{activeStudios.length - 3}
+              </span>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Footer: tasks + time */}
+      <div
+        className="px-3 py-2 border-t flex items-center justify-between gap-2"
+        style={{ borderColor: skin.colors.border + '60' }}
+      >
+        <div className="flex-1 min-w-0">
+          <ProgressBar stats={taskStats} skin={skin} />
+          {taskStats.total === 0 && (
+            <span className="text-[10px]" style={{ color: skin.colors.textMuted }}>
+              No active tasks
+            </span>
+          )}
+        </div>
+        <span
+          className="text-[10px] shrink-0"
+          style={{ color: skin.colors.textMuted, fontFamily: skin.fonts.mono }}
+        >
+          {timeAgo(agent.updatedAt)}
+        </span>
+      </div>
+    </button>
+  );
+}
+
+export function AgentCards() {
+  const skin = getSkin(useCommandStore((s) => s.skin));
+  const agents = useCommandStore((s) => s.agents);
+  const studios = useCommandStore((s) => s.studios);
+  const tasks = useCommandStore((s) => s.tasks);
+  const selectAgent = useCommandStore((s) => s.selectAgent);
+
+  const activeAgents = agents.filter((a) => a.lifecycle === 'running');
+  const idleAgents = agents.filter((a) => a.lifecycle !== 'running');
+
+  return (
+    <div className="h-full overflow-y-auto p-6" style={{ backgroundColor: skin.colors.bg }}>
+      {/* Summary bar */}
+      <div className="flex items-center gap-4 mb-5">
+        <h2
+          className="text-xs font-bold tracking-wider uppercase"
+          style={{ fontFamily: skin.fonts.heading, color: skin.colors.accent, fontSize: '10px' }}
+        >
+          Agent Workbench
+        </h2>
+        <div
+          className="flex items-center gap-3 text-[11px]"
+          style={{ color: skin.colors.textMuted }}
+        >
+          <span>
+            <span style={{ color: skin.colors.agentActive }}>{activeAgents.length}</span> active
+          </span>
+          <span>{agents.length} total</span>
+          <span>{studios.filter((s) => s.status === 'active').length} studios</span>
+        </div>
+      </div>
+
+      {/* Active agents */}
+      {activeAgents.length > 0 && (
+        <div className="mb-6">
+          <div
+            className="text-[10px] uppercase tracking-wider mb-2"
+            style={{ color: skin.colors.agentActive, fontFamily: skin.fonts.mono }}
+          >
+            Working
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+            {activeAgents.map((agent) => (
+              <AgentCard
+                key={agent.agentId}
+                agent={agent}
+                studios={studios.filter((s) => s.agentId === agent.agentId)}
+                taskStats={computeTaskStats(agent.agentId, tasks)}
+                skin={skin}
+                onSelect={() => selectAgent(agent.agentId)}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Idle agents */}
+      {idleAgents.length > 0 && (
+        <div>
+          <div
+            className="text-[10px] uppercase tracking-wider mb-2"
+            style={{ color: skin.colors.textMuted, fontFamily: skin.fonts.mono }}
+          >
+            Idle
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+            {idleAgents.map((agent) => (
+              <AgentCard
+                key={agent.agentId}
+                agent={agent}
+                studios={studios.filter((s) => s.agentId === agent.agentId)}
+                taskStats={computeTaskStats(agent.agentId, tasks)}
+                skin={skin}
+                onSelect={() => selectAgent(agent.agentId)}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/components/command/agent-panel.tsx
+++ b/packages/web/src/components/command/agent-panel.tsx
@@ -98,6 +98,14 @@ export function AgentPanel() {
               {agent.phase ? ` · ${agent.phase}` : ''}
             </span>
           </div>
+          {agent.activeThreadKey && (
+            <div
+              className="text-xs mt-1 px-1.5 py-0.5 rounded inline-block"
+              style={{ backgroundColor: skin.colors.bg, color: skin.colors.accent }}
+            >
+              {agent.activeThreadKey}
+            </div>
+          )}
         </div>
 
         {agent.role && (

--- a/packages/web/src/components/command/command-center.tsx
+++ b/packages/web/src/components/command/command-center.tsx
@@ -8,15 +8,16 @@ import { SpatialMap } from './spatial-map';
 import { TaskGraph } from './task-graph';
 import { ActivityLog } from './activity-log';
 import { AgentPanel } from './agent-panel';
+import { AgentCards } from './agent-cards';
 import { SkinPicker } from './skin-picker';
 
-type ViewMode = 'split' | 'map' | 'graph';
+type ViewMode = 'split' | 'map' | 'graph' | 'cards';
 
 export function CommandCenter() {
   useCommandData();
 
   const skin = getSkin(useCommandStore((s) => s.skin));
-  const [viewMode, setViewMode] = useState<ViewMode>('map');
+  const [viewMode, setViewMode] = useState<ViewMode>('cards');
 
   return (
     <div
@@ -39,21 +40,31 @@ export function CommandCenter() {
             COMMAND CENTER
           </h1>
           <div className="flex items-center gap-1">
-            {(['split', 'map', 'graph'] as ViewMode[]).map((mode) => (
-              <button
-                key={mode}
-                onClick={() => setViewMode(mode)}
-                className="px-2 py-0.5 rounded text-xs transition-all"
-                style={{
-                  backgroundColor: viewMode === mode ? skin.colors.accent + '20' : 'transparent',
-                  color: viewMode === mode ? skin.colors.accent : skin.colors.textMuted,
-                  fontFamily: skin.fonts.mono,
-                  fontSize: '11px',
-                }}
-              >
-                {mode === 'split' ? 'SPLIT' : mode === 'map' ? 'MAP' : 'TASKS'}
-              </button>
-            ))}
+            {(['cards', 'split', 'map', 'graph'] as ViewMode[]).map((mode) => {
+              const label =
+                mode === 'cards'
+                  ? 'CARDS'
+                  : mode === 'split'
+                    ? 'SPLIT'
+                    : mode === 'map'
+                      ? 'MAP'
+                      : 'TASKS';
+              return (
+                <button
+                  key={mode}
+                  onClick={() => setViewMode(mode)}
+                  className="px-2 py-0.5 rounded text-xs transition-all"
+                  style={{
+                    backgroundColor: viewMode === mode ? skin.colors.accent + '20' : 'transparent',
+                    color: viewMode === mode ? skin.colors.accent : skin.colors.textMuted,
+                    fontFamily: skin.fonts.mono,
+                    fontSize: '11px',
+                  }}
+                >
+                  {label}
+                </button>
+              );
+            })}
           </div>
         </div>
         <SkinPicker />
@@ -63,7 +74,12 @@ export function CommandCenter() {
       <div className="flex-1 flex overflow-hidden">
         {/* Left panel: spatial map + task graph */}
         <div className="flex-1 flex flex-col relative">
-          {viewMode === 'split' ? (
+          {viewMode === 'cards' ? (
+            <div className="flex-1 relative">
+              <AgentCards />
+              <AgentPanel />
+            </div>
+          ) : viewMode === 'split' ? (
             <>
               <div className="relative" style={{ height: '60%' }}>
                 <SpatialMap />

--- a/packages/web/src/components/command/spatial-map.tsx
+++ b/packages/web/src/components/command/spatial-map.tsx
@@ -344,6 +344,13 @@ function drawAgent(
   ctx.font = `${Math.max(8, 10 * z)}px ${skin.fonts.mono}`;
   ctx.textAlign = 'center';
   ctx.fillText(phaseText, pos.x, barY + barHeight + 6 * z);
+
+  // Active thread key (what artifact they're working on)
+  if (agent.activeThreadKey) {
+    ctx.fillStyle = skin.colors.accent;
+    ctx.font = `${Math.max(7, 9 * z)}px ${skin.fonts.mono}`;
+    ctx.fillText(agent.activeThreadKey, pos.x, barY + barHeight + 18 * z);
+  }
 }
 
 export function SpatialMap() {

--- a/packages/web/src/components/session-viewer/conversation-viewer.tsx
+++ b/packages/web/src/components/session-viewer/conversation-viewer.tsx
@@ -1,0 +1,299 @@
+'use client';
+
+import { useMemo, useRef, useEffect } from 'react';
+import { useApiQuery, useApiPost, useQueryClient } from '@/lib/api';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { parseTranscript } from './transcript-parser';
+import { MessageBubble } from './message-bubble';
+import type { ToolResultBlock } from './types';
+
+interface TranscriptPayload {
+  version?: number;
+  events?: unknown[];
+}
+
+interface ConversationResponse {
+  session: {
+    id: string;
+    agentId: string;
+    agentName: string;
+    backend: string | null;
+    backendSessionId: string | null;
+    lifecycle: string | null;
+    currentPhase: string | null;
+    activeThreadKey: string | null;
+    startedAt: string;
+    updatedAt: string;
+    endedAt: string | null;
+  };
+  source: 'synced' | 'local' | 'none';
+  backend: string;
+  transcript: TranscriptPayload | null;
+  totalEvents: number;
+}
+
+interface SessionLogsResponse {
+  session: {
+    id: string;
+    agentId: string;
+    status: string;
+    currentPhase: string | null;
+    backend: string | null;
+    backendSessionId: string | null;
+    startedAt: string;
+    updatedAt: string;
+    endedAt: string | null;
+  };
+  logs: Array<{
+    id: string;
+    source: string;
+    type: string;
+    role: 'in' | 'out' | 'system';
+    content: string;
+    timestamp: string;
+  }>;
+  pagination: { total: number; limit: number; offset: number; hasMore: boolean };
+  sources: { cloud: number; synced: number; local: number };
+}
+
+function phaseColor(phase: string | null, lifecycle: string | null): string {
+  if (lifecycle === 'running') {
+    if (phase === 'runtime:generating') return 'bg-blue-100 text-blue-700';
+    return 'bg-green-100 text-green-700';
+  }
+  if (phase?.startsWith('blocked')) return 'bg-amber-100 text-amber-700';
+  if (lifecycle === 'idle') return 'bg-green-100 text-green-700';
+  return 'bg-gray-100 text-gray-600';
+}
+
+function phaseLabel(phase: string | null, lifecycle: string | null): string {
+  if (lifecycle === 'running') {
+    if (phase === 'runtime:generating') return 'Generating';
+    return phase ?? 'Running';
+  }
+  if (lifecycle === 'idle') return phase ?? 'Idle';
+  if (lifecycle === 'completed') return 'Completed';
+  return phase ?? lifecycle ?? 'unknown';
+}
+
+import type { ConversationTurn, TextBlock } from './types';
+
+function logsToTurns(logs: SessionLogsResponse['logs']): ConversationTurn[] {
+  const sorted = [...logs].sort(
+    (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
+  );
+  return sorted
+    .filter((log) => log.content?.trim())
+    .map((log) => ({
+      id: log.id,
+      role:
+        log.role === 'in'
+          ? ('user' as const)
+          : log.role === 'out'
+            ? ('assistant' as const)
+            : ('system' as const),
+      timestamp: log.timestamp,
+      blocks: [{ kind: 'text' as const, text: log.content } satisfies TextBlock],
+    }));
+}
+
+export function ConversationViewer({ sessionId }: { sessionId: string }) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const queryClient = useQueryClient();
+
+  const { data: conversationData, error: conversationError } = useApiQuery<ConversationResponse>(
+    ['session-conversation', sessionId],
+    `/api/admin/sessions/${sessionId}/conversation`,
+    { refetchInterval: 10000, retry: false }
+  );
+
+  const useLogsEndpoint = conversationError != null;
+
+  const { data: logsData } = useApiQuery<SessionLogsResponse>(
+    ['session-logs-viewer', sessionId],
+    `/api/admin/sessions/${sessionId}/logs?limit=200&offset=0&includeLocal=true`,
+    { refetchInterval: 15000, enabled: useLogsEndpoint }
+  );
+
+  const syncTranscript = useApiPost<{ ok: boolean; lineCount: number }, Record<string, never>>(
+    `/api/admin/sessions/${sessionId}/sync-transcript`,
+    {
+      onSuccess: async () => {
+        await queryClient.invalidateQueries({ queryKey: ['session-conversation', sessionId] });
+        await queryClient.invalidateQueries({ queryKey: ['session-logs-viewer', sessionId] });
+      },
+    }
+  );
+
+  const { turns, source, totalEvents, session, backend } = useMemo(() => {
+    if (conversationData) {
+      const events = conversationData.transcript?.events ?? [];
+      const parsed = events.length > 0 ? parseTranscript(conversationData.backend, events) : [];
+      return {
+        turns: parsed,
+        source: conversationData.source,
+        totalEvents: conversationData.totalEvents,
+        session: conversationData.session,
+        backend: conversationData.backend,
+      };
+    }
+
+    if (logsData) {
+      return {
+        turns: logsToTurns(logsData.logs),
+        source: (logsData.sources.synced > 0
+          ? 'synced'
+          : logsData.sources.local > 0
+            ? 'local'
+            : 'cloud') as 'synced' | 'local' | 'cloud',
+        totalEvents: logsData.pagination.total,
+        session: {
+          ...logsData.session,
+          agentName: logsData.session.agentId,
+          lifecycle: logsData.session.status,
+          activeThreadKey: null,
+        },
+        backend: logsData.session.backend ?? 'claude-code',
+      };
+    }
+
+    return { turns: [], source: 'none' as const, totalEvents: 0, session: null, backend: '' };
+  }, [conversationData, logsData]);
+
+  const toolResults = useMemo(() => {
+    const map = new Map<string, ToolResultBlock>();
+    for (const turn of turns) {
+      for (const block of turn.blocks) {
+        if (block.kind === 'tool-result') {
+          map.set(block.toolUseId, block);
+        }
+      }
+    }
+    return map;
+  }, [turns]);
+
+  const isLive = session?.lifecycle === 'running';
+
+  useEffect(() => {
+    if (scrollRef.current && turns.length > 0) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [turns.length]);
+
+  if (!conversationData && !logsData && !conversationError) {
+    return (
+      <div className="flex-1 flex items-center justify-center text-gray-400">
+        <div className="text-center">
+          <div className="animate-pulse text-lg mb-2">Loading conversation…</div>
+          <div className="text-xs">{sessionId.slice(0, 8)}</div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!session) return null;
+
+  const agentName = session.agentName || session.agentId;
+
+  return (
+    <div className="flex-1 flex flex-col h-full overflow-hidden">
+      {/* Session header */}
+      <div className="shrink-0 px-4 py-3 border-b border-gray-200 bg-white">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2 flex-wrap">
+            <h2 className="font-semibold text-gray-900">{agentName}</h2>
+            <Badge variant="outline" className="text-xs font-mono">
+              {session.agentId}
+            </Badge>
+            <Badge className={`text-xs ${phaseColor(session.currentPhase, session.lifecycle)}`}>
+              {phaseLabel(session.currentPhase, session.lifecycle)}
+            </Badge>
+            {'activeThreadKey' in session && session.activeThreadKey && (
+              <Badge
+                variant="outline"
+                className="text-xs font-mono text-indigo-600 border-indigo-300"
+              >
+                {session.activeThreadKey}
+              </Badge>
+            )}
+            {isLive && (
+              <span className="flex items-center gap-1 text-xs text-green-600">
+                <span className="w-1.5 h-1.5 rounded-full bg-green-500 animate-pulse" />
+                live
+              </span>
+            )}
+          </div>
+          <div className="flex items-center gap-2">
+            {useLogsEndpoint && (
+              <Badge variant="outline" className="text-[10px] text-amber-600 border-amber-300">
+                flat view
+              </Badge>
+            )}
+            <Badge variant="outline" className="text-[10px]">
+              {source === 'synced'
+                ? 'Cloud'
+                : source === 'local'
+                  ? 'Local'
+                  : source === 'cloud'
+                    ? 'Activity'
+                    : 'No transcript'}
+            </Badge>
+            <span className="text-xs text-gray-400">{totalEvents} events</span>
+            {source !== 'synced' && (
+              <Button
+                size="sm"
+                variant="outline"
+                className="text-xs h-7"
+                onClick={() => syncTranscript.mutate({})}
+                disabled={syncTranscript.isPending}
+              >
+                {syncTranscript.isPending ? 'Syncing…' : 'Sync'}
+              </Button>
+            )}
+          </div>
+        </div>
+        {backend && (
+          <div className="flex items-center gap-3 mt-1 text-xs text-gray-500">
+            <span>{backend}</span>
+            {session.backendSessionId && (
+              <code className="font-mono text-[10px] text-gray-400">
+                {session.backendSessionId.slice(0, 12)}…
+              </code>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Conversation body */}
+      <div ref={scrollRef} className="flex-1 overflow-y-auto px-4 py-4 space-y-3 bg-gray-50/50">
+        {turns.length === 0 && source === 'none' ? (
+          <div className="flex flex-col items-center justify-center h-full text-gray-400 gap-3">
+            <p className="text-sm">No transcript available for this session.</p>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => syncTranscript.mutate({})}
+              disabled={syncTranscript.isPending}
+            >
+              {syncTranscript.isPending ? 'Syncing…' : 'Sync transcript from local'}
+            </Button>
+          </div>
+        ) : turns.length === 0 ? (
+          <div className="flex items-center justify-center h-full text-gray-400">
+            <p className="text-sm">Transcript is empty.</p>
+          </div>
+        ) : (
+          turns.map((turn) => (
+            <MessageBubble
+              key={turn.id}
+              turn={turn}
+              agentName={turn.role === 'assistant' ? agentName : undefined}
+              toolResults={toolResults}
+            />
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/session-viewer/conversation-viewer.tsx
+++ b/packages/web/src/components/session-viewer/conversation-viewer.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useMemo, useRef, useEffect } from 'react';
+import { useMemo, useRef, useEffect, useCallback } from 'react';
+import { useVirtualizer } from '@tanstack/react-virtual';
 import { useApiQuery, useApiPost, useQueryClient } from '@/lib/api';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -174,12 +175,27 @@ export function ConversationViewer({ sessionId }: { sessionId: string }) {
   }, [turns]);
 
   const isLive = session?.lifecycle === 'running';
+  const prevTurnCount = useRef(0);
+
+  const virtualizer = useVirtualizer({
+    count: turns.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => 80,
+    overscan: 10,
+  });
+
+  const scrollToBottom = useCallback(() => {
+    if (turns.length > 0) {
+      virtualizer.scrollToIndex(turns.length - 1, { align: 'end' });
+    }
+  }, [virtualizer, turns.length]);
 
   useEffect(() => {
-    if (scrollRef.current && turns.length > 0) {
-      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    if (turns.length > 0 && turns.length !== prevTurnCount.current) {
+      prevTurnCount.current = turns.length;
+      requestAnimationFrame(scrollToBottom);
     }
-  }, [turns.length]);
+  }, [turns.length, scrollToBottom]);
 
   if (!conversationData && !logsData && !conversationError) {
     return (
@@ -239,7 +255,9 @@ export function ConversationViewer({ sessionId }: { sessionId: string }) {
                     ? 'Activity'
                     : 'No transcript'}
             </Badge>
-            <span className="text-xs text-gray-400">{totalEvents} events</span>
+            <span className="text-xs text-gray-400">
+              {turns.length} turns · {totalEvents} events
+            </span>
             {source !== 'synced' && (
               <Button
                 size="sm"
@@ -265,8 +283,8 @@ export function ConversationViewer({ sessionId }: { sessionId: string }) {
         )}
       </div>
 
-      {/* Conversation body */}
-      <div ref={scrollRef} className="flex-1 overflow-y-auto px-4 py-4 space-y-3 bg-gray-50/50">
+      {/* Conversation body — virtualized */}
+      <div ref={scrollRef} className="flex-1 overflow-y-auto bg-gray-50/50">
         {turns.length === 0 && source === 'none' ? (
           <div className="flex flex-col items-center justify-center h-full text-gray-400 gap-3">
             <p className="text-sm">No transcript available for this session.</p>
@@ -284,14 +302,38 @@ export function ConversationViewer({ sessionId }: { sessionId: string }) {
             <p className="text-sm">Transcript is empty.</p>
           </div>
         ) : (
-          turns.map((turn) => (
-            <MessageBubble
-              key={turn.id}
-              turn={turn}
-              agentName={turn.role === 'assistant' ? agentName : undefined}
-              toolResults={toolResults}
-            />
-          ))
+          <div
+            style={{ height: virtualizer.getTotalSize(), position: 'relative' }}
+            className="px-4"
+          >
+            {virtualizer.getVirtualItems().map((virtualRow) => {
+              const turn = turns[virtualRow.index];
+              return (
+                <div
+                  key={turn.id}
+                  data-index={virtualRow.index}
+                  ref={virtualizer.measureElement}
+                  style={{
+                    position: 'absolute',
+                    top: 0,
+                    left: 0,
+                    right: 0,
+                    transform: `translateY(${virtualRow.start}px)`,
+                    paddingLeft: '1rem',
+                    paddingRight: '1rem',
+                    paddingTop: virtualRow.index === 0 ? '1rem' : '0.375rem',
+                    paddingBottom: virtualRow.index === turns.length - 1 ? '1rem' : '0.375rem',
+                  }}
+                >
+                  <MessageBubble
+                    turn={turn}
+                    agentName={turn.role === 'assistant' ? agentName : undefined}
+                    toolResults={toolResults}
+                  />
+                </div>
+              );
+            })}
+          </div>
         )}
       </div>
     </div>

--- a/packages/web/src/components/session-viewer/conversation-viewer.tsx
+++ b/packages/web/src/components/session-viewer/conversation-viewer.tsx
@@ -27,7 +27,7 @@ interface ConversationResponse {
     updatedAt: string;
     endedAt: string | null;
   };
-  source: 'synced' | 'local' | 'none';
+  source: 'synced' | 'local' | 'cloud' | 'none';
   backend: string;
   transcript: TranscriptPayload | null;
   totalEvents: number;

--- a/packages/web/src/components/session-viewer/message-bubble.tsx
+++ b/packages/web/src/components/session-viewer/message-bubble.tsx
@@ -1,0 +1,141 @@
+'use client';
+
+import { useState } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import type { ConversationTurn, ToolCallBlock, ToolResultBlock } from './types';
+import { ToolCallCard } from './tool-call-card';
+
+function ThinkingToggle({ text }: { text: string }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="my-1">
+      <button
+        onClick={() => setOpen(!open)}
+        className="flex items-center gap-1.5 text-xs text-gray-400 hover:text-gray-600 transition-colors"
+      >
+        <span className="font-mono">{open ? '▾' : '▸'}</span>
+        <span className="italic">thinking…</span>
+      </button>
+      {open && (
+        <div className="mt-1 pl-4 border-l-2 border-gray-200 text-xs text-gray-500 whitespace-pre-wrap max-h-64 overflow-y-auto">
+          {text.length > 2000 ? text.slice(0, 2000) + '…' : text}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SystemBadge({ text, subtype }: { text: string; subtype?: string }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="my-1 flex justify-center">
+      <button
+        onClick={() => setOpen(!open)}
+        className="text-[11px] text-gray-400 bg-gray-100 rounded-full px-3 py-0.5 hover:bg-gray-200 transition-colors"
+      >
+        {subtype ?? 'system'} {open ? '▾' : '▸'}
+      </button>
+      {open && (
+        <div className="absolute mt-7 z-10 bg-white border border-gray-200 rounded-lg shadow-lg p-3 max-w-lg max-h-48 overflow-y-auto text-xs text-gray-600 whitespace-pre-wrap">
+          {text}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function formatTime(ts: string): string {
+  if (!ts) return '';
+  try {
+    return new Date(ts).toLocaleTimeString('en-US', {
+      hour: 'numeric',
+      minute: '2-digit',
+      hour12: true,
+    });
+  } catch {
+    return '';
+  }
+}
+
+export function MessageBubble({
+  turn,
+  agentName,
+  toolResults,
+}: {
+  turn: ConversationTurn;
+  agentName?: string;
+  toolResults: Map<string, ToolResultBlock>;
+}) {
+  if (turn.role === 'system') {
+    const block = turn.blocks[0];
+    if (!block) return null;
+    if (block.kind === 'system') {
+      return <SystemBadge text={block.text} subtype={block.subtype} />;
+    }
+    return null;
+  }
+
+  const isUser = turn.role === 'user';
+  const hasOnlyToolResults = turn.blocks.every((b) => b.kind === 'tool-result');
+  if (hasOnlyToolResults) return null;
+
+  return (
+    <div className={`flex ${isUser ? 'justify-end' : 'justify-start'} group`}>
+      <div className={`max-w-[85%] ${isUser ? 'items-end' : 'items-start'} flex flex-col`}>
+        {/* Header */}
+        <div className={`flex items-center gap-2 mb-0.5 ${isUser ? 'flex-row-reverse' : ''}`}>
+          {!isUser && agentName && (
+            <span className="text-xs font-semibold text-gray-700">{agentName}</span>
+          )}
+          <span className="text-[10px] text-gray-400 opacity-0 group-hover:opacity-100 transition-opacity">
+            {formatTime(turn.timestamp)}
+          </span>
+        </div>
+
+        {/* Content blocks */}
+        <div className={`space-y-1 ${isUser ? 'text-right' : ''}`}>
+          {turn.blocks.map((block, i) => {
+            if (block.kind === 'text') {
+              return (
+                <div
+                  key={i}
+                  className={`rounded-2xl px-4 py-2.5 inline-block text-left ${
+                    isUser
+                      ? 'bg-blue-600 text-white'
+                      : 'bg-white border border-gray-200 text-gray-900'
+                  }`}
+                >
+                  <div
+                    className={`prose prose-sm max-w-none ${
+                      isUser
+                        ? 'prose-invert prose-p:text-white prose-strong:text-white prose-code:text-blue-100'
+                        : 'prose-p:text-gray-900'
+                    }`}
+                  >
+                    <ReactMarkdown remarkPlugins={[remarkGfm]}>{block.text}</ReactMarkdown>
+                  </div>
+                </div>
+              );
+            }
+
+            if (block.kind === 'thinking') {
+              return <ThinkingToggle key={i} text={block.text} />;
+            }
+
+            if (block.kind === 'tool-call') {
+              const result = toolResults.get(block.toolUseId);
+              return <ToolCallCard key={i} call={block as ToolCallBlock} result={result} />;
+            }
+
+            if (block.kind === 'system') {
+              return <SystemBadge key={i} text={block.text} subtype={block.subtype} />;
+            }
+
+            return null;
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/session-viewer/session-sidebar.tsx
+++ b/packages/web/src/components/session-viewer/session-sidebar.tsx
@@ -1,8 +1,7 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { useApiQuery } from '@/lib/api';
-import { Badge } from '@/components/ui/badge';
 import clsx from 'clsx';
 
 interface SessionWorkspace {
@@ -41,6 +40,21 @@ const AGENT_COLORS: Record<string, string> = {
   benson: 'bg-emerald-500',
 };
 
+type StatusFilter = 'all' | 'active' | 'completed';
+
+function isActive(s: Session): boolean {
+  return s.lifecycle === 'running' || s.lifecycle === 'idle';
+}
+
+function isCompleted(s: Session): boolean {
+  return (
+    s.lifecycle === 'completed' ||
+    s.lifecycle === 'complete' ||
+    s.lifecycle === 'failed' ||
+    s.lifecycle === 'paused'
+  );
+}
+
 function formatRelative(date: string): string {
   const diff = Date.now() - new Date(date).getTime();
   const mins = Math.floor(diff / 60000);
@@ -74,6 +88,135 @@ function phaseText(lifecycle: string | null, phase: string | null): string {
   return phase ?? lifecycle ?? '';
 }
 
+function matchesSearch(session: Session, query: string): boolean {
+  const q = query.toLowerCase();
+  return (
+    session.agentId.toLowerCase().includes(q) ||
+    session.agentName.toLowerCase().includes(q) ||
+    (session.activeThreadKey?.toLowerCase().includes(q) ?? false) ||
+    (session.studio?.branch?.toLowerCase().includes(q) ?? false) ||
+    (session.studio?.slug?.toLowerCase().includes(q) ?? false) ||
+    (session.currentPhase?.toLowerCase().includes(q) ?? false) ||
+    (session.backend?.toLowerCase().includes(q) ?? false)
+  );
+}
+
+function SessionItem({
+  session,
+  isSelected,
+  onSelect,
+}: {
+  session: Session;
+  isSelected: boolean;
+  onSelect: (id: string) => void;
+}) {
+  const dot = statusDot(session.lifecycle, session.currentPhase);
+  return (
+    <button
+      onClick={() => onSelect(session.id)}
+      className={clsx(
+        'w-full text-left px-3 py-1.5 transition-colors',
+        isSelected
+          ? 'bg-blue-50 border-l-2 border-blue-500'
+          : 'hover:bg-gray-50 border-l-2 border-transparent'
+      )}
+    >
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-1.5 min-w-0">
+          <div
+            className={clsx(
+              'w-1.5 h-1.5 rounded-full shrink-0',
+              dot.color,
+              dot.pulse && 'animate-pulse'
+            )}
+          />
+          <span className="text-xs text-gray-600 truncate">
+            {phaseText(session.lifecycle, session.currentPhase) || 'session'}
+          </span>
+        </div>
+        <span className="text-[10px] text-gray-400 shrink-0 ml-1">
+          {formatRelative(session.updatedAt)}
+        </span>
+      </div>
+
+      {session.activeThreadKey && (
+        <div className="mt-0.5 pl-3">
+          <span className="text-[10px] font-mono text-indigo-500 truncate block">
+            {session.activeThreadKey}
+          </span>
+        </div>
+      )}
+
+      <div className="flex items-center gap-2 mt-0.5 pl-3 text-[10px] text-gray-400">
+        {session.studio?.branch && <span className="truncate">{session.studio.branch}</span>}
+        {session.studio?.slug && !session.studio.branch && (
+          <span className="truncate">{session.studio.slug}</span>
+        )}
+        {session.backend && <span className="shrink-0">{session.backend}</span>}
+        {session.messageCount != null && session.messageCount > 0 && (
+          <span className="shrink-0">{session.messageCount} msgs</span>
+        )}
+      </div>
+    </button>
+  );
+}
+
+function AgentGroup({
+  agentId,
+  sessions,
+  selectedId,
+  onSelect,
+  defaultExpanded,
+}: {
+  agentId: string;
+  sessions: Session[];
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+  defaultExpanded: boolean;
+}) {
+  const [expanded, setExpanded] = useState(defaultExpanded);
+  const activeCount = sessions.filter((s) => s.lifecycle === 'running').length;
+
+  return (
+    <div>
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="w-full px-3 pt-2.5 pb-1 flex items-center gap-1.5 hover:bg-gray-50 transition-colors"
+      >
+        <svg
+          className={clsx(
+            'w-3 h-3 text-gray-400 transition-transform shrink-0',
+            expanded && 'rotate-90'
+          )}
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+        </svg>
+        <div
+          className={`w-2.5 h-2.5 rounded-full shrink-0 ${AGENT_COLORS[agentId] ?? 'bg-gray-400'}`}
+        />
+        <span className="text-xs font-semibold text-gray-700 capitalize">{agentId}</span>
+        <span className="text-[10px] text-gray-400">{sessions.length}</span>
+        {activeCount > 0 && (
+          <span className="text-[10px] text-green-600 ml-auto">{activeCount} active</span>
+        )}
+      </button>
+      {expanded &&
+        sessions.map((session) => (
+          <SessionItem
+            key={session.id}
+            session={session}
+            isSelected={session.id === selectedId}
+            onSelect={onSelect}
+          />
+        ))}
+    </div>
+  );
+}
+
 export function SessionSidebar({
   selectedId,
   onSelect,
@@ -81,6 +224,9 @@ export function SessionSidebar({
   selectedId: string | null;
   onSelect: (id: string) => void;
 }) {
+  const [search, setSearch] = useState('');
+  const [filter, setFilter] = useState<StatusFilter>('all');
+
   const { data } = useApiQuery<SessionsResponse>(
     ['session-viewer-sessions'],
     '/api/admin/sessions',
@@ -89,106 +235,99 @@ export function SessionSidebar({
 
   const sessions = data?.sessions ?? [];
 
+  const filtered = useMemo(() => {
+    let result = sessions;
+    if (filter === 'active') result = result.filter(isActive);
+    else if (filter === 'completed') result = result.filter(isCompleted);
+    if (search.trim()) result = result.filter((s) => matchesSearch(s, search.trim()));
+    return result;
+  }, [sessions, filter, search]);
+
   const grouped = useMemo(() => {
     const groups = new Map<string, Session[]>();
-    for (const s of sessions) {
+    for (const s of filtered) {
       const key = s.agentId;
       if (!groups.has(key)) groups.set(key, []);
       groups.get(key)!.push(s);
     }
-    const active = Array.from(groups.entries()).filter(([, ss]) =>
+    const withActive = Array.from(groups.entries()).filter(([, ss]) =>
       ss.some((s) => s.lifecycle === 'running')
     );
-    const idle = Array.from(groups.entries()).filter(
+    const withoutActive = Array.from(groups.entries()).filter(
       ([, ss]) => !ss.some((s) => s.lifecycle === 'running')
     );
-    return [...active, ...idle];
+    return [...withActive, ...withoutActive];
+  }, [filtered]);
+
+  const counts = useMemo(() => {
+    const running = sessions.filter((s) => s.lifecycle === 'running').length;
+    const active = sessions.filter(isActive).length;
+    const completed = sessions.filter(isCompleted).length;
+    return { running, active, completed, total: sessions.length };
   }, [sessions]);
 
   return (
     <div className="h-full flex flex-col border-r border-gray-200 bg-white" style={{ width: 280 }}>
+      {/* Header */}
       <div className="px-3 py-2.5 border-b border-gray-200 shrink-0">
         <h2 className="text-xs font-bold tracking-wider text-gray-500 uppercase">Sessions</h2>
         <div className="flex gap-2 mt-1 text-[10px] text-gray-400">
-          <span>{sessions.filter((s) => s.lifecycle === 'running').length} active</span>
+          <span>{counts.running} running</span>
           <span>·</span>
-          <span>{sessions.length} total</span>
+          <span>{counts.total} total</span>
         </div>
       </div>
 
+      {/* Search */}
+      <div className="px-3 py-2 border-b border-gray-100 shrink-0">
+        <input
+          type="text"
+          placeholder="Search sessions…"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="w-full text-xs px-2 py-1.5 rounded border border-gray-200 bg-gray-50 placeholder:text-gray-400 focus:outline-none focus:ring-1 focus:ring-blue-400 focus:border-blue-400"
+        />
+      </div>
+
+      {/* Filter tabs */}
+      <div className="flex px-3 py-1.5 gap-1 border-b border-gray-100 shrink-0">
+        {(['all', 'active', 'completed'] as const).map((f) => (
+          <button
+            key={f}
+            onClick={() => setFilter(f)}
+            className={clsx(
+              'text-[10px] px-2 py-0.5 rounded-full capitalize transition-colors',
+              filter === f ? 'bg-gray-900 text-white' : 'text-gray-500 hover:bg-gray-100'
+            )}
+          >
+            {f}
+            <span className="ml-1 opacity-60">
+              {f === 'all' ? counts.total : f === 'active' ? counts.active : counts.completed}
+            </span>
+          </button>
+        ))}
+      </div>
+
+      {/* Session list */}
       <div className="flex-1 overflow-y-auto">
         {grouped.map(([agentId, agentSessions]) => (
-          <div key={agentId}>
-            <div className="px-3 pt-3 pb-1 flex items-center gap-1.5">
-              <div
-                className={`w-2.5 h-2.5 rounded-full ${AGENT_COLORS[agentId] ?? 'bg-gray-400'}`}
-              />
-              <span className="text-xs font-semibold text-gray-700 capitalize">{agentId}</span>
-              <span className="text-[10px] text-gray-400">{agentSessions.length}</span>
-            </div>
-            {agentSessions.map((session) => {
-              const dot = statusDot(session.lifecycle, session.currentPhase);
-              const isSelected = session.id === selectedId;
-              return (
-                <button
-                  key={session.id}
-                  onClick={() => onSelect(session.id)}
-                  className={clsx(
-                    'w-full text-left px-3 py-2 transition-colors',
-                    isSelected
-                      ? 'bg-blue-50 border-l-2 border-blue-500'
-                      : 'hover:bg-gray-50 border-l-2 border-transparent'
-                  )}
-                >
-                  <div className="flex items-center justify-between">
-                    <div className="flex items-center gap-1.5 min-w-0">
-                      <div
-                        className={clsx(
-                          'w-1.5 h-1.5 rounded-full shrink-0',
-                          dot.color,
-                          dot.pulse && 'animate-pulse'
-                        )}
-                      />
-                      <span className="text-xs text-gray-600 truncate">
-                        {phaseText(session.lifecycle, session.currentPhase) || 'session'}
-                      </span>
-                    </div>
-                    <span className="text-[10px] text-gray-400 shrink-0 ml-1">
-                      {formatRelative(session.updatedAt)}
-                    </span>
-                  </div>
-
-                  {session.activeThreadKey && (
-                    <div className="mt-0.5">
-                      <span className="text-[10px] font-mono text-indigo-500">
-                        {session.activeThreadKey}
-                      </span>
-                    </div>
-                  )}
-
-                  <div className="flex items-center gap-2 mt-0.5 text-[10px] text-gray-400">
-                    {session.studio?.branch && (
-                      <span className="truncate">{session.studio.branch}</span>
-                    )}
-                    {session.studio?.slug && !session.studio.branch && (
-                      <span className="truncate">{session.studio.slug}</span>
-                    )}
-                    {session.backend && <span className="shrink-0">{session.backend}</span>}
-                  </div>
-
-                  {session.messageCount != null && session.messageCount > 0 && (
-                    <div className="text-[10px] text-gray-400 mt-0.5">
-                      {session.messageCount} messages
-                    </div>
-                  )}
-                </button>
-              );
-            })}
-          </div>
+          <AgentGroup
+            key={agentId}
+            agentId={agentId}
+            sessions={agentSessions}
+            selectedId={selectedId}
+            onSelect={onSelect}
+            defaultExpanded={
+              agentSessions.some((s) => s.lifecycle === 'running') ||
+              agentSessions.some((s) => s.id === selectedId)
+            }
+          />
         ))}
 
-        {sessions.length === 0 && (
-          <div className="px-3 py-8 text-center text-xs text-gray-400">No active sessions</div>
+        {filtered.length === 0 && (
+          <div className="px-3 py-8 text-center text-xs text-gray-400">
+            {search ? 'No sessions match your search' : 'No sessions'}
+          </div>
         )}
       </div>
     </div>

--- a/packages/web/src/components/session-viewer/session-sidebar.tsx
+++ b/packages/web/src/components/session-viewer/session-sidebar.tsx
@@ -1,0 +1,196 @@
+'use client';
+
+import { useMemo } from 'react';
+import { useApiQuery } from '@/lib/api';
+import { Badge } from '@/components/ui/badge';
+import clsx from 'clsx';
+
+interface SessionWorkspace {
+  id: string;
+  branch: string | null;
+  repoName: string | null;
+  slug: string | null;
+}
+
+interface Session {
+  id: string;
+  agentId: string;
+  agentName: string;
+  agentRole: string | null;
+  backend: string | null;
+  lifecycle: string | null;
+  currentPhase: string | null;
+  activeThreadKey: string | null;
+  startedAt: string;
+  updatedAt: string;
+  endedAt: string | null;
+  messageCount: number | null;
+  studio: SessionWorkspace | null;
+}
+
+interface SessionsResponse {
+  stats: Record<string, number>;
+  sessions: Session[];
+}
+
+const AGENT_COLORS: Record<string, string> = {
+  wren: 'bg-rose-500',
+  lumen: 'bg-cyan-500',
+  aster: 'bg-yellow-500',
+  myra: 'bg-violet-500',
+  benson: 'bg-emerald-500',
+};
+
+function formatRelative(date: string): string {
+  const diff = Date.now() - new Date(date).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return 'now';
+  if (mins < 60) return `${mins}m`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h`;
+  return `${Math.floor(hours / 24)}d`;
+}
+
+function statusDot(
+  lifecycle: string | null,
+  phase: string | null
+): { color: string; pulse: boolean } {
+  if (lifecycle === 'running') {
+    if (phase === 'runtime:generating') return { color: 'bg-blue-500', pulse: true };
+    return { color: 'bg-green-500', pulse: true };
+  }
+  if (phase?.startsWith('blocked')) return { color: 'bg-amber-500', pulse: false };
+  if (lifecycle === 'idle') return { color: 'bg-green-400', pulse: false };
+  return { color: 'bg-gray-400', pulse: false };
+}
+
+function phaseText(lifecycle: string | null, phase: string | null): string {
+  if (lifecycle === 'running') {
+    if (phase === 'runtime:generating') return 'generating';
+    return phase?.replace('runtime:', '') ?? 'running';
+  }
+  if (phase?.startsWith('blocked')) return phase;
+  if (lifecycle === 'idle') return phase ?? 'idle';
+  return phase ?? lifecycle ?? '';
+}
+
+export function SessionSidebar({
+  selectedId,
+  onSelect,
+}: {
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+}) {
+  const { data } = useApiQuery<SessionsResponse>(
+    ['session-viewer-sessions'],
+    '/api/admin/sessions',
+    { refetchInterval: 15000, staleTime: 0 }
+  );
+
+  const sessions = data?.sessions ?? [];
+
+  const grouped = useMemo(() => {
+    const groups = new Map<string, Session[]>();
+    for (const s of sessions) {
+      const key = s.agentId;
+      if (!groups.has(key)) groups.set(key, []);
+      groups.get(key)!.push(s);
+    }
+    const active = Array.from(groups.entries()).filter(([, ss]) =>
+      ss.some((s) => s.lifecycle === 'running')
+    );
+    const idle = Array.from(groups.entries()).filter(
+      ([, ss]) => !ss.some((s) => s.lifecycle === 'running')
+    );
+    return [...active, ...idle];
+  }, [sessions]);
+
+  return (
+    <div className="h-full flex flex-col border-r border-gray-200 bg-white" style={{ width: 280 }}>
+      <div className="px-3 py-2.5 border-b border-gray-200 shrink-0">
+        <h2 className="text-xs font-bold tracking-wider text-gray-500 uppercase">Sessions</h2>
+        <div className="flex gap-2 mt-1 text-[10px] text-gray-400">
+          <span>{sessions.filter((s) => s.lifecycle === 'running').length} active</span>
+          <span>·</span>
+          <span>{sessions.length} total</span>
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-y-auto">
+        {grouped.map(([agentId, agentSessions]) => (
+          <div key={agentId}>
+            <div className="px-3 pt-3 pb-1 flex items-center gap-1.5">
+              <div
+                className={`w-2.5 h-2.5 rounded-full ${AGENT_COLORS[agentId] ?? 'bg-gray-400'}`}
+              />
+              <span className="text-xs font-semibold text-gray-700 capitalize">{agentId}</span>
+              <span className="text-[10px] text-gray-400">{agentSessions.length}</span>
+            </div>
+            {agentSessions.map((session) => {
+              const dot = statusDot(session.lifecycle, session.currentPhase);
+              const isSelected = session.id === selectedId;
+              return (
+                <button
+                  key={session.id}
+                  onClick={() => onSelect(session.id)}
+                  className={clsx(
+                    'w-full text-left px-3 py-2 transition-colors',
+                    isSelected
+                      ? 'bg-blue-50 border-l-2 border-blue-500'
+                      : 'hover:bg-gray-50 border-l-2 border-transparent'
+                  )}
+                >
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-1.5 min-w-0">
+                      <div
+                        className={clsx(
+                          'w-1.5 h-1.5 rounded-full shrink-0',
+                          dot.color,
+                          dot.pulse && 'animate-pulse'
+                        )}
+                      />
+                      <span className="text-xs text-gray-600 truncate">
+                        {phaseText(session.lifecycle, session.currentPhase) || 'session'}
+                      </span>
+                    </div>
+                    <span className="text-[10px] text-gray-400 shrink-0 ml-1">
+                      {formatRelative(session.updatedAt)}
+                    </span>
+                  </div>
+
+                  {session.activeThreadKey && (
+                    <div className="mt-0.5">
+                      <span className="text-[10px] font-mono text-indigo-500">
+                        {session.activeThreadKey}
+                      </span>
+                    </div>
+                  )}
+
+                  <div className="flex items-center gap-2 mt-0.5 text-[10px] text-gray-400">
+                    {session.studio?.branch && (
+                      <span className="truncate">{session.studio.branch}</span>
+                    )}
+                    {session.studio?.slug && !session.studio.branch && (
+                      <span className="truncate">{session.studio.slug}</span>
+                    )}
+                    {session.backend && <span className="shrink-0">{session.backend}</span>}
+                  </div>
+
+                  {session.messageCount != null && session.messageCount > 0 && (
+                    <div className="text-[10px] text-gray-400 mt-0.5">
+                      {session.messageCount} messages
+                    </div>
+                  )}
+                </button>
+              );
+            })}
+          </div>
+        ))}
+
+        {sessions.length === 0 && (
+          <div className="px-3 py-8 text-center text-xs text-gray-400">No active sessions</div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/session-viewer/tool-call-card.tsx
+++ b/packages/web/src/components/session-viewer/tool-call-card.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import { useState } from 'react';
+import type { ToolCallBlock, ToolResultBlock } from './types';
+
+const TOOL_CATEGORIES: Record<string, { label: string; color: string }> = {
+  Read: { label: 'Read', color: 'text-emerald-600' },
+  Write: { label: 'Write', color: 'text-amber-600' },
+  Edit: { label: 'Edit', color: 'text-amber-600' },
+  Bash: { label: 'Bash', color: 'text-violet-600' },
+  Agent: { label: 'Agent', color: 'text-blue-600' },
+  WebSearch: { label: 'Search', color: 'text-cyan-600' },
+  WebFetch: { label: 'Fetch', color: 'text-cyan-600' },
+};
+
+function getToolMeta(name: string): { label: string; color: string } {
+  if (TOOL_CATEGORIES[name]) return TOOL_CATEGORIES[name];
+  if (name.startsWith('mcp__')) {
+    const parts = name.split('__');
+    const server = parts[1] ?? 'mcp';
+    const tool = parts.slice(2).join('__');
+    return { label: `${server}/${tool}`, color: 'text-indigo-600' };
+  }
+  return { label: name, color: 'text-gray-600' };
+}
+
+function formatInput(input: unknown): string {
+  if (!input || typeof input !== 'object') return '';
+  const obj = input as Record<string, unknown>;
+  const keys = Object.keys(obj);
+  if (keys.length === 0) return '';
+
+  const parts: string[] = [];
+  for (const key of keys.slice(0, 4)) {
+    const val = obj[key];
+    if (typeof val === 'string') {
+      parts.push(`${key}: ${val.length > 60 ? val.slice(0, 60) + '…' : val}`);
+    } else if (typeof val === 'number' || typeof val === 'boolean') {
+      parts.push(`${key}: ${val}`);
+    }
+  }
+  if (keys.length > 4) parts.push(`+${keys.length - 4} more`);
+  return parts.join(' · ');
+}
+
+function truncateResult(content: string, max = 300): string {
+  if (content.length <= max) return content;
+  return content.slice(0, max) + '…';
+}
+
+export function ToolCallCard({ call, result }: { call: ToolCallBlock; result?: ToolResultBlock }) {
+  const [expanded, setExpanded] = useState(false);
+  const meta = getToolMeta(call.name);
+  const summary = formatInput(call.input);
+
+  return (
+    <div className="my-1.5 rounded-lg border border-gray-200 bg-gray-50/80 overflow-hidden">
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-gray-100/80 transition-colors"
+      >
+        <span className="text-xs font-mono font-medium shrink-0" style={{ minWidth: '16px' }}>
+          {expanded ? '▾' : '▸'}
+        </span>
+        <span className={`text-xs font-semibold font-mono shrink-0 ${meta.color}`}>
+          {meta.label}
+        </span>
+        {summary && <span className="text-xs text-gray-500 truncate">{summary}</span>}
+        {result && (
+          <span
+            className={`ml-auto text-[10px] px-1.5 py-0.5 rounded font-medium shrink-0 ${
+              result.isError ? 'bg-red-100 text-red-700' : 'bg-emerald-100 text-emerald-700'
+            }`}
+          >
+            {result.isError ? 'error' : 'ok'}
+          </span>
+        )}
+      </button>
+
+      {expanded && (
+        <div className="border-t border-gray-200 px-3 py-2 space-y-2">
+          {call.input != null &&
+          typeof call.input === 'object' &&
+          Object.keys(call.input as Record<string, unknown>).length > 0 ? (
+            <div>
+              <div className="text-[10px] uppercase tracking-wider text-gray-400 mb-1">Input</div>
+              <pre className="text-xs text-gray-700 bg-white rounded border border-gray-100 p-2 overflow-x-auto max-h-48 overflow-y-auto whitespace-pre-wrap break-words">
+                {JSON.stringify(call.input, null, 2)}
+              </pre>
+            </div>
+          ) : null}
+          {result && (
+            <div>
+              <div className="text-[10px] uppercase tracking-wider text-gray-400 mb-1">Result</div>
+              <pre
+                className={`text-xs rounded border p-2 overflow-x-auto max-h-64 overflow-y-auto whitespace-pre-wrap break-words ${
+                  result.isError
+                    ? 'text-red-700 bg-red-50 border-red-100'
+                    : 'text-gray-700 bg-white border-gray-100'
+                }`}
+              >
+                {truncateResult(result.content, 2000)}
+              </pre>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/components/session-viewer/transcript-parser.ts
+++ b/packages/web/src/components/session-viewer/transcript-parser.ts
@@ -1,0 +1,337 @@
+import type {
+  ConversationTurn,
+  ContentBlock,
+  TextBlock,
+  ToolCallBlock,
+  ToolResultBlock,
+  ThinkingBlock,
+  SystemBlock,
+} from './types';
+
+// Claude Code JSONL event shapes
+interface ClaudeEvent {
+  type: string;
+  uuid?: string;
+  parentUuid?: string;
+  timestamp?: string;
+  message?: {
+    role?: string;
+    content?: (RawContentItem | string)[] | string;
+    model?: string;
+    stop_reason?: string;
+  };
+  attachment?: {
+    type: string;
+    content?: string;
+    hookName?: string;
+    [key: string]: unknown;
+  };
+  toolUseResult?: unknown;
+  operation?: string;
+  sessionId?: string;
+  content?: string;
+  lastPrompt?: string;
+  [key: string]: unknown;
+}
+
+interface RawContentItem {
+  type: string;
+  text?: string;
+  id?: string;
+  name?: string;
+  input?: unknown;
+  tool_use_id?: string;
+  content?: unknown;
+  is_error?: boolean;
+  thinking?: string;
+  [key: string]: unknown;
+}
+
+function parseClaudeContentBlock(item: RawContentItem): ContentBlock | null {
+  if (item.type === 'text') {
+    const text = typeof item.text === 'string' ? item.text : '';
+    if (!text.trim()) return null;
+    return { kind: 'text', text } satisfies TextBlock;
+  }
+
+  if (item.type === 'tool_use') {
+    return {
+      kind: 'tool-call',
+      toolUseId: String(item.id ?? ''),
+      name: String(item.name ?? 'unknown'),
+      input: item.input,
+    } satisfies ToolCallBlock;
+  }
+
+  if (item.type === 'tool_result') {
+    let content: string;
+    if (typeof item.content === 'string') {
+      content = item.content;
+    } else if (Array.isArray(item.content)) {
+      content = item.content
+        .map((c: unknown) => {
+          if (typeof c === 'string') return c;
+          if (c && typeof c === 'object' && 'text' in c)
+            return String((c as Record<string, unknown>).text);
+          return JSON.stringify(c);
+        })
+        .join('\n');
+    } else {
+      content = String(item.content ?? '');
+    }
+    return {
+      kind: 'tool-result',
+      toolUseId: String(item.tool_use_id ?? ''),
+      content,
+      isError: item.is_error === true,
+    } satisfies ToolResultBlock;
+  }
+
+  if (item.type === 'thinking') {
+    const thinking = typeof item.thinking === 'string' ? item.thinking : '';
+    if (!thinking.trim()) return null;
+    return { kind: 'thinking', text: thinking } satisfies ThinkingBlock;
+  }
+
+  return null;
+}
+
+export function parseClaudeTranscript(events: unknown[]): ConversationTurn[] {
+  const turns: ConversationTurn[] = [];
+  let currentAssistantTurn: ConversationTurn | null = null;
+
+  for (const raw of events) {
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) continue;
+    const event = raw as ClaudeEvent;
+
+    if (event.type === 'queue-operation' || event.type === 'last-prompt') continue;
+
+    if (event.type === 'attachment') {
+      const att = event.attachment;
+      if (!att) continue;
+
+      if (att.type === 'hook_success' || att.type === 'hook_error') {
+        const hookContent = typeof att.content === 'string' ? att.content : '';
+        if (hookContent.trim()) {
+          turns.push({
+            id: event.uuid ?? `sys-${turns.length}`,
+            role: 'system',
+            timestamp: event.timestamp ?? '',
+            blocks: [
+              {
+                kind: 'system',
+                text: hookContent.length > 500 ? hookContent.slice(0, 500) + '...' : hookContent,
+                subtype: att.hookName ?? 'hook',
+              } satisfies SystemBlock,
+            ],
+          });
+        }
+      }
+      continue;
+    }
+
+    if (event.type === 'user') {
+      currentAssistantTurn = null;
+      const content = event.message?.content;
+      if (!content) continue;
+
+      const blocks: ContentBlock[] = [];
+
+      if (Array.isArray(content)) {
+        for (const item of content) {
+          if (typeof item === 'string') {
+            if (item.trim()) blocks.push({ kind: 'text', text: item });
+            continue;
+          }
+          if (!item || typeof item !== 'object') continue;
+          const parsed = parseClaudeContentBlock(item as RawContentItem);
+          if (parsed) blocks.push(parsed);
+        }
+      } else if (typeof content === 'string') {
+        if (content.trim()) blocks.push({ kind: 'text', text: content });
+      }
+
+      if (blocks.length === 0) continue;
+
+      turns.push({
+        id: event.uuid ?? `user-${turns.length}`,
+        role: 'user',
+        timestamp: event.timestamp ?? '',
+        blocks,
+      });
+      continue;
+    }
+
+    if (event.type === 'assistant') {
+      const content = event.message?.content;
+      if (!content || !Array.isArray(content)) continue;
+
+      const blocks: ContentBlock[] = [];
+      for (const item of content) {
+        if (!item || typeof item !== 'object') continue;
+        const parsed = parseClaudeContentBlock(item as RawContentItem);
+        if (parsed) blocks.push(parsed);
+      }
+
+      if (blocks.length === 0) continue;
+
+      if (currentAssistantTurn) {
+        currentAssistantTurn.blocks.push(...blocks);
+        currentAssistantTurn.timestamp = event.timestamp ?? currentAssistantTurn.timestamp;
+      } else {
+        currentAssistantTurn = {
+          id: event.uuid ?? `asst-${turns.length}`,
+          role: 'assistant',
+          timestamp: event.timestamp ?? '',
+          blocks,
+        };
+        turns.push(currentAssistantTurn);
+      }
+      continue;
+    }
+  }
+
+  return turns;
+}
+
+export function parseCodexTranscript(events: unknown[]): ConversationTurn[] {
+  const turns: ConversationTurn[] = [];
+
+  for (const raw of events) {
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) continue;
+    const event = raw as Record<string, unknown>;
+
+    const type = String(event.type ?? event.role ?? '');
+    const timestamp = String(event.timestamp ?? event.created_at ?? event.ts ?? '');
+
+    if (type === 'user' || type === 'input') {
+      const text = extractTextContent(event);
+      if (text) {
+        turns.push({
+          id: String(event.id ?? `codex-user-${turns.length}`),
+          role: 'user',
+          timestamp,
+          blocks: [{ kind: 'text', text }],
+        });
+      }
+    } else if (type === 'assistant' || type === 'output' || type === 'response') {
+      const blocks = extractContentBlocks(event);
+      if (blocks.length > 0) {
+        turns.push({
+          id: String(event.id ?? `codex-asst-${turns.length}`),
+          role: 'assistant',
+          timestamp,
+          blocks,
+        });
+      }
+    }
+  }
+
+  return turns;
+}
+
+export function parseGeminiTranscript(events: unknown[]): ConversationTurn[] {
+  const turns: ConversationTurn[] = [];
+
+  if (!Array.isArray(events)) return turns;
+
+  for (const raw of events) {
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) continue;
+    const event = raw as Record<string, unknown>;
+
+    const role = String(event.role ?? event.author ?? '');
+    const timestamp = String(event.timestamp ?? event.createTime ?? '');
+
+    const parts = Array.isArray(event.parts) ? event.parts : [];
+    const blocks: ContentBlock[] = [];
+
+    for (const part of parts) {
+      if (!part || typeof part !== 'object') continue;
+      const p = part as Record<string, unknown>;
+      if (typeof p.text === 'string' && p.text.trim()) {
+        blocks.push({ kind: 'text', text: p.text });
+      } else if (p.functionCall && typeof p.functionCall === 'object') {
+        const fc = p.functionCall as Record<string, unknown>;
+        blocks.push({
+          kind: 'tool-call',
+          toolUseId: String(fc.id ?? `gemini-tc-${turns.length}`),
+          name: String(fc.name ?? 'unknown'),
+          input: fc.args ?? {},
+        });
+      } else if (p.functionResponse && typeof p.functionResponse === 'object') {
+        const fr = p.functionResponse as Record<string, unknown>;
+        blocks.push({
+          kind: 'tool-result',
+          toolUseId: String(fr.id ?? ''),
+          content:
+            typeof fr.response === 'string' ? fr.response : JSON.stringify(fr.response ?? ''),
+          isError: false,
+        });
+      }
+    }
+
+    if (blocks.length === 0) {
+      const text = extractTextContent(event);
+      if (text) blocks.push({ kind: 'text', text });
+    }
+
+    if (blocks.length > 0) {
+      turns.push({
+        id: String(event.id ?? `gemini-${turns.length}`),
+        role: role === 'user' ? 'user' : role === 'model' ? 'assistant' : 'system',
+        timestamp,
+        blocks,
+      });
+    }
+  }
+
+  return turns;
+}
+
+function extractTextContent(event: Record<string, unknown>): string {
+  if (typeof event.content === 'string') return event.content;
+  if (typeof event.text === 'string') return event.text;
+  if (typeof event.message === 'string') return event.message;
+  if (event.message && typeof event.message === 'object') {
+    const msg = event.message as Record<string, unknown>;
+    if (typeof msg.content === 'string') return msg.content;
+    if (Array.isArray(msg.content)) {
+      return msg.content
+        .filter(
+          (b): b is { text: string } =>
+            b && typeof b === 'object' && typeof (b as Record<string, unknown>).text === 'string'
+        )
+        .map((b) => b.text)
+        .join('\n');
+    }
+  }
+  return '';
+}
+
+function extractContentBlocks(event: Record<string, unknown>): ContentBlock[] {
+  const blocks: ContentBlock[] = [];
+  const content = (event.message as Record<string, unknown> | undefined)?.content ?? event.content;
+
+  if (typeof content === 'string') {
+    if (content.trim()) blocks.push({ kind: 'text', text: content });
+    return blocks;
+  }
+
+  if (Array.isArray(content)) {
+    for (const item of content) {
+      if (!item || typeof item !== 'object') continue;
+      const ci = item as RawContentItem;
+      const parsed = parseClaudeContentBlock(ci);
+      if (parsed) blocks.push(parsed);
+    }
+  }
+
+  return blocks;
+}
+
+export function parseTranscript(backend: string, events: unknown[]): ConversationTurn[] {
+  const b = backend.toLowerCase();
+  if (b.includes('gemini')) return parseGeminiTranscript(events);
+  if (b.includes('codex')) return parseCodexTranscript(events);
+  return parseClaudeTranscript(events);
+}

--- a/packages/web/src/components/session-viewer/transcript-parser.ts
+++ b/packages/web/src/components/session-viewer/transcript-parser.ts
@@ -329,8 +329,67 @@ function extractContentBlocks(event: Record<string, unknown>): ContentBlock[] {
   return blocks;
 }
 
+export function parseInkTranscript(events: unknown[]): ConversationTurn[] {
+  const turns: ConversationTurn[] = [];
+
+  for (const raw of events) {
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) continue;
+    const event = raw as Record<string, unknown>;
+
+    const type = String(event.type ?? '');
+    const direction = String(event.direction ?? '');
+    const content = typeof event.content === 'string' ? event.content : '';
+    const timestamp = String(event.timestamp ?? event.created_at ?? '');
+    const id = String(event.id ?? `ink-${turns.length}`);
+
+    if ((type === 'message_in' || type === 'message') && direction === 'in') {
+      if (content.trim()) {
+        turns.push({
+          id,
+          role: 'user',
+          timestamp,
+          blocks: [{ kind: 'text', text: content }],
+        });
+      }
+      continue;
+    }
+
+    if ((type === 'message_out' || type === 'message') && direction === 'out') {
+      if (content.trim()) {
+        turns.push({
+          id,
+          role: 'assistant',
+          timestamp,
+          blocks: [{ kind: 'text', text: content }],
+        });
+      }
+      continue;
+    }
+
+    if (type === 'agent_spawn' || type === 'agent_complete' || type === 'error') {
+      const label =
+        type === 'agent_spawn'
+          ? 'session started'
+          : type === 'agent_complete'
+            ? 'session completed'
+            : 'error';
+      const detail = content.trim() ? `${label}: ${content.slice(0, 300)}` : label;
+      turns.push({
+        id,
+        role: 'system',
+        timestamp,
+        blocks: [{ kind: 'system', text: detail, subtype: type }],
+      });
+      continue;
+    }
+  }
+
+  return turns;
+}
+
 export function parseTranscript(backend: string, events: unknown[]): ConversationTurn[] {
   const b = backend.toLowerCase();
+  if (b === 'ink') return parseInkTranscript(events);
   if (b.includes('gemini')) return parseGeminiTranscript(events);
   if (b.includes('codex')) return parseCodexTranscript(events);
   return parseClaudeTranscript(events);

--- a/packages/web/src/components/session-viewer/types.ts
+++ b/packages/web/src/components/session-viewer/types.ts
@@ -1,0 +1,92 @@
+export interface ConversationTurn {
+  id: string;
+  role: 'user' | 'assistant' | 'system';
+  timestamp: string;
+  blocks: ContentBlock[];
+}
+
+export type ContentBlock =
+  | TextBlock
+  | ToolCallBlock
+  | ToolResultBlock
+  | ThinkingBlock
+  | SystemBlock;
+
+export interface TextBlock {
+  kind: 'text';
+  text: string;
+}
+
+export interface ToolCallBlock {
+  kind: 'tool-call';
+  toolUseId: string;
+  name: string;
+  input: unknown;
+}
+
+export interface ToolResultBlock {
+  kind: 'tool-result';
+  toolUseId: string;
+  content: string;
+  isError: boolean;
+}
+
+export interface ThinkingBlock {
+  kind: 'thinking';
+  text: string;
+}
+
+export interface SystemBlock {
+  kind: 'system';
+  text: string;
+  subtype?: string;
+}
+
+export interface SessionInfo {
+  id: string;
+  agentId: string;
+  agentName: string;
+  backend: string | null;
+  backendSessionId: string | null;
+  lifecycle: string | null;
+  currentPhase: string | null;
+  activeThreadKey: string | null;
+  startedAt: string;
+  updatedAt: string;
+  endedAt: string | null;
+  studio: {
+    id: string;
+    branch: string | null;
+    repoName: string | null;
+    slug: string | null;
+  } | null;
+}
+
+export interface ConversationResponse {
+  session: SessionInfo;
+  backend: string;
+  turns: ConversationTurn[];
+  source: 'synced' | 'local' | 'cloud' | 'none';
+  totalEvents: number;
+}
+
+export interface SessionListItem {
+  id: string;
+  agentId: string;
+  agentName: string;
+  agentRole: string | null;
+  backend: string | null;
+  lifecycle: string | null;
+  currentPhase: string | null;
+  activeThreadKey: string | null;
+  startedAt: string;
+  updatedAt: string;
+  endedAt: string | null;
+  messageCount: number | null;
+  studio: {
+    id: string;
+    branch: string | null;
+    repoName: string | null;
+    slug: string | null;
+  } | null;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2002,6 +2002,7 @@ __metadata:
     "@supabase/supabase-js": "npm:^2.39.3"
     "@tailwindcss/typography": "npm:^0.5.15"
     "@tanstack/react-query": "npm:^5.62.0"
+    "@tanstack/react-virtual": "npm:^3.13.26"
     "@tiptap/core": "npm:^3.2.0"
     "@tiptap/extension-highlight": "npm:^3.2.0"
     "@tiptap/extension-link": "npm:^3.2.0"
@@ -4622,6 +4623,25 @@ __metadata:
   peerDependencies:
     react: ^18 || ^19
   checksum: 10/7ae88b64c1122b62275a76b7f51f54ba611b946477bda32cad8ccba85aec51e6bb0ec9fd41192bb816dc5fc883d67244e1772ae137a46dad4a861d3f43a779b1
+  languageName: node
+  linkType: hard
+
+"@tanstack/react-virtual@npm:^3.13.26":
+  version: 3.13.26
+  resolution: "@tanstack/react-virtual@npm:3.13.26"
+  dependencies:
+    "@tanstack/virtual-core": "npm:3.16.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10/76373506b3ab0a7870299099f994398ab7ec06b889e27f056e6bcaf26984cbedb7b763f9d3965249f3699780c43c21fd245048a320e06fe1cdae48859a9c5f2f
+  languageName: node
+  linkType: hard
+
+"@tanstack/virtual-core@npm:3.16.0":
+  version: 3.16.0
+  resolution: "@tanstack/virtual-core@npm:3.16.0"
+  checksum: 10/e55c70b5d3f68894804f645fe67738bbcca5d5ced333f96c2bda0d4c6f3198e5f97a3a18021b1491e850a2b4a64bdaafab250a6ee8bb1f312e6d5179656c35d7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Follow-up to #372 (which added `active_thread_key` to sessions). This PR surfaces it everywhere consumers need it:

- **`bootstrap` → `activeSessions`**: each session now includes `activeThreadKey`
- **`get_session`**: response includes `activeThreadKey`
- **`list_sessions`**: response includes `activeThreadKey`
- **CLI hooks**: auto-sets `activeThreadKey` from the trigger's `threadKey` on session start, so triggered sessions (e.g., PR reviews) show the artifact immediately
- **Ink-reminder**: now prompts agents to set `activeThreadKey` when working on a specific artifact
- **Command Center**: renders `activeThreadKey` in spatial map (below phase label), agent panel (accent badge), and activity log (inline next to phase)

## Test plan

- [x] All 2403 unit tests pass
- [ ] Verify bootstrap response includes `activeThreadKey` in `activeSessions`
- [ ] Verify triggered session auto-populates `activeThreadKey`
- [ ] Visual check: Command Center shows thread key on spatial map and agent panel

— Wren