### PR TITLE
feat: audio provider abstraction with ElevenLabs TTS (by Wren)

### DIFF
--- a/packages/api/src/channels/audio-transcription.test.ts
+++ b/packages/api/src/channels/audio-transcription.test.ts
@@ -42,7 +42,7 @@ describe('AudioTranscriptionService', () => {
   });
 
   it('transcribes audio file via OpenAI endpoint', async () => {
-    const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'pcp-audio-test-'));
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'ink-audio-test-'));
     const filePath = path.join(tmpDir, 'note.ogg');
     await writeFile(filePath, Buffer.from('test-audio-bytes'));
 
@@ -79,7 +79,7 @@ describe('AudioTranscriptionService', () => {
   });
 
   it('falls back to CLI provider when OpenAI transcription fails', async () => {
-    const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'pcp-audio-cli-test-'));
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'ink-audio-cli-test-'));
     const filePath = path.join(tmpDir, 'note.ogg');
     await writeFile(filePath, Buffer.from('transcript from cli provider'));
 

--- a/packages/api/src/channels/audio-transcription.ts
+++ b/packages/api/src/channels/audio-transcription.ts
@@ -1,32 +1,12 @@
-import { readFile, stat } from 'fs/promises';
-import path from 'path';
+import { stat } from 'fs/promises';
 import { logger } from '../utils/logger';
-import {
-  normalizeBaseUrl,
-  parseIntEnv,
-  parseProviderList,
-  runShellCommand,
-  shellEscape,
-  truncate,
-} from './provider-utils';
+import { normalizeBaseUrl, parseIntEnv, parseProviderList, truncate } from './provider-utils';
+import { OpenAITranscriptionProvider, CliTranscriptionProvider } from './audio';
+import type { AudioTranscriptionProvider, AudioTranscriptionInput } from './audio';
 
-const DEFAULT_MODEL = 'gpt-4o-mini-transcribe';
-const DEFAULT_TIMEOUT_MS = 30_000;
-const DEFAULT_MAX_BYTES = 20 * 1024 * 1024; // 20MB
-const DEFAULT_MAX_CHARS = 4_000;
+export type { AudioTranscriptionInput };
+
 const DEFAULT_PROVIDER_ORDER = ['openai', 'cli'];
