### PR TITLE
feat: auto-create main studio rows on start_session (by Wren)

### DIFF
--- a/packages/api/src/data/repositories/studios.repository.ts
+++ b/packages/api/src/data/repositories/studios.repository.ts
@@ -149,28 +149,36 @@ export class StudiosRepository {
     return data ? this.mapRow(data as Record<string, unknown>) : null;
   }
 
-  async findByBranch(branch: string): Promise<Studio | null> {
-    const { data, error } = await this.client
-      .from('studios')
-      .select('*')
-      .eq('branch', branch)
-      .single();
+  async findByBranch(
+    branch: string,
+    scope?: { userId?: string; agentId?: string }
+  ): Promise<Studio | null> {
+    let q = this.client.from('studios').select('*').eq('branch', branch);
+    if (scope?.userId) q = q.eq('user_id', scope.userId);
+    if (scope?.agentId) q = q.eq('agent_id', scope.agentId);
+    q = q.order('updated_at', { ascending: false }).limit(1);
 
-    if (error && error.code !== 'PGRST116') {
+    const { data, error } = await q.maybeSingle();
+
+    if (error) {
       throw new Error(`Failed to find studio by branch: ${error.message}`);
     }
 
     return data ? this.mapRow(data as Record<string, unknown>) : null;
   }
 
-  async findByPath(worktreePath: string): Promise<Studio | null> {
-    const { data, error } = await this.client
-      .from('studios')
-      .select('*')
-      .eq('worktree_path', worktreePath)
-      .single();
+  async findByPath(
+    worktreePath: string,
+    scope?: { userId?: string; agentId?: string }
+  ): Promise<Studio | null> {
+    let q = this.client.from('studios').select('*').eq('worktree_path', worktreePath);
+    if (scope?.userId) q = q.eq('user_id', scope.userId);
+    if (scope?.agentId) q = q.eq('agent_id', scope.agentId);
+    q = q.order('updated_at', { ascending: false }).limit(1);
 
-    if (error && error.code !== 'PGRST116') {
+    const { data, error } = await q.maybeSingle();
+
+    if (error) {
       throw new Error(`Failed to find studio by path: ${error.message}`);
     }
 

--- a/packages/api/src/mcp/tools/index.ts
+++ b/packages/api/src/mcp/tools/index.ts
@@ -1838,6 +1838,12 @@ User can be identified by ONE of: userId, email, phone, or platform + platformId
             .string()
             .optional()
             .describe('Model identifier (e.g., "opus-4-6", "sonnet", "o3")'),
+          repoRoot: z
+            .string()
+            .optional()
+            .describe(
+              'Absolute path to the repository root. When studioId is "main" and no studio row exists, a studio is auto-created at this path.'
+            ),
           metadata: z.record(z.unknown()).optional().describe('Session metadata'),
           forceNew: z
             .boolean()

--- a/packages/api/src/mcp/tools/memory-handlers.ts
+++ b/packages/api/src/mcp/tools/memory-handlers.ts
@@ -21,6 +21,7 @@ import {
 import { getEffectiveAgentId } from '../../auth/enforce-identity';
 import type { MemorySource, Salience, Session } from '../../data/models/memory';
 import { getCloudSkillsService } from '../../skills/cloud-service';
+import { resolveMainStudio } from '../../services/sessions/session-service';
 
 // Helper to safely read a file, returning null if it doesn't exist
 async function safeReadFile(filePath: string): Promise<string | null> {
@@ -440,6 +441,12 @@ export const startSessionSchema = userIdentifierBaseSchema.extend({
       'Contact ID for per-sender session isolation. When set, the session is scoped to this contact.'
     ),
   metadata: z.record(z.unknown()).optional().describe('Additional session metadata'),
+  repoRoot: z
+    .string()
+    .optional()
+    .describe(
+      'Absolute path to the repository root. When studioId is "main" and no studio row exists, a studio is auto-created at this path.'
+    ),
   forceNew: z
     .boolean()
     .optional()
@@ -991,8 +998,18 @@ export async function handleStartSession(args: unknown, dataComposer: DataCompos
   const params = startSessionSchema.parse(args);
   const { user, resolvedBy } = await resolveUserOrThrow(params, dataComposer);
   const rawStudioId = resolveStudioId(params);
-  const studioScope = resolveStudioScope(rawStudioId);
+  let studioScope = resolveStudioScope(rawStudioId);
   const agentId = getEffectiveAgentId(params.agentId);
+
+  // When studioScope is null ("main" sentinel) and repoRoot is provided,
+  // resolve to a real studio UUID — auto-creating the studio if needed.
+  if (studioScope === null && params.repoRoot && agentId) {
+    const client = dataComposer.getClient();
+    const mainStudioId = await resolveMainStudio(client, user.id, params.repoRoot, agentId, {
+      autoCreate: true,
+    });
+    if (mainStudioId) studioScope = mainStudioId;
+  }
 
   // Session matching priority:
   // 1. threadKey match — find active session with same agent+threadKey

--- a/packages/api/src/mcp/tools/studio-handlers.ts
+++ b/packages/api/src/mcp/tools/studio-handlers.ts
@@ -93,6 +93,10 @@ const getStudioSchema = userIdentifierBaseSchema.extend({
   studioId: z.string().uuid().optional().describe('Studio UUID'),
   branch: z.string().optional().describe('Branch name to look up'),
   path: z.string().optional().describe('Worktree path to look up'),
+  agentId: z
+    .string()
+    .optional()
+    .describe('Agent ID to disambiguate when multiple agents share the same branch or path'),
 });
 
 const updateStudioSchema = userIdentifierBaseSchema.extend({
@@ -342,18 +346,19 @@ export async function handleListStudios(args: unknown, dataComposer: DataCompose
 
 export async function handleGetStudio(args: unknown, dataComposer: DataComposer) {
   const parsed = getStudioSchema.parse(args);
-  await resolveUserOrThrow(parsed, dataComposer);
+  const { user } = await resolveUserOrThrow(parsed, dataComposer);
 
   const studiosRepo = dataComposer.repositories.studios;
+  const scope = { userId: user.id, agentId: parsed.agentId };
   let studio = null;
 
   // Try identifiers in order: studioId, branch, path
   if (parsed.studioId) {
     studio = await studiosRepo.findById(parsed.studioId);
   } else if (parsed.branch) {
-    studio = await studiosRepo.findByBranch(parsed.branch);
+    studio = await studiosRepo.findByBranch(parsed.branch, scope);
   } else if (parsed.path) {
-    studio = await studiosRepo.findByPath(parsed.path);
+    studio = await studiosRepo.findByPath(parsed.path, scope);
   } else {
     return errorResponse('Must provide at least one of: studioId, branch, or path');
   }
@@ -536,19 +541,20 @@ export async function handleCloseStudio(args: unknown, dataComposer: DataCompose
 
 export async function handleAdoptStudio(args: unknown, dataComposer: DataComposer) {
   const parsed = adoptStudioSchema.parse(args);
-  await resolveUserOrThrow(parsed, dataComposer);
+  const { user } = await resolveUserOrThrow(parsed, dataComposer);
 
   const { agentId, sessionId, routePatterns } = parsed;
   const studiosRepo = dataComposer.repositories.studios;
+  const scope = { userId: user.id, agentId };
 
   // Find studio by ID, branch, or path
   let studio = null;
   if (parsed.studioId) {
     studio = await studiosRepo.findById(parsed.studioId);
   } else if (parsed.branch) {
-    studio = await studiosRepo.findByBranch(parsed.branch);
+    studio = await studiosRepo.findByBranch(parsed.branch, scope);
   } else if (parsed.worktreePath) {
-    studio = await studiosRepo.findByPath(parsed.worktreePath);
+    studio = await studiosRepo.findByPath(parsed.worktreePath, scope);
   } else {
     return errorResponse('Must provide at least one of: studioId, branch, or worktreePath');
   }

--- a/packages/api/src/services/sessions/auto-create-studio.integration.test.ts
+++ b/packages/api/src/services/sessions/auto-create-studio.integration.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Auto-Create Main Studio Integration Tests
+ *
+ * Tests that start_session with studioId="main" + repoRoot auto-creates
+ * a studio row and writes a real UUID to the session's studio_id.
+ * Simulates the hook→start_session flow against the real database.
+ *
+ * Requires: running PCP server (default http://localhost:3001)
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { getDataComposer, type DataComposer } from '../../data/composer';
+import { handleStartSession, startSessionSchema } from '../../mcp/tools/memory-handlers';
+import {
+  ensureEchoIntegrationFixture,
+  INTEGRATION_TEST_USER_ID,
+  INTEGRATION_TEST_AGENT_ID,
+  INTEGRATION_TEST_USER_EMAIL,
+} from '../../test/integration-fixtures';
+
+const TEST_REPO_ROOT = `/tmp/pcp-test-repo-${Date.now()}`;
+
+describe('Auto-Create Main Studio Integration', () => {
+  let dataComposer: DataComposer;
+  const createdSessionIds: string[] = [];
+  const createdStudioIds: string[] = [];
+
+  beforeAll(async () => {
+    dataComposer = await getDataComposer();
+    await ensureEchoIntegrationFixture(dataComposer);
+  });
+
+  afterAll(async () => {
+    const supabase = dataComposer.getClient();
+
+    if (createdSessionIds.length > 0) {
+      await supabase
+        .from('sessions')
+        .update({ ended_at: new Date().toISOString() })
+        .in('id', createdSessionIds);
+    }
+
+    if (createdStudioIds.length > 0) {
+      await supabase.from('studios').delete().in('id', createdStudioIds);
+    }
+  });
+
+  it('auto-creates a studio row when studioId="main" and repoRoot is provided', async () => {
+    const result = await handleStartSession(
+      {
+        email: INTEGRATION_TEST_USER_EMAIL,
+        agentId: INTEGRATION_TEST_AGENT_ID,
+        studioId: 'main',
+        repoRoot: TEST_REPO_ROOT,
+      },
+      dataComposer
+    );
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.success).toBe(true);
+
+    const sessionId = parsed.session.id;
+    createdSessionIds.push(sessionId);
+
+    // The session should have a real UUID studio_id, not NULL
+    const studioId = parsed.session.studioId;
+    expect(studioId).toBeTruthy();
+    expect(studioId).not.toBe('main');
+    // UUID format check
+    expect(studioId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+    createdStudioIds.push(studioId);
+
+    // Verify the studio row exists in the database
+    const { data: studio } = await dataComposer
+      .getClient()
+      .from('studios')
+      .select('id, repo_root, worktree_path, agent_id, slug, status, metadata')
+      .eq('id', studioId)
+      .single();
+
+    expect(studio).not.toBeNull();
+    expect(studio!.repo_root).toBe(TEST_REPO_ROOT);
+    expect(studio!.worktree_path).toBe(TEST_REPO_ROOT);
+    expect(studio!.agent_id).toBe(INTEGRATION_TEST_AGENT_ID);
+    expect(studio!.status).toBe('active');
+    expect((studio!.metadata as Record<string, unknown>)?.autoCreated).toBe(true);
+  });
+
+  it('reuses existing studio on second start_session call (idempotent)', async () => {
+    // Call start_session again with the same repoRoot
+    const result = await handleStartSession(
+      {
+        email: INTEGRATION_TEST_USER_EMAIL,
+        agentId: INTEGRATION_TEST_AGENT_ID,
+        studioId: 'main',
+        repoRoot: TEST_REPO_ROOT,
+      },
+      dataComposer
+    );
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.success).toBe(true);
+
+    const sessionId = parsed.session.id;
+    if (!createdSessionIds.includes(sessionId)) {
+      createdSessionIds.push(sessionId);
+    }
+
+    // Should reuse the same studio from the first test
+    const studioId = parsed.session.studioId;
+    expect(studioId).toBe(createdStudioIds[0]);
+
+    // Verify only one studio row exists for this repo root + agent
+    const { data: studios } = await dataComposer
+      .getClient()
+      .from('studios')
+      .select('id')
+      .eq('repo_root', TEST_REPO_ROOT)
+      .eq('agent_id', INTEGRATION_TEST_AGENT_ID)
+      .eq('user_id', INTEGRATION_TEST_USER_ID);
+
+    expect(studios).toHaveLength(1);
+  });
+
+  it('falls back to NULL studio when repoRoot is not provided', async () => {
+    const result = await handleStartSession(
+      {
+        email: INTEGRATION_TEST_USER_EMAIL,
+        agentId: INTEGRATION_TEST_AGENT_ID,
+        studioId: 'main',
+        // No repoRoot — can't auto-create
+        forceNew: true,
+      },
+      dataComposer
+    );
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.success).toBe(true);
+
+    const sessionId = parsed.session.id;
+    createdSessionIds.push(sessionId);
+
+    // Without repoRoot, studio_id should be null/undefined (legacy behavior)
+    expect(parsed.session.studioId).toBeFalsy();
+  });
+
+  it('auto-creates separate studios for different repo roots', async () => {
+    const otherRepoRoot = `${TEST_REPO_ROOT}-other`;
+
+    const result = await handleStartSession(
+      {
+        email: INTEGRATION_TEST_USER_EMAIL,
+        agentId: INTEGRATION_TEST_AGENT_ID,
+        studioId: 'main',
+        repoRoot: otherRepoRoot,
+        forceNew: true,
+      },
+      dataComposer
+    );
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.success).toBe(true);
+
+    const sessionId = parsed.session.id;
+    createdSessionIds.push(sessionId);
+
+    const studioId = parsed.session.studioId;
+    expect(studioId).toBeTruthy();
+    // Different repo root should get a different studio row
+    expect(studioId).not.toBe(createdStudioIds[0]);
+    createdStudioIds.push(studioId);
+
+    // Verify the second studio has the correct repo root
+    const { data: studio } = await dataComposer
+      .getClient()
+      .from('studios')
+      .select('repo_root')
+      .eq('id', studioId)
+      .single();
+
+    expect(studio!.repo_root).toBe(otherRepoRoot);
+  });
+});

--- a/packages/api/src/services/sessions/auto-create-studio.integration.test.ts
+++ b/packages/api/src/services/sessions/auto-create-studio.integration.test.ts
@@ -10,12 +10,11 @@
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { getDataComposer, type DataComposer } from '../../data/composer';
-import { handleStartSession, startSessionSchema } from '../../mcp/tools/memory-handlers';
+import { handleStartSession } from '../../mcp/tools/memory-handlers';
 import {
   ensureEchoIntegrationFixture,
   INTEGRATION_TEST_USER_ID,
   INTEGRATION_TEST_AGENT_ID,
-  INTEGRATION_TEST_USER_EMAIL,
 } from '../../test/integration-fixtures';
 
 const TEST_REPO_ROOT = `/tmp/pcp-test-repo-${Date.now()}`;
@@ -48,7 +47,7 @@ describe('Auto-Create Main Studio Integration', () => {
   it('auto-creates a studio row when studioId="main" and repoRoot is provided', async () => {
     const result = await handleStartSession(
       {
-        email: INTEGRATION_TEST_USER_EMAIL,
+        userId: INTEGRATION_TEST_USER_ID,
         agentId: INTEGRATION_TEST_AGENT_ID,
         studioId: 'main',
         repoRoot: TEST_REPO_ROOT,
@@ -90,7 +89,7 @@ describe('Auto-Create Main Studio Integration', () => {
     // Call start_session again with the same repoRoot
     const result = await handleStartSession(
       {
-        email: INTEGRATION_TEST_USER_EMAIL,
+        userId: INTEGRATION_TEST_USER_ID,
         agentId: INTEGRATION_TEST_AGENT_ID,
         studioId: 'main',
         repoRoot: TEST_REPO_ROOT,
@@ -125,7 +124,7 @@ describe('Auto-Create Main Studio Integration', () => {
   it('falls back to NULL studio when repoRoot is not provided', async () => {
     const result = await handleStartSession(
       {
-        email: INTEGRATION_TEST_USER_EMAIL,
+        userId: INTEGRATION_TEST_USER_ID,
         agentId: INTEGRATION_TEST_AGENT_ID,
         studioId: 'main',
         // No repoRoot — can't auto-create
@@ -149,7 +148,7 @@ describe('Auto-Create Main Studio Integration', () => {
 
     const result = await handleStartSession(
       {
-        email: INTEGRATION_TEST_USER_EMAIL,
+        userId: INTEGRATION_TEST_USER_ID,
         agentId: INTEGRATION_TEST_AGENT_ID,
         studioId: 'main',
         repoRoot: otherRepoRoot,

--- a/packages/api/src/services/sessions/resolve-main-studio.test.ts
+++ b/packages/api/src/services/sessions/resolve-main-studio.test.ts
@@ -96,6 +96,18 @@ describe('resolveMainStudio', () => {
     expect(mockSupabase.from).toHaveBeenCalledTimes(1);
   });
 
+  it('scopes lookup by worktree_path to avoid matching feature studios', async () => {
+    const chain = createChainableMock({ data: null });
+    const mockSupabase = { from: vi.fn().mockReturnValue(chain) };
+
+    await resolveMainStudio(mockSupabase as never, userId, repoRoot, agentId);
+
+    // Verify worktree_path filter is applied (prevents returning a feature
+    // studio that shares repo_root but has a different worktree_path)
+    expect(chain.eq).toHaveBeenCalledWith('worktree_path', repoRoot);
+    expect(chain.eq).toHaveBeenCalledWith('repo_root', repoRoot);
+  });
+
   it('handles unique constraint race (23505) with retry', async () => {
     const racedId = 'studio-uuid-raced';
     let callCount = 0;

--- a/packages/api/src/services/sessions/resolve-main-studio.test.ts
+++ b/packages/api/src/services/sessions/resolve-main-studio.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { resolveMainStudio, isMainStudio } from './session-service';
+
+function createChainableMock(terminalResult: unknown) {
+  const chain: Record<string, unknown> = {};
+  const chainMethods = ['select', 'eq', 'not', 'is', 'neq', 'in', 'order', 'limit', 'insert'];
+  for (const m of chainMethods) {
+    chain[m] = vi.fn().mockReturnValue(chain);
+  }
+  chain.maybeSingle = vi.fn().mockResolvedValue(terminalResult);
+  chain.single = vi.fn().mockResolvedValue(terminalResult);
+  return chain;
+}
+
+describe('resolveMainStudio', () => {
+  const userId = 'user-123';
+  const agentId = 'wren';
+  const repoRoot = '/Users/test/ws/my-project';
+
+  it('returns existing studio id when found', async () => {
+    const existingId = 'studio-uuid-existing';
+    const mockSupabase = {
+      from: vi
+        .fn()
+        .mockReturnValue(
+          createChainableMock({ data: { id: existingId, updated_at: new Date().toISOString() } })
+        ),
+    };
+
+    const result = await resolveMainStudio(mockSupabase as never, userId, repoRoot, agentId, {
+      autoCreate: true,
+    });
+
+    expect(result).toBe(existingId);
+    expect(mockSupabase.from).toHaveBeenCalledWith('studios');
+  });
+
+  it('auto-creates studio when not found and autoCreate=true', async () => {
+    const createdId = 'studio-uuid-new';
+    let callCount = 0;
+    const mockSupabase = {
+      from: vi.fn().mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          // First call: lookup returns no match
+          return createChainableMock({ data: null });
+        }
+        // Second call: insert returns new studio
+        const insertChain = createChainableMock({ data: { id: createdId }, error: null });
+        return insertChain;
+      }),
+    };
+
+    const result = await resolveMainStudio(mockSupabase as never, userId, repoRoot, agentId, {
+      autoCreate: true,
+    });
+
+    expect(result).toBe(createdId);
+    expect(mockSupabase.from).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns undefined when not found and autoCreate is false', async () => {
+    const mockSupabase = {
+      from: vi.fn().mockReturnValue(createChainableMock({ data: null })),
+    };
+
+    const result = await resolveMainStudio(mockSupabase as never, userId, repoRoot, agentId);
+
+    expect(result).toBeUndefined();
+    expect(mockSupabase.from).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns undefined when autoCreate=true but repoRoot is missing', async () => {
+    const mockSupabase = {
+      from: vi.fn().mockReturnValue(createChainableMock({ data: null })),
+    };
+
+    const result = await resolveMainStudio(mockSupabase as never, userId, undefined, agentId, {
+      autoCreate: true,
+    });
+
+    expect(result).toBeUndefined();
+    expect(mockSupabase.from).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns undefined when autoCreate=true but agentId is missing', async () => {
+    const mockSupabase = {
+      from: vi.fn().mockReturnValue(createChainableMock({ data: null })),
+    };
+
+    const result = await resolveMainStudio(mockSupabase as never, userId, repoRoot, undefined, {
+      autoCreate: true,
+    });
+
+    expect(result).toBeUndefined();
+    expect(mockSupabase.from).toHaveBeenCalledTimes(1);
+  });
+
+  it('handles unique constraint race (23505) with retry', async () => {
+    const racedId = 'studio-uuid-raced';
+    let callCount = 0;
+    const mockSupabase = {
+      from: vi.fn().mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          // Lookup: no match
+          return createChainableMock({ data: null });
+        }
+        if (callCount === 2) {
+          // Insert: unique constraint violation
+          return createChainableMock({
+            data: null,
+            error: { code: '23505', message: 'duplicate' },
+          });
+        }
+        // Retry lookup: found the concurrently-created row
+        return createChainableMock({ data: { id: racedId, updated_at: new Date().toISOString() } });
+      }),
+    };
+
+    const result = await resolveMainStudio(mockSupabase as never, userId, repoRoot, agentId, {
+      autoCreate: true,
+    });
+
+    expect(result).toBe(racedId);
+    expect(mockSupabase.from).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe('isMainStudio', () => {
+  it('returns true for "main"', () => {
+    expect(isMainStudio('main')).toBe(true);
+  });
+
+  it('returns false for undefined', () => {
+    expect(isMainStudio(undefined)).toBe(false);
+  });
+
+  it('returns false for null', () => {
+    expect(isMainStudio(null)).toBe(false);
+  });
+
+  it('returns false for a UUID', () => {
+    expect(isMainStudio('a1b2c3d4-e5f6-7890-abcd-ef1234567890')).toBe(false);
+  });
+});

--- a/packages/api/src/services/sessions/session-service.ts
+++ b/packages/api/src/services/sessions/session-service.ts
@@ -10,6 +10,7 @@
 
 import { randomUUID } from 'crypto';
 import { access } from 'fs/promises';
+import path from 'path';
 import { SupabaseClient } from '@supabase/supabase-js';
 import jwt from 'jsonwebtoken';
 import type { Database } from '../../data/supabase/types.js';
@@ -1624,29 +1625,75 @@ This session will continue with a fresh context after compaction. Your identity,
  * target project. When no repoRoot is provided, falls back to process.cwd()
  * (the server's working directory).
  *
- * Returns undefined when no matching studio exists — callers should use
- * defaultWorkingDirectory as the spawn path (the root repo itself).
+ * When `autoCreate` is true and both `agentId` and `repoRoot` are provided,
+ * auto-creates a studio row so every root-repo session gets a real
+ * studio_id instead of NULL.  Falls back to undefined when the caller
+ * didn't supply enough info to safely auto-create.
  */
 export async function resolveMainStudio(
   supabase: SupabaseClient<Database>,
   userId: string,
   repoRoot?: string,
-  agentId?: string
+  agentId?: string,
+  options?: { autoCreate?: boolean }
 ): Promise<string | undefined> {
   const targetRoot = repoRoot || process.cwd();
-  let query = supabase
+
+  const lookupQuery = () => {
+    let q = supabase
+      .from('studios')
+      .select('id, updated_at')
+      .eq('user_id', userId)
+      .eq('repo_root', targetRoot)
+      .in('status', ['active', 'idle', 'archived'])
+      .order('updated_at', { ascending: false })
+      .limit(1);
+    if (agentId) q = q.eq('agent_id', agentId);
+    return q;
+  };
+
+  const { data: match } = await lookupQuery().maybeSingle();
+  if (match?.id) return match.id;
+
+  // Auto-create only when explicitly opted in AND both agentId and repoRoot
+  // are provided — avoids creating spurious studios from fallback paths.
+  if (!options?.autoCreate || !agentId || !repoRoot) return undefined;
+
+  const slug = path.basename(targetRoot);
+  const { data: created, error } = await supabase
     .from('studios')
-    .select('id, updated_at')
-    .eq('user_id', userId)
-    .eq('repo_root', targetRoot)
-    .in('status', ['active', 'idle', 'archived'])
-    .order('updated_at', { ascending: false })
-    .limit(1);
-  if (agentId) {
-    query = query.eq('agent_id', agentId);
+    .insert({
+      user_id: userId,
+      agent_id: agentId,
+      repo_root: targetRoot,
+      worktree_path: targetRoot,
+      branch: 'main',
+      slug,
+      status: 'active',
+      purpose: 'Root repository studio (auto-created)',
+      metadata: { autoCreated: true },
+    })
+    .select('id')
+    .single();
+
+  if (error) {
+    // Unique constraint race — another concurrent request already created it
+    if (error.code === '23505') {
+      const { data: retry } = await lookupQuery().maybeSingle();
+      return retry?.id || undefined;
+    }
+    logger.warn('Failed to auto-create main studio', { error, userId, agentId, repoRoot });
+    return undefined;
   }
-  const { data: match } = await query.maybeSingle();
-  return match?.id || undefined;
+
+  logger.info('Auto-created main studio for root repo', {
+    studioId: created.id,
+    userId,
+    agentId,
+    repoRoot: targetRoot,
+    slug,
+  });
+  return created.id;
 }
 
 /**

--- a/packages/api/src/services/sessions/session-service.ts
+++ b/packages/api/src/services/sessions/session-service.ts
@@ -1645,6 +1645,7 @@ export async function resolveMainStudio(
       .select('id, updated_at')
       .eq('user_id', userId)
       .eq('repo_root', targetRoot)
+      .eq('worktree_path', targetRoot)
       .in('status', ['active', 'idle', 'archived'])
       .order('updated_at', { ascending: false })
       .limit(1);

--- a/packages/cli/src/commands/hooks.ts
+++ b/packages/cli/src/commands/hooks.ts
@@ -1905,18 +1905,24 @@ async function onSessionStartHandler(options?: { backend?: string }): Promise<vo
       '*FAILED: Could not reach Inkwell server for `bootstrap`. You should call the `bootstrap` MCP tool manually to reload your identity context.*';
   }
 
+  // Resolve repo root for studio auto-creation and session routing.
+  let repoRoot: string | undefined;
+  try {
+    repoRoot = execSync('git rev-parse --show-toplevel', {
+      cwd,
+      encoding: 'utf-8',
+    }).trim();
+  } catch {
+    // Not a git repo — repoRoot stays undefined
+  }
+
   // Auto-register CLI-created studio in the cloud if not yet tracked
   if (studioName && !studioId) {
     try {
-      const gitRoot = execSync('git rev-parse --show-toplevel', {
-        cwd,
-        encoding: 'utf-8',
-      }).trim();
-
       const createArgs: Record<string, unknown> = {
         email: config?.email,
         agentId,
-        repoRoot: gitRoot,
+        repoRoot: repoRoot || cwd,
         slug: studioName,
         skipGitOperations: true,
       };
@@ -2017,6 +2023,7 @@ async function onSessionStartHandler(options?: { backend?: string }): Promise<vo
         backend: sessionBackend,
       };
       if (studioId) startArgs.studioId = studioId;
+      if (repoRoot) startArgs.repoRoot = repoRoot;
       const started = await callPcpTool('start_session', startArgs);
       const startedSession = started.session as Record<string, unknown> | undefined;
       if (startedSession && typeof startedSession.id === 'string') {

--- a/supabase/migrations/20260513192116_studio_unique_per_agent.sql
+++ b/supabase/migrations/20260513192116_studio_unique_per_agent.sql
@@ -1,0 +1,13 @@
+-- Relax UNIQUE(worktree_path) to UNIQUE(worktree_path, agent_id).
+--
+-- The old single-column constraint prevents multiple agents from having
+-- their own studio row for the same root repo (e.g., wren + lumen both
+-- working in ~/ws/pcp).  The new composite index keeps one-studio-per-
+-- agent-per-path while allowing per-agent rows.
+
+ALTER TABLE studios DROP CONSTRAINT IF EXISTS studios_worktree_path_key;
+DROP INDEX IF EXISTS studios_worktree_path_key;
+
+CREATE UNIQUE INDEX studios_worktree_path_agent_key
+  ON studios (worktree_path, agent_id)
+  WHERE agent_id IS NOT NULL;

--- a/supabase/migrations/20260513192116_studio_unique_per_agent.sql
+++ b/supabase/migrations/20260513192116_studio_unique_per_agent.sql
@@ -1,13 +1,23 @@
--- Relax UNIQUE(worktree_path) to UNIQUE(worktree_path, agent_id).
+-- Relax single-column unique constraints on studios to composites.
 --
--- The old single-column constraint prevents multiple agents from having
--- their own studio row for the same root repo (e.g., wren + lumen both
--- working in ~/ws/pcp).  The new composite index keeps one-studio-per-
--- agent-per-path while allowing per-agent rows.
+-- The old UNIQUE(worktree_path) and UNIQUE(branch) prevent multiple agents
+-- from having their own studio row for the same root repo or branch
+-- (e.g., wren + lumen both working in ~/ws/pcp on main).
+--
+-- New composites keep one-studio-per-agent-per-path while allowing
+-- per-agent rows, and allow multiple root-repo studios with branch='main'.
 
+-- worktree_path: one studio per agent per filesystem path
 ALTER TABLE studios DROP CONSTRAINT IF EXISTS studios_worktree_path_key;
 DROP INDEX IF EXISTS studios_worktree_path_key;
 
 CREATE UNIQUE INDEX studios_worktree_path_agent_key
   ON studios (worktree_path, agent_id)
   WHERE agent_id IS NOT NULL;
+
+-- branch: drop the single-column unique. Multiple root-repo studios (one per
+-- agent, or one per project) all use branch='main'. The worktree_path+agent_id
+-- composite above is the dedup key; branch uniqueness is no longer meaningful.
+ALTER TABLE studios DROP CONSTRAINT IF EXISTS studios_branch_key;
+DROP INDEX IF EXISTS studios_branch_key;
+DROP INDEX IF EXISTS studios_branch_agent_key;


### PR DESCRIPTION
## Summary

- When `studioId="main"` and `repoRoot` is provided in `start_session`, auto-creates a studio row for the root repo instead of writing `studio_id=NULL`. Every root-repo session now gets a real UUID, making the work visible in dashboards and eliminating the NULL sentinel special case.
- Migration relaxes `UNIQUE(worktree_path)` → composite `UNIQUE(worktree_path, agent_id)` and drops `UNIQUE(branch)` entirely, enabling per-agent studio rows and multiple root-repo studios with `branch='main'`.
- Auto-create is opt-in via `autoCreate` flag — existing trigger routing / spawn path (which only does lookups) is unaffected.
- CLI hooks now pass `repoRoot` to `start_session` so the server has the info needed to auto-create.

## Key design decisions

- **Guard**: only auto-creates when both `agentId` AND explicit `repoRoot` are provided — the `process.cwd()` fallback (server's own directory) never triggers creation
- **Idempotent**: handles unique constraint races with retry lookup
- **Metadata flag**: `autoCreated: true` on studio metadata so dashboards can distinguish manual vs auto studios
- **Backward compatible**: existing `NULL`-studio sessions continue working; `resolveStudioScope("main") → null` path still works as fallback when `repoRoot` isn't available

## Test plan

- [x] Unit tests for `resolveMainStudio`: existing lookup, auto-create, missing params guard, unique constraint race (10 tests)
- [x] Integration tests simulating hook→start_session flow: auto-create on first call, idempotent reuse, NULL fallback without repoRoot, separate studios for different repo roots (4 tests)
- [x] Full unit test suite: 2407 passing
- [ ] Manual: start a Claude Code session in root repo, verify studio row in DB
- [ ] Manual: verify dashboard shows auto-created studio

— Wren