### PR TITLE
fix: disable chunked memory recall by default (by Lumen)

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,12 @@ MEMORY_EMBEDDINGS_ENABLED=false
 
 in `.env.local`.
 
+Chunked multi-vector memory recall is experimental and off by default. To test it explicitly, set:
+
+```bash
+MEMORY_CHUNKED_RECALL_ENABLED=true
+```
+
 ### Alternative: Use Inkwell from another platform
 
 If you're using [OpenClaw](https://github.com/openclaw) or another MCP-compatible client, you can connect directly to the Inkwell server without the `ink` CLI:

--- a/packages/api/src/config/env.ts
+++ b/packages/api/src/config/env.ts
@@ -177,6 +177,10 @@ const envSchema = z.object({
   MEMORY_EMBEDDING_DIMENSIONS: optionalNumber,
   MEMORY_EMBEDDING_QUERY_THRESHOLD: optionalNumber,
   MEMORY_EMBEDDING_MATCH_COUNT_MULTIPLIER: optionalNumber,
+  MEMORY_CHUNKED_RECALL_ENABLED: z
+    .enum(['true', 'false'])
+    .default('false')
+    .transform((v) => v === 'true'),
   MEMORY_LLM_EXTRACTION_ENABLED: z
     .enum(['true', 'false'])
     .default('false')

--- a/packages/api/src/data/repositories/memory-repository.test.ts
+++ b/packages/api/src/data/repositories/memory-repository.test.ts
@@ -1205,6 +1205,7 @@ describe('MemoryRepository', () => {
           dimensions: 1024,
           queryThreshold: 0.2,
           matchCountMultiplier: 5,
+          chunkedRecallEnabled: false,
           ollamaBaseUrl: 'http://localhost:11434',
           openaiBaseUrl: 'https://api.openai.com',
           hasOpenAIKey: false,
@@ -1230,25 +1231,24 @@ describe('MemoryRepository', () => {
         expect.arrayContaining([
           expect.objectContaining({
             memory_id: 'mem-hm-5',
-            chunk_type: 'summary',
+            chunk_type: 'content',
             chunk_index: 0,
-            chunk_text: 'Chunked summary',
           }),
         ]),
         expect.objectContaining({ onConflict: 'memory_id,chunk_index' })
       );
-      expect(chunkRows.some((row) => row.chunk_type === 'content')).toBe(true);
-      expect(chunkRows.some((row) => row.chunk_type === 'topic')).toBe(true);
+      expect(chunkRows.every((row) => row.chunk_type === 'content')).toBe(true);
       expect(mockSupabase._queryBuilder.update).toHaveBeenCalledWith(
         expect.objectContaining({
-          embedding_chunks_version: 2,
+          embedding_chunks_version: 3,
           embedding_chunk_count: chunkRows.length,
           metadata: expect.objectContaining({
             embedding_chunks: expect.objectContaining({
               chunkCount: chunkRows.length,
-              version: 2,
+              version: 3,
               viewCounts: expect.objectContaining({
-                summary: 1,
+                content: chunkRows.length,
+                summary: 0,
               }),
             }),
             embedding: expect.objectContaining({
@@ -1508,6 +1508,65 @@ describe('MemoryRepository', () => {
   });
 
   describe('semantic recall integration', () => {
+    it('uses legacy memory embeddings when chunked recall is disabled', async () => {
+      const rpc = vi.fn().mockResolvedValue({
+        data: [
+          {
+            id: 'mem-sem-legacy-default',
+            user_id: 'user-456',
+            content: 'Legacy semantic memory',
+            summary: 'Legacy semantic memory',
+            topic_key: 'project:pcp/memory',
+            source: 'observation',
+            salience: 'high',
+            topics: ['project:pcp/memory'],
+            agent_id: 'lumen',
+            embedding: '[0.1,0.2,0.3]',
+            metadata: {},
+            version: 1,
+            created_at: '2026-03-16T00:00:00Z',
+            expires_at: null,
+            sb_id: null,
+            similarity: 0.88,
+          },
+        ],
+        error: null,
+      });
+      (mockSupabase as any).rpc = rpc;
+      (repo as any).embeddingRouter = {
+        embedQuery: vi.fn().mockResolvedValue({
+          vector: [0.1, 0.2, 0.3],
+          provider: 'openai',
+          model: 'text-embedding-3-small',
+          dimensions: 1024,
+        }),
+        getRuntimeConfig: vi.fn().mockReturnValue({
+          enabled: true,
+          provider: 'openai',
+          model: 'text-embedding-3-small',
+          dimensions: 1024,
+          queryThreshold: 0.2,
+          matchCountMultiplier: 5,
+          chunkedRecallEnabled: false,
+          ollamaBaseUrl: 'http://localhost:11434',
+          openaiBaseUrl: 'https://api.openai.com',
+          hasOpenAIKey: true,
+        }),
+      };
+
+      const results = await repo.recall('user-456', 'semantic query', { recallMode: 'semantic' });
+
+      expect(rpc).toHaveBeenCalledTimes(1);
+      expect(rpc).toHaveBeenCalledWith(
+        'match_memories',
+        expect.objectContaining({
+          query_embedding: '[0.1,0.2,0.3]',
+        })
+      );
+      expect(results).toHaveLength(1);
+      expect(results[0].id).toBe('mem-sem-legacy-default');
+    });
+
     it('serializes query embeddings for chunk matcher RPC', async () => {
       const rpc = vi.fn().mockResolvedValue({
         data: [
@@ -1561,6 +1620,7 @@ describe('MemoryRepository', () => {
           dimensions: 1024,
           queryThreshold: 0.2,
           matchCountMultiplier: 5,
+          chunkedRecallEnabled: true,
           ollamaBaseUrl: 'http://localhost:11434',
           openaiBaseUrl: 'https://api.openai.com',
           hasOpenAIKey: true,
@@ -1625,6 +1685,7 @@ describe('MemoryRepository', () => {
           dimensions: 1024,
           queryThreshold: 0.2,
           matchCountMultiplier: 5,
+          chunkedRecallEnabled: true,
           ollamaBaseUrl: 'http://localhost:11434',
           openaiBaseUrl: 'https://api.openai.com',
           hasOpenAIKey: true,
@@ -1751,6 +1812,7 @@ describe('MemoryRepository', () => {
           dimensions: 1024,
           queryThreshold: 0.2,
           matchCountMultiplier: 5,
+          chunkedRecallEnabled: true,
           ollamaBaseUrl: 'http://localhost:11434',
           openaiBaseUrl: 'https://api.openai.com',
           hasOpenAIKey: true,

--- a/packages/api/src/data/repositories/memory-repository.ts
+++ b/packages/api/src/data/repositories/memory-repository.ts
@@ -815,6 +815,10 @@ export class MemoryRepository {
       return null;
     }
 
+    if (!config.chunkedRecallEnabled) {
+      return this.tryLegacySemanticRecallCandidates(userId, options, limit, offset, queryEmbedding);
+    }
+
     const matchCount = Math.max(
       limit,
       (offset + limit) * Math.max(1, config.matchCountMultiplier || 1)
@@ -864,7 +868,9 @@ export class MemoryRepository {
 
       const matchedChunkType =
         row.matched_chunk_type &&
-        ['summary', 'fact', 'topic', 'entity', 'content'].includes(row.matched_chunk_type)
+        ['summary', 'fact', 'topic', 'entity', 'current_state', 'content'].includes(
+          row.matched_chunk_type
+        )
           ? (row.matched_chunk_type as MemoryChunkType)
           : inferChunkTypeFromMetadata(row.matched_chunk_index, memory.metadata);
       const semanticScore = Math.max(0, Math.min(1, row.similarity ?? 0));

--- a/packages/api/src/services/embeddings/memory-chunks.test.ts
+++ b/packages/api/src/services/embeddings/memory-chunks.test.ts
@@ -8,7 +8,7 @@ import {
 import { memoryExtractionsSchema } from '../memory-llm-extraction';
 
 describe('memory chunk multi-view helpers', () => {
-  it('builds summary, fact, topic, entity, and content views when structured data is available', () => {
+  it('builds a single raw content view for short memories by default', () => {
     const chunks = buildMemoryEmbeddingChunks({
       summary: 'Policy B replaces Policy A for wound escalation.',
       content:
@@ -20,16 +20,16 @@ describe('memory chunk multi-view helpers', () => {
       model: { maxInputChars: 1200 } as { maxInputChars: number },
     });
 
-    expect(chunks.some((chunk) => chunk.chunkType === 'summary')).toBe(true);
-    expect(chunks.some((chunk) => chunk.chunkType === 'fact')).toBe(true);
-    expect(chunks.some((chunk) => chunk.chunkType === 'topic')).toBe(true);
-    expect(chunks.some((chunk) => chunk.chunkType === 'entity')).toBe(true);
-    expect(chunks.some((chunk) => chunk.chunkType === 'content')).toBe(true);
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].chunkType).toBe('content');
 
     const viewCounts = countChunkViews(chunks);
-    expect(viewCounts.summary).toBe(1);
+    expect(viewCounts.summary).toBe(0);
+    expect(viewCounts.fact).toBe(0);
+    expect(viewCounts.topic).toBe(0);
+    expect(viewCounts.entity).toBe(0);
     expect(viewCounts.current_state).toBe(0);
-    expect(viewCounts.content).toBeGreaterThan(0);
+    expect(viewCounts.content).toBe(1);
 
     const metadata = {
       embedding_chunks: {
@@ -38,7 +38,26 @@ describe('memory chunk multi-view helpers', () => {
       },
     };
 
+    expect(inferChunkTypeFromMetadata(0, metadata)).toBe('content');
+  });
+
+  it('infers legacy pre-v3 chunk metadata using the old derived-first order', () => {
+    const metadata = {
+      embedding_chunks: {
+        version: 2,
+        viewCounts: {
+          summary: 1,
+          fact: 1,
+          topic: 1,
+          entity: 0,
+          current_state: 0,
+          content: 1,
+        },
+      },
+    };
+
     expect(inferChunkTypeFromMetadata(0, metadata)).toBe('summary');
+    expect(inferChunkTypeFromMetadata(3, metadata)).toBe('content');
   });
 
   it('prefers llm-derived summary, durable fact, entity, and current state chunks when provided', () => {
@@ -112,9 +131,10 @@ describe('memory chunk multi-view helpers', () => {
     expect(viewCounts.fact).toBe(1);
     expect(viewCounts.entity).toBe(1);
     expect(viewCounts.current_state).toBe(1);
+    expect(viewCounts.content).toBe(1);
   });
 
-  it('uses heuristic extraction mode by default even when llm metadata exists', () => {
+  it('does not create heuristic or LLM-derived views by default when LLM mode is not enabled', () => {
     const llmExtractions = memoryExtractionsSchema.parse({
       version: 1,
       provider: 'openai',
@@ -137,7 +157,20 @@ describe('memory chunk multi-view helpers', () => {
     });
 
     expect(chunks.some((chunk) => chunk.chunkType === 'current_state')).toBe(false);
-    expect(chunks.some((chunk) => chunk.chunkType === 'fact')).toBe(true);
+    expect(chunks.some((chunk) => chunk.chunkType === 'fact')).toBe(false);
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].chunkType).toBe('content');
+  });
+
+  it('splits content only when it exceeds the vetted model input limit', () => {
+    const chunks = buildMemoryEmbeddingChunks({
+      content: `${'A'.repeat(1300)}. ${'B'.repeat(1300)}.`,
+      model: { maxInputChars: 1200 } as { maxInputChars: number },
+    });
+
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.every((chunk) => chunk.chunkType === 'content')).toBe(true);
+    expect(chunks.every((chunk) => chunk.text.length <= 1100)).toBe(true);
   });
 
   it('sanitizes unpaired unicode surrogates before chunk persistence', () => {

--- a/packages/api/src/services/embeddings/memory-chunks.ts
+++ b/packages/api/src/services/embeddings/memory-chunks.ts
@@ -14,14 +14,18 @@ import { type VettedEmbeddingModel } from './vetted-models';
 export { MEMORY_EMBEDDING_CHUNKS_VERSION };
 const DEFAULT_MAX_CHARS = 1000;
 const DEFAULT_OVERLAP_CHARS = 150;
-const MAX_FACT_CHUNKS = 3;
-const MAX_ENTITY_CHUNKS = 2;
-const MIN_FACT_SENTENCE_CHARS = 48;
-const MAX_FACT_SENTENCE_CHARS = 280;
 
 export type MemoryChunkType = 'summary' | 'fact' | 'topic' | 'entity' | 'current_state' | 'content';
 export type MemoryExtractionChunkMode = 'heuristic' | 'llm' | 'merged';
 const CHUNK_TYPE_ORDER: MemoryChunkType[] = [
+  'content',
+  'summary',
+  'fact',
+  'topic',
+  'entity',
+  'current_state',
+];
+const LEGACY_CHUNK_TYPE_ORDER: MemoryChunkType[] = [
   'summary',
   'fact',
   'topic',
@@ -150,103 +154,6 @@ function sanitizeChunkText(text: string): string {
   return replaceUnpairedSurrogates(text);
 }
 
-function splitIntoSentences(text: string): string[] {
-  const normalized = text
-    .replace(/\r/g, '\n')
-    .split(/\n+/)
-    .flatMap((line) => line.split(/(?<=[.!?])\s+/))
-    .map(normalizeWhitespace)
-    .filter(Boolean);
-
-  return normalized;
-}
-
-function sentenceScore(sentence: string): number {
-  const lowered = sentence.toLowerCase();
-  const cueWords = [
-    ' must ',
-    ' should ',
-    ' decided ',
-    ' because ',
-    ' prefer ',
-    ' important ',
-    ' override',
-    ' replace',
-    ' policy',
-    ' convention',
-    ' requires ',
-    ' means ',
-  ];
-
-  let score = 0;
-  if (/\d/.test(sentence)) score += 0.3;
-  if (cueWords.some((cue) => lowered.includes(cue.trim()) || lowered.includes(cue))) score += 0.4;
-  if (/[A-Z][a-z]+(?:\s+[A-Z][a-z]+)+/.test(sentence) || /\b[A-Z]{2,}\b/.test(sentence)) {
-    score += 0.2;
-  }
-
-  const tokens = lowered.split(/[^a-z0-9]+/).filter((token) => token.length > 2);
-  const uniqueTokens = new Set(tokens);
-  if (tokens.length > 0) score += Math.min(0.3, uniqueTokens.size / Math.max(tokens.length, 1) / 2);
-
-  return score;
-}
-
-function buildFactChunks(text: string): MemoryEmbeddingChunk[] {
-  const sentences = splitIntoSentences(text)
-    .filter(
-      (sentence) =>
-        sentence.length >= MIN_FACT_SENTENCE_CHARS && sentence.length <= MAX_FACT_SENTENCE_CHARS
-    )
-    .map((sentence) => ({ sentence, score: sentenceScore(sentence) }))
-    .filter((entry) => entry.score > 0.2)
-    .sort((a, b) => b.score - a.score || b.sentence.length - a.sentence.length);
-
-  const seen = new Set<string>();
-  const chunks: MemoryEmbeddingChunk[] = [];
-
-  for (const entry of sentences) {
-    const normalized = entry.sentence.toLowerCase();
-    if (seen.has(normalized)) continue;
-    seen.add(normalized);
-    chunks.push({
-      chunkIndex: chunks.length,
-      chunkType: 'fact',
-      text: entry.sentence,
-      startOffset: 0,
-      endOffset: entry.sentence.length,
-    });
-    if (chunks.length >= MAX_FACT_CHUNKS) break;
-  }
-
-  return chunks;
-}
-
-function buildTopicChunks(params: {
-  topicKey?: string | null;
-  topics?: string[] | null;
-  source?: string | null;
-  salience?: string | null;
-}): MemoryEmbeddingChunk[] {
-  const lines: string[] = [];
-  if (params.topicKey?.trim()) lines.push(`topic key: ${params.topicKey.trim()}`);
-  const normalizedTopics = (params.topics || []).map((topic) => topic.trim()).filter(Boolean);
-  if (normalizedTopics.length > 0) lines.push(`topics: ${normalizedTopics.join(', ')}`);
-  if (params.source?.trim()) lines.push(`source: ${params.source.trim()}`);
-  if (params.salience?.trim()) lines.push(`salience: ${params.salience.trim()}`);
-  const text = lines.join('\n').trim();
-  if (!text) return [];
-  return [
-    {
-      chunkIndex: 0,
-      chunkType: 'topic',
-      text,
-      startOffset: 0,
-      endOffset: text.length,
-    },
-  ];
-}
-
 function buildChunksFromTexts(chunkType: MemoryChunkType, texts: string[]): MemoryEmbeddingChunk[] {
   return texts
     .map((text) => sanitizeChunkText(normalizeWhitespace(text)))
@@ -258,67 +165,6 @@ function buildChunksFromTexts(chunkType: MemoryChunkType, texts: string[]): Memo
       startOffset: 0,
       endOffset: text.length,
     }));
-}
-
-function extractEntityPhrases(text: string): string[] {
-  const matches = [
-    ...text.matchAll(/\b[A-Z][a-z]+(?:\s+[A-Z][a-z]+){0,3}\b/g),
-    ...text.matchAll(/\b[A-Z]{2,}(?:\s+[A-Z]{2,})*\b/g),
-  ].map((match) => normalizeWhitespace(match[0] || ''));
-
-  const unique = new Set<string>();
-  for (const phrase of matches) {
-    if (phrase.length < 3) continue;
-    unique.add(phrase);
-    if (unique.size >= 8) break;
-  }
-
-  return Array.from(unique);
-}
-
-function buildEntityChunks(params: {
-  summary?: string | null;
-  content: string;
-  topicKey?: string | null;
-  topics?: string[] | null;
-}): MemoryEmbeddingChunk[] {
-  const phrases = new Set<string>();
-
-  for (const topic of params.topics || []) {
-    const normalized = topic
-      .split(':')
-      .map((part) => part.trim())
-      .filter(Boolean)
-      .join(' ');
-    if (normalized) phrases.add(normalized);
-  }
-
-  if (params.topicKey?.trim()) {
-    const normalized = params.topicKey
-      .split(':')
-      .map((part) => part.trim())
-      .filter(Boolean)
-      .join(' ');
-    if (normalized) phrases.add(normalized);
-  }
-
-  for (const phrase of extractEntityPhrases(`${params.summary || ''}\n${params.content}`)) {
-    phrases.add(phrase);
-    if (phrases.size >= 10) break;
-  }
-
-  const entries = Array.from(phrases)
-    .map(normalizeWhitespace)
-    .filter(Boolean)
-    .slice(0, MAX_ENTITY_CHUNKS);
-
-  return entries.map((entry, index) => ({
-    chunkIndex: index,
-    chunkType: 'entity',
-    text: `entity focus: ${entry}`,
-    startOffset: 0,
-    endOffset: entry.length,
-  }));
 }
 
 function reindexChunks(chunks: MemoryEmbeddingChunk[], startIndex: number): MemoryEmbeddingChunk[] {
@@ -363,8 +209,14 @@ export function inferChunkTypeFromMetadata(
 
   if (!viewCounts) return null;
 
+  const version = typeof embeddingChunks.version === 'number' ? embeddingChunks.version : null;
+  const chunkTypeOrder =
+    version !== null && version >= MEMORY_EMBEDDING_CHUNKS_VERSION
+      ? CHUNK_TYPE_ORDER
+      : LEGACY_CHUNK_TYPE_ORDER;
+
   let offset = 0;
-  for (const chunkType of CHUNK_TYPE_ORDER) {
+  for (const chunkType of chunkTypeOrder) {
     const rawCount = viewCounts[chunkType];
     const count = typeof rawCount === 'number' ? rawCount : 0;
     if (chunkIndex < offset + count) return chunkType;
@@ -385,43 +237,35 @@ export function buildMemoryEmbeddingChunks(params: {
   llmExtractions?: MemoryExtractions | Record<string, unknown> | null;
   extractionMode?: MemoryExtractionChunkMode;
 }): MemoryEmbeddingChunk[] {
-  const { summary, content, topicKey, topics, source, salience, model = null } = params;
+  const { content, model = null } = params;
   const maxChars = pickMaxChunkChars(model);
   const chunks: MemoryEmbeddingChunk[] = [];
   const llmExtractions = normalizeMemoryExtractions(params.llmExtractions);
   const extractionMode = params.extractionMode || 'heuristic';
-  const includeHeuristic = extractionMode === 'heuristic' || extractionMode === 'merged';
   const includeLlm = extractionMode === 'llm' || extractionMode === 'merged';
+
+  // The raw episodic memory is the authoritative representation. For normal-size memories this
+  // produces exactly one embedding; content is split only when it exceeds the vetted model limit.
+  chunks.push(
+    ...reindexChunks(buildContentChunks(content, maxChars, DEFAULT_OVERLAP_CHARS), chunks.length)
+  );
 
   const extractedSummaryTexts = llmExtractions?.summary
     ? buildSummaryEmbeddingTexts(llmExtractions.summary)
     : [];
-  const normalizedSummary = summary?.trim();
-  const summaryTexts = [
-    ...(includeLlm ? extractedSummaryTexts : []),
-    ...(includeHeuristic && normalizedSummary ? [normalizedSummary] : []),
-  ];
+  const summaryTexts = includeLlm ? extractedSummaryTexts : [];
   chunks.push(...reindexChunks(buildChunksFromTexts('summary', summaryTexts), chunks.length));
 
   const durableFactTexts = llmExtractions?.durable_fact
     ? buildDurableFactEmbeddingTexts(llmExtractions.durable_fact)
     : [];
-  const factChunks = [
-    ...(includeLlm ? buildChunksFromTexts('fact', durableFactTexts) : []),
-    ...(includeHeuristic ? buildFactChunks(`${normalizedSummary || ''}\n${content}`) : []),
-  ];
+  const factChunks = includeLlm ? buildChunksFromTexts('fact', durableFactTexts) : [];
   chunks.push(...reindexChunks(factChunks, chunks.length));
-  chunks.push(
-    ...reindexChunks(buildTopicChunks({ topicKey, topics, source, salience }), chunks.length)
-  );
 
   const entityTexts = llmExtractions?.entity
     ? buildEntityEmbeddingTexts(llmExtractions.entity)
     : [];
-  const entityChunks = [
-    ...(includeLlm ? buildChunksFromTexts('entity', entityTexts) : []),
-    ...(includeHeuristic ? buildEntityChunks({ summary, content, topicKey, topics }) : []),
-  ];
+  const entityChunks = includeLlm ? buildChunksFromTexts('entity', entityTexts) : [];
   chunks.push(...reindexChunks(entityChunks, chunks.length));
 
   const currentStateTexts = llmExtractions?.current_state
@@ -432,9 +276,6 @@ export function buildMemoryEmbeddingChunks(params: {
       ...reindexChunks(buildChunksFromTexts('current_state', currentStateTexts), chunks.length)
     );
   }
-  chunks.push(
-    ...reindexChunks(buildContentChunks(content, maxChars, DEFAULT_OVERLAP_CHARS), chunks.length)
-  );
 
   return chunks;
 }

--- a/packages/api/src/services/embeddings/router.test.ts
+++ b/packages/api/src/services/embeddings/router.test.ts
@@ -9,6 +9,7 @@ const baseConfig: EmbeddingRuntimeConfig = {
   dimensions: 1024,
   queryThreshold: 0.2,
   matchCountMultiplier: 5,
+  chunkedRecallEnabled: false,
   ollamaBaseUrl: 'http://localhost:11434',
   openaiBaseUrl: 'https://api.openai.com',
   hasOpenAIKey: true,

--- a/packages/api/src/services/embeddings/router.ts
+++ b/packages/api/src/services/embeddings/router.ts
@@ -22,6 +22,7 @@ export interface EmbeddingRuntimeConfig {
   dimensions: number;
   queryThreshold: number;
   matchCountMultiplier: number;
+  chunkedRecallEnabled: boolean;
   ollamaBaseUrl: string;
   openaiBaseUrl: string;
   hasOpenAIKey: boolean;
@@ -80,6 +81,7 @@ function buildRuntimeConfig(): EmbeddingRuntimeConfig {
     dimensions,
     queryThreshold: env.MEMORY_EMBEDDING_QUERY_THRESHOLD,
     matchCountMultiplier: env.MEMORY_EMBEDDING_MATCH_COUNT_MULTIPLIER,
+    chunkedRecallEnabled: env.MEMORY_CHUNKED_RECALL_ENABLED,
     ollamaBaseUrl: env.OLLAMA_BASE_URL,
     openaiBaseUrl: env.OPENAI_BASE_URL || DEFAULT_OPENAI_BASE_URL,
     hasOpenAIKey: Boolean(env.OPENAI_API_KEY),

--- a/packages/api/src/services/embeddings/vetted-models.ts
+++ b/packages/api/src/services/embeddings/vetted-models.ts
@@ -45,7 +45,9 @@ export const VETTED_EMBEDDING_MODELS: VettedEmbeddingModel[] = [
     model: 'text-embedding-3-small',
     recommendedFor: 'Reliable API default',
     dimensions: [1536, 1024, 512, 256],
-    notes: 'Strong cost/performance API model for production defaults.',
+    maxInputChars: 24000,
+    notes:
+      'Strong cost/performance API model for production defaults. Char limit is a conservative proxy for the 8192-token embedding input limit.',
     default: true,
   },
   {
@@ -53,7 +55,9 @@ export const VETTED_EMBEDDING_MODELS: VettedEmbeddingModel[] = [
     model: 'text-embedding-3-large',
     recommendedFor: 'Highest API retrieval quality',
     dimensions: [3072, 2048, 1024, 512, 256],
-    notes: 'Highest quality API option with larger vectors/cost.',
+    maxInputChars: 24000,
+    notes:
+      'Highest quality API option with larger vectors/cost. Char limit is a conservative proxy for the 8192-token embedding input limit.',
   },
 ];
 

--- a/packages/api/src/services/memory-benchmark-constants.ts
+++ b/packages/api/src/services/memory-benchmark-constants.ts
@@ -1,3 +1,3 @@
 export const MEMORY_EXTRACTION_VERSION = 2;
-export const MEMORY_EMBEDDING_CHUNKS_VERSION = 2;
+export const MEMORY_EMBEDDING_CHUNKS_VERSION = 3;
 export const DEFAULT_MEMORY_LLM_MODEL = 'gpt-4.1-mini';

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -262,6 +262,12 @@ To explicitly disable embeddings and keep text-only recall:
 echo 'MEMORY_EMBEDDINGS_ENABLED=false' >> .env.local
 ```
 
+Chunked multi-vector recall is experimental and disabled by default. To test it explicitly:
+
+```bash
+echo 'MEMORY_CHUNKED_RECALL_ENABLED=true' >> .env.local
+```
+
 ### Identity Resolution
 
 The agent ID is resolved in order:


### PR DESCRIPTION
## Summary
- Disable chunked multi-vector memory recall by default via `MEMORY_CHUNKED_RECALL_ENABLED=false`.
- Route semantic recall to the legacy one-vector `match_memories` RPC unless chunked recall is explicitly enabled.
- Remove heuristic/rule-based summary/fact/topic/entity chunk production entirely from the write path.
- Normal writes embed raw content first and only split content when it exceeds the vetted embedding model input limit.
- Keep LLM-derived memory views available behind explicit extraction mode, and preserve legacy chunk-type inference for pre-v3 metadata.

## Why
Local production recall was timing out on `match_memory_embedding_chunks` after benchmark data created ~768k chunk rows. The default heuristic chunk generation was also producing low-value vectors we no longer trust from the benchmark work.

Production embeddings currently use local Ollama (`mxbai-embed-large`), whose vetted config is 1200 chars; with the safety margin, content chunks split around 1100 chars. So for our current local model, short memories become one raw-content vector and only longer memories split.

## Verification
- `yarn workspace @inklabs/api test src/services/embeddings/memory-chunks.test.ts src/data/repositories/memory-repository.test.ts src/services/embeddings/router.test.ts` ✅
- `yarn workspace @inklabs/api type-check` still fails on pre-existing unrelated errors in `channels/gateway.ts` and `mcp/server.ts`.

— Lumen