-
-function normalizeMime(value?: string): string {
-  if (!value) return 'application/octet-stream';
-  return value.trim() || 'application/octet-stream';
-}
-
-
-export interface AudioTranscriptionInput {
-  filePath: string;
-  contentType?: string;
-  filename?: string;
-}
 
 export interface AudioTranscriptionConfig {
   enabled: boolean;
@@ -40,85 +20,6 @@ export interface AudioTranscriptionConfig {
   cliCommand?: string;
 }
 
-interface AudioTranscriptionProvider {
-  name: string;
-  transcribe(input: AudioTranscriptionInput): Promise<string | undefined>;
-}
-
-class OpenAITranscriptionProvider implements AudioTranscriptionProvider {
-  readonly name = 'openai';
-
-  constructor(
-    private readonly config: Pick<
-      AudioTranscriptionConfig,
-      'apiKey' | 'baseUrl' | 'model' | 'timeoutMs'
-    >
-  ) {}
-
-  async transcribe(input: AudioTranscriptionInput): Promise<string | undefined> {
-    if (!this.config.apiKey) return undefined;
-
-    const bytes = await readFile(input.filePath);
-    const filename = input.filename?.trim() || path.basename(input.filePath) || 'audio';
-    const mime = normalizeMime(input.contentType);
-
-    const form = new FormData();
-    form.append('file', new Blob([new Uint8Array(bytes)], { type: mime }), filename);
-    form.append('model', this.config.model);
-
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), this.config.timeoutMs);
-
-    try {
-      const response = await fetch(`${this.config.baseUrl}/audio/transcriptions`, {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${this.config.apiKey}`,
-        },
-        body: form,
-        signal: controller.signal,
-      });
-
-      if (!response.ok) {
-        return undefined;
-      }
-
-      const payload = (await response.json()) as { text?: string };
-      return payload.text?.trim() || undefined;
-    } finally {
-      clearTimeout(timeout);
-    }
-  }
-}
-
-class CliTranscriptionProvider implements AudioTranscriptionProvider {
-  readonly name = 'cli';
-
-  constructor(
-    private readonly commandTemplate: string,
-    private readonly timeoutMs: number
-  ) {}
-
-  async transcribe(input: AudioTranscriptionInput): Promise<string | undefined> {
-    const command = this.commandTemplate
-      .replace(/\{input\}/g, shellEscape(input.filePath))
-      .replace(/\{mime\}/g, shellEscape(normalizeMime(input.contentType)));
-
-    const result = await runShellCommand(command, this.timeoutMs);
-    if (result.timedOut || result.code !== 0) {
-      logger.warn('Audio transcription CLI provider failed', {
-        code: result.code,
-        timedOut: result.timedOut,
-        stderr: result.stderr.slice(0, 200),
-      });
-      return undefined;
-    }
-
-    const transcript = result.stdout.trim();
-    return transcript || undefined;
-  }
-}
-
 export class AudioTranscriptionService {
   private readonly providers: AudioTranscriptionProvider[];
 
@@ -126,10 +27,10 @@ export class AudioTranscriptionService {
     const enabled = process.env.AUDIO_TRANSCRIPTION_ENABLED !== 'false';
     const apiKey = process.env.OPENAI_API_KEY;
     const baseUrl = normalizeBaseUrl(process.env.AUDIO_TRANSCRIPTION_BASE_URL);
-    const model = process.env.AUDIO_TRANSCRIPTION_MODEL?.trim() || DEFAULT_MODEL;
-    const timeoutMs = parseIntEnv(process.env.AUDIO_TRANSCRIPTION_TIMEOUT_MS, DEFAULT_TIMEOUT_MS);
-    const maxBytes = parseIntEnv(process.env.AUDIO_TRANSCRIPTION_MAX_BYTES, DEFAULT_MAX_BYTES);
-    const maxChars = parseIntEnv(process.env.AUDIO_TRANSCRIPTION_MAX_CHARS, DEFAULT_MAX_CHARS);
+    const model = process.env.AUDIO_TRANSCRIPTION_MODEL?.trim() || 'gpt-4o-mini-transcribe';
+    const timeoutMs = parseIntEnv(process.env.AUDIO_TRANSCRIPTION_TIMEOUT_MS, 30_000);
+    const maxBytes = parseIntEnv(process.env.AUDIO_TRANSCRIPTION_MAX_BYTES, 20 * 1024 * 1024);
+    const maxChars = parseIntEnv(process.env.AUDIO_TRANSCRIPTION_MAX_CHARS, 4_000);
     const providers = parseProviderList(
       process.env.AUDIO_TRANSCRIPTION_PROVIDERS,
       DEFAULT_PROVIDER_ORDER
@@ -163,17 +64,24 @@ export class AudioTranscriptionService {
     const providers: AudioTranscriptionProvider[] = [];
 
     for (const name of configured) {
-      if (name === 'openai') {
-        providers.push(
-          new OpenAITranscriptionProvider({
-            apiKey: this.config.apiKey,
-            baseUrl: this.config.baseUrl,
-            model: this.config.model,
-            timeoutMs: this.config.timeoutMs,
-          })
-        );
-      } else if (name === 'cli' && this.config.cliCommand) {
-        providers.push(new CliTranscriptionProvider(this.config.cliCommand, this.config.timeoutMs));
+      switch (name) {
+        case 'openai':
+          providers.push(
+            new OpenAITranscriptionProvider({
+              apiKey: this.config.apiKey,
+              baseUrl: this.config.baseUrl,
+              model: this.config.model,
+              timeoutMs: this.config.timeoutMs,
+            })
+          );
+          break;
+        case 'cli':
+          if (this.config.cliCommand) {
+            providers.push(
+              new CliTranscriptionProvider(this.config.cliCommand, this.config.timeoutMs)
+            );
+          }
+          break;
       }
     }
 

--- a/packages/api/src/channels/audio/audio-utils.test.ts
+++ b/packages/api/src/channels/audio/audio-utils.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from 'vitest';
 import { createTempAudioPath, removeTempAudioDir } from './audio-utils';
 
 describe('removeTempAudioDir', () => {
-  it('removes a pcp-tts-* directory under os.tmpdir()', async () => {
+  it('removes a ink-tts-* directory under os.tmpdir()', async () => {
     const filePath = await createTempAudioPath('mp3');
     await writeFile(filePath, 'test');
 
@@ -17,7 +17,7 @@ describe('removeTempAudioDir', () => {
     await expect(stat(dir)).rejects.toThrow();
   });
 
-  it('does not remove a non-pcp-tts directory', async () => {
+  it('does not remove a non-ink-tts directory', async () => {
     const dir = await mkdtemp(path.join(os.tmpdir(), 'other-prefix-'));
     const filePath = path.join(dir, 'audio.mp3');
     await writeFile(filePath, 'test');

--- a/packages/api/src/channels/audio/audio-utils.test.ts
+++ b/packages/api/src/channels/audio/audio-utils.test.ts
@@ -1,0 +1,36 @@
+import { mkdtemp, stat, writeFile } from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+import { createTempAudioPath, removeTempAudioDir } from './audio-utils';
+
+describe('removeTempAudioDir', () => {
+  it('removes a pcp-tts-* directory under os.tmpdir()', async () => {
+    const filePath = await createTempAudioPath('mp3');
+    await writeFile(filePath, 'test');
+
+    const dir = path.dirname(filePath);
+    expect((await stat(dir)).isDirectory()).toBe(true);
+
+    await removeTempAudioDir(filePath);
+
+    await expect(stat(dir)).rejects.toThrow();
+  });
+
+  it('does not remove a non-pcp-tts directory', async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), 'other-prefix-'));
+    const filePath = path.join(dir, 'audio.mp3');
+    await writeFile(filePath, 'test');
+
+    await removeTempAudioDir(filePath);
+
+    expect((await stat(dir)).isDirectory()).toBe(true);
+
+    const { rm } = await import('fs/promises');
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('no-ops on a relative path', async () => {
+    await removeTempAudioDir('reply.mp3');
+  });
+});

--- a/packages/api/src/channels/audio/audio-utils.ts
+++ b/packages/api/src/channels/audio/audio-utils.ts
@@ -1,0 +1,43 @@
+import { mkdtemp } from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { randomUUID } from 'crypto';
+
+export function extensionForFormat(format: string): string {
+  switch (format) {
+    case 'mp3':
+      return 'mp3';
+    case 'wav':
+      return 'wav';
+    case 'pcm':
+      return 'pcm';
+    case 'flac':
+      return 'flac';
+    case 'opus':
+      return 'ogg';
+    default:
+      return 'ogg';
+  }
+}
+
+export function contentTypeForFormat(format: string): string {
+  switch (format) {
+    case 'mp3':
+      return 'audio/mpeg';
+    case 'wav':
+      return 'audio/wav';
+    case 'pcm':
+      return 'audio/L16';
+    case 'flac':
+      return 'audio/flac';
+    case 'opus':
+      return 'audio/ogg';
+    default:
+      return 'audio/ogg';
+  }
+}
+
+export async function createTempAudioPath(extension: string): Promise<string> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), 'pcp-tts-'));
+  return path.join(dir, `${randomUUID()}.${extension}`);
+}

--- a/packages/api/src/channels/audio/audio-utils.ts
+++ b/packages/api/src/channels/audio/audio-utils.ts
@@ -42,6 +42,16 @@ export async function createTempAudioPath(extension: string): Promise<string> {
   return path.join(dir, `${randomUUID()}.${extension}`);
 }
 
+const TMP_PREFIX = 'pcp-tts-';
+
 export async function removeTempAudioDir(filePath: string): Promise<void> {
-  await rm(path.dirname(filePath), { recursive: true, force: true }).catch(() => {});
+  const dir = path.dirname(filePath);
+  const tmpRoot = os.tmpdir();
+  if (
+    path.isAbsolute(dir) &&
+    path.dirname(dir) === tmpRoot &&
+    path.basename(dir).startsWith(TMP_PREFIX)
+  ) {
+    await rm(dir, { recursive: true, force: true }).catch(() => {});
+  }
 }

--- a/packages/api/src/channels/audio/audio-utils.ts
+++ b/packages/api/src/channels/audio/audio-utils.ts
@@ -38,11 +38,11 @@ export function contentTypeForFormat(format: string): string {
 }
 
 export async function createTempAudioPath(extension: string): Promise<string> {
-  const dir = await mkdtemp(path.join(os.tmpdir(), 'pcp-tts-'));
+  const dir = await mkdtemp(path.join(os.tmpdir(), TMP_PREFIX));
   return path.join(dir, `${randomUUID()}.${extension}`);
 }
 
-const TMP_PREFIX = 'pcp-tts-';
+const TMP_PREFIX = 'ink-tts-';
 
 export async function removeTempAudioDir(filePath: string): Promise<void> {
   const dir = path.dirname(filePath);

--- a/packages/api/src/channels/audio/audio-utils.ts
+++ b/packages/api/src/channels/audio/audio-utils.ts
@@ -1,4 +1,4 @@
-import { mkdtemp } from 'fs/promises';
+import { mkdtemp, rm } from 'fs/promises';
 import os from 'os';
 import path from 'path';
 import { randomUUID } from 'crypto';
@@ -40,4 +40,8 @@ export function contentTypeForFormat(format: string): string {
 export async function createTempAudioPath(extension: string): Promise<string> {
   const dir = await mkdtemp(path.join(os.tmpdir(), 'pcp-tts-'));
   return path.join(dir, `${randomUUID()}.${extension}`);
+}
+
+export async function removeTempAudioDir(filePath: string): Promise<void> {
+  await rm(path.dirname(filePath), { recursive: true, force: true }).catch(() => {});
 }

--- a/packages/api/src/channels/audio/cli-stt.ts
+++ b/packages/api/src/channels/audio/cli-stt.ts
@@ -1,0 +1,36 @@
+import { logger } from '../../utils/logger';
+import { runShellCommand, shellEscape } from '../provider-utils';
+import type { AudioTranscriptionProvider, AudioTranscriptionInput } from './stt-provider';
+
+function normalizeMime(value?: string): string {
+  if (!value) return 'application/octet-stream';
+  return value.trim() || 'application/octet-stream';
+}
+
+export class CliTranscriptionProvider implements AudioTranscriptionProvider {
+  readonly name = 'cli';
+
+  constructor(
+    private readonly commandTemplate: string,
+    private readonly timeoutMs: number
+  ) {}
+
+  async transcribe(input: AudioTranscriptionInput): Promise<string | undefined> {
+    const command = this.commandTemplate
+      .replace(/\{input\}/g, shellEscape(input.filePath))
+      .replace(/\{mime\}/g, shellEscape(normalizeMime(input.contentType)));
+
+    const result = await runShellCommand(command, this.timeoutMs);
+    if (result.timedOut || result.code !== 0) {
+      logger.warn('Audio transcription CLI provider failed', {
+        code: result.code,
+        timedOut: result.timedOut,
+        stderr: result.stderr.slice(0, 200),
+      });
+      return undefined;
+    }
+
+    const transcript = result.stdout.trim();
+    return transcript || undefined;
+  }
+}

--- a/packages/api/src/channels/audio/cli-tts.ts
+++ b/packages/api/src/channels/audio/cli-tts.ts
@@ -1,7 +1,12 @@
-import { rm, stat } from 'fs/promises';
+import { stat } from 'fs/promises';
 import { logger } from '../../utils/logger';
 import { runShellCommand, shellEscape } from '../provider-utils';
-import { createTempAudioPath, extensionForFormat, contentTypeForFormat } from './audio-utils';
+import {
+  createTempAudioPath,
+  removeTempAudioDir,
+  extensionForFormat,
+  contentTypeForFormat,
+} from './audio-utils';
 import type { TextToSpeechProvider, TextToSpeechInput, SynthesizedAudio } from './tts-provider';
 
 export class CliTextToSpeechProvider implements TextToSpeechProvider {
@@ -26,7 +31,7 @@ export class CliTextToSpeechProvider implements TextToSpeechProvider {
 
     const result = await runShellCommand(command, this.timeoutMs);
     if (result.timedOut || result.code !== 0) {
-      await rm(filePath, { force: true }).catch(() => {});
+      await removeTempAudioDir(filePath);
       logger.warn('TTS CLI provider failed', {
         code: result.code,
         timedOut: result.timedOut,
@@ -38,11 +43,11 @@ export class CliTextToSpeechProvider implements TextToSpeechProvider {
     try {
       const details = await stat(filePath);
       if (details.size <= 0) {
-        await rm(filePath, { force: true }).catch(() => {});
+        await removeTempAudioDir(filePath);
         return undefined;
       }
     } catch {
-      await rm(filePath, { force: true }).catch(() => {});
+      await removeTempAudioDir(filePath);
       return undefined;
     }
 
@@ -51,7 +56,7 @@ export class CliTextToSpeechProvider implements TextToSpeechProvider {
       contentType: contentTypeForFormat(this.format),
       filename: `reply.${extension}`,
       cleanup: async () => {
-        await rm(filePath, { force: true }).catch(() => {});
+        await removeTempAudioDir(filePath);
       },
     };
   }

--- a/packages/api/src/channels/audio/cli-tts.ts
+++ b/packages/api/src/channels/audio/cli-tts.ts
@@ -1,0 +1,58 @@
+import { rm, stat } from 'fs/promises';
+import { logger } from '../../utils/logger';
+import { runShellCommand, shellEscape } from '../provider-utils';
+import { createTempAudioPath, extensionForFormat, contentTypeForFormat } from './audio-utils';
+import type { TextToSpeechProvider, TextToSpeechInput, SynthesizedAudio } from './tts-provider';
+
+export class CliTextToSpeechProvider implements TextToSpeechProvider {
+  readonly name = 'cli';
+
+  constructor(
+    private readonly commandTemplate: string,
+    private readonly timeoutMs: number,
+    private readonly format: string
+  ) {}
+
+  async synthesize(input: TextToSpeechInput): Promise<SynthesizedAudio | undefined> {
+    const prompt = input.text.trim();
+    if (!prompt) return undefined;
+
+    const extension = extensionForFormat(this.format);
+    const filePath = await createTempAudioPath(extension);
+    const command = this.commandTemplate
+      .replace(/\{text\}/g, shellEscape(prompt))
+      .replace(/\{output\}/g, shellEscape(filePath))
+      .replace(/\{format\}/g, shellEscape(this.format));
+
+    const result = await runShellCommand(command, this.timeoutMs);
+    if (result.timedOut || result.code !== 0) {
+      await rm(filePath, { force: true }).catch(() => {});
+      logger.warn('TTS CLI provider failed', {
+        code: result.code,
+        timedOut: result.timedOut,
+        stderr: result.stderr.slice(0, 200),
+      });
+      return undefined;
+    }
+
+    try {
+      const details = await stat(filePath);
+      if (details.size <= 0) {
+        await rm(filePath, { force: true }).catch(() => {});
+        return undefined;
+      }
+    } catch {
+      await rm(filePath, { force: true }).catch(() => {});
+      return undefined;
+    }
+
+    return {
+      filePath,
+      contentType: contentTypeForFormat(this.format),
+      filename: `reply.${extension}`,
+      cleanup: async () => {
+        await rm(filePath, { force: true }).catch(() => {});
+      },
+    };
+  }
+}

--- a/packages/api/src/channels/audio/elevenlabs-tts.test.ts
+++ b/packages/api/src/channels/audio/elevenlabs-tts.test.ts
@@ -1,0 +1,105 @@
+import { rm, readFile } from 'fs/promises';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ElevenLabsTextToSpeechProvider } from './elevenlabs-tts';
+
+describe('ElevenLabsTextToSpeechProvider', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns undefined when no API key is set', async () => {
+    const provider = new ElevenLabsTextToSpeechProvider({});
+    const result = await provider.synthesize({ text: 'hello' });
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined for empty text', async () => {
+    const provider = new ElevenLabsTextToSpeechProvider({ apiKey: 'test-key' });
+    const result = await provider.synthesize({ text: '   ' });
+    expect(result).toBeUndefined();
+  });
+
+  it('synthesizes audio via ElevenLabs API', async () => {
+    const raw = new Uint8Array([0x66, 0x61, 0x6b, 0x65, 0x2d, 0x6d, 0x70, 0x33]);
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        arrayBuffer: async () => raw.buffer.slice(raw.byteOffset, raw.byteOffset + raw.byteLength),
+      }))
+    );
+
+    const provider = new ElevenLabsTextToSpeechProvider({
+      apiKey: 'test-key',
+      voice: 'test-voice',
+      model: 'eleven_flash_v2_5',
+    });
+
+    const result = await provider.synthesize({ text: 'hello world' });
+    expect(result).toBeDefined();
+    expect(result!.contentType).toBe('audio/mpeg');
+    expect(result!.filename).toBe('reply.mp3');
+
+    const written = await readFile(result!.filePath);
+    expect(written.length).toBe(raw.length);
+
+    await result!.cleanup();
+  });
+
+  it('sends correct request parameters', async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      arrayBuffer: async () => Buffer.from('audio').buffer.slice(0),
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const provider = new ElevenLabsTextToSpeechProvider({
+      apiKey: 'my-key',
+      voice: 'my-voice',
+      model: 'my-model',
+      format: 'pcm_16000',
+      baseUrl: 'https://custom.api.com/v1',
+    });
+
+    const result = await provider.synthesize({ text: 'test' });
+    expect(result).toBeDefined();
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, options] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://custom.api.com/v1/text-to-speech/my-voice?output_format=pcm_16000');
+    expect(options.method).toBe('POST');
+    expect(options.headers['xi-api-key']).toBe('my-key');
+
+    const body = JSON.parse(options.body);
+    expect(body.text).toBe('test');
+    expect(body.model_id).toBe('my-model');
+
+    await result!.cleanup();
+  });
+
+  it('returns undefined on non-ok response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: false }))
+    );
+
+    const provider = new ElevenLabsTextToSpeechProvider({ apiKey: 'test-key' });
+    const result = await provider.synthesize({ text: 'hello' });
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined on empty response body', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        arrayBuffer: async () => new ArrayBuffer(0),
+      }))
+    );
+
+    const provider = new ElevenLabsTextToSpeechProvider({ apiKey: 'test-key' });
+    const result = await provider.synthesize({ text: 'hello' });
+    expect(result).toBeUndefined();
+  });
+});

--- a/packages/api/src/channels/audio/elevenlabs-tts.test.ts
+++ b/packages/api/src/channels/audio/elevenlabs-tts.test.ts
@@ -1,4 +1,5 @@
-import { rm, readFile } from 'fs/promises';
+import { readFile, stat } from 'fs/promises';
+import path from 'path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ElevenLabsTextToSpeechProvider } from './elevenlabs-tts';
 
@@ -87,6 +88,29 @@ describe('ElevenLabsTextToSpeechProvider', () => {
     const provider = new ElevenLabsTextToSpeechProvider({ apiKey: 'test-key' });
     const result = await provider.synthesize({ text: 'hello' });
     expect(result).toBeUndefined();
+  });
+
+  it('cleanup removes the parent temp directory', async () => {
+    const raw = new Uint8Array([0x61, 0x62, 0x63]);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        arrayBuffer: async () => raw.buffer.slice(raw.byteOffset, raw.byteOffset + raw.byteLength),
+      }))
+    );
+
+    const provider = new ElevenLabsTextToSpeechProvider({ apiKey: 'test-key' });
+    const result = await provider.synthesize({ text: 'hello' });
+    expect(result).toBeDefined();
+
+    const parentDir = path.dirname(result!.filePath);
+    const before = await stat(parentDir);
+    expect(before.isDirectory()).toBe(true);
+
+    await result!.cleanup();
+
+    await expect(stat(parentDir)).rejects.toThrow();
   });
 
   it('returns undefined on empty response body', async () => {

--- a/packages/api/src/channels/audio/elevenlabs-tts.ts
+++ b/packages/api/src/channels/audio/elevenlabs-tts.ts
@@ -1,6 +1,6 @@
-import { writeFile, rm } from 'fs/promises';
+import { writeFile } from 'fs/promises';
 import { truncate } from '../provider-utils';
-import { createTempAudioPath } from './audio-utils';
+import { createTempAudioPath, removeTempAudioDir } from './audio-utils';
 import type {
   TextToSpeechProvider,
   TextToSpeechProviderConfig,
@@ -88,7 +88,7 @@ export class ElevenLabsTextToSpeechProvider implements TextToSpeechProvider {
         contentType: outputFormatToContentType(this.format),
         filename: `reply.${extension}`,
         cleanup: async () => {
-          await rm(filePath, { force: true }).catch(() => {});
+          await removeTempAudioDir(filePath);
         },
       };
     } finally {

--- a/packages/api/src/channels/audio/elevenlabs-tts.ts
+++ b/packages/api/src/channels/audio/elevenlabs-tts.ts
@@ -1,0 +1,98 @@
+import { writeFile, rm } from 'fs/promises';
+import { truncate } from '../provider-utils';
+import { createTempAudioPath } from './audio-utils';
+import type {
+  TextToSpeechProvider,
+  TextToSpeechProviderConfig,
+  TextToSpeechInput,
+  SynthesizedAudio,
+} from './tts-provider';
+
+const DEFAULT_BASE_URL = 'https://api.elevenlabs.io/v1';
+const DEFAULT_MODEL = 'eleven_flash_v2_5';
+const DEFAULT_VOICE = 'JBFqnCBsd6RMkjVDRZzb';
+const DEFAULT_FORMAT = 'mp3_44100_128';
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_MAX_CHARS = 5_000;
+
+function outputFormatToExtension(format: string): string {
+  if (format.startsWith('mp3')) return 'mp3';
+  if (format.startsWith('pcm')) return 'pcm';
+  if (format === 'ulaw_8000') return 'wav';
+  return 'mp3';
+}
+
+function outputFormatToContentType(format: string): string {
+  if (format.startsWith('mp3')) return 'audio/mpeg';
+  if (format.startsWith('pcm')) return 'audio/L16';
+  if (format === 'ulaw_8000') return 'audio/wav';
+  return 'audio/mpeg';
+}
+
+export class ElevenLabsTextToSpeechProvider implements TextToSpeechProvider {
+  readonly name = 'elevenlabs';
+  private readonly apiKey: string | undefined;
+  private readonly baseUrl: string;
+  private readonly model: string;
+  private readonly voice: string;
+  private readonly format: string;
+  private readonly timeoutMs: number;
+  private readonly maxChars: number;
+
+  constructor(config: TextToSpeechProviderConfig = {}) {
+    this.apiKey = config.apiKey;
+    this.baseUrl = (config.baseUrl || DEFAULT_BASE_URL).replace(/\/+$/, '');
+    this.model = config.model || DEFAULT_MODEL;
+    this.voice = config.voice || DEFAULT_VOICE;
+    this.format = config.format || DEFAULT_FORMAT;
+    this.timeoutMs = config.timeoutMs || DEFAULT_TIMEOUT_MS;
+    this.maxChars = config.maxChars || DEFAULT_MAX_CHARS;
+  }
+
+  async synthesize(input: TextToSpeechInput): Promise<SynthesizedAudio | undefined> {
+    if (!this.apiKey) return undefined;
+
+    const prompt = truncate(input.text.trim(), this.maxChars);
+    if (!prompt) return undefined;
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    try {
+      const url = `${this.baseUrl}/text-to-speech/${this.voice}?output_format=${this.format}`;
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'xi-api-key': this.apiKey,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          text: prompt,
+          model_id: this.model,
+        }),
+        signal: controller.signal,
+      });
+
+      if (!response.ok) return undefined;
+
+      const arrayBuffer = await response.arrayBuffer();
+      const bytes = Buffer.from(arrayBuffer);
+      if (bytes.length === 0) return undefined;
+
+      const extension = outputFormatToExtension(this.format);
+      const filePath = await createTempAudioPath(extension);
+      await writeFile(filePath, bytes);
+
+      return {
+        filePath,
+        contentType: outputFormatToContentType(this.format),
+        filename: `reply.${extension}`,
+        cleanup: async () => {
+          await rm(filePath, { force: true }).catch(() => {});
+        },
+      };
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}

--- a/packages/api/src/channels/audio/index.ts
+++ b/packages/api/src/channels/audio/index.ts
@@ -1,0 +1,19 @@
+export type {
+  TextToSpeechProvider,
+  TextToSpeechProviderConfig,
+  TextToSpeechInput,
+  SynthesizedAudio,
+} from './tts-provider';
+export type {
+  AudioTranscriptionProvider,
+  AudioTranscriptionProviderConfig,
+  AudioTranscriptionInput,
+} from './stt-provider';
+
+export { OpenAITextToSpeechProvider } from './openai-tts';
+export { ElevenLabsTextToSpeechProvider } from './elevenlabs-tts';
+export { CliTextToSpeechProvider } from './cli-tts';
+export { OpenAITranscriptionProvider } from './openai-stt';
+export { CliTranscriptionProvider } from './cli-stt';
+
+export { extensionForFormat, contentTypeForFormat, createTempAudioPath } from './audio-utils';

--- a/packages/api/src/channels/audio/index.ts
+++ b/packages/api/src/channels/audio/index.ts
@@ -16,4 +16,9 @@ export { CliTextToSpeechProvider } from './cli-tts';
 export { OpenAITranscriptionProvider } from './openai-stt';
 export { CliTranscriptionProvider } from './cli-stt';
 
-export { extensionForFormat, contentTypeForFormat, createTempAudioPath } from './audio-utils';
+export {
+  extensionForFormat,
+  contentTypeForFormat,
+  createTempAudioPath,
+  removeTempAudioDir,
+} from './audio-utils';

--- a/packages/api/src/channels/audio/openai-stt.ts
+++ b/packages/api/src/channels/audio/openai-stt.ts
@@ -1,0 +1,64 @@
+import { readFile } from 'fs/promises';
+import path from 'path';
+import type {
+  AudioTranscriptionProvider,
+  AudioTranscriptionProviderConfig,
+  AudioTranscriptionInput,
+} from './stt-provider';
+
+const DEFAULT_BASE_URL = 'https://api.openai.com/v1';
+const DEFAULT_MODEL = 'gpt-4o-mini-transcribe';
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+function normalizeMime(value?: string): string {
+  if (!value) return 'application/octet-stream';
+  return value.trim() || 'application/octet-stream';
+}
+
+export class OpenAITranscriptionProvider implements AudioTranscriptionProvider {
+  readonly name = 'openai';
+  private readonly apiKey: string | undefined;
+  private readonly baseUrl: string;
+  private readonly model: string;
+  private readonly timeoutMs: number;
+
+  constructor(config: AudioTranscriptionProviderConfig = {}) {
+    this.apiKey = config.apiKey;
+    this.baseUrl = (config.baseUrl || DEFAULT_BASE_URL).replace(/\/+$/, '');
+    this.model = config.model || DEFAULT_MODEL;
+    this.timeoutMs = config.timeoutMs || DEFAULT_TIMEOUT_MS;
+  }
+
+  async transcribe(input: AudioTranscriptionInput): Promise<string | undefined> {
+    if (!this.apiKey) return undefined;
+
+    const bytes = await readFile(input.filePath);
+    const filename = input.filename?.trim() || path.basename(input.filePath) || 'audio';
+    const mime = normalizeMime(input.contentType);
+
+    const form = new FormData();
+    form.append('file', new Blob([new Uint8Array(bytes)], { type: mime }), filename);
+    form.append('model', this.model);
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    try {
+      const response = await fetch(`${this.baseUrl}/audio/transcriptions`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${this.apiKey}`,
+        },
+        body: form,
+        signal: controller.signal,
+      });
+
+      if (!response.ok) return undefined;
+
+      const payload = (await response.json()) as { text?: string };
+      return payload.text?.trim() || undefined;
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}

