### PR TITLE
fix: retry transient PG errors + guard heartbeat init (by Wren)

### DIFF
--- a/packages/api/src/mcp/tools/inbox-handlers.ts
+++ b/packages/api/src/mcp/tools/inbox-handlers.ts
@@ -1084,92 +1084,103 @@ export async function handleGetInbox(args: unknown, dataComposer: DataComposer) 
         .limit(20);
 
       if (threads?.length) {
-        threadsWithUnread = await Promise.all(
-          threads.map(
-            async (t: {
-              id: string;
-              thread_key: string;
-              title: string | null;
-              created_by_agent_id: string;
-              updated_at: string;
-            }) => {
-              // Get participants (include joined_at for unread baseline)
-              const { data: parts } = await threadTable(supabase, 'inbox_thread_participants')
-                .select('agent_id, joined_at')
-                .eq('thread_id', t.id);
-              const participants = (parts || []).map((p: { agent_id: string }) => p.agent_id);
+        const tIds = threads.map((t: { id: string }) => t.id);
 
-              // Get last read timestamp (only meaningful with agentId)
-              let lastReadAt: string | null = null;
-              let joinedAt: string | null = null;
-              if (agentId) {
-                const { data: readStatus } = await threadTable(supabase, 'inbox_thread_read_status')
-                  .select('last_read_at')
-                  .eq('thread_id', t.id)
-                  .eq('agent_id', agentId)
-                  .maybeSingle();
-                lastReadAt = readStatus?.last_read_at || null;
+        // Batch 1: all participants for all threads (was N queries)
+        const { data: allParts } = await threadTable(supabase, 'inbox_thread_participants')
+          .select('thread_id, agent_id, joined_at')
+          .in('thread_id', tIds);
+        const partsByThread = new Map<string, Array<{ agent_id: string; joined_at?: string }>>();
+        for (const p of allParts || []) {
+          const arr = partsByThread.get(p.thread_id) || [];
+          arr.push(p);
+          partsByThread.set(p.thread_id, arr);
+        }
 
-                // If no read status exists, use the participant's joined_at as
-                // baseline so messages from before they joined don't count as
-                // unread. Without this, a participant who has never read a thread
-                // sees the entire history as "unread" on every poll — causing
-                // replay floods on session restart.
-                const callerPart = (parts || []).find(
-                  (p: { agent_id: string }) => p.agent_id === agentId
-                ) as { joined_at?: string } | undefined;
-                joinedAt = callerPart?.joined_at || null;
-              }
+        // Batch 2: all read statuses for all threads (was N queries)
+        const readStatusByThread = new Map<string, string | null>();
+        if (agentId) {
+          const { data: allReadStatuses } = await threadTable(supabase, 'inbox_thread_read_status')
+            .select('thread_id, last_read_at')
+            .in('thread_id', tIds)
+            .eq('agent_id', agentId);
+          for (const rs of allReadStatuses || []) {
+            readStatusByThread.set(rs.thread_id, rs.last_read_at);
+          }
+        }
 
-              // Count unread messages. Baseline priority:
-              //   1. last_read_at (explicit read pointer)
-              //   2. joined_at (participant join time — no replay of pre-join history)
-              //   3. no filter (shouldn't happen — agent is always a participant)
-              const unreadBaseline = lastReadAt || joinedAt;
-              let countQuery = threadTable(supabase, 'inbox_thread_messages')
-                .select('*', { count: 'exact', head: true })
-                .eq('thread_id', t.id);
+        // Batch 3: recent messages for all threads — used for both unread counts
+        // and preview messages (was 2N queries). Fetch enough to cover previews +
+        // reasonable unread counts. Threads with >50 unread will show a lower-bound.
+        const MSG_BATCH_LIMIT = Math.max(tIds.length * 20, 200);
+        const { data: allMsgs } = await threadTable(supabase, 'inbox_thread_messages')
+          .select('thread_id, sender_agent_id, content, message_type, created_at, metadata')
+          .in('thread_id', tIds)
+          .order('created_at', { ascending: false })
+          .limit(MSG_BATCH_LIMIT);
 
-              if (unreadBaseline) {
-                countQuery = countQuery.gt('created_at', unreadBaseline);
-              }
+        const msgsByThread = new Map<
+          string,
+          Array<{
+            thread_id: string;
+            sender_agent_id: string;
+            content: string;
+            message_type: string;
+            created_at: string;
+            metadata: unknown;
+          }>
+        >();
+        for (const m of allMsgs || []) {
+          const arr = msgsByThread.get(m.thread_id) || [];
+          arr.push(m);
+          msgsByThread.set(m.thread_id, arr);
+        }
 
-              const { count } = await countQuery;
+        // Assemble thread summaries from batched data (pure JS, zero queries)
+        threadsWithUnread = threads.map(
+          (t: {
+            id: string;
+            thread_key: string;
+            title: string | null;
+            created_by_agent_id: string;
+            updated_at: string;
+          }) => {
+            const parts = partsByThread.get(t.id) || [];
+            const participants = parts.map((p) => p.agent_id);
 
-              // Get preview messages (last 3 non-system messages)
-              const { data: previewRows } = await threadTable(supabase, 'inbox_thread_messages')
-                .select('sender_agent_id, content, message_type, created_at')
-                .eq('thread_id', t.id)
-                .neq('message_type', 'system')
-                .order('created_at', { ascending: false })
-                .limit(3);
-
-              const previewMessages = (previewRows || [])
-                .reverse()
-                .map(
-                  (m: {
-                    sender_agent_id: string;
-                    content: string;
-                    message_type: string;
-                    created_at: string;
-                  }) => ({
-                    senderAgentId: m.sender_agent_id,
-                    content: m.content,
-                    messageType: m.message_type,
-                    createdAt: m.created_at,
-                  })
-                );
-
-              return {
-                threadKey: t.thread_key,
-                title: t.title,
-                participants,
-                unreadCount: count || 0,
-                lastMessageAt: t.updated_at,
-                previewMessages,
-              };
+            let lastReadAt: string | null = readStatusByThread.get(t.id) || null;
+            let joinedAt: string | null = null;
+            if (agentId) {
+              const callerPart = parts.find((p) => p.agent_id === agentId);
+              joinedAt = callerPart?.joined_at || null;
             }
-          )
+
+            const unreadBaseline = lastReadAt || joinedAt;
+            const threadMsgs = msgsByThread.get(t.id) || [];
+            const unreadCount = unreadBaseline
+              ? threadMsgs.filter((m) => m.created_at > unreadBaseline).length
+              : threadMsgs.length;
+
+            const previewMessages = threadMsgs
+              .filter((m) => m.message_type !== 'system')
+              .slice(0, 3)
+              .reverse()
+              .map((m) => ({
+                senderAgentId: m.sender_agent_id,
+                content: m.content,
+                messageType: m.message_type,
+                createdAt: m.created_at,
+              }));
+
+            return {
+              threadKey: t.thread_key,
+              title: t.title,
+              participants,
+              unreadCount,
+              lastMessageAt: t.updated_at,
+              previewMessages,
+            };
+          }
         );
 
         // Only include threads that actually have unread messages
@@ -1177,44 +1188,33 @@ export async function handleGetInbox(args: unknown, dataComposer: DataComposer) 
 
         // Channel poll studio filtering (defense-in-depth): when channelPoll=true
         // and no session_id filter was applied, fall back to message-metadata-based
-        // studio ownership check. When session filtering is active (callerSessionId
-        // is set), skip this — session_id on participants is the primary routing.
+        // studio ownership check. Uses the already-batched messages (no extra queries).
         if (channelPoll && agentId && !callerSessionId) {
           const reqCtx = getRequestContext();
           const sessCtx = getSessionContext();
           const callerStudioId = reqCtx?.studioId || sessCtx?.studioId || null;
 
           if (callerStudioId) {
-            const filteredThreads: typeof threadsWithUnread = [];
+            // Build a threadKey→threadId map for lookup
+            const keyToId = new Map<string, string>(
+              threads.map((t: { id: string; thread_key: string }) => [t.thread_key, t.id])
+            );
 
-            for (const thread of threadsWithUnread) {
-              // Fetch our agent's messages on this thread to check studio ownership
-              const threadRow = threads?.find(
-                (t: { thread_key: string }) => t.thread_key === thread.threadKey
-              );
-              if (!threadRow) {
-                filteredThreads.push(thread); // safety fallback — include if we can't check
-                continue;
-              }
-
-              const { data: ourMessages } = await threadTable(supabase, 'inbox_thread_messages')
-                .select('metadata')
-                .eq('thread_id', (threadRow as { id: string }).id)
-                .eq('sender_agent_id', agentId)
-                .order('created_at', { ascending: false })
-                .limit(5);
-
-              if (isThreadOwnedByStudio(ourMessages || [], callerStudioId)) {
-                filteredThreads.push(thread);
-              } else {
+            threadsWithUnread = threadsWithUnread.filter((thread) => {
+              const tid = keyToId.get(thread.threadKey);
+              if (!tid) return true; // safety fallback
+              const ourMsgs = (msgsByThread.get(tid) || [])
+                .filter((m) => m.sender_agent_id === agentId)
+                .slice(0, 5);
+              const owned = isThreadOwnedByStudio(ourMsgs, callerStudioId);
+              if (!owned) {
                 logger.debug('[ChannelPoll] Filtered thread (owned by different studio)', {
                   threadKey: thread.threadKey,
                   callerStudioId,
                 });
               }
-            }
-
-            threadsWithUnread = filteredThreads;
+              return owned;
+            });
           }
         }
 

--- a/packages/api/src/mcp/tools/index.ts
+++ b/packages/api/src/mcp/tools/index.ts
@@ -367,6 +367,18 @@ export function registerAllTools(
   // Calls exceeding SLOW_TOOL_THRESHOLD_MS are logged at warn level.
   // ---------------------------------------------------------------------------
   const SLOW_TOOL_THRESHOLD_MS = 500;
+  const TRANSIENT_PG_PATTERNS = [
+    'current transaction is aborted',
+    'connection terminated unexpectedly',
+    'server closed the connection unexpectedly',
+    'could not obtain connection',
+    'remaining connection slots are reserved',
+  ];
+  function isTransientPgError(err: unknown): boolean {
+    const msg = err instanceof Error ? err.message : String(err);
+    return TRANSIENT_PG_PATTERNS.some((p) => msg.includes(p));
+  }
+
   const originalRegisterTool = server.registerTool.bind(server);
   (server as any).registerTool = (name: string, ...rest: any[]) => {
     const handler = rest[rest.length - 1];
@@ -383,6 +395,22 @@ export function registerAllTools(
           }
           return result;
         } catch (error) {
+          if (isTransientPgError(error)) {
+            logger.warn(`[retry] ${name}: transient PG error, retrying once`, {
+              error: error instanceof Error ? error.message : String(error),
+            });
+            await new Promise((r) => setTimeout(r, 150));
+            try {
+              const result = await handler(...handlerArgs);
+              const durationMs = Math.round(performance.now() - start);
+              logger.info(`[retry] ${name}: retry succeeded (${durationMs}ms)`);
+              return result;
+            } catch (retryError) {
+              const durationMs = Math.round(performance.now() - start);
+              logger.warn(`[timing] ${name}: ${durationMs}ms (RETRY FAILED)`);
+              throw retryError;
+            }
+          }
           const durationMs = Math.round(performance.now() - start);
           logger.warn(`[timing] ${name}: ${durationMs}ms (ERROR)`);
           throw error;

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -1381,9 +1381,8 @@ async function shutdown(): Promise<void> {
   forceKillTimer.unref(); // Don't let the timer itself keep the process alive
 
   try {
-    // Stop heartbeat cron job
+    // Stop heartbeat cron job (logs internally)
     stopHeartbeatService();
-    logger.info('Heartbeat service stopped');
 
     // Remove agent gateway listeners to release event loop references
     getAgentGateway().removeAllListeners();

--- a/packages/api/src/services/heartbeat.ts
+++ b/packages/api/src/services/heartbeat.ts
@@ -56,6 +56,13 @@ let heartbeatCallback: (() => Promise<void>) | null = null;
  * Initialize the heartbeat service
  */
 export function initHeartbeatService(config: HeartbeatConfig = {}): void {
+  // Guard: stop any existing cron before creating a new one (prevents leaked tasks on hot reload)
+  if (cronTask) {
+    cronTask.stop();
+    cronTask = null;
+    logger.warn('Stopped existing heartbeat cron before re-initializing');
+  }
+
   const {
     interval = '*/5 * * * *', // Every 5 minutes
     enableLocalCron = process.env.NODE_ENV !== 'production',


### PR DESCRIPTION
## Summary

Three fixes for the server instability observed on 2026-05-15:

- **Batch `get_inbox` thread queries — eliminate N+1.** The handler was running 4 queries per thread (participants, read status, unread count, preview messages) × up to 20 threads = ~80 queries per call. Under concurrent load (15+ bootstrap calls hitting simultaneously), this saturated the Supabase connection pool and caused 4-5 minute hangs with "No connection established" errors as MCP clients timed out. Replaced with 3 batched queries + JS-side grouping. Total queries: ~8 down from ~85. The channelPoll studio ownership check also uses the already-fetched message data instead of per-thread queries.

- **Retry transient Postgres errors** in all MCP tool handlers. Wraps the existing timing middleware with a one-retry fallback for known transient errors: `current transaction is aborted`, `connection terminated unexpectedly`, pool exhaustion, etc. The retry fires after 150ms — enough for Supavisor to rotate the poisoned connection out of the pool.

- **Guard `initHeartbeatService()` against leaked cron tasks.** Stops any existing cron before creating a new one. Prevents duplicate heartbeat ticks if the function is called twice (e.g., tsx watch hot-reload edge case). Also removes the duplicate "Heartbeat service stopped" shutdown log (both the function and caller were logging the same message).

## Test plan

- [x] `npx vitest run packages/api/src/mcp/tools/inbox-handlers` — 37 tests pass
- [x] `npx vitest run packages/api/src/services/heartbeat` — 18 tests pass
- [x] `npx vitest run packages/api/src/mcp/tools/index` — 2 tests pass
- [x] Type-check clean (no new errors vs main)
- [ ] Manual: restart dev server, confirm `get_inbox` responds in <2s under normal load
- [ ] Manual: verify single "Heartbeat service stopped" on ^C
- [ ] Manual: confirm `list_sessions` works after server restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)