### PR TITLE
feat: ink studio register command (by Wren)

### DIFF
--- a/packages/api/src/mcp/tools/index.ts
+++ b/packages/api/src/mcp/tools/index.ts
@@ -279,6 +279,7 @@ import {
   handleUpdateStudio,
   handleCloseStudio,
   handleAdoptStudio,
+  handleRegisterStudio,
   studioToolDefinitions,
 } from './studio-handlers';
 
@@ -5755,6 +5756,33 @@ User can be identified by ONE of: userId, email, phone, or platform + platformId
         return await handleAdoptStudio(args, dataComposer);
       } catch (error) {
         logger.error('Error in adopt_studio:', error);
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                success: false,
+                error: error instanceof Error ? error.message : 'Unknown error',
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  server.registerTool(
+    'register_studio',
+    {
+      description: `Register an existing repository as a studio. Creates a studio row for the root repo if one does not exist, or returns the existing one.`,
+      inputSchema: studioToolDefinitions[6].schema,
+    },
+    async (args: Record<string, unknown>) => {
+      try {
+        return await handleRegisterStudio(args, dataComposer);
+      } catch (error) {
+        logger.error('Error in register_studio:', error);
         return {
           content: [
             {

--- a/packages/api/src/mcp/tools/studio-handlers.ts
+++ b/packages/api/src/mcp/tools/studio-handlers.ts
@@ -14,6 +14,7 @@ import type { DataComposer } from '../../data/composer';
 import { resolveUserOrThrow, userIdentifierBaseSchema } from '../../services/user-resolver';
 import { logger } from '../../utils/logger';
 import { ensureStudioSettings } from '../../services/studio-settings';
+import { resolveMainStudio } from '../../services/sessions/session-service';
 
 // ============== Helpers ==============
 
@@ -605,6 +606,48 @@ export async function handleAdoptStudio(args: unknown, dataComposer: DataCompose
   });
 }
 
+const registerStudioSchema = userIdentifierBaseSchema.extend({
+  agentId: z.string().describe('Agent ID to own the studio'),
+  repoRoot: z.string().describe('Absolute path to the repository root'),
+});
+
+export async function handleRegisterStudio(args: unknown, dataComposer: DataComposer) {
+  const parsed = registerStudioSchema.parse(args);
+  const { user } = await resolveUserOrThrow(parsed, dataComposer);
+
+  const studioId = await resolveMainStudio(
+    dataComposer.getClient(),
+    user.id,
+    parsed.repoRoot,
+    parsed.agentId,
+    { autoCreate: true }
+  );
+
+  if (!studioId) {
+    return errorResponse('Failed to register studio — could not create or find studio row');
+  }
+
+  const studio = await dataComposer.repositories.studios.findById(studioId);
+  if (!studio) {
+    return errorResponse('Studio was created but could not be retrieved');
+  }
+
+  const wasCreated = !!(studio.metadata as Record<string, unknown>)?.autoCreated;
+
+  return successResponse({
+    studio: {
+      id: studio.id,
+      slug: studio.slug,
+      repoRoot: studio.repoRoot,
+      worktreePath: studio.worktreePath,
+      branch: studio.branch,
+      agentId: studio.agentId,
+      status: studio.status,
+    },
+    created: wasCreated,
+  });
+}
+
 // ============== Tool Registration ==============
 
 export const studioToolDefinitions = [
@@ -648,5 +691,12 @@ export const studioToolDefinitions = [
       'Adopt an existing studio by linking a new session to it and setting it to active. Useful when resuming work in a previously created worktree.',
     schema: adoptStudioSchema,
     handler: handleAdoptStudio,
+  },
+  {
+    name: 'register_studio',
+    description:
+      'Register an existing repository as a studio. Creates a studio row for the root repo if one does not exist, or returns the existing one. Use this to make repos visible in the dashboard without starting a session.',
+    schema: registerStudioSchema,
+    handler: handleRegisterStudio,
   },
 ];

--- a/packages/api/src/mcp/tools/studio-handlers.ts
+++ b/packages/api/src/mcp/tools/studio-handlers.ts
@@ -615,13 +615,19 @@ export async function handleRegisterStudio(args: unknown, dataComposer: DataComp
   const parsed = registerStudioSchema.parse(args);
   const { user } = await resolveUserOrThrow(parsed, dataComposer);
 
-  const studioId = await resolveMainStudio(
+  // Check if studio already exists before auto-create
+  const existingId = await resolveMainStudio(
     dataComposer.getClient(),
     user.id,
     parsed.repoRoot,
-    parsed.agentId,
-    { autoCreate: true }
+    parsed.agentId
   );
+
+  const studioId =
+    existingId ??
+    (await resolveMainStudio(dataComposer.getClient(), user.id, parsed.repoRoot, parsed.agentId, {
+      autoCreate: true,
+    }));
 
   if (!studioId) {
     return errorResponse('Failed to register studio — could not create or find studio row');
@@ -631,8 +637,6 @@ export async function handleRegisterStudio(args: unknown, dataComposer: DataComp
   if (!studio) {
     return errorResponse('Studio was created but could not be retrieved');
   }
-
-  const wasCreated = !!(studio.metadata as Record<string, unknown>)?.autoCreated;
 
   return successResponse({
     studio: {
@@ -644,7 +648,7 @@ export async function handleRegisterStudio(args: unknown, dataComposer: DataComp
       agentId: studio.agentId,
       status: studio.status,
     },
-    created: wasCreated,
+    created: !existingId,
   });
 }
 

--- a/packages/cli/src/commands/studio.ts
+++ b/packages/cli/src/commands/studio.ts
@@ -1469,6 +1469,56 @@ export {
 };
 export type { InitResult };
 
+async function registerStudioCommand(options: { agent?: string }): Promise<void> {
+  const gitRoot = findGitRoot();
+  const repoRoot = resolveCanonicalRepoRoot(gitRoot);
+  const agentId = options.agent || resolveAgentId();
+  const email = getCurrentUser();
+
+  if (!agentId) {
+    console.error(chalk.red('No agent ID found. Use --agent <id> or set up .ink/identity.json'));
+    process.exit(1);
+  }
+
+  if (!email) {
+    console.error(chalk.red('No user identity found. Run ink login first.'));
+    process.exit(1);
+  }
+
+  const repoName = basename(repoRoot);
+  console.log(chalk.dim(`Registering ${repoName} for agent ${agentId}...`));
+
+  try {
+    const result = await callPcpTool('register_studio', {
+      email,
+      agentId,
+      repoRoot,
+    });
+
+    if (result.error) {
+      console.error(chalk.red(`Failed: ${(result as Record<string, unknown>).error}`));
+      process.exit(1);
+    }
+
+    const studio = result.studio as Record<string, string>;
+    const wasCreated = result.created as boolean;
+
+    if (wasCreated) {
+      console.log(chalk.green(`✓ Registered studio for ${repoName}`));
+    } else {
+      console.log(chalk.green(`✓ Studio already exists for ${repoName}`));
+    }
+    console.log(chalk.dim(`  id:    ${studio.id}`));
+    console.log(chalk.dim(`  slug:  ${studio.slug}`));
+    console.log(chalk.dim(`  agent: ${studio.agentId}`));
+    console.log(chalk.dim(`  path:  ${studio.worktreePath}`));
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(chalk.red(`Failed to register studio: ${message}`));
+    process.exit(1);
+  }
+}
+
 export function registerStudioCommands(program: Command): void {
   const studio = program
     .command('studio')
@@ -1584,6 +1634,12 @@ export function registerStudioCommands(program: Command): void {
     .option('-n, --name <name>', 'Binary name (default: ink-<agent> from .ink/identity.json)')
     .option('--unlink', 'Remove the linked binary instead of creating it')
     .action(cliLinkCommand);
+
+  studio
+    .command('register')
+    .description('Register the current repository as a studio (makes it visible in the dashboard)')
+    .option('-a, --agent <agent>', 'Agent ID to own the studio')
+    .action(registerStudioCommand);
 
   registerStudioSandboxCommands(studio);
 }


### PR DESCRIPTION
## Summary

- Adds `ink studio register` CLI command and `register_studio` MCP tool for registering existing repositories as studios without starting a session
- Run `ink studio register` in any git repo with `.ink/identity.json` to create (or find) the root-repo studio row, making the repo visible in the Command Center dashboard
- Builds on #374's `resolveMainStudio` auto-create infrastructure

## Usage

```bash
# In any initialized repo
cd ~/ws/inkah
ink studio register

# With explicit agent
ink studio register --agent wren
```

## Test plan

- [x] Full test suite: 2408 passing (137 files)
- [x] CLI type-check clean
- [ ] Manual: run `ink studio register` in inkah, inktrade, pcp — verify studio rows created
- [ ] Manual: verify studios appear in Command Center dashboard

— Wren