--- a/packages/api/src/channels/audio/openai-tts.ts
+++ b/packages/api/src/channels/audio/openai-tts.ts
@@ -1,6 +1,11 @@
-import { writeFile, rm } from 'fs/promises';
+import { writeFile } from 'fs/promises';
 import { truncate } from '../provider-utils';
-import { createTempAudioPath, extensionForFormat, contentTypeForFormat } from './audio-utils';
+import {
+  createTempAudioPath,
+  removeTempAudioDir,
+  extensionForFormat,
+  contentTypeForFormat,
+} from './audio-utils';
 import type {
   TextToSpeechProvider,
   TextToSpeechProviderConfig,
@@ -75,7 +80,7 @@ export class OpenAITextToSpeechProvider implements TextToSpeechProvider {
         contentType: contentTypeForFormat(this.format),
         filename: `reply.${extension}`,
         cleanup: async () => {
-          await rm(filePath, { force: true }).catch(() => {});
+          await removeTempAudioDir(filePath);
         },
       };
     } finally {

--- a/packages/api/src/channels/audio/openai-tts.ts
+++ b/packages/api/src/channels/audio/openai-tts.ts
@@ -1,0 +1,85 @@
+import { writeFile, rm } from 'fs/promises';
+import { truncate } from '../provider-utils';
+import { createTempAudioPath, extensionForFormat, contentTypeForFormat } from './audio-utils';
+import type {
+  TextToSpeechProvider,
+  TextToSpeechProviderConfig,
+  TextToSpeechInput,
+  SynthesizedAudio,
+} from './tts-provider';
+
+const DEFAULT_BASE_URL = 'https://api.openai.com/v1';
+const DEFAULT_MODEL = 'gpt-4o-mini-tts';
+const DEFAULT_VOICE = 'alloy';
+const DEFAULT_FORMAT = 'opus';
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_MAX_CHARS = 4_000;
+
+export class OpenAITextToSpeechProvider implements TextToSpeechProvider {
+  readonly name = 'openai';
+  private readonly apiKey: string | undefined;
+  private readonly baseUrl: string;
+  private readonly model: string;
+  private readonly voice: string;
+  private readonly format: string;
+  private readonly timeoutMs: number;
+  private readonly maxChars: number;
+
+  constructor(config: TextToSpeechProviderConfig = {}) {
+    this.apiKey = config.apiKey;
+    this.baseUrl = (config.baseUrl || DEFAULT_BASE_URL).replace(/\/+$/, '');
+    this.model = config.model || DEFAULT_MODEL;
+    this.voice = config.voice || DEFAULT_VOICE;
+    this.format = config.format || DEFAULT_FORMAT;
+    this.timeoutMs = config.timeoutMs || DEFAULT_TIMEOUT_MS;
+    this.maxChars = config.maxChars || DEFAULT_MAX_CHARS;
+  }
+
+  async synthesize(input: TextToSpeechInput): Promise<SynthesizedAudio | undefined> {
+    if (!this.apiKey) return undefined;
+
+    const prompt = truncate(input.text.trim(), this.maxChars);
+    if (!prompt) return undefined;
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    try {
+      const response = await fetch(`${this.baseUrl}/audio/speech`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${this.apiKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          model: this.model,
+          voice: this.voice,
+          input: prompt,
+          response_format: this.format,
+        }),
+        signal: controller.signal,
+      });
+
+      if (!response.ok) return undefined;
+
+      const arrayBuffer = await response.arrayBuffer();
+      const bytes = Buffer.from(arrayBuffer);
+      if (bytes.length === 0) return undefined;
+
+      const extension = extensionForFormat(this.format);
+      const filePath = await createTempAudioPath(extension);
+      await writeFile(filePath, bytes);
+
+      return {
+        filePath,
+        contentType: contentTypeForFormat(this.format),
+        filename: `reply.${extension}`,
+        cleanup: async () => {
+          await rm(filePath, { force: true }).catch(() => {});
+        },
+      };
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}

--- a/packages/api/src/channels/audio/stt-provider.ts
+++ b/packages/api/src/channels/audio/stt-provider.ts
@@ -1,0 +1,17 @@
+export interface AudioTranscriptionInput {
+  filePath: string;
+  contentType?: string;
+  filename?: string;
+}
+
+export interface AudioTranscriptionProvider {
+  readonly name: string;
+  transcribe(input: AudioTranscriptionInput): Promise<string | undefined>;
+}
+
+export interface AudioTranscriptionProviderConfig {
+  apiKey?: string;
+  baseUrl?: string;
+  model?: string;
+  timeoutMs?: number;
+}

--- a/packages/api/src/channels/audio/tts-provider.ts
+++ b/packages/api/src/channels/audio/tts-provider.ts
@@ -1,0 +1,25 @@
+export interface TextToSpeechInput {
+  text: string;
+}
+
+export interface SynthesizedAudio {
+  filePath: string;
+  contentType: string;
+  filename: string;
+  cleanup: () => Promise<void>;
+}
+
+export interface TextToSpeechProvider {
+  readonly name: string;
+  synthesize(input: TextToSpeechInput): Promise<SynthesizedAudio | undefined>;
+}
+
+export interface TextToSpeechProviderConfig {
+  apiKey?: string;
+  baseUrl?: string;
+  model?: string;
+  voice?: string;
+  format?: string;
+  timeoutMs?: number;
+  maxChars?: number;
+}

--- a/packages/api/src/channels/text-to-speech.test.ts
+++ b/packages/api/src/channels/text-to-speech.test.ts
@@ -64,7 +64,7 @@ describe('TextToSpeechService', () => {
   });
 
   it('returns synthesized audio from provider chain', async () => {
-    const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'pcp-tts-test-'));
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'ink-tts-test-'));
     const filePath = path.join(tmpDir, 'reply.ogg');
     await writeFile(filePath, Buffer.from('audio-bytes'));
 

