### PR TITLE
fix: add ~/.ink/files to Claude Code --add-dir for media access (by Wren)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,15 @@ Inkwell uses Supabase (PostgreSQL) as its database. There are **two access paths
 
 5. **Never expose the service role key to the client.** It lives in `.env.local` (server only) and must never appear in `NEXT_PUBLIC_*` environment variables.
 
+### File Access & Media Isolation (TODO)
+
+Server-spawned Claude sessions currently get `--add-dir ~/.ink/files` for media access (Telegram downloads, Gmail attachments, etc.). This is a shared directory — **all SBs can read all SBs' files**. Future work should consider:
+
+- **Per-agent file namespacing**: `~/.ink/files/<agentId>/telegram/` instead of `~/.ink/files/telegram/`
+- **Scoped `--add-dir`**: only grant access to the spawned agent's own subdirectory
+- **Cross-agent file sharing**: explicit mechanism for one SB to share a file with another (vs. implicit shared access)
+- **File lifecycle**: cleanup policy for downloaded media (currently accumulates indefinitely)
+
 ## Timezone Handling (IMPORTANT)
 
 **Always convert UTC timestamps to the user's local timezone when displaying.**

--- a/packages/api/src/services/sessions/claude-runner.ts
+++ b/packages/api/src/services/sessions/claude-runner.ts
@@ -26,6 +26,8 @@ import {
   resolveSpawnTarget,
   CONTAINER_RUNNER_FILES,
 } from '@inklabs/shared';
+import { homedir } from 'os';
+import { join } from 'path';
 import { ensureStudioSettings, applyPermissionOverlay } from '../studio-settings.js';
 
 /** Maximum time (ms) to wait for a Claude Code subprocess before killing it.
@@ -159,6 +161,10 @@ export class ClaudeRunner implements IRunner {
     if (config.appendSystemPrompt) {
       args.push('--append-system-prompt', config.appendSystemPrompt);
     }
+
+    // Allow access to ~/.ink/files (Telegram/Discord/Slack media downloads, Gmail attachments)
+    const inkFilesDir = join(homedir(), '.ink', 'files');
+    args.push('--add-dir', inkFilesDir);
 
     return args;
   }


### PR DESCRIPTION
## Summary

- Pass `--add-dir ~/.ink/files` when spawning Claude Code subprocesses, so Myra (and other server-spawned agents) can read media files downloaded by the Telegram/Discord/Slack listeners
- Previously, the Telegram listener downloaded images to `~/.ink/files/telegram/` but Claude Code's sandbox blocked access to that path — Myra could see metadata about the file but couldn't open it

## What was happening

1. User sends screenshot to Myra on Telegram
2. Telegram listener downloads file to `~/.ink/files/telegram/<fileId>_<timestamp>.jpg`
3. Claude Code session spawns with only the working directory accessible
4. Myra tries to read the file path → "file download path is outside my accessible directories"

## Fix

One line in `claude-runner.ts:buildArgs()` — adds `--add-dir ~/.ink/files` to every spawned session. This covers Telegram, Discord, Slack media downloads, and Gmail attachments.

## Test plan

- [x] All 2441 tests pass
- [ ] Send Myra a screenshot on Telegram → verify she can read and describe it

🤖 Generated with [Claude Code](https://claude.com/claude-code)