### PR TITLE
feat: multimodal image support — pass images directly to LLM (by Wren)

### DIFF
--- a/packages/api/src/channels/gateway.ts
+++ b/packages/api/src/channels/gateway.ts
@@ -59,6 +59,14 @@ export interface ChannelGatewayConfig {
   dataComposer?: DataComposer;
 }
 
+export interface GatewayMediaAttachment {
+  type: 'image' | 'video' | 'audio' | 'document';
+  path?: string;
+  url?: string;
+  contentType?: string;
+  filename?: string;
+}
+
 export type IncomingMessageHandler = (
   channel: GatewayChannel,
   conversationId: string,
@@ -67,7 +75,7 @@ export type IncomingMessageHandler = (
   metadata?: {
     userId?: string;
     replyToMessageId?: string;
-    media?: Array<{ type: 'image' | 'video' | 'audio' | 'document'; path?: string; url?: string }>;
+    media?: GatewayMediaAttachment[];
     chatType?: 'direct' | 'group' | 'channel';
     mentions?: { users: string[]; botMentioned: boolean };
     platformAccountId?: string;
@@ -86,7 +94,7 @@ const DEFAULT_BUFFER_DELAY_MS = 2000; // Wait 2 seconds for additional messages
 interface BufferedMessage {
   content: string;
   timestamp: Date;
-  media?: Array<{ type: 'image' | 'video' | 'audio' | 'document'; path?: string; url?: string }>;
+  media?: GatewayMediaAttachment[];
 }
 
 interface MessageBuffer {
@@ -390,11 +398,7 @@ export class ChannelGateway extends EventEmitter {
     metadata?: {
       userId?: string;
       replyToMessageId?: string;
-      media?: Array<{
-        type: 'image' | 'video' | 'audio' | 'document';
-        path?: string;
-        url?: string;
-      }>;
+      media?: GatewayMediaAttachment[];
       chatType?: 'direct' | 'group' | 'channel';
       mentions?: { users: string[]; botMentioned: boolean };
       platformAccountId?: string;
@@ -546,11 +550,7 @@ export class ChannelGateway extends EventEmitter {
     metadata?: {
       userId?: string;
       replyToMessageId?: string;
-      media?: Array<{
-        type: 'image' | 'video' | 'audio' | 'document';
-        path?: string;
-        url?: string;
-      }>;
+      media?: GatewayMediaAttachment[];
       chatType?: 'direct' | 'group' | 'channel';
       mentions?: { users: string[]; botMentioned: boolean };
       platformAccountId?: string;

--- a/packages/api/src/channels/media-group-buffer.test.ts
+++ b/packages/api/src/channels/media-group-buffer.test.ts
@@ -331,6 +331,27 @@ describe('MediaGroupBuffer', () => {
   // Metadata preservation
   // --------------------------------------------------------------------------
 
+  it('preserves contentType through combined media', async () => {
+    const msg1 = makeMessage({
+      messageId: 'msg-1',
+      media: [{ type: 'image', path: '/tmp/photo1.jpg', contentType: 'image/jpeg' }],
+    });
+    const msg2 = makeMessage({
+      messageId: 'msg-2',
+      media: [{ type: 'image', path: '/tmp/photo2.png', contentType: 'image/png' }],
+    });
+
+    buffer.add('group-1', msg1);
+    buffer.add('group-1', msg2);
+
+    await vi.advanceTimersByTimeAsync(500);
+
+    const combined = flushCallback.mock.calls[0][0] as InboundMessage;
+    expect(combined.media).toHaveLength(2);
+    expect(combined.media![0].contentType).toBe('image/jpeg');
+    expect(combined.media![1].contentType).toBe('image/png');
+  });
+
   it('preserves sender, conversationId, platform, and chatType from first message', async () => {
     const msg1 = makeMessage({
       sender: { id: '100', username: 'alice', name: 'Alice' },

--- a/packages/api/src/channels/telegram-listener.ts
+++ b/packages/api/src/channels/telegram-listener.ts
@@ -808,7 +808,7 @@ export class TelegramListener extends EventEmitter {
       const largestPhoto = msg.photo[msg.photo.length - 1];
       const localPath = await this.downloadFile(largestPhoto.file_id);
       if (localPath) {
-        mediaAttachments.push({ type: 'image', path: localPath });
+        mediaAttachments.push({ type: 'image', path: localPath, contentType: 'image/jpeg' });
         logger.info('Photo attachment downloaded', {
           fileId: largestPhoto.file_id,
           localPath,

--- a/packages/api/src/services/sessions/ink-runner.test.ts
+++ b/packages/api/src/services/sessions/ink-runner.test.ts
@@ -1,12 +1,59 @@
 import { describe, it, expect, vi } from 'vitest';
 import { InkRunner } from './ink-runner';
 import type { InkToolDefinition } from '../../agent/tools/pi-coding-tools';
+import type { ImageContent } from './types';
 
 vi.mock('../../utils/logger', () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
 }));
 
 describe('InkRunner', () => {
+  describe('buildUserContent', () => {
+    it('returns plain string when no images', () => {
+      const runner = new InkRunner({ apiKey: 'test-key' });
+      const result = (runner as any).buildUserContent('Hello world');
+      expect(result).toBe('Hello world');
+    });
+
+    it('returns plain string when images is empty array', () => {
+      const runner = new InkRunner({ apiKey: 'test-key' });
+      const result = (runner as any).buildUserContent('Hello world', []);
+      expect(result).toBe('Hello world');
+    });
+
+    it('returns multimodal content blocks when images are present', () => {
+      const runner = new InkRunner({ apiKey: 'test-key' });
+      const images: ImageContent[] = [
+        { type: 'image', source: 'base64', mediaType: 'image/jpeg', data: 'abc123' },
+      ];
+      const result = (runner as any).buildUserContent('Describe this', images);
+
+      expect(Array.isArray(result)).toBe(true);
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual({
+        type: 'image',
+        source: { type: 'base64', media_type: 'image/jpeg', data: 'abc123' },
+      });
+      expect(result[1]).toEqual({ type: 'text', text: 'Describe this' });
+    });
+
+    it('handles multiple images in a gallery', () => {
+      const runner = new InkRunner({ apiKey: 'test-key' });
+      const images: ImageContent[] = [
+        { type: 'image', source: 'base64', mediaType: 'image/jpeg', data: 'img1' },
+        { type: 'image', source: 'base64', mediaType: 'image/png', data: 'img2' },
+        { type: 'image', source: 'base64', mediaType: 'image/webp', data: 'img3' },
+      ];
+      const result = (runner as any).buildUserContent('Gallery caption', images);
+
+      expect(result).toHaveLength(4);
+      expect(result[0].type).toBe('image');
+      expect(result[1].type).toBe('image');
+      expect(result[2].type).toBe('image');
+      expect(result[3]).toEqual({ type: 'text', text: 'Gallery caption' });
+    });
+  });
+
   describe('agentId propagation', () => {
     it('creates guarded bash tools when agentId is provided', async () => {
       const runner = new InkRunner({ apiKey: 'test-key' });

--- a/packages/api/src/services/sessions/ink-runner.ts
+++ b/packages/api/src/services/sessions/ink-runner.ts
@@ -16,6 +16,7 @@ import type {
   ChannelType,
   IRunner,
   ToolCall,
+  ImageContent,
 } from './types.js';
 import { formatInjectedContext } from './context-builder.js';
 import { buildIdentityPrompt } from './claude-runner.js';
@@ -55,6 +56,7 @@ export class InkRunner implements IRunner {
       backendSessionId?: string;
       injectedContext?: InjectedContext;
       config: ClaudeRunnerConfig;
+      imageContents?: ImageContent[];
     }
   ): Promise<RunnerResult> {
     const { injectedContext, config } = options;
@@ -84,8 +86,11 @@ export class InkRunner implements IRunner {
       executorMap.set(tool.schema.name, tool.execute);
     }
 
+    // Build first user message — multimodal when images present
+    const userContent = this.buildUserContent(fullMessage, options.imageContents);
+
     // Run the agentic loop
-    const messages: Anthropic.MessageParam[] = [{ role: 'user', content: fullMessage }];
+    const messages: Anthropic.MessageParam[] = [{ role: 'user', content: userContent }];
     const responses: ChannelResponse[] = [];
     const toolCalls: ToolCall[] = [];
     let totalInputTokens = 0;
@@ -200,6 +205,27 @@ export class InkRunner implements IRunner {
       finalTextResponse: finalTextResponse || undefined,
       toolCalls,
     };
+  }
+
+  private buildUserContent(
+    text: string,
+    imageContents?: ImageContent[]
+  ): string | Anthropic.ContentBlockParam[] {
+    if (!imageContents || imageContents.length === 0) return text;
+
+    const blocks: Anthropic.ContentBlockParam[] = [];
+    for (const img of imageContents) {
+      blocks.push({
+        type: 'image',
+        source: {
+          type: 'base64',
+          media_type: img.mediaType as Anthropic.Base64ImageSource['media_type'],
+          data: img.data,
+        },
+      });
+    }
+    blocks.push({ type: 'text', text });
+    return blocks;
   }
 
   private ensureClient(): void {

--- a/packages/api/src/services/sessions/session-service.test.ts
+++ b/packages/api/src/services/sessions/session-service.test.ts
@@ -39,6 +39,17 @@ vi.mock('./claude-runner.js', async (importOriginal) => {
   };
 });
 
+// Mock fs/promises for readImageAttachments tests
+vi.mock('fs/promises', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    stat: vi.fn().mockResolvedValue({ size: 1024 }),
+    readFile: vi.fn().mockResolvedValue(Buffer.from('fake-image-data')),
+    access: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
 describe('SessionService', () => {
   let sessionService: SessionService;
 
@@ -1687,6 +1698,129 @@ describe('SessionService', () => {
 
       // Default session was ended, so a new session should be created
       expect(mockRepository.create).toHaveBeenCalled();
+    });
+  });
+
+  describe('Multimodal Image Handling', () => {
+    it('passes imageContents to runner when image media is present', async () => {
+      const session = createMockSession({ lifecycle: 'idle' });
+      vi.mocked(mockRepository.findByUserAndAgent).mockResolvedValue(session);
+
+      const request = createMockRequest({
+        metadata: {
+          media: [{ type: 'image', path: '/tmp/photo1.jpg', contentType: 'image/jpeg' }],
+        },
+      });
+
+      await sessionService.handleMessage(request);
+
+      expect(mockClaudeRunner.run).toHaveBeenCalledTimes(1);
+      const runOptions = vi.mocked(mockClaudeRunner.run).mock.calls[0][1];
+      expect(runOptions.imageContents).toBeDefined();
+      expect(runOptions.imageContents).toHaveLength(1);
+      expect(runOptions.imageContents![0]).toEqual({
+        type: 'image',
+        source: 'base64',
+        mediaType: 'image/jpeg',
+        data: Buffer.from('fake-image-data').toString('base64'),
+      });
+    });
+
+    it('passes multiple images from a gallery', async () => {
+      const session = createMockSession({ lifecycle: 'idle' });
+      vi.mocked(mockRepository.findByUserAndAgent).mockResolvedValue(session);
+
+      const request = createMockRequest({
+        metadata: {
+          media: [
+            { type: 'image', path: '/tmp/photo1.jpg', contentType: 'image/jpeg' },
+            { type: 'image', path: '/tmp/photo2.png', contentType: 'image/png' },
+            { type: 'image', path: '/tmp/photo3.webp', contentType: 'image/webp' },
+          ],
+        },
+      });
+
+      await sessionService.handleMessage(request);
+
+      const runOptions = vi.mocked(mockClaudeRunner.run).mock.calls[0][1];
+      expect(runOptions.imageContents).toHaveLength(3);
+      expect(runOptions.imageContents![0].mediaType).toBe('image/jpeg');
+      expect(runOptions.imageContents![1].mediaType).toBe('image/png');
+      expect(runOptions.imageContents![2].mediaType).toBe('image/webp');
+    });
+
+    it('skips non-image media attachments', async () => {
+      const session = createMockSession({ lifecycle: 'idle' });
+      vi.mocked(mockRepository.findByUserAndAgent).mockResolvedValue(session);
+
+      const request = createMockRequest({
+        metadata: {
+          media: [
+            { type: 'document', path: '/tmp/file.pdf', contentType: 'application/pdf' },
+            { type: 'audio', path: '/tmp/voice.ogg', contentType: 'audio/ogg' },
+          ],
+        },
+      });
+
+      await sessionService.handleMessage(request);
+
+      const runOptions = vi.mocked(mockClaudeRunner.run).mock.calls[0][1];
+      expect(runOptions.imageContents).toBeUndefined();
+    });
+
+    it('skips unsupported image types', async () => {
+      const { stat } = await import('fs/promises');
+      vi.mocked(stat).mockResolvedValue({ size: 1024 } as any);
+
+      const session = createMockSession({ lifecycle: 'idle' });
+      vi.mocked(mockRepository.findByUserAndAgent).mockResolvedValue(session);
+
+      const request = createMockRequest({
+        metadata: {
+          media: [{ type: 'image', path: '/tmp/photo.bmp', contentType: 'image/bmp' }],
+        },
+      });
+
+      await sessionService.handleMessage(request);
+
+      const runOptions = vi.mocked(mockClaudeRunner.run).mock.calls[0][1];
+      expect(runOptions.imageContents).toBeUndefined();
+    });
+
+    it('respects MAX_IMAGES limit of 10', async () => {
+      const session = createMockSession({ lifecycle: 'idle' });
+      vi.mocked(mockRepository.findByUserAndAgent).mockResolvedValue(session);
+
+      const media = Array.from({ length: 15 }, (_, i) => ({
+        type: 'image' as const,
+        path: `/tmp/photo${i}.jpg`,
+        contentType: 'image/jpeg',
+      }));
+
+      const request = createMockRequest({ metadata: { media } });
+      await sessionService.handleMessage(request);
+
+      const runOptions = vi.mocked(mockClaudeRunner.run).mock.calls[0][1];
+      expect(runOptions.imageContents).toHaveLength(10);
+    });
+
+    it('skips images that exceed MAX_IMAGE_BYTES', async () => {
+      const { stat } = await import('fs/promises');
+      vi.mocked(stat).mockResolvedValue({ size: 25 * 1024 * 1024 } as any);
+
+      const session = createMockSession({ lifecycle: 'idle' });
+      vi.mocked(mockRepository.findByUserAndAgent).mockResolvedValue(session);
+
+      const request = createMockRequest({
+        metadata: {
+          media: [{ type: 'image', path: '/tmp/huge.jpg', contentType: 'image/jpeg' }],
+        },
+      });
+
+      await sessionService.handleMessage(request);
+
+      const runOptions = vi.mocked(mockClaudeRunner.run).mock.calls[0][1];
+      expect(runOptions.imageContents).toBeUndefined();
     });
   });
 });

--- a/packages/api/src/services/sessions/session-service.test.ts
+++ b/packages/api/src/services/sessions/session-service.test.ts
@@ -58,6 +58,7 @@ describe('SessionService', () => {
   let mockContextBuilder: IContextBuilder;
   let mockClaudeRunner: IClaudeRunner;
   let mockCodexRunner: IClaudeRunner;
+  let mockInkRunner: IClaudeRunner;
   let mockActivityStream: IActivityStream;
 
   const createMockSession = (overrides: Partial<Session> = {}): Session => ({
@@ -170,6 +171,10 @@ describe('SessionService', () => {
         .mockResolvedValue(createMockClaudeResult({ backendSessionId: 'codex-session-1' })),
     };
 
+    mockInkRunner = {
+      run: vi.fn().mockResolvedValue(createMockClaudeResult({ backendSessionId: 'ink-session-1' })),
+    };
+
     mockActivityStream = {
       logMessage: vi.fn().mockResolvedValue({ id: 'msg-123' }),
       logActivity: vi.fn().mockResolvedValue({ id: 'activity-123' }),
@@ -186,7 +191,10 @@ describe('SessionService', () => {
         mcpConfigPath: '/test/.mcp.json',
         compactionThreshold: 150000,
       },
-      mockCodexRunner
+      mockCodexRunner,
+      undefined,
+      undefined,
+      mockInkRunner
     );
   });
 
@@ -1702,8 +1710,8 @@ describe('SessionService', () => {
   });
 
   describe('Multimodal Image Handling', () => {
-    it('passes imageContents to runner when image media is present', async () => {
-      const session = createMockSession({ lifecycle: 'idle' });
+    it('passes imageContents to ink runner when image media is present', async () => {
+      const session = createMockSession({ lifecycle: 'idle', backend: 'ink' });
       vi.mocked(mockRepository.findByUserAndAgent).mockResolvedValue(session);
 
       const request = createMockRequest({
@@ -1714,8 +1722,8 @@ describe('SessionService', () => {
 
       await sessionService.handleMessage(request);
 
-      expect(mockClaudeRunner.run).toHaveBeenCalledTimes(1);
-      const runOptions = vi.mocked(mockClaudeRunner.run).mock.calls[0][1];
+      expect(mockInkRunner.run).toHaveBeenCalledTimes(1);
+      const runOptions = vi.mocked(mockInkRunner.run).mock.calls[0][1];
       expect(runOptions.imageContents).toBeDefined();
       expect(runOptions.imageContents).toHaveLength(1);
       expect(runOptions.imageContents![0]).toEqual({
@@ -1727,7 +1735,7 @@ describe('SessionService', () => {
     });
 
     it('passes multiple images from a gallery', async () => {
-      const session = createMockSession({ lifecycle: 'idle' });
+      const session = createMockSession({ lifecycle: 'idle', backend: 'ink' });
       vi.mocked(mockRepository.findByUserAndAgent).mockResolvedValue(session);
 
       const request = createMockRequest({
@@ -1742,15 +1750,31 @@ describe('SessionService', () => {
 
       await sessionService.handleMessage(request);
 
-      const runOptions = vi.mocked(mockClaudeRunner.run).mock.calls[0][1];
+      const runOptions = vi.mocked(mockInkRunner.run).mock.calls[0][1];
       expect(runOptions.imageContents).toHaveLength(3);
       expect(runOptions.imageContents![0].mediaType).toBe('image/jpeg');
       expect(runOptions.imageContents![1].mediaType).toBe('image/png');
       expect(runOptions.imageContents![2].mediaType).toBe('image/webp');
     });
 
+    it('skips image reading for CLI backends', async () => {
+      const session = createMockSession({ lifecycle: 'idle', backend: 'claude-code' });
+      vi.mocked(mockRepository.findByUserAndAgent).mockResolvedValue(session);
+
+      const request = createMockRequest({
+        metadata: {
+          media: [{ type: 'image', path: '/tmp/photo1.jpg', contentType: 'image/jpeg' }],
+        },
+      });
+
+      await sessionService.handleMessage(request);
+
+      const runOptions = vi.mocked(mockClaudeRunner.run).mock.calls[0][1];
+      expect(runOptions.imageContents).toBeUndefined();
+    });
+
     it('skips non-image media attachments', async () => {
-      const session = createMockSession({ lifecycle: 'idle' });
+      const session = createMockSession({ lifecycle: 'idle', backend: 'ink' });
       vi.mocked(mockRepository.findByUserAndAgent).mockResolvedValue(session);
 
       const request = createMockRequest({
@@ -1764,7 +1788,7 @@ describe('SessionService', () => {
 
       await sessionService.handleMessage(request);
 
-      const runOptions = vi.mocked(mockClaudeRunner.run).mock.calls[0][1];
+      const runOptions = vi.mocked(mockInkRunner.run).mock.calls[0][1];
       expect(runOptions.imageContents).toBeUndefined();
     });
 
@@ -1772,7 +1796,7 @@ describe('SessionService', () => {
       const { stat } = await import('fs/promises');
       vi.mocked(stat).mockResolvedValue({ size: 1024 } as any);
 
-      const session = createMockSession({ lifecycle: 'idle' });
+      const session = createMockSession({ lifecycle: 'idle', backend: 'ink' });
       vi.mocked(mockRepository.findByUserAndAgent).mockResolvedValue(session);
 
       const request = createMockRequest({
@@ -1783,12 +1807,12 @@ describe('SessionService', () => {
 
       await sessionService.handleMessage(request);
 
-      const runOptions = vi.mocked(mockClaudeRunner.run).mock.calls[0][1];
+      const runOptions = vi.mocked(mockInkRunner.run).mock.calls[0][1];
       expect(runOptions.imageContents).toBeUndefined();
     });
 
     it('respects MAX_IMAGES limit of 10', async () => {
-      const session = createMockSession({ lifecycle: 'idle' });
+      const session = createMockSession({ lifecycle: 'idle', backend: 'ink' });
       vi.mocked(mockRepository.findByUserAndAgent).mockResolvedValue(session);
 
       const media = Array.from({ length: 15 }, (_, i) => ({
@@ -1800,7 +1824,7 @@ describe('SessionService', () => {
       const request = createMockRequest({ metadata: { media } });
       await sessionService.handleMessage(request);
 
-      const runOptions = vi.mocked(mockClaudeRunner.run).mock.calls[0][1];
+      const runOptions = vi.mocked(mockInkRunner.run).mock.calls[0][1];
       expect(runOptions.imageContents).toHaveLength(10);
     });
 
@@ -1808,7 +1832,7 @@ describe('SessionService', () => {
       const { stat } = await import('fs/promises');
       vi.mocked(stat).mockResolvedValue({ size: 25 * 1024 * 1024 } as any);
 
-      const session = createMockSession({ lifecycle: 'idle' });
+      const session = createMockSession({ lifecycle: 'idle', backend: 'ink' });
       vi.mocked(mockRepository.findByUserAndAgent).mockResolvedValue(session);
 
       const request = createMockRequest({
@@ -1819,7 +1843,7 @@ describe('SessionService', () => {
 
       await sessionService.handleMessage(request);
 
-      const runOptions = vi.mocked(mockClaudeRunner.run).mock.calls[0][1];
+      const runOptions = vi.mocked(mockInkRunner.run).mock.calls[0][1];
       expect(runOptions.imageContents).toBeUndefined();
     });
   });

--- a/packages/api/src/services/sessions/session-service.ts
+++ b/packages/api/src/services/sessions/session-service.ts
@@ -9,7 +9,7 @@
  */
 
 import { randomUUID } from 'crypto';
-import { access } from 'fs/promises';
+import { access, readFile, stat } from 'fs/promises';
 import path from 'path';
 import { SupabaseClient } from '@supabase/supabase-js';
 import jwt from 'jsonwebtoken';
@@ -27,6 +27,7 @@ import type {
   ISessionRepository,
   IContextBuilder,
   ToolCall,
+  ImageContent,
 } from './types.js';
 import type { Json } from '../../data/supabase/types.js';
 import { SessionRepository } from './session-repository.js';
@@ -539,6 +540,9 @@ export class SessionService implements ISessionService {
     // Mark session as running before backend turn
     await this.repository.update(session.id, { lifecycle: 'running' });
 
+    // Read image attachments for multimodal-capable backends
+    const imageContents = await this.readImageAttachments(request.metadata?.media);
+
     let result;
     let turnDurationMs: number;
     const turnStartMs = Date.now();
@@ -547,6 +551,7 @@ export class SessionService implements ISessionService {
         backendSessionId: session.backendSessionId || undefined,
         injectedContext: session.backendSessionId ? undefined : injectedContext,
         config: runnerConfig,
+        imageContents: imageContents.length > 0 ? imageContents : undefined,
       });
       turnDurationMs = Date.now() - turnStartMs;
     } catch (runnerError) {
@@ -1550,6 +1555,47 @@ This session will continue with a fresh context after compaction. Your identity,
    * External channel messages are wrapped in <untrusted-data> tags following
    * Supabase's proven pattern for prompt injection protection.
    */
+  private async readImageAttachments(
+    media?: import('./types.js').MediaAttachment[]
+  ): Promise<ImageContent[]> {
+    if (!media || media.length === 0) return [];
+
+    const MAX_IMAGE_BYTES = 20 * 1024 * 1024;
+    const MAX_IMAGES = 10;
+    const SUPPORTED_TYPES = new Set(['image/jpeg', 'image/png', 'image/gif', 'image/webp']);
+
+    const images: ImageContent[] = [];
+
+    for (const attachment of media) {
+      if (images.length >= MAX_IMAGES) break;
+      if (attachment.type !== 'image') continue;
+      if (!attachment.path) continue;
+
+      const mimeType = attachment.contentType || attachment.mimeType || 'image/jpeg';
+      if (!SUPPORTED_TYPES.has(mimeType)) continue;
+
+      try {
+        const info = await stat(attachment.path);
+        if (info.size <= 0 || info.size > MAX_IMAGE_BYTES) continue;
+
+        const bytes = await readFile(attachment.path);
+        images.push({
+          type: 'image',
+          source: 'base64',
+          mediaType: mimeType,
+          data: bytes.toString('base64'),
+        });
+      } catch (error) {
+        logger.warn('Failed to read image attachment for multimodal', {
+          filePath: attachment.path,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    return images;
+  }
+
   private formatMessage(request: SessionRequest, timezone?: string): string {
     const { sender, content, channel, conversationId, metadata } = request;
     const isExternalChannel =

--- a/packages/api/src/services/sessions/session-service.ts
+++ b/packages/api/src/services/sessions/session-service.ts
@@ -540,8 +540,9 @@ export class SessionService implements ISessionService {
     // Mark session as running before backend turn
     await this.repository.update(session.id, { lifecycle: 'running' });
 
-    // Read image attachments for multimodal-capable backends
-    const imageContents = await this.readImageAttachments(request.metadata?.media);
+    // Read image attachments only for vision-capable backends (ink runner calls Anthropic API directly)
+    const imageContents =
+      resolvedBackend === 'ink' ? await this.readImageAttachments(request.metadata?.media) : [];
 
     let result;
     let turnDurationMs: number;

--- a/packages/api/src/services/sessions/types.ts
+++ b/packages/api/src/services/sessions/types.ts
@@ -23,8 +23,10 @@ export type ChatType = 'direct' | 'group' | 'supergroup' | 'channel';
 
 export interface MediaAttachment {
   type: 'image' | 'video' | 'audio' | 'document' | 'voice';
+  path?: string;
   url?: string;
   data?: Buffer;
+  contentType?: string;
   mimeType?: string;
   filename?: string;
 }
@@ -102,6 +104,17 @@ export interface Session {
   // Flexible metadata
   metadata: Record<string, unknown>;
 }
+
+// ─── Multimodal Content Types ───
+
+export interface ImageContent {
+  type: 'image';
+  source: 'base64';
+  mediaType: string;
+  data: string;
+}
+
+export type ContentBlock = { type: 'text'; text: string } | ImageContent;
 
 // ─── Request/Response Types ───
 
@@ -477,6 +490,7 @@ export interface IRunner {
       backendSessionId?: string;
       injectedContext?: InjectedContext;
       config: ClaudeRunnerConfig;
+      imageContents?: ImageContent[];
     }
   ): Promise<RunnerResult>;
 }


### PR DESCRIPTION
## Summary

When users send photos/screenshots via Telegram, the LLM now **actually sees the image** instead of just getting a text summary from a smaller model.

### Before
1. User sends screenshot to Myra on Telegram
2. Media pipeline sends image to gpt-4.1-mini → gets ~300 token text description
3. Myra's LLM sees `[Image analysis] Summary: screenshot of a healthcare page` — can't read specific details

### After
1. User sends screenshot to Myra on Telegram
2. Session service reads the image file and base64-encodes it
3. Ink runner constructs multimodal Anthropic content blocks (image + text)
4. Myra's LLM **sees the actual image** alongside the message — can read text, details, everything
5. Text analysis fallback still runs for non-vision backends (Claude Code, Codex, Gemini)

### Changes

- **`ImageContent` / `ContentBlock` types** in session types — structured multimodal content representation
- **`IRunner.run()` options** — now accepts optional `imageContents` array
- **`InkRunner.buildUserContent()`** — constructs `Anthropic.ContentBlockParam[]` with image + text blocks when images present
- **`SessionService.readImageAttachments()`** — reads image files from media attachments (up to 10 images, 20MB each, jpeg/png/gif/webp), gated to ink backend only
- **`MediaAttachment` type** — added `path` and `contentType` fields (matching runtime reality)
- **`GatewayMediaAttachment`** — extracted shared type replacing 4 inline declarations, includes `contentType`/`filename`
- **Telegram listener** — sets `contentType: 'image/jpeg'` on photo attachments

### Architecture

The design is additive — no existing behavior changes:
- Text analysis from `MediaUnderstandingService` still runs (prompt injection detection, non-vision backend fallback)
- `formattedMessage` string still carries the `[Image analysis]` text block
- Image data is **additionally** passed via `imageContents` to the runner
- Only the ink-runner (direct Anthropic API) uses the image data; CLI-based runners skip `readImageAttachments()` entirely

### Gallery & Cross-channel

- **Gallery support works out of the box** — `MediaGroupBuffer` already combines album photos into a single `InboundMessage.media[]`, and `readImageAttachments()` iterates all attachments (up to 10)
- **WhatsApp and Discord already compatible** — both listeners populate `type`, `path`, and `contentType` on media attachments, matching the `readImageAttachments()` contract

## Test plan

- [x] All 2441 tests pass locally (139 files, 0 failures)
- [x] Zero new type errors
- [x] Lumen review: LGTM (review id `4286504088`)
- [x] Gallery: `contentType` propagation through `MediaGroupBuffer` (new test)
- [x] InkRunner: `buildUserContent` multimodal block construction — single image, gallery (3 images), empty (new tests)
- [x] SessionService: `readImageAttachments` — ink backend passes images, CLI backend skips, non-image filtered, unsupported types filtered, MAX_IMAGES=10 limit, MAX_IMAGE_BYTES=20MB limit (7 new tests)
- [ ] Manual: send a screenshot to Myra on Telegram → verify she can read specific text/details
- [ ] Manual: send a photo with caption → verify both caption and image content are understood

— Wren