--- a/packages/api/src/channels/text-to-speech.test.ts
+++ b/packages/api/src/channels/text-to-speech.test.ts
@@ -31,6 +31,38 @@ describe('TextToSpeechService', () => {
     expect(result).toBeUndefined();
   });
 
+  it('builds elevenlabs provider from config', () => {
+    const service = new TextToSpeechService({
+      enabled: true,
+      baseUrl: 'https://api.openai.com/v1',
+      model: 'gpt-4o-mini-tts',
+      voice: 'alloy',
+      format: 'opus',
+      timeoutMs: 5000,
+      maxChars: 1000,
+      providers: ['elevenlabs', 'openai'],
+      elevenlabsApiKey: 'el-test-key',
+    });
+
+    expect(service.isEnabled()).toBe(true);
+  });
+
+  it('skips elevenlabs when no API key and falls through', async () => {
+    const service = new TextToSpeechService({
+      enabled: true,
+      baseUrl: 'https://api.openai.com/v1',
+      model: 'gpt-4o-mini-tts',
+      voice: 'alloy',
+      format: 'opus',
+      timeoutMs: 5000,
+      maxChars: 1000,
+      providers: ['elevenlabs'],
+    });
+
+    const result = await service.synthesize({ text: 'hello' });
+    expect(result).toBeUndefined();
+  });
+
   it('returns synthesized audio from provider chain', async () => {
     const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'pcp-tts-test-'));
     const filePath = path.join(tmpDir, 'reply.ogg');

