### PR TITLE
feat: port exact-detail memory experiments (by Lumen)

### DIFF
--- a/packages/api/src/config/env.ts
+++ b/packages/api/src/config/env.ts
@@ -204,6 +204,10 @@ const envSchema = z.object({
     .enum(['true', 'false'])
     .default('false')
     .transform((v) => v === 'true'),
+  MEMORY_LLM_EXACT_DETAILS_ENABLED: z
+    .enum(['true', 'false'])
+    .default('false')
+    .transform((v) => v === 'true'),
   OLLAMA_BASE_URL: optionalUrl,
   OPENAI_API_KEY: optionalString,
   OPENAI_BASE_URL: optionalUrl,

--- a/packages/api/src/data/models/memory.ts
+++ b/packages/api/src/data/models/memory.ts
@@ -67,6 +67,7 @@ export interface MemoryCreateInput {
 export type MemorySearchChunkType =
   | 'summary'
   | 'fact'
+  | 'exact_detail'
   | 'topic'
   | 'entity'
   | 'current_state'

--- a/packages/api/src/data/models/memory.ts
+++ b/packages/api/src/data/models/memory.ts
@@ -67,7 +67,7 @@ export interface MemoryCreateInput {
 export type MemorySearchChunkType =
   | 'summary'
   | 'fact'
-  | 'exact_detail'
+  | 'exact_details'
   | 'topic'
   | 'entity'
   | 'current_state'

--- a/packages/api/src/data/repositories/memory-repository.test.ts
+++ b/packages/api/src/data/repositories/memory-repository.test.ts
@@ -1830,7 +1830,7 @@ describe('MemoryRepository', () => {
         1,
         'match_memory_embedding_chunks',
         expect.objectContaining({
-          p_chunk_types: ['summary', 'fact', 'exact_detail', 'topic', 'entity', 'current_state'],
+          p_chunk_types: ['summary', 'fact', 'exact_details', 'topic', 'entity', 'current_state'],
         })
       );
       expect(rpc).toHaveBeenNthCalledWith(

--- a/packages/api/src/data/repositories/memory-repository.test.ts
+++ b/packages/api/src/data/repositories/memory-repository.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { MemoryRepository, computeKnowledgeMemoryScore } from './memory-repository';
 import { createMockSupabaseClient, type MockSupabaseClient } from '../../test/mocks/supabase.mock';
 import type { SupabaseClient } from '@supabase/supabase-js';
+import { MEMORY_EMBEDDING_CHUNKS_VERSION } from '../../services/embeddings/memory-chunks';
 
 describe('MemoryRepository', () => {
   let mockSupabase: MockSupabaseClient;
@@ -1240,12 +1241,12 @@ describe('MemoryRepository', () => {
       expect(chunkRows.every((row) => row.chunk_type === 'content')).toBe(true);
       expect(mockSupabase._queryBuilder.update).toHaveBeenCalledWith(
         expect.objectContaining({
-          embedding_chunks_version: 3,
+          embedding_chunks_version: MEMORY_EMBEDDING_CHUNKS_VERSION,
           embedding_chunk_count: chunkRows.length,
           metadata: expect.objectContaining({
             embedding_chunks: expect.objectContaining({
               chunkCount: chunkRows.length,
-              version: 3,
+              version: MEMORY_EMBEDDING_CHUNKS_VERSION,
               viewCounts: expect.objectContaining({
                 content: chunkRows.length,
                 summary: 0,
@@ -1829,7 +1830,7 @@ describe('MemoryRepository', () => {
         1,
         'match_memory_embedding_chunks',
         expect.objectContaining({
-          p_chunk_types: ['summary', 'fact', 'topic', 'entity', 'current_state'],
+          p_chunk_types: ['summary', 'fact', 'exact_detail', 'topic', 'entity', 'current_state'],
         })
       );
       expect(rpc).toHaveBeenNthCalledWith(

--- a/packages/api/src/data/repositories/memory-repository.ts
+++ b/packages/api/src/data/repositories/memory-repository.ts
@@ -94,6 +94,7 @@ const EMBEDDING_PERSIST_RETRY_ATTEMPTS = 3;
 const DERIVED_CHUNK_TYPES: MemoryChunkType[] = [
   'summary',
   'fact',
+  'exact_detail',
   'topic',
   'entity',
   'current_state',
@@ -109,6 +110,8 @@ function computeChunkTypeBoost(chunkType?: MemoryChunkType | null): number {
   switch (chunkType) {
     case 'fact':
       return 0.08;
+    case 'exact_detail':
+      return 0.09;
     case 'topic':
       return 0.05;
     case 'entity':
@@ -868,7 +871,7 @@ export class MemoryRepository {
 
       const matchedChunkType =
         row.matched_chunk_type &&
-        ['summary', 'fact', 'topic', 'entity', 'current_state', 'content'].includes(
+        ['summary', 'fact', 'exact_detail', 'topic', 'entity', 'current_state', 'content'].includes(
           row.matched_chunk_type
         )
           ? (row.matched_chunk_type as MemoryChunkType)

--- a/packages/api/src/data/repositories/memory-repository.ts
+++ b/packages/api/src/data/repositories/memory-repository.ts
@@ -94,7 +94,7 @@ const EMBEDDING_PERSIST_RETRY_ATTEMPTS = 3;
 const DERIVED_CHUNK_TYPES: MemoryChunkType[] = [
   'summary',
   'fact',
-  'exact_detail',
+  'exact_details',
   'topic',
   'entity',
   'current_state',
@@ -110,7 +110,7 @@ function computeChunkTypeBoost(chunkType?: MemoryChunkType | null): number {
   switch (chunkType) {
     case 'fact':
       return 0.08;
-    case 'exact_detail':
+    case 'exact_details':
       return 0.09;
     case 'topic':
       return 0.05;
@@ -871,9 +871,15 @@ export class MemoryRepository {
 
       const matchedChunkType =
         row.matched_chunk_type &&
-        ['summary', 'fact', 'exact_detail', 'topic', 'entity', 'current_state', 'content'].includes(
-          row.matched_chunk_type
-        )
+        [
+          'summary',
+          'fact',
+          'exact_details',
+          'topic',
+          'entity',
+          'current_state',
+          'content',
+        ].includes(row.matched_chunk_type)
           ? (row.matched_chunk_type as MemoryChunkType)
           : inferChunkTypeFromMetadata(row.matched_chunk_index, memory.metadata);
       const semanticScore = Math.max(0, Math.min(1, row.similarity ?? 0));

--- a/packages/api/src/scripts/audit-memory-llm-extractions.ts
+++ b/packages/api/src/scripts/audit-memory-llm-extractions.ts
@@ -3,6 +3,7 @@ import type { Database } from '../data/supabase/types';
 import {
   buildDurableFactEmbeddingTexts,
   buildEntityEmbeddingTexts,
+  buildExactDetailsEmbeddingTexts,
   buildSummaryEmbeddingTexts,
   normalizeMemoryExtractions,
   type MemoryExtractions,
@@ -61,6 +62,7 @@ interface CaseCoverage {
   entityHasAnswer: boolean;
   durableFactHasAnswer: boolean;
   summaryHasAnswer: boolean;
+  exactDetailsHasAnswer: boolean;
   derivedHasAnswer: boolean;
   maxDerivedAnswerTokenCoverage: number;
   sourceSnippet: string;
@@ -79,21 +81,26 @@ interface AuditSummary {
     entity: number;
     durableFact: number;
     summary: number;
+    exactDetails: number;
     rawEntity: number;
     rawDurableFact: number;
     rawSummary: number;
+    rawExactDetails: number;
   };
   extractionCounts: {
     entityItems: number;
     durableFactItems: number;
     summaryKeyPoints: number;
+    exactDetailItems: number;
     emptyEntityMemories: number;
     emptyDurableFactMemories: number;
+    emptyExactDetailsMemories: number;
   };
   rawOverflowCounts: {
     entity: number;
     durableFact: number;
     summaryKeyPoints: number;
+    exactDetails: number;
   };
   labelLeakCounts: {
     benchmarkTerms: number;
@@ -115,6 +122,7 @@ interface AuditSummary {
     entityHasAnswer: number;
     durableFactHasAnswer: number;
     summaryHasAnswer: number;
+    exactDetailsHasAnswer: number;
     derivedHasAnswer: number;
     derivedMissWhenTargetContentHasAnswer: number;
     derivedMissWhenTargetExtractionInputHasAnswer: number;
@@ -231,7 +239,7 @@ function snippetAroundAnswer(text: string, answer: string | number, maxChars = 7
 
 function extractionText(
   extraction: MemoryExtractions | null,
-  kind?: 'entity' | 'durable' | 'summary'
+  kind?: 'entity' | 'durable' | 'summary' | 'exact'
 ) {
   if (!extraction) return '';
   const parts: string[] = [];
@@ -244,10 +252,16 @@ function extractionText(
   if ((!kind || kind === 'summary') && extraction.summary) {
     parts.push(buildSummaryEmbeddingTexts(extraction.summary).join('\n'));
   }
+  if ((!kind || kind === 'exact') && extraction.exact_details) {
+    parts.push(buildExactDetailsEmbeddingTexts(extraction.exact_details).join('\n'));
+  }
   return parts.join('\n');
 }
 
-function rawArrayLength(raw: unknown, key: 'entities' | 'durableFacts' | 'keyPoints'): number {
+function rawArrayLength(
+  raw: unknown,
+  key: 'entities' | 'durableFacts' | 'keyPoints' | 'exactDetails'
+): number {
   const value = asRecord(raw)[key];
   return Array.isArray(value) ? value.length : 0;
 }
@@ -340,7 +354,10 @@ function auditCaseCoverage(params: {
     const summaryText = targetMemories
       .map((item) => extractionText(item.extraction, 'summary'))
       .join('\n');
-    const derivedText = [entityText, durableText, summaryText].join('\n');
+    const exactDetailsText = targetMemories
+      .map((item) => extractionText(item.extraction, 'exact'))
+      .join('\n');
+    const derivedText = [entityText, durableText, summaryText, exactDetailsText].join('\n');
 
     cases.push({
       caseId,
@@ -354,6 +371,7 @@ function auditCaseCoverage(params: {
       entityHasAnswer: hasAnswer(entityText, benchmarkCase.answer),
       durableFactHasAnswer: hasAnswer(durableText, benchmarkCase.answer),
       summaryHasAnswer: hasAnswer(summaryText, benchmarkCase.answer),
+      exactDetailsHasAnswer: hasAnswer(exactDetailsText, benchmarkCase.answer),
       derivedHasAnswer: hasAnswer(derivedText, benchmarkCase.answer),
       maxDerivedAnswerTokenCoverage: answerTokenCoverage(derivedText, benchmarkCase.answer),
       sourceSnippet: snippetAroundAnswer(targetContent, benchmarkCase.answer),
@@ -379,18 +397,22 @@ function summarizeAudits(params: {
     entity: 0,
     durableFact: 0,
     summary: 0,
+    exactDetails: 0,
     rawEntity: 0,
     rawDurableFact: 0,
     rawSummary: 0,
+    rawExactDetails: 0,
   };
   const extractionCounts = {
     entityItems: 0,
     durableFactItems: 0,
     summaryKeyPoints: 0,
+    exactDetailItems: 0,
     emptyEntityMemories: 0,
     emptyDurableFactMemories: 0,
+    emptyExactDetailsMemories: 0,
   };
-  const rawOverflowCounts = { entity: 0, durableFact: 0, summaryKeyPoints: 0 };
+  const rawOverflowCounts = { entity: 0, durableFact: 0, summaryKeyPoints: 0, exactDetails: 0 };
   const labelLeakCounts = { benchmarkTerms: 0, targetDistractorTerms: 0 };
   const contentLimit = {
     maxInputChars: env.MEMORY_LLM_MAX_INPUT_CHARS,
@@ -413,14 +435,17 @@ function summarizeAudits(params: {
       missingExtractionCount += 1;
       continue;
     }
-    const hasAllKinds = Boolean(extraction.entity && extraction.durable_fact && extraction.summary);
+    const hasAllKinds = Boolean(
+      extraction.entity && extraction.durable_fact && extraction.summary && extraction.exact_details
+    );
     increment(extractionVersionCounts, String(extraction.version));
     increment(extractionProviderCounts, extraction.provider);
     if (
       hasAllKinds &&
       extraction.raw?.entity &&
       extraction.raw?.durable_fact &&
-      extraction.raw?.summary
+      extraction.raw?.summary &&
+      extraction.raw?.exact_details
     ) {
       completeExtractionCount += 1;
     }
@@ -445,6 +470,13 @@ function summarizeAudits(params: {
     if (extraction.summary) {
       normalizedPresence.summary += 1;
       extractionCounts.summaryKeyPoints += extraction.summary.keyPoints.length;
+    }
+    if (extraction.exact_details) {
+      normalizedPresence.exactDetails += 1;
+      extractionCounts.exactDetailItems += extraction.exact_details.exactDetails.length;
+      if (extraction.exact_details.exactDetails.length === 0) {
+        extractionCounts.emptyExactDetailsMemories += 1;
+      }
     }
 
     if (extraction.raw?.entity) {
@@ -472,6 +504,15 @@ function summarizeAudits(params: {
         (extraction.summary?.keyPoints.length || 0)
       ) {
         rawOverflowCounts.summaryKeyPoints += 1;
+      }
+    }
+    if (extraction.raw?.exact_details) {
+      normalizedPresence.rawExactDetails += 1;
+      if (
+        rawArrayLength(extraction.raw.exact_details, 'exactDetails') >
+        (extraction.exact_details?.exactDetails.length || 0)
+      ) {
+        rawOverflowCounts.exactDetails += 1;
       }
     }
 
@@ -513,6 +554,8 @@ function summarizeAudits(params: {
       entityHasAnswer: params.caseCoverage.filter((item) => item.entityHasAnswer).length,
       durableFactHasAnswer: params.caseCoverage.filter((item) => item.durableFactHasAnswer).length,
       summaryHasAnswer: params.caseCoverage.filter((item) => item.summaryHasAnswer).length,
+      exactDetailsHasAnswer: params.caseCoverage.filter((item) => item.exactDetailsHasAnswer)
+        .length,
       derivedHasAnswer: params.caseCoverage.filter((item) => item.derivedHasAnswer).length,
       derivedMissWhenTargetContentHasAnswer: params.caseCoverage.filter(
         (item) => item.targetContentHasAnswer && !item.derivedHasAnswer
@@ -557,7 +600,7 @@ function buildMarkdownReport(params: {
     `- Label leakage: benchmark terms in ${params.summary.labelLeakCounts.benchmarkTerms}, target/distractor terms in ${params.summary.labelLeakCounts.targetDistractorTerms}`
   );
   lines.push(
-    `- Raw overflow preserved: entity=${params.summary.rawOverflowCounts.entity}, durable_fact=${params.summary.rawOverflowCounts.durableFact}, summary_key_points=${params.summary.rawOverflowCounts.summaryKeyPoints}`
+    `- Raw overflow preserved: entity=${params.summary.rawOverflowCounts.entity}, durable_fact=${params.summary.rawOverflowCounts.durableFact}, summary_key_points=${params.summary.rawOverflowCounts.summaryKeyPoints}, exact_details=${params.summary.rawOverflowCounts.exactDetails}`
   );
   lines.push(
     `- Extraction versions: ${Object.entries(params.summary.extractionVersionCounts)
@@ -588,6 +631,9 @@ function buildMarkdownReport(params: {
     `- Summary view contains answer: ${params.summary.answerCoverage.summaryHasAnswer}/${params.summary.answerCoverage.cases} (${pct(params.summary.answerCoverage.summaryHasAnswer, params.summary.answerCoverage.cases)})`
   );
   lines.push(
+    `- Exact-details view contains answer: ${params.summary.answerCoverage.exactDetailsHasAnswer}/${params.summary.answerCoverage.cases} (${pct(params.summary.answerCoverage.exactDetailsHasAnswer, params.summary.answerCoverage.cases)})`
+  );
+  lines.push(
     `- Any derived view contains answer: ${params.summary.answerCoverage.derivedHasAnswer}/${params.summary.answerCoverage.cases} (${pct(params.summary.answerCoverage.derivedHasAnswer, params.summary.answerCoverage.cases)})`
   );
   lines.push(
@@ -604,6 +650,14 @@ function buildMarkdownReport(params: {
   )) {
     lines.push(`- ${type}: ${count}`);
   }
+  lines.push('');
+  lines.push('## Exact details');
+  lines.push('');
+  lines.push(`- Normalized rows: ${params.summary.normalizedPresence.exactDetails}`);
+  lines.push(`- Items: ${params.summary.extractionCounts.exactDetailItems}`);
+  lines.push(
+    `- Empty exact-detail memories: ${params.summary.extractionCounts.emptyExactDetailsMemories}`
+  );
   lines.push('');
   lines.push('## Durable fact categories');
   lines.push('');
@@ -636,7 +690,7 @@ function buildMarkdownReport(params: {
     lines.push(`- Extraction-visible input has answer: ${item.targetExtractionInputHasAnswer}`);
     lines.push(`- Target over input cap: ${item.targetOverInputLimit}`);
     lines.push(
-      `- Entity/fact/summary hit: ${item.entityHasAnswer}/${item.durableFactHasAnswer}/${item.summaryHasAnswer}`
+      `- Entity/fact/summary/exact hit: ${item.entityHasAnswer}/${item.durableFactHasAnswer}/${item.summaryHasAnswer}/${item.exactDetailsHasAnswer}`
     );
     lines.push(`- Derived answer token coverage: ${item.maxDerivedAnswerTokenCoverage.toFixed(2)}`);
     lines.push(`- Source: ${item.sourceSnippet}`);
@@ -653,7 +707,7 @@ function buildMarkdownReport(params: {
     lines.push(`- Extraction-visible input has answer: ${item.targetExtractionInputHasAnswer}`);
     lines.push(`- Target over input cap: ${item.targetOverInputLimit}`);
     lines.push(
-      `- Entity/fact/summary hit: ${item.entityHasAnswer}/${item.durableFactHasAnswer}/${item.summaryHasAnswer}`
+      `- Entity/fact/summary/exact hit: ${item.entityHasAnswer}/${item.durableFactHasAnswer}/${item.summaryHasAnswer}/${item.exactDetailsHasAnswer}`
     );
     lines.push(`- Source: ${item.sourceSnippet}`);
     lines.push(`- Derived: ${item.derivedSnippet}`);

--- a/packages/api/src/scripts/extract-memory-llm-views.ts
+++ b/packages/api/src/scripts/extract-memory-llm-views.ts
@@ -9,6 +9,7 @@ import {
   buildCurrentStateEmbeddingTexts,
   buildDurableFactEmbeddingTexts,
   buildEntityEmbeddingTexts,
+  buildExactDetailsEmbeddingTexts,
   buildSummaryEmbeddingTexts,
   MemoryLlmExtractor,
   normalizeMemoryExtractions,
@@ -67,6 +68,9 @@ function buildExtractionEmbeddingTexts(
     current_state: llmExtractions.current_state
       ? buildCurrentStateEmbeddingTexts(llmExtractions.current_state)
       : [],
+    exact_details: llmExtractions.exact_details
+      ? buildExactDetailsEmbeddingTexts(llmExtractions.exact_details)
+      : [],
   };
 }
 
@@ -113,6 +117,9 @@ function mergeMemoryExtractions(
     current_state: replaceKinds.has('current_state')
       ? next.current_state
       : (next.current_state ?? existing?.current_state),
+    exact_details: replaceKinds.has('exact_details')
+      ? next.exact_details
+      : (next.exact_details ?? existing?.exact_details),
     version: next.version,
     provider: next.provider,
     model: next.model,
@@ -552,12 +559,13 @@ async function processMemoryBatch(params: {
 }
 
 function getEnabledKinds(options: { batchAllKinds?: boolean } = {}): ExtractionKind[] {
-  if (options.batchAllKinds) return ['entity', 'durable_fact', 'summary'];
+  if (options.batchAllKinds) return ['entity', 'durable_fact', 'summary', 'exact_details'];
   const enabledKinds: ExtractionKind[] = [];
   if (env.MEMORY_LLM_ENTITY_ENABLED) enabledKinds.push('entity');
   if (env.MEMORY_LLM_DURABLE_FACT_ENABLED) enabledKinds.push('durable_fact');
   if (env.MEMORY_LLM_SUMMARY_ENABLED) enabledKinds.push('summary');
   if (env.MEMORY_LLM_CURRENT_STATE_ENABLED) enabledKinds.push('current_state');
+  if (env.MEMORY_LLM_EXACT_DETAILS_ENABLED) enabledKinds.push('exact_details');
   return enabledKinds;
 }
 
@@ -601,6 +609,9 @@ function assignExtractionPayload(
       break;
     case 'current_state':
       payload.current_state = result as MemoryExtractions['current_state'];
+      break;
+    case 'exact_details':
+      payload.exact_details = result as MemoryExtractions['exact_details'];
       break;
   }
 }
@@ -690,7 +701,7 @@ class RunnerBackedMemoryExtractor {
     const normalized = normalizeMemoryExtractions(payload);
     return normalized &&
       Object.keys(normalized).some((key) =>
-        ['entity', 'durable_fact', 'summary', 'current_state'].includes(key)
+        ['entity', 'durable_fact', 'summary', 'current_state', 'exact_details'].includes(key)
       )
       ? normalized
       : null;
@@ -903,7 +914,7 @@ class RunnerBackedMemoryExtractor {
           invalid ||
           !normalized ||
           !Object.keys(normalized).some((key) =>
-            ['entity', 'durable_fact', 'summary', 'current_state'].includes(key)
+            ['entity', 'durable_fact', 'summary', 'current_state', 'exact_details'].includes(key)
           )
         ) {
           invalidMemoryIds.add(resultItem.memoryId);

--- a/packages/api/src/scripts/extract-memory-llm-views.ts
+++ b/packages/api/src/scripts/extract-memory-llm-views.ts
@@ -559,7 +559,8 @@ async function processMemoryBatch(params: {
 }
 
 function getEnabledKinds(options: { batchAllKinds?: boolean } = {}): ExtractionKind[] {
-  if (options.batchAllKinds) return ['entity', 'durable_fact', 'summary', 'exact_details'];
+  if (options.batchAllKinds)
+    return ['entity', 'durable_fact', 'summary', 'current_state', 'exact_details'];
   const enabledKinds: ExtractionKind[] = [];
   if (env.MEMORY_LLM_ENTITY_ENABLED) enabledKinds.push('entity');
   if (env.MEMORY_LLM_DURABLE_FACT_ENABLED) enabledKinds.push('durable_fact');

--- a/packages/api/src/services/embeddings/memory-chunks.test.ts
+++ b/packages/api/src/services/embeddings/memory-chunks.test.ts
@@ -29,7 +29,7 @@ describe('memory chunk multi-view helpers', () => {
     expect(viewCounts.topic).toBe(0);
     expect(viewCounts.entity).toBe(0);
     expect(viewCounts.current_state).toBe(0);
-    expect(viewCounts.exact_detail).toBe(0);
+    expect(viewCounts.exact_details).toBe(0);
     expect(viewCounts.content).toBe(1);
 
     const metadata = {
@@ -135,7 +135,7 @@ describe('memory chunk multi-view helpers', () => {
       'action relevance'
     );
     expect(chunks.find((chunk) => chunk.chunkType === 'fact')?.text).toContain('durable fact:');
-    expect(chunks.find((chunk) => chunk.chunkType === 'exact_detail')?.text).toContain(
+    expect(chunks.find((chunk) => chunk.chunkType === 'exact_details')?.text).toContain(
       'exact detail: state'
     );
     expect(chunks.find((chunk) => chunk.chunkType === 'entity')?.text).toContain('entity: Wren');
@@ -146,7 +146,7 @@ describe('memory chunk multi-view helpers', () => {
     const viewCounts = countChunkViews(chunks);
     expect(viewCounts.summary).toBe(1);
     expect(viewCounts.fact).toBe(1);
-    expect(viewCounts.exact_detail).toBe(1);
+    expect(viewCounts.exact_details).toBe(1);
     expect(viewCounts.entity).toBe(1);
     expect(viewCounts.current_state).toBe(1);
     expect(viewCounts.content).toBe(1);

--- a/packages/api/src/services/embeddings/memory-chunks.test.ts
+++ b/packages/api/src/services/embeddings/memory-chunks.test.ts
@@ -29,6 +29,7 @@ describe('memory chunk multi-view helpers', () => {
     expect(viewCounts.topic).toBe(0);
     expect(viewCounts.entity).toBe(0);
     expect(viewCounts.current_state).toBe(0);
+    expect(viewCounts.exact_detail).toBe(0);
     expect(viewCounts.content).toBe(1);
 
     const metadata = {
@@ -60,7 +61,7 @@ describe('memory chunk multi-view helpers', () => {
     expect(inferChunkTypeFromMetadata(3, metadata)).toBe('content');
   });
 
-  it('prefers llm-derived summary, durable fact, entity, and current state chunks when provided', () => {
+  it('prefers llm-derived summary, durable fact, exact detail, entity, and current state chunks when provided', () => {
     const llmExtractions = memoryExtractionsSchema.parse({
       version: 1,
       provider: 'openai',
@@ -80,6 +81,19 @@ describe('memory chunk multi-view helpers', () => {
             object: 'durable_fact index',
             evidence:
               'Current state should stay separate from durable facts because it is volatile.',
+          },
+        ],
+      },
+      exact_details: {
+        exactDetails: [
+          {
+            kind: 'state',
+            subject: 'dev server',
+            predicate: 'restart behavior',
+            value: 'auto-restarts on file change',
+            status: 'active',
+            evidence:
+              'Current state is also important: like the currently running dev server will autorestart.',
           },
         ],
       },
@@ -121,6 +135,9 @@ describe('memory chunk multi-view helpers', () => {
       'action relevance'
     );
     expect(chunks.find((chunk) => chunk.chunkType === 'fact')?.text).toContain('durable fact:');
+    expect(chunks.find((chunk) => chunk.chunkType === 'exact_detail')?.text).toContain(
+      'exact detail: state'
+    );
     expect(chunks.find((chunk) => chunk.chunkType === 'entity')?.text).toContain('entity: Wren');
     expect(chunks.find((chunk) => chunk.chunkType === 'current_state')?.text).toContain(
       'current state:'
@@ -129,6 +146,7 @@ describe('memory chunk multi-view helpers', () => {
     const viewCounts = countChunkViews(chunks);
     expect(viewCounts.summary).toBe(1);
     expect(viewCounts.fact).toBe(1);
+    expect(viewCounts.exact_detail).toBe(1);
     expect(viewCounts.entity).toBe(1);
     expect(viewCounts.current_state).toBe(1);
     expect(viewCounts.content).toBe(1);

--- a/packages/api/src/services/embeddings/memory-chunks.ts
+++ b/packages/api/src/services/embeddings/memory-chunks.ts
@@ -19,7 +19,7 @@ const DEFAULT_OVERLAP_CHARS = 150;
 export type MemoryChunkType =
   | 'summary'
   | 'fact'
-  | 'exact_detail'
+  | 'exact_details'
   | 'topic'
   | 'entity'
   | 'current_state'
@@ -29,7 +29,7 @@ const CHUNK_TYPE_ORDER: MemoryChunkType[] = [
   'content',
   'summary',
   'fact',
-  'exact_detail',
+  'exact_details',
   'topic',
   'entity',
   'current_state',
@@ -37,7 +37,7 @@ const CHUNK_TYPE_ORDER: MemoryChunkType[] = [
 const LEGACY_CHUNK_TYPE_ORDER: MemoryChunkType[] = [
   'summary',
   'fact',
-  'exact_detail',
+  'exact_details',
   'topic',
   'entity',
   'current_state',
@@ -59,7 +59,7 @@ export interface EmbeddedMemoryChunk extends MemoryEmbeddingChunk {
 export interface MemoryChunkViewCounts {
   summary: number;
   fact: number;
-  exact_detail: number;
+  exact_details: number;
   topic: number;
   entity: number;
   current_state: number;
@@ -70,7 +70,7 @@ function emptyViewCounts(): MemoryChunkViewCounts {
   return {
     summary: 0,
     fact: 0,
-    exact_detail: 0,
+    exact_details: 0,
     topic: 0,
     entity: 0,
     current_state: 0,
@@ -279,7 +279,7 @@ export function buildMemoryEmbeddingChunks(params: {
     : [];
   if (includeLlm) {
     chunks.push(
-      ...reindexChunks(buildChunksFromTexts('exact_detail', exactDetailTexts), chunks.length)
+      ...reindexChunks(buildChunksFromTexts('exact_details', exactDetailTexts), chunks.length)
     );
   }
 

--- a/packages/api/src/services/embeddings/memory-chunks.ts
+++ b/packages/api/src/services/embeddings/memory-chunks.ts
@@ -4,6 +4,7 @@ import {
   buildCurrentStateEmbeddingTexts,
   buildDurableFactEmbeddingTexts,
   buildEntityEmbeddingTexts,
+  buildExactDetailsEmbeddingTexts,
   buildSummaryEmbeddingTexts,
   normalizeMemoryExtractions,
   type MemoryExtractions,
@@ -15,12 +16,20 @@ export { MEMORY_EMBEDDING_CHUNKS_VERSION };
 const DEFAULT_MAX_CHARS = 1000;
 const DEFAULT_OVERLAP_CHARS = 150;
 
-export type MemoryChunkType = 'summary' | 'fact' | 'topic' | 'entity' | 'current_state' | 'content';
+export type MemoryChunkType =
+  | 'summary'
+  | 'fact'
+  | 'exact_detail'
+  | 'topic'
+  | 'entity'
+  | 'current_state'
+  | 'content';
 export type MemoryExtractionChunkMode = 'heuristic' | 'llm' | 'merged';
 const CHUNK_TYPE_ORDER: MemoryChunkType[] = [
   'content',
   'summary',
   'fact',
+  'exact_detail',
   'topic',
   'entity',
   'current_state',
@@ -28,6 +37,7 @@ const CHUNK_TYPE_ORDER: MemoryChunkType[] = [
 const LEGACY_CHUNK_TYPE_ORDER: MemoryChunkType[] = [
   'summary',
   'fact',
+  'exact_detail',
   'topic',
   'entity',
   'current_state',
@@ -49,6 +59,7 @@ export interface EmbeddedMemoryChunk extends MemoryEmbeddingChunk {
 export interface MemoryChunkViewCounts {
   summary: number;
   fact: number;
+  exact_detail: number;
   topic: number;
   entity: number;
   current_state: number;
@@ -59,6 +70,7 @@ function emptyViewCounts(): MemoryChunkViewCounts {
   return {
     summary: 0,
     fact: 0,
+    exact_detail: 0,
     topic: 0,
     entity: 0,
     current_state: 0,
@@ -207,7 +219,7 @@ export function inferChunkTypeFromMetadata(
       ? (embeddingChunks.viewCounts as Record<string, unknown>)
       : null;
 
-  if (!viewCounts) return null;
+  if (!embeddingChunks || !viewCounts) return null;
 
   const version = typeof embeddingChunks.version === 'number' ? embeddingChunks.version : null;
   const chunkTypeOrder =
@@ -261,6 +273,15 @@ export function buildMemoryEmbeddingChunks(params: {
     : [];
   const factChunks = includeLlm ? buildChunksFromTexts('fact', durableFactTexts) : [];
   chunks.push(...reindexChunks(factChunks, chunks.length));
+
+  const exactDetailTexts = llmExtractions?.exact_details
+    ? buildExactDetailsEmbeddingTexts(llmExtractions.exact_details)
+    : [];
+  if (includeLlm) {
+    chunks.push(
+      ...reindexChunks(buildChunksFromTexts('exact_detail', exactDetailTexts), chunks.length)
+    );
+  }
 
   const entityTexts = llmExtractions?.entity
     ? buildEntityEmbeddingTexts(llmExtractions.entity)

--- a/packages/api/src/services/memory-benchmark-constants.ts
+++ b/packages/api/src/services/memory-benchmark-constants.ts
@@ -1,3 +1,3 @@
-export const MEMORY_EXTRACTION_VERSION = 2;
+export const MEMORY_EXTRACTION_VERSION = 3;
 export const MEMORY_EMBEDDING_CHUNKS_VERSION = 3;
 export const DEFAULT_MEMORY_LLM_MODEL = 'gpt-4.1-mini';

--- a/packages/api/src/services/memory-llm-extraction.test.ts
+++ b/packages/api/src/services/memory-llm-extraction.test.ts
@@ -8,12 +8,15 @@ import {
   buildDurableFactExtractionPrompt,
   buildEntityEmbeddingTexts,
   buildEntityExtractionPrompt,
+  buildExactDetailsEmbeddingTexts,
+  buildExactDetailsExtractionPrompt,
   buildSummaryEmbeddingTexts,
   buildSummaryExtractionPrompt,
   coerceExtractionPayload,
   currentStateExtractionSchema,
   durableFactExtractionSchema,
   entityExtractionSchema,
+  exactDetailsExtractionSchema,
   MemoryLlmExtractor,
   memoryExtractionsSchema,
   normalizeMemoryExtractions,
@@ -63,6 +66,14 @@ describe('memory-llm-extraction', () => {
     expect(prompt.kind).toBe('current_state');
     expect(prompt.userPrompt).toContain('present or near-present operational state');
     expect(prompt.userPrompt).toContain('dev server auto-restarts');
+  });
+
+  it('builds an exact-details prompt for atomic source-grounded values', () => {
+    const prompt = buildExactDetailsExtractionPrompt(source);
+    expect(prompt.kind).toBe('exact_details');
+    expect(prompt.userPrompt).toContain('subject / predicate / value');
+    expect(prompt.userPrompt).toContain('counts, dates/times/durations');
+    expect(prompt.schemaDescription).toContain('exactDetails');
   });
 
   it('builds a batch extraction prompt that keeps memories independent', () => {
@@ -146,6 +157,25 @@ describe('memory-llm-extraction', () => {
     expect(buildCurrentStateEmbeddingTexts(parsed)[0]).toContain('volatility: volatile');
   });
 
+  it('formats embedding texts from exact detail extraction', () => {
+    const parsed = exactDetailsExtractionSchema.parse({
+      exactDetails: [
+        {
+          kind: 'quantity',
+          subject: 'smoker purchase',
+          predicate: 'occurred',
+          value: '38',
+          unit: 'days ago',
+          status: 'active',
+          evidence: 'I bought the smoker 38 days ago.',
+        },
+      ],
+    });
+
+    expect(buildExactDetailsEmbeddingTexts(parsed)[0]).toContain('exact detail: quantity');
+    expect(buildExactDetailsEmbeddingTexts(parsed)[0]).toContain('value: 38');
+  });
+
   it('normalizes extraction metadata', () => {
     const normalized = normalizeMemoryExtractions({
       version: 1,
@@ -220,10 +250,23 @@ describe('memory-llm-extraction', () => {
       ],
     });
     const summary = coerceExtractionPayload('summary', rawSummary);
+    const exactDetails = coerceExtractionPayload('exact_details', {
+      details: [
+        {
+          kind: 'count',
+          entity: 'garage',
+          attribute: 'spare screwdriver count',
+          detail: '1',
+          quote: 'There is one spare screwdriver in the garage.',
+        },
+      ],
+    });
 
     expect(entity?.entities[0]?.entityType).toBe('other');
     expect(entity?.entities[0]?.aliases).toHaveLength(6);
     expect(summary?.keyPoints).toHaveLength(6);
+    expect(exactDetails?.exactDetails[0]?.kind).toBe('other');
+    expect(exactDetails?.exactDetails[0]?.value).toBe('1');
     expect(rawSummary.keyPoints).toHaveLength(7);
   });
 

--- a/packages/api/src/services/memory-llm-extraction.ts
+++ b/packages/api/src/services/memory-llm-extraction.ts
@@ -55,12 +55,44 @@ export const currentStateExtractionSchema = z.object({
   evidence: z.string().min(1),
 });
 
+const exactDetailKindSchema = z.enum([
+  'quantity',
+  'date_time',
+  'state',
+  'location',
+  'possession',
+  'completion',
+  'list_item',
+  'identifier',
+  'relationship',
+  'constraint',
+  'other',
+]);
+
+const exactDetailStatusSchema = z.enum(['active', 'historical', 'superseded', 'uncertain']);
+
+export const exactDetailExtractionItemSchema = z.object({
+  kind: exactDetailKindSchema,
+  subject: z.string().min(1),
+  predicate: z.string().min(1),
+  value: z.string().min(1),
+  unit: z.string().optional(),
+  qualifier: z.string().optional(),
+  timeScope: z.string().optional(),
+  status: exactDetailStatusSchema.default('active'),
+  evidence: z.string().min(1),
+});
+
 export const entityExtractionSchema = z.object({
   entities: z.array(entityExtractionItemSchema).max(8),
 });
 
 export const durableFactExtractionSchema = z.object({
   durableFacts: z.array(durableFactExtractionItemSchema).max(10),
+});
+
+export const exactDetailsExtractionSchema = z.object({
+  exactDetails: z.array(exactDetailExtractionItemSchema).max(24),
 });
 
 export const memoryExtractionsSchema = z.object({
@@ -72,6 +104,7 @@ export const memoryExtractionsSchema = z.object({
   durable_fact: durableFactExtractionSchema.optional(),
   summary: summaryExtractionSchema.optional(),
   current_state: currentStateExtractionSchema.optional(),
+  exact_details: exactDetailsExtractionSchema.optional(),
   raw: z
     .object({
       provider: z.string().optional(),
@@ -81,6 +114,7 @@ export const memoryExtractionsSchema = z.object({
       durable_fact: z.unknown().optional(),
       summary: z.unknown().optional(),
       current_state: z.unknown().optional(),
+      exact_details: z.unknown().optional(),
     })
     .passthrough()
     .optional(),
@@ -107,7 +141,20 @@ export interface MemoryExtractionSource {
   salience?: string | null;
 }
 
-export type ExtractionKind = 'entity' | 'durable_fact' | 'summary' | 'current_state';
+export type ExtractionKind =
+  | 'entity'
+  | 'durable_fact'
+  | 'summary'
+  | 'current_state'
+  | 'exact_details';
+
+const EXTRACTION_KINDS: ExtractionKind[] = [
+  'entity',
+  'durable_fact',
+  'summary',
+  'current_state',
+  'exact_details',
+];
 
 export interface BatchMemoryExtractionSource {
   memoryId: string;
@@ -248,6 +295,30 @@ export function buildCurrentStateExtractionPrompt(
   };
 }
 
+export function buildExactDetailsExtractionPrompt(
+  source: MemoryExtractionSource
+): ExtractionPromptBundle {
+  return {
+    kind: 'exact_details',
+    systemPrompt:
+      'You extract exact retrieval-critical details from a single memory record. Return strict JSON only. Exact details are small atomic values that generic summaries often lose: counts, dates, durations, list-item mappings, names, IDs, paths, URLs, yes/no states, possession/location facts, and source-stated corrections or unsupported premises. Do not speculate. Each detail must include direct evidence from the memory.',
+    schemaDescription:
+      'JSON schema: {"exactDetails": [{"kind": "quantity"|"date_time"|"state"|"location"|"possession"|"completion"|"list_item"|"identifier"|"relationship"|"constraint"|"other", "subject": string, "predicate": string, "value": string, "unit"?: string, "qualifier"?: string, "timeScope"?: string, "status": "active"|"historical"|"superseded"|"uncertain", "evidence": string}]}',
+    userPrompt: [
+      'Extraction type: exact_details',
+      'Task:',
+      '- Extract source-grounded atomic details likely to be needed for exact answer questions or operational decisions.',
+      '- Preserve numbers/counts, dates/times/durations, names/IDs/URLs/paths, list-item mappings, materials/tools, quantities, colors, yes/no states, possession/location facts, completion states, ordering/comparison facts, and explicit corrections/overrides.',
+      '- Include assistant-response details when a future question could ask what the assistant said, recommended, listed, or calculated.',
+      '- If the memory says a premise is false or unsupported, record the stated correction as an exact detail with kind "state" or "other".',
+      '- Use subject / predicate / value so the fact can later behave like structured metadata. Keep value exact, including units when present.',
+      '- Prefer 4-8 high-signal details; use an empty exactDetails array if none are useful. The normalized store supports up to 24 details and preserves raw overflow separately.',
+      '',
+      buildSourceBlock(source),
+    ].join('\n'),
+  };
+}
+
 export function buildExtractionPrompt(
   source: MemoryExtractionSource,
   kind: ExtractionKind
@@ -261,6 +332,8 @@ export function buildExtractionPrompt(
       return buildSummaryExtractionPrompt(source);
     case 'current_state':
       return buildCurrentStateExtractionPrompt(source);
+    case 'exact_details':
+      return buildExactDetailsExtractionPrompt(source);
   }
 }
 
@@ -279,6 +352,8 @@ export function buildBatchExtractionPrompt(
         return '"summary": {"summary": string, "keyPoints": string[], "actionRelevance": string}';
       case 'current_state':
         return '"current_state": {"state": string, "scope": string, "status": string, "volatility": "volatile"|"semi-stable"|"stable", "evidence": string}';
+      case 'exact_details':
+        return '"exact_details": {"exactDetails": [{"kind": "quantity"|"date_time"|"state"|"location"|"possession"|"completion"|"list_item"|"identifier"|"relationship"|"constraint"|"other", "subject": string, "predicate": string, "value": string, "unit"?: string, "qualifier"?: string, "timeScope"?: string, "status": "active"|"historical"|"superseded"|"uncertain", "evidence": string}]}';
     }
   });
 
@@ -298,6 +373,7 @@ export function buildBatchExtractionPrompt(
       '- For summary extraction: summarize only that single source memory. Do not aggregate across the batch. Optimize for future retrieval and decision support.',
       '- Summary keyPoints should include exact values, names, durations, URLs, or list-item mappings when those are likely future follow-up targets.',
       '- For current_state extraction: include only present or near-present operational state supported by that memory.',
+      '- For exact_details extraction: extract precise atomic metadata that summaries lose: counts, dates/times/durations, names/IDs/URLs/paths, list-item mappings, materials/tools, yes/no states, possession/location facts, completion states, and explicit corrections/overrides. Prefer 4-8 high-signal details; return an empty exactDetails array if none are useful.',
       '- Evidence must quote or closely paraphrase text from the same memory.',
       '',
       'Input memories JSON:',
@@ -358,6 +434,28 @@ export function buildCurrentStateEmbeddingTexts(
   ];
 }
 
+export function buildExactDetailsEmbeddingTexts(
+  payload: z.infer<typeof exactDetailsExtractionSchema>
+): string[] {
+  return payload.exactDetails.map((detail) =>
+    compactWhitespace(
+      [
+        `exact detail: ${detail.kind}`,
+        `subject: ${detail.subject}`,
+        `predicate: ${detail.predicate}`,
+        `value: ${detail.value}`,
+        detail.unit ? `unit: ${detail.unit}` : null,
+        detail.qualifier ? `qualifier: ${detail.qualifier}` : null,
+        detail.timeScope ? `time scope: ${detail.timeScope}` : null,
+        `status: ${detail.status}`,
+        `evidence: ${quote(detail.evidence)}`,
+      ]
+        .filter(Boolean)
+        .join('; ')
+    )
+  );
+}
+
 export function normalizeMemoryExtractions(value: unknown): MemoryExtractions | null {
   const parsed = memoryExtractionsSchema.safeParse(value);
   return parsed.success ? parsed.data : null;
@@ -366,6 +464,8 @@ export function normalizeMemoryExtractions(value: unknown): MemoryExtractions | 
 const ENTITY_TYPES = new Set(entityExtractionItemSchema.shape.entityType.options);
 const DURABLE_FACT_CATEGORIES = new Set(durableFactExtractionItemSchema.shape.category.options);
 const VOLATILITY_VALUES = new Set(currentStateExtractionSchema.shape.volatility.options);
+const EXACT_DETAIL_KINDS = new Set(exactDetailKindSchema.options);
+const EXACT_DETAIL_STATUSES = new Set(exactDetailStatusSchema.options);
 
 function asRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === 'object' && !Array.isArray(value)
@@ -465,6 +565,57 @@ function coerceCurrentStateExtraction(raw: unknown): z.infer<typeof currentState
   });
 }
 
+function coerceExactDetailsExtraction(raw: unknown): z.infer<typeof exactDetailsExtractionSchema> {
+  const record = asRecord(raw);
+  const rawDetails =
+    record.exactDetails ?? record.exact_details ?? record.details ?? record.exact_details_list;
+  const exactDetails = (Array.isArray(rawDetails) ? rawDetails : [])
+    .map((item) => {
+      const detail = asRecord(item);
+      const subject =
+        asNonEmptyString(detail.subject) ||
+        asNonEmptyString(detail.entity) ||
+        asNonEmptyString(detail.name);
+      const predicate =
+        asNonEmptyString(detail.predicate) ||
+        asNonEmptyString(detail.attribute) ||
+        asNonEmptyString(detail.relation) ||
+        asNonEmptyString(detail.field) ||
+        'has exact detail';
+      const value =
+        asNonEmptyString(detail.value) ||
+        asNonEmptyString(detail.object) ||
+        asNonEmptyString(detail.detail) ||
+        asNonEmptyString(detail.exactText);
+      const evidence =
+        asNonEmptyString(detail.evidence) ||
+        asNonEmptyString(detail.quote) ||
+        asNonEmptyString(detail.sourceText) ||
+        value;
+      if (!subject || !value || !evidence) return null;
+      const rawKind = asNonEmptyString(detail.kind);
+      const rawStatus = asNonEmptyString(detail.status);
+      return {
+        kind: rawKind && EXACT_DETAIL_KINDS.has(rawKind as never) ? rawKind : 'other',
+        subject,
+        predicate,
+        value,
+        ...(asNonEmptyString(detail.unit) ? { unit: asNonEmptyString(detail.unit) as string } : {}),
+        ...(asNonEmptyString(detail.qualifier)
+          ? { qualifier: asNonEmptyString(detail.qualifier) as string }
+          : {}),
+        ...(asNonEmptyString(detail.timeScope)
+          ? { timeScope: asNonEmptyString(detail.timeScope) as string }
+          : {}),
+        status: rawStatus && EXACT_DETAIL_STATUSES.has(rawStatus as never) ? rawStatus : 'active',
+        evidence,
+      };
+    })
+    .filter((item): item is z.infer<typeof exactDetailExtractionItemSchema> => Boolean(item))
+    .slice(0, 24);
+  return exactDetailsExtractionSchema.parse({ exactDetails });
+}
+
 export function coerceExtractionPayload(
   kind: ExtractionKind,
   raw: unknown
@@ -478,6 +629,8 @@ export function coerceExtractionPayload(
       return coerceSummaryExtraction(raw);
     case 'current_state':
       return coerceCurrentStateExtraction(raw);
+    case 'exact_details':
+      return coerceExactDetailsExtraction(raw);
   }
 }
 
@@ -498,6 +651,9 @@ function assignExtractionPayload(
       break;
     case 'current_state':
       payload.current_state = result as MemoryExtractions['current_state'];
+      break;
+    case 'exact_details':
+      payload.exact_details = result as MemoryExtractions['exact_details'];
       break;
   }
 }
@@ -524,6 +680,7 @@ function buildRuntimeConfig(): ExtractionRuntimeConfig {
   if (env.MEMORY_LLM_DURABLE_FACT_ENABLED) enabledKinds.push('durable_fact');
   if (env.MEMORY_LLM_SUMMARY_ENABLED) enabledKinds.push('summary');
   if (env.MEMORY_LLM_CURRENT_STATE_ENABLED) enabledKinds.push('current_state');
+  if (env.MEMORY_LLM_EXACT_DETAILS_ENABLED) enabledKinds.push('exact_details');
 
   return {
     enabled: env.MEMORY_LLM_EXTRACTION_ENABLED,
@@ -612,9 +769,7 @@ export class MemoryLlmExtractor {
 
     const normalized = normalizeMemoryExtractions(payload);
     return normalized &&
-      Object.keys(normalized).some((key) =>
-        ['entity', 'durable_fact', 'summary', 'current_state'].includes(key)
-      )
+      Object.keys(normalized).some((key) => EXTRACTION_KINDS.includes(key as ExtractionKind))
       ? normalized
       : null;
   }

--- a/packages/benchmarks/src/benchmark-memory-dream.logic.test.ts
+++ b/packages/benchmarks/src/benchmark-memory-dream.logic.test.ts
@@ -272,6 +272,8 @@ describe('benchmark-memory-dream logic', () => {
     expect(prompt.userPrompt).toContain('\"sessionId\": \"s1\"');
     expect(prompt.userPrompt).toContain('No future evaluation question is available');
     expect(prompt.userPrompt).not.toContain('question for later evaluation only');
+    expect(prompt.userPrompt).toContain('quantity_count');
+    expect(prompt.userPrompt).toContain('negative_or_premise');
   });
 
   it('coerces runner dream JSON into evidence-linked state without trusting metadata as answer text', () => {

--- a/packages/benchmarks/src/benchmark-memory-dream.logic.test.ts
+++ b/packages/benchmarks/src/benchmark-memory-dream.logic.test.ts
@@ -121,6 +121,64 @@ describe('benchmark-memory-dream logic', () => {
     expect(hasOptionalAnswer(rendered, '38')).toBe(true);
   });
 
+  it('promotes exact detail views into evidence-linked local dream facts', () => {
+    const state = createInitialDreamState('case-smoker', 'online');
+    const [session] = buildOrderedDreamSessions(
+      {
+        id: 'case-smoker',
+        query: 'How many days ago did I buy a smoker?',
+        answer: '38',
+        answerSessionIds: ['s1'],
+        sessions: [
+          {
+            sessionId: 's1',
+            content: 'session s1\nuser: I bought the smoker 38 days ago.',
+            hasAnswer: true,
+            isAnswerSession: true,
+            turnCount: 1,
+          },
+        ],
+      },
+      [
+        {
+          id: 'mem-s1',
+          content: 'session s1\nuser: I bought the smoker 38 days ago.',
+          summary: null,
+          created_at: '2026-01-01T00:00:00Z',
+          metadata: {
+            llm_extractions: {
+              exact_details: {
+                exactDetails: [
+                  {
+                    kind: 'quantity',
+                    subject: 'smoker purchase',
+                    predicate: 'happened',
+                    value: '38',
+                    unit: 'days ago',
+                    status: 'active',
+                    evidence: 'I bought the smoker 38 days ago.',
+                  },
+                ],
+              },
+            },
+          },
+        },
+      ]
+    ).sessions;
+
+    const updated = applyLocalDreamUpdate(state, session);
+
+    expect(updated.durableFacts).toHaveLength(1);
+    expect(updated.durableFacts[0]).toMatchObject({
+      category: 'exact_quantity',
+      subject: 'smoker purchase',
+      object: '38 days ago',
+      evidenceMemoryIds: ['mem-s1'],
+      evidenceSessionIds: ['s1'],
+    });
+    expect(renderDreamStateForAnswerCheck(updated)).toContain('38 days ago');
+  });
+
   it('keeps richer entity descriptions when later mentions are terse', () => {
     const state = createInitialDreamState('case-entity', 'online');
     const [detailed, terse] = buildOrderedDreamSessions(

--- a/packages/benchmarks/src/benchmark-memory-dream.logic.ts
+++ b/packages/benchmarks/src/benchmark-memory-dream.logic.ts
@@ -189,6 +189,17 @@ function stripSessionHeader(content: string): string {
   return content.replace(/^session\s+[^\r\n]+[\r\n]+/i, '');
 }
 
+const EXACT_DETAIL_RULES = [
+  '- Preserve exact small details as durableFacts/currentStates even when they seem mundane: counts, quantities, durations, dates, ordinals, yes/no completion or possession, locations, materials, tools, titles, names, quoted wording, and unsupported/conflicting premises.',
+  '- User-authored exact details outrank generic assistant advice. For visible user turns, preserve every explicit personal count, amount, duration, date, quantity, possession, location, and completion/status value unless it is clearly not about the user/case state.',
+  '- Do not let assistant numbered advice lists crowd out user-state numbers. Generic list numbering from advice is low priority; user statements like "I have 37 coins" are high priority.',
+  '- Use precise durableFact categories when helpful: quantity_count, state_transition, possession_location, list_entry, exact_span, negative_or_premise, decision, constraint, process, status.',
+  '- For list/table/enumeration content, preserve numbered or ordinal items as durableFacts using the ordinal/key and exact item text when visible.',
+  '- For location or possession updates, write the latest active currentStates record and mark older conflicting facts superseded when evidence supports a change.',
+  '- For absence or premise-mismatch evidence, write what the source actually states and what remains unsupported; do not invent the missing premise.',
+  '- Prefer preserving exact values over broad topical summaries. A compact ledger can omit generic advice before it omits source-grounded values, counts, locations, or exact spans.',
+];
+
 function queryTokens(query: string): string[] {
   return uniqueStrings(
     query
@@ -600,6 +611,7 @@ export function buildOnlineDreamPrompt(params: {
       'Integration rules:',
       '- Treat episodes as chronological within this case.',
       '- Preserve current state updates, quantities, decisions, constraints, process rules, list/table mappings, and exact values when evidence supports them.',
+      ...EXACT_DETAIL_RULES,
       '- If a new episode updates an old value, mark the old fact superseded and write the new active value with evidence links.',
       '- If a value requires arithmetic or accumulation, perform the update and keep both evidence session ids.',
       '- Explicit aggregate/count statements are authoritative state. Do not replace an explicit total with a smaller count of named examples.',
@@ -857,6 +869,7 @@ export function buildBatchDreamPrompt(params: {
       'Reconciliation rules:',
       '- Treat episodes as chronological within this case.',
       '- Preserve current state updates, quantities, decisions, constraints, process rules, list/table mappings, and exact values when evidence supports them.',
+      ...EXACT_DETAIL_RULES,
       '- If a later episode updates an earlier value, mark the older fact superseded and keep the latest active value with evidence links.',
       '- If a value requires arithmetic or accumulation, perform the update and keep all supporting evidence session ids.',
       '- Explicit aggregate/count statements are authoritative state. Do not replace an explicit total with a smaller count of named examples.',

--- a/packages/benchmarks/src/benchmark-memory-dream.logic.ts
+++ b/packages/benchmarks/src/benchmark-memory-dream.logic.ts
@@ -87,6 +87,7 @@ export interface OrderedDreamSession {
 export interface DreamExtractionViews {
   entities: ExtractedEntity[];
   durableFacts: ExtractedDurableFact[];
+  exactDetails: ExtractedExactDetail[];
   summary: ExtractedSummary | null;
   currentState: ExtractedCurrentState | null;
 }
@@ -104,6 +105,18 @@ export interface ExtractedDurableFact {
   category: string;
   subject?: string;
   object?: string;
+  evidence: string;
+}
+
+export interface ExtractedExactDetail {
+  kind: string;
+  subject: string;
+  predicate: string;
+  value: string;
+  unit?: string;
+  qualifier?: string;
+  timeScope?: string;
+  status: 'active' | 'historical' | 'superseded' | 'uncertain';
   evidence: string;
 }
 
@@ -347,6 +360,35 @@ function extractCurrentState(raw: unknown): ExtractedCurrentState | null {
   };
 }
 
+function extractExactDetails(raw: unknown): ExtractedExactDetail[] {
+  const record = asRecord(raw);
+  return asArray(record?.exactDetails)
+    .map((item) => {
+      const detail = asRecord(item);
+      const subject = asString(detail?.subject);
+      const predicate = asString(detail?.predicate);
+      const value = asString(detail?.value);
+      const evidence = asString(detail?.evidence);
+      if (!subject || !predicate || !value || !evidence) return null;
+      const rawStatus = asString(detail?.status);
+      return {
+        kind: asString(detail?.kind) || 'other',
+        subject,
+        predicate,
+        value,
+        unit: asString(detail?.unit) || undefined,
+        qualifier: asString(detail?.qualifier) || undefined,
+        timeScope: asString(detail?.timeScope) || undefined,
+        status:
+          rawStatus === 'historical' || rawStatus === 'superseded' || rawStatus === 'uncertain'
+            ? rawStatus
+            : 'active',
+        evidence,
+      };
+    })
+    .filter((detail): detail is ExtractedExactDetail => Boolean(detail));
+}
+
 export function parseLongMemSessionId(content: string): string | null {
   const match = content.match(/^session\s+([^\r\n]+)[\r\n]+/i);
   return match?.[1]?.trim() || null;
@@ -357,6 +399,7 @@ export function extractDreamViews(metadata: Record<string, unknown> | null): Dre
   return {
     entities: extractEntities(llmExtractions?.entity),
     durableFacts: extractDurableFacts(llmExtractions?.durable_fact),
+    exactDetails: extractExactDetails(llmExtractions?.exact_details),
     summary: extractSummary(llmExtractions?.summary),
     currentState: extractCurrentState(llmExtractions?.current_state),
   };
@@ -513,6 +556,49 @@ export function applyLocalDreamUpdate(
     });
   }
 
+  for (const detail of session.extractions.exactDetails) {
+    const valueWithUnit = [detail.value, detail.unit].filter(Boolean).join(' ');
+    const factText = [
+      `${detail.subject} ${detail.predicate} ${valueWithUnit}`.trim(),
+      detail.qualifier ? `(${detail.qualifier})` : '',
+      detail.timeScope ? `[${detail.timeScope}]` : '',
+    ]
+      .filter(Boolean)
+      .join(' ');
+    const fact: ExtractedDurableFact = {
+      fact: factText,
+      category: `exact_${detail.kind}`,
+      subject: detail.subject,
+      object: valueWithUnit || detail.value,
+      evidence: detail.evidence,
+    };
+    const key = normalizeKey(
+      ['exact', detail.kind, detail.subject, detail.predicate, valueWithUnit || detail.value]
+        .filter(Boolean)
+        .join('|')
+    );
+    const existing = factMap.get(key);
+    const status =
+      detail.status === 'superseded'
+        ? 'superseded'
+        : detail.status === 'uncertain'
+          ? 'uncertain'
+          : (existing?.status ?? 'active');
+    moveToEnd(factMap, key, {
+      key,
+      fact: fact.fact,
+      category: fact.category,
+      subject: fact.subject,
+      object: fact.object,
+      evidence: fact.evidence,
+      status,
+      evidenceMemoryIds: mergeEvidenceIds(existing?.evidenceMemoryIds || [], session.memoryId),
+      evidenceSessionIds: mergeEvidenceIds(existing?.evidenceSessionIds || [], session.sessionId),
+      firstSeenSessionId: existing?.firstSeenSessionId || session.sessionId,
+      lastSeenSessionId: session.sessionId,
+    });
+  }
+
   if (session.extractions.currentState) {
     const currentState = session.extractions.currentState;
     const key = currentStateKey(currentState);
@@ -654,6 +740,11 @@ function compactDreamExtractionViews(views: DreamExtractionViews): DreamExtracti
       ...fact,
       fact: clampText(fact.fact, 260),
       evidence: clampText(fact.evidence, 180),
+    })),
+    exactDetails: views.exactDetails.slice(0, 12).map((detail) => ({
+      ...detail,
+      value: clampText(detail.value, 160),
+      evidence: clampText(detail.evidence, 180),
     })),
     summary: views.summary
       ? {

--- a/packages/benchmarks/src/benchmark-memory-recall.config.test.ts
+++ b/packages/benchmarks/src/benchmark-memory-recall.config.test.ts
@@ -29,6 +29,7 @@ describe('benchmark-memory-recall config helpers', () => {
       MEMORY_LLM_DURABLE_FACT_ENABLED: 'false',
       MEMORY_LLM_SUMMARY_ENABLED: 'true',
       MEMORY_LLM_CURRENT_STATE_ENABLED: 'false',
+      MEMORY_LLM_EXACT_DETAILS_ENABLED: 'true',
     } as NodeJS.ProcessEnv);
 
     expect(key).toContain('chunks-v');

--- a/packages/benchmarks/src/benchmark-memory-recall.config.ts
+++ b/packages/benchmarks/src/benchmark-memory-recall.config.ts
@@ -43,6 +43,7 @@ export function buildRepresentationKey(env: NodeJS.ProcessEnv = process.env): st
     env.MEMORY_LLM_DURABLE_FACT_ENABLED || 'false',
     env.MEMORY_LLM_SUMMARY_ENABLED || 'false',
     env.MEMORY_LLM_CURRENT_STATE_ENABLED || 'false',
+    env.MEMORY_LLM_EXACT_DETAILS_ENABLED || 'false',
   ];
   return slugify(parts.join('-'));
 }

--- a/packages/benchmarks/src/benchmark-memory-recall.variant.test.ts
+++ b/packages/benchmarks/src/benchmark-memory-recall.variant.test.ts
@@ -14,9 +14,11 @@ describe('benchmark-memory-recall variants', () => {
       'content-plus-entity-parallel'
     );
     expect(parseBenchmarkRecallVariant('content+entity+fact')).toBe('content-plus-entity-fact');
+    expect(parseBenchmarkRecallVariant('content+exact')).toBe('content-plus-exact');
     expect(parseBenchmarkRecallVariant('content+derived')).toBe('content-plus-derived');
     expect(parseBenchmarkRecallVariant('entities')).toBe('entity-only');
     expect(parseBenchmarkRecallVariant('durable-facts')).toBe('fact-only');
+    expect(parseBenchmarkRecallVariant('exact-details')).toBe('exact-only');
     expect(parseBenchmarkRecallVariant('derived')).toBe('derived-only');
     expect(parseBenchmarkRecallVariant('no-chrono')).toBe('multiview-no-chrono');
     expect(parseBenchmarkRecallVariant('unknown')).toBe('default');
@@ -54,7 +56,7 @@ describe('benchmark-memory-recall variants', () => {
       })
     ).toMatchObject({
       recallMode: 'semantic',
-      semanticChunkTypes: ['summary', 'fact', 'topic', 'entity'],
+      semanticChunkTypes: ['summary', 'fact', 'exact_detail', 'topic', 'entity'],
       applyChunkTypeBoosts: false,
     });
   });
@@ -160,6 +162,36 @@ describe('benchmark-memory-recall variants', () => {
     });
   });
 
+  it('builds explicit exact-detail options for semantic recall', () => {
+    expect(
+      buildBenchmarkRecallOptions({
+        mode: 'semantic',
+        variant: 'exact-only',
+        limit: 5,
+        agentId: 'lumen',
+        topics: ['benchmark:memory-recall:case-exact'],
+      })
+    ).toMatchObject({
+      recallMode: 'semantic',
+      semanticChunkTypes: ['exact_detail'],
+      applyChunkTypeBoosts: false,
+    });
+
+    expect(
+      buildBenchmarkRecallOptions({
+        mode: 'semantic',
+        variant: 'content-plus-exact',
+        limit: 5,
+        agentId: 'lumen',
+        topics: ['benchmark:memory-recall:case-content-exact'],
+      })
+    ).toMatchObject({
+      recallMode: 'semantic',
+      semanticChunkTypes: ['content', 'exact_detail'],
+      applyChunkTypeBoosts: false,
+    });
+  });
+
   it('builds explicit content-plus-derived semantic options', () => {
     expect(
       buildBenchmarkRecallOptions({
@@ -171,7 +203,15 @@ describe('benchmark-memory-recall variants', () => {
       })
     ).toMatchObject({
       recallMode: 'semantic',
-      semanticChunkTypes: ['content', 'summary', 'fact', 'topic', 'entity', 'current_state'],
+      semanticChunkTypes: [
+        'content',
+        'summary',
+        'fact',
+        'exact_detail',
+        'topic',
+        'entity',
+        'current_state',
+      ],
       applyChunkTypeBoosts: false,
     });
   });

--- a/packages/benchmarks/src/benchmark-memory-recall.variant.test.ts
+++ b/packages/benchmarks/src/benchmark-memory-recall.variant.test.ts
@@ -56,7 +56,7 @@ describe('benchmark-memory-recall variants', () => {
       })
     ).toMatchObject({
       recallMode: 'semantic',
-      semanticChunkTypes: ['summary', 'fact', 'exact_detail', 'topic', 'entity'],
+      semanticChunkTypes: ['summary', 'fact', 'exact_details', 'topic', 'entity'],
       applyChunkTypeBoosts: false,
     });
   });
@@ -173,7 +173,7 @@ describe('benchmark-memory-recall variants', () => {
       })
     ).toMatchObject({
       recallMode: 'semantic',
-      semanticChunkTypes: ['exact_detail'],
+      semanticChunkTypes: ['exact_details'],
       applyChunkTypeBoosts: false,
     });
 
@@ -187,7 +187,7 @@ describe('benchmark-memory-recall variants', () => {
       })
     ).toMatchObject({
       recallMode: 'semantic',
-      semanticChunkTypes: ['content', 'exact_detail'],
+      semanticChunkTypes: ['content', 'exact_details'],
       applyChunkTypeBoosts: false,
     });
   });
@@ -207,7 +207,7 @@ describe('benchmark-memory-recall variants', () => {
         'content',
         'summary',
         'fact',
-        'exact_detail',
+        'exact_details',
         'topic',
         'entity',
         'current_state',

--- a/packages/benchmarks/src/benchmark-memory-recall.variant.ts
+++ b/packages/benchmarks/src/benchmark-memory-recall.variant.ts
@@ -7,12 +7,14 @@ export type BenchmarkRecallVariant =
   | 'content-plus-entity'
   | 'content-plus-entity-parallel'
   | 'content-plus-fact'
+  | 'content-plus-exact'
   | 'content-plus-summary'
   | 'content-plus-summary-fact'
   | 'content-plus-entity-fact'
   | 'content-plus-derived'
   | 'entity-only'
   | 'fact-only'
+  | 'exact-only'
   | 'summary-only'
   | 'current-state-only'
   | 'derived-only'
@@ -35,6 +37,11 @@ const VARIANT_ALIASES: Record<string, BenchmarkRecallVariant> = {
   'content-plus-fact': 'content-plus-fact',
   'content+fact': 'content-plus-fact',
   'raw-plus-fact': 'content-plus-fact',
+  'content-plus-exact': 'content-plus-exact',
+  'content+exact': 'content-plus-exact',
+  'content-plus-exact-detail': 'content-plus-exact',
+  'content+exact-detail': 'content-plus-exact',
+  'raw-plus-exact': 'content-plus-exact',
   'content-plus-summary': 'content-plus-summary',
   'content+summary': 'content-plus-summary',
   'raw-plus-summary': 'content-plus-summary',
@@ -56,6 +63,12 @@ const VARIANT_ALIASES: Record<string, BenchmarkRecallVariant> = {
   'durable-facts': 'fact-only',
   'durable-fact-only': 'fact-only',
   'durable-facts-only': 'fact-only',
+  'exact-only': 'exact-only',
+  exact: 'exact-only',
+  'exact-detail': 'exact-only',
+  'exact-details': 'exact-only',
+  'exact-detail-only': 'exact-only',
+  'exact-details-only': 'exact-only',
   'summary-only': 'summary-only',
   summary: 'summary-only',
   summaries: 'summary-only',
@@ -113,6 +126,11 @@ function buildVariantSemanticOptions(
         semanticChunkTypes: ['content', 'fact'],
         applyChunkTypeBoosts: false,
       };
+    case 'content-plus-exact':
+      return {
+        semanticChunkTypes: ['content', 'exact_detail'],
+        applyChunkTypeBoosts: false,
+      };
     case 'content-plus-summary':
       return {
         semanticChunkTypes: ['content', 'summary'],
@@ -130,12 +148,25 @@ function buildVariantSemanticOptions(
       };
     case 'content-plus-derived':
       return {
-        semanticChunkTypes: ['content', 'summary', 'fact', 'topic', 'entity', 'current_state'],
+        semanticChunkTypes: [
+          'content',
+          'summary',
+          'fact',
+          'exact_detail',
+          'topic',
+          'entity',
+          'current_state',
+        ],
         applyChunkTypeBoosts: false,
       };
     case 'fact-only':
       return {
         semanticChunkTypes: ['fact'],
+        applyChunkTypeBoosts: false,
+      };
+    case 'exact-only':
+      return {
+        semanticChunkTypes: ['exact_detail'],
         applyChunkTypeBoosts: false,
       };
     case 'summary-only':
@@ -150,12 +181,12 @@ function buildVariantSemanticOptions(
       };
     case 'derived-only':
       return {
-        semanticChunkTypes: ['summary', 'fact', 'topic', 'entity'],
+        semanticChunkTypes: ['summary', 'fact', 'exact_detail', 'topic', 'entity'],
         applyChunkTypeBoosts: false,
       };
     case 'multiview-no-boost':
       return {
-        semanticChunkTypes: ['summary', 'fact', 'topic', 'entity', 'content'],
+        semanticChunkTypes: ['summary', 'fact', 'exact_detail', 'topic', 'entity', 'content'],
         applyChunkTypeBoosts: false,
       };
     case 'multiview-no-chrono':
@@ -193,6 +224,7 @@ function buildVariantHybridOptions(
     case 'content-plus-entity':
     case 'content-plus-entity-parallel':
     case 'content-plus-fact':
+    case 'content-plus-exact':
     case 'content-plus-summary':
     case 'content-plus-summary-fact':
     case 'content-plus-entity-fact':
@@ -205,6 +237,7 @@ function buildVariantHybridOptions(
       };
     case 'entity-only':
     case 'fact-only':
+    case 'exact-only':
     case 'summary-only':
     case 'current-state-only':
       return {

--- a/packages/benchmarks/src/benchmark-memory-recall.variant.ts
+++ b/packages/benchmarks/src/benchmark-memory-recall.variant.ts
@@ -128,7 +128,7 @@ function buildVariantSemanticOptions(
       };
     case 'content-plus-exact':
       return {
-        semanticChunkTypes: ['content', 'exact_detail'],
+        semanticChunkTypes: ['content', 'exact_details'],
         applyChunkTypeBoosts: false,
       };
     case 'content-plus-summary':
@@ -152,7 +152,7 @@ function buildVariantSemanticOptions(
           'content',
           'summary',
           'fact',
-          'exact_detail',
+          'exact_details',
           'topic',
           'entity',
           'current_state',
@@ -166,7 +166,7 @@ function buildVariantSemanticOptions(
       };
     case 'exact-only':
       return {
-        semanticChunkTypes: ['exact_detail'],
+        semanticChunkTypes: ['exact_details'],
         applyChunkTypeBoosts: false,
       };
     case 'summary-only':
@@ -181,12 +181,12 @@ function buildVariantSemanticOptions(
       };
     case 'derived-only':
       return {
-        semanticChunkTypes: ['summary', 'fact', 'exact_detail', 'topic', 'entity'],
+        semanticChunkTypes: ['summary', 'fact', 'exact_details', 'topic', 'entity'],
         applyChunkTypeBoosts: false,
       };
     case 'multiview-no-boost':
       return {
-        semanticChunkTypes: ['summary', 'fact', 'exact_detail', 'topic', 'entity', 'content'],
+        semanticChunkTypes: ['summary', 'fact', 'exact_details', 'topic', 'entity', 'content'],
         applyChunkTypeBoosts: false,
       };
     case 'multiview-no-chrono':


### PR DESCRIPTION
## Summary
- Ports the unmerged post-PR #363 follow-up work onto current `main`.
- Adds an `exact_details` LLM extraction view for precise values that summaries/dreams tend to lose: counts, dates, durations, list-item mappings, identifiers, paths, URLs, yes/no states, etc.
- Adds exact-details embedding text generation and benchmark variants (`content-plus-exact`, `exact-only`).
- Updates dream prompts/local dream state to preserve exact details during consolidation.

## Feature gating / production safety
- Extraction remains gated by `MEMORY_LLM_EXTRACTION_ENABLED` plus per-kind flags.
- Exact details only run when `MEMORY_LLM_EXACT_DETAILS_ENABLED=true` or explicit benchmark/script options request all kinds.
- `batchAllKinds` now truly includes all extraction kinds, including `current_state` and `exact_details`; this path is only used by explicit benchmark/backfill script invocations.
- Memory chunk creation still respects the merged hotfix behavior: raw content first, no heuristic/rule-based chunk derivation, and derived chunks only when LLM extraction metadata exists with `MEMORY_EXTRACTION_MODE=llm|merged`.
- Chunked recall remains off by default through `MEMORY_CHUNKED_RECALL_ENABLED=false`; exact-details query variants are experimental and require enabling chunked recall in benchmark configs.

## Refresh / review follow-up
- Rebased the existing PR branch onto current `main` (`d906a41b`) — did **not** recreate the branch/PR.
- Fixed Wren's naming note: the chunk type is now `exact_details`, matching the extraction kind. No `exact_detail` singular chunk type remains.
- Kept the original branch/PR and force-pushed the refreshed branch.

## Verification
- `yarn workspace @inklabs/api test src/services/memory-llm-extraction.test.ts src/services/embeddings/memory-chunks.test.ts src/data/repositories/memory-repository.test.ts` ✅ — 95 tests
- `yarn workspace @inklabs/benchmarks test` ✅ — 38 tests
- `yarn workspace @inklabs/api type-check` ⚠️ still fails on pre-existing unrelated errors in `channels/gateway.ts` and `mcp/server.ts`; no memory/extraction type errors remain.

— Lumen