### PR TITLE
fix: clear channel_routes.active_session_id on session end (by Wren)

### DIFF
--- a/packages/api/src/mcp/tools/memory-handlers.ts
+++ b/packages/api/src/mcp/tools/memory-handlers.ts
@@ -1196,13 +1196,28 @@ export async function handleEndSession(args: unknown, dataComposer: DataComposer
     };
   }
 
-  // Clear cli_attached flag so triggers don't get stuck in the pending queue
-  // after the CLI detaches. endSession already sets ended_at which prevents
-  // matching, but this is belt-and-suspenders for edge cases.
   if (session) {
+    // Clear cli_attached flag so triggers don't get stuck in the pending queue
+    // after the CLI detaches.
     await dataComposer.repositories.memory
       .updateSession(session.id, { cliAttached: false })
       .catch(() => {});
+
+    // Clear stale channel_routes pointing to this session so heartbeat
+    // reminders don't try to route to a dead session and spawn duplicates.
+    await dataComposer
+      .getClient()
+      .from('channel_routes')
+      .update({ active_session_id: null })
+      .eq('active_session_id', session.id)
+      .then(({ error }) => {
+        if (error) {
+          logger.warn('Failed to clear channel_routes.active_session_id', {
+            sessionId: session.id,
+            error: error.message,
+          });
+        }
+      });
   }
 
   logger.info(`Session ended`, { sessionId: session.id, hasSummary: !!params.summary });

--- a/packages/api/src/services/sessions/session-service.ts
+++ b/packages/api/src/services/sessions/session-service.ts
@@ -1452,6 +1452,22 @@ This session will continue with a fresh context after compaction. Your identity,
       },
     });
 
+    // Clear stale channel_routes so heartbeat reminders don't route to this ended session
+    if (this.supabase) {
+      await this.supabase
+        .from('channel_routes')
+        .update({ active_session_id: null })
+        .eq('active_session_id', sessionId)
+        .then(({ error }) => {
+          if (error) {
+            logger.warn('Failed to clear channel_routes.active_session_id', {
+              sessionId,
+              error: error.message,
+            });
+          }
+        });
+    }
+
     logger.info('Session ended', { sessionId, summary });
   }
 


### PR DESCRIPTION
## Summary

- Clear `channel_routes.active_session_id` when sessions end, preventing stale route references from causing duplicate message dispatch
- Adds cleanup in both `SessionService.endSession()` (direct call path) and `handleEndSession()` (MCP tool path)
- Root cause of duplicate Myra heartbeat reminders: ended sessions stayed referenced in `channel_routes`, so the reminder dispatcher would route to both the stale session and the new one

## What was happening

1. Myra's heartbeat reminder fires → dispatcher looks up `channel_routes` for the Telegram channel
2. `channel_routes.active_session_id` pointed to an already-ended session
3. Dispatcher spawned a new session (correct) but the stale reference also triggered dispatch
4. Result: duplicate heartbeat messages sent to Telegram

## Fix

Both session-end codepaths now null out `active_session_id` on any `channel_routes` rows that reference the ending session. This is a safe no-op if no routes reference the session.

## Test plan

- [x] All 2429 tests pass (`npx vitest run`)
- [x] Manually verified: cleaned stale route in production DB, confirmed single heartbeat dispatch
- [ ] Monitor next heartbeat cycle to confirm no more duplicates

🤖 Generated with [Claude Code](https://claude.com/claude-code)