--- a/packages/api/src/channels/text-to-speech.ts
+++ b/packages/api/src/channels/text-to-speech.ts
@@ -1,78 +1,20 @@
-import { mkdtemp, rm, stat, writeFile } from 'fs/promises';
-import os from 'os';
-import path from 'path';
-import { randomUUID } from 'crypto';
 import { logger } from '../utils/logger';
+import { normalizeBaseUrl, parseIntEnv, parseProviderList } from './provider-utils';
 import {
-  normalizeBaseUrl,
-  parseIntEnv,
-  parseProviderList,
-  runShellCommand,
-  shellEscape,
-  truncate,
-} from './provider-utils';
+  OpenAITextToSpeechProvider,
+  ElevenLabsTextToSpeechProvider,
+  CliTextToSpeechProvider,
+} from './audio';
+import type { TextToSpeechProvider, TextToSpeechInput, SynthesizedAudio } from './audio';
 
-const DEFAULT_MODEL = 'gpt-4o-mini-tts';
-const DEFAULT_VOICE = 'alloy';
-const DEFAULT_FORMAT = 'opus';
-const DEFAULT_TIMEOUT_MS = 30_000;
-const DEFAULT_MAX_CHARS = 4_000;
+export type { TextToSpeechInput, SynthesizedAudio };
+
 const DEFAULT_PROVIDER_ORDER = ['openai', 'cli'];
 
 function normalizeFormat(value: string | undefined): string {
   const format = value?.trim().toLowerCase();
-  if (!format) return DEFAULT_FORMAT;
+  if (!format) return 'opus';
   return format;
-}
-
-function extensionForFormat(format: string): string {
-  switch (format) {
-    case 'mp3':
-      return 'mp3';
-    case 'wav':
-      return 'wav';
-    case 'pcm':
-      return 'pcm';
-    case 'flac':
-      return 'flac';
-    case 'opus':
-      return 'ogg';
-    default:
-      return 'ogg';
-  }
-}
-
-function contentTypeForFormat(format: string): string {
-  switch (format) {
-    case 'mp3':
-      return 'audio/mpeg';
-    case 'wav':
-      return 'audio/wav';
-    case 'pcm':
-      return 'audio/L16';
-    case 'flac':
-      return 'audio/flac';
-    case 'opus':
-      return 'audio/ogg';
-    default:
-      return 'audio/ogg';
-  }
-}
-
-async function createTempAudioPath(extension: string): Promise<string> {
-  const dir = await mkdtemp(path.join(os.tmpdir(), 'pcp-tts-'));
-  return path.join(dir, `${randomUUID()}.${extension}`);
-}
-
-export interface TextToSpeechInput {
-  text: string;
-}
-
-export interface SynthesizedAudio {
-  filePath: string;
-  contentType: string;
-  filename: string;
-  cleanup: () => Promise<void>;
 }
 
 export interface TextToSpeechConfig {
@@ -86,123 +28,9 @@ export interface TextToSpeechConfig {
   maxChars: number;
   providers?: string[];
   cliCommand?: string;
-}
-
-interface TextToSpeechProvider {
-  name: string;
-  synthesize(input: TextToSpeechInput): Promise<SynthesizedAudio | undefined>;
-}
-
-class OpenAITextToSpeechProvider implements TextToSpeechProvider {
-  readonly name = 'openai';
-
-  constructor(
-    private readonly config: Pick<
-      TextToSpeechConfig,
-      'apiKey' | 'baseUrl' | 'model' | 'voice' | 'format' | 'timeoutMs' | 'maxChars'
-    >
-  ) {}
-
-  async synthesize(input: TextToSpeechInput): Promise<SynthesizedAudio | undefined> {
-    if (!this.config.apiKey) return undefined;
-
-    const prompt = truncate(input.text.trim(), this.config.maxChars);
-    if (!prompt) return undefined;
-
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), this.config.timeoutMs);
-
-    try {
-      const response = await fetch(`${this.config.baseUrl}/audio/speech`, {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${this.config.apiKey}`,
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          model: this.config.model,
-          voice: this.config.voice,
-          input: prompt,
-          response_format: this.config.format,
-        }),
-        signal: controller.signal,
-      });
-
-      if (!response.ok) return undefined;
-
-      const arrayBuffer = await response.arrayBuffer();
-      const bytes = Buffer.from(arrayBuffer);
-      if (bytes.length === 0) return undefined;
-
-      const extension = extensionForFormat(this.config.format);
-      const filePath = await createTempAudioPath(extension);
-      await writeFile(filePath, bytes);
-
-      return {
-        filePath,
-        contentType: contentTypeForFormat(this.config.format),
-        filename: `reply.${extension}`,
-        cleanup: async () => {
-          await rm(path.dirname(filePath), { recursive: true, force: true });
-        },
-      };
-    } finally {
-      clearTimeout(timeout);
-    }
-  }
-}
-
-class CliTextToSpeechProvider implements TextToSpeechProvider {
-  readonly name = 'cli';
-
-  constructor(
-    private readonly commandTemplate: string,
-    private readonly timeoutMs: number,
-    private readonly format: string
-  ) {}
-
-  async synthesize(input: TextToSpeechInput): Promise<SynthesizedAudio | undefined> {
-    const prompt = input.text.trim();
-    if (!prompt) return undefined;
-
-    const extension = extensionForFormat(this.format);
-    const filePath = await createTempAudioPath(extension);
-    const command = this.commandTemplate
-      .replace(/\{text\}/g, shellEscape(prompt))
-      .replace(/\{output\}/g, shellEscape(filePath))
-      .replace(/\{format\}/g, shellEscape(this.format));
-
-    const result = await runShellCommand(command, this.timeoutMs);
-    if (result.timedOut || result.code !== 0) {
-      await rm(path.dirname(filePath), { recursive: true, force: true });
-      logger.warn('TTS CLI provider failed', {
-        code: result.code,
-        timedOut: result.timedOut,
-        stderr: result.stderr.slice(0, 200),
-      });
-      return undefined;
-    }
-
-    try {
-      const details = await stat(filePath);
-      if (details.size <= 0) {
-        await rm(path.dirname(filePath), { recursive: true, force: true });
-        return undefined;
-      }
-    } catch {
-      await rm(path.dirname(filePath), { recursive: true, force: true });
-      return undefined;
-    }
-
-    return {
-      filePath,
-      contentType: contentTypeForFormat(this.format),
-      filename: `reply.${extension}`,
-      cleanup: async () => {
-        await rm(path.dirname(filePath), { recursive: true, force: true });
-      },
-    };
-  }
+  elevenlabsApiKey?: string;
+  elevenlabsVoice?: string;
+  elevenlabsModel?: string;
 }
 
 export class TextToSpeechService {
@@ -212,13 +40,16 @@ export class TextToSpeechService {
     const enabled = process.env.AUDIO_TTS_ENABLED === 'true';
     const apiKey = process.env.OPENAI_API_KEY;
     const baseUrl = normalizeBaseUrl(process.env.AUDIO_TTS_BASE_URL);
-    const model = process.env.AUDIO_TTS_MODEL?.trim() || DEFAULT_MODEL;
-    const voice = process.env.AUDIO_TTS_VOICE?.trim() || DEFAULT_VOICE;
+    const model = process.env.AUDIO_TTS_MODEL?.trim() || 'gpt-4o-mini-tts';
+    const voice = process.env.AUDIO_TTS_VOICE?.trim() || 'alloy';
     const format = normalizeFormat(process.env.AUDIO_TTS_FORMAT);
-    const timeoutMs = parseIntEnv(process.env.AUDIO_TTS_TIMEOUT_MS, DEFAULT_TIMEOUT_MS);
-    const maxChars = parseIntEnv(process.env.AUDIO_TTS_MAX_CHARS, DEFAULT_MAX_CHARS);
+    const timeoutMs = parseIntEnv(process.env.AUDIO_TTS_TIMEOUT_MS, 30_000);
+    const maxChars = parseIntEnv(process.env.AUDIO_TTS_MAX_CHARS, 4_000);
     const providers = parseProviderList(process.env.AUDIO_TTS_PROVIDERS, DEFAULT_PROVIDER_ORDER);
     const cliCommand = process.env.AUDIO_TTS_CLI_COMMAND?.trim();
+    const elevenlabsApiKey = process.env.ELEVENLABS_API_KEY?.trim();
+    const elevenlabsVoice = process.env.ELEVENLABS_TTS_VOICE?.trim();
+    const elevenlabsModel = process.env.ELEVENLABS_TTS_MODEL?.trim();
 
     return new TextToSpeechService({
       enabled,
@@ -231,6 +62,9 @@ export class TextToSpeechService {
       maxChars,
       providers,
       cliCommand,
+      elevenlabsApiKey,
+      elevenlabsVoice,
+      elevenlabsModel,
     });
   }
 
@@ -248,26 +82,41 @@ export class TextToSpeechService {
     const providers: TextToSpeechProvider[] = [];
 
     for (const name of configured) {
-      if (name === 'openai') {
-        providers.push(
-          new OpenAITextToSpeechProvider({
-            apiKey: this.config.apiKey,
-            baseUrl: this.config.baseUrl,
-            model: this.config.model,
-            voice: this.config.voice,
-            format: this.config.format,
-            timeoutMs: this.config.timeoutMs,
-            maxChars: this.config.maxChars,
-          })
-        );
-      } else if (name === 'cli' && this.config.cliCommand) {
-        providers.push(
-          new CliTextToSpeechProvider(
-            this.config.cliCommand,
-            this.config.timeoutMs,
-            this.config.format
-          )
-        );
+      switch (name) {
+        case 'openai':
+          providers.push(
+            new OpenAITextToSpeechProvider({
+              apiKey: this.config.apiKey,
+              baseUrl: this.config.baseUrl,
+              model: this.config.model,
+              voice: this.config.voice,
+              format: this.config.format,
+              timeoutMs: this.config.timeoutMs,
+              maxChars: this.config.maxChars,
+            })
+          );
+          break;
+        case 'elevenlabs':
+          providers.push(
+            new ElevenLabsTextToSpeechProvider({
+              apiKey: this.config.elevenlabsApiKey,
+              voice: this.config.elevenlabsVoice,
+              model: this.config.elevenlabsModel,
+              timeoutMs: this.config.timeoutMs,
+            })
+          );
+          break;
+        case 'cli':
+          if (this.config.cliCommand) {
+            providers.push(
+              new CliTextToSpeechProvider(
+                this.config.cliCommand,
+                this.config.timeoutMs,
+                this.config.format
+              )
+            );
+          }
+          break;
       }
     }
 


### PR DESCRIPTION
## Summary

- Extracts TTS and STT provider implementations from monolithic service files into `packages/api/src/channels/audio/` with a composition-based architecture
- Adds `TextToSpeechProvider` and `AudioTranscriptionProvider` interfaces — easy for others to implement new providers against
- Adds ElevenLabs TTS provider (`ELEVENLABS_API_KEY`, optional `ELEVENLABS_TTS_VOICE` / `ELEVENLABS_TTS_MODEL` env overrides)
- Existing OpenAI and CLI providers extracted into standalone modules
- Service files (`text-to-speech.ts`, `audio-transcription.ts`) now import from `./audio/` barrel — `buildProviders()` uses switch dispatch with `elevenlabs` as a new option
- Shared utilities (format mapping, temp file creation) in `audio-utils.ts`

### New files

```
packages/api/src/channels/audio/
├── index.ts              # barrel export
├── tts-provider.ts       # TextToSpeechProvider interface + types
├── stt-provider.ts       # AudioTranscriptionProvider interface + types
├── audio-utils.ts        # extensionForFormat, contentTypeForFormat, createTempAudioPath
├── openai-tts.ts         # OpenAI TTS provider
├── openai-stt.ts         # OpenAI STT (Whisper) provider
├── elevenlabs-tts.ts     # ElevenLabs TTS provider (NEW)
├── cli-tts.ts            # CLI TTS provider
├── cli-stt.ts            # CLI STT provider
└── elevenlabs-tts.test.ts
```

### Usage

Set `AUDIO_TTS_PROVIDERS=elevenlabs,openai,cli` and `ELEVENLABS_API_KEY=...` to enable ElevenLabs as the preferred TTS provider with OpenAI/CLI fallback.

## Test plan

- [x] All 172 existing channel tests pass
- [x] 6 new ElevenLabs provider tests (no key, empty text, synthesis, request params, non-ok response, empty body)
- [x] 2 new service-level tests (elevenlabs provider wiring, no-key fallthrough)
- [x] Type-check passes (no new errors)
- [ ] Manual: set `ELEVENLABS_API_KEY` and `AUDIO_TTS_PROVIDERS=elevenlabs` on dev server, send voice message via Telegram, verify ElevenLabs voice reply

— Wren