### PR TITLE
fix(cli): REPL UX polish — input history, escape dismiss, ctrl+c hint (by Wren)

### DIFF
--- a/packages/api/src/mcp/tools/memory-handlers.ts
+++ b/packages/api/src/mcp/tools/memory-handlers.ts
@@ -207,6 +207,7 @@ export function buildKnowledgeSummary(memories: import('../../data/models/memory
     topicSummary?: string;
   }>;
   memoriesIncluded: number;
+  memoryIds: string[];
 } {
   const budget = getMemoryBudget();
 
@@ -257,6 +258,7 @@ export function buildKnowledgeSummary(memories: import('../../data/models/memory
   let charsUsed = 0;
   let memoriesIncluded = 0;
   const includedTopics = new Set<string>();
+  const includedMemoryIds: string[] = [];
   const overflowTopics: typeof sortedGroups = [];
 
   for (const group of sortedGroups) {
@@ -276,6 +278,7 @@ export function buildKnowledgeSummary(memories: import('../../data/models/memory
       charsUsed += groupText.length;
       memoriesIncluded += group.memories.length;
       includedTopics.add(group.topicKey);
+      for (const mem of group.memories) includedMemoryIds.push(mem.id);
     } else if (charsUsed + header.length + 50 <= budget) {
       // Try to fit at least the header + first memory
       const firstMem = group.memories[0];
@@ -291,6 +294,7 @@ export function buildKnowledgeSummary(memories: import('../../data/models/memory
         charsUsed += totalPartial.length;
         memoriesIncluded += 1;
         includedTopics.add(group.topicKey);
+        includedMemoryIds.push(firstMem.id);
       } else {
         overflowTopics.push(group);
       }
@@ -307,7 +311,12 @@ export function buildKnowledgeSummary(memories: import('../../data/models/memory
     topicSummary: g.topicSummary,
   }));
 
-  return { knowledgeSummary: summary.trim(), topicIndex, memoriesIncluded };
+  return {
+    knowledgeSummary: summary.trim(),
+    topicIndex,
+    memoriesIncluded,
+    memoryIds: includedMemoryIds,
+  };
 }
 
 function truncateContent(content: string, maxLen: number): string {
@@ -2439,6 +2448,10 @@ export async function handleBootstrap(args: unknown, dataComposer: DataComposer)
 
             // Topic index: all topics with counts + recency (navigate with recall(topics: [...]))
             topicIndex: topicIndex.length > 0 ? topicIndex : null,
+
+            // Memory IDs included in knowledgeSummary — used by passive recall to avoid
+            // re-injecting memories that are already in context from bootstrap
+            memoryIds: knowledgeSummaryResult?.memoryIds || [],
 
             // Database identity (structural fields only — heartbeat/soul already in identityFiles)
             dbIdentity: dbIdentity

--- a/packages/api/src/mcp/tools/memory-handlers.ts
+++ b/packages/api/src/mcp/tools/memory-handlers.ts
@@ -2329,8 +2329,12 @@ export async function handleBootstrap(args: unknown, dataComposer: DataComposer)
     }
   }
 
+  const usedCache = !!cachedSummary;
   const knowledgeSummary = cachedSummary || knowledgeSummaryResult?.knowledgeSummary || '';
   const topicIndex = knowledgeSummaryResult?.topicIndex || [];
+  // Only return memoryIds when using the freshly computed summary — cached summaries
+  // may have been built from a different memory set (different thread/focus/limit).
+  const knowledgeMemoryIds = usedCache ? [] : knowledgeSummaryResult?.memoryIds || [];
 
   logger.info(`Bootstrap loaded for user ${user.id}`, {
     agentId: agentId || 'none',
@@ -2339,7 +2343,7 @@ export async function handleBootstrap(args: unknown, dataComposer: DataComposer)
     memoryCount: knowledgeMemories.length,
     knowledgeSummaryChars: knowledgeSummary.length,
     topicCount: topicIndex.length,
-    usedCache: !!cachedSummary,
+    usedCache,
     memorySelectionContext: {
       threadKey: inferredThreadKey || null,
       hasFocusText: !!focusText,
@@ -2450,8 +2454,9 @@ export async function handleBootstrap(args: unknown, dataComposer: DataComposer)
             topicIndex: topicIndex.length > 0 ? topicIndex : null,
 
             // Memory IDs included in knowledgeSummary — used by passive recall to avoid
-            // re-injecting memories that are already in context from bootstrap
-            memoryIds: knowledgeSummaryResult?.memoryIds || [],
+            // re-injecting memories already in context. Empty when summary served from
+            // cache (cache may have been built from a different memory set).
+            memoryIds: knowledgeMemoryIds,
 
             // Database identity (structural fields only — heartbeat/soul already in identityFiles)
             dbIdentity: dbIdentity

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -2098,6 +2098,12 @@ export async function runChat(options: ChatOptions): Promise<void> {
       );
     }
 
+    // Seed passive recall dedup with memory IDs already in bootstrap context
+    const bootstrapMemoryIds = bootstrapResult.memoryIds as string[] | undefined;
+    if (bootstrapMemoryIds && bootstrapMemoryIds.length > 0) {
+      passiveRecallHandle.seedBootstrapIds(bootstrapMemoryIds);
+    }
+
     ledger.addEntry(
       'system',
       `Bootstrapped as ${agentId}${timezone ? ` (${String(timezone)})` : ''}${
@@ -3768,6 +3774,10 @@ export async function runChat(options: ChatOptions): Promise<void> {
               showInPanel([`Identity context refreshed: ~${ctxTokens.toLocaleString()} tokens`]);
             } else {
               showInPanel(['Bootstrap returned no identity context.']);
+            }
+            const refreshMemoryIds = refreshResult.memoryIds as string[] | undefined;
+            if (refreshMemoryIds && refreshMemoryIds.length > 0) {
+              passiveRecallHandle.seedBootstrapIds(refreshMemoryIds);
             }
           }
           break;

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -2006,9 +2006,7 @@ export async function runChat(options: ChatOptions): Promise<void> {
   } catch {
     /* not a git repo */
   }
-  const initialInfoItems = ['/help', 'esc cancel', 'ctrl+c ×2 quit', shortCwd, gitBranch].filter(
-    Boolean
-  );
+  const initialInfoItems = [shortCwd, gitBranch].filter(Boolean);
   statusLane.setInfoItems(initialInfoItems);
 
   // Ink renderer — created lazily after the banner section has printed
@@ -3300,9 +3298,12 @@ export async function runChat(options: ChatOptions): Promise<void> {
       .catch(() => undefined); // never block the REPL
 
     if (!runResult.success) {
-      printLine(chalk.red(`\n[${runtime.backend}] exit=${runResult.exitCode}`));
-      if (runResult.stderr) {
-        printLine(chalk.dim(runResult.stderr));
+      const isSignalExit = runResult.exitCode !== undefined && runResult.exitCode >= 128;
+      if (!isSignalExit) {
+        printLine(chalk.red(`\n[${runtime.backend}] exit=${runResult.exitCode}`));
+        if (runResult.stderr) {
+          printLine(chalk.dim(runResult.stderr));
+        }
       }
     }
 

--- a/packages/cli/src/repl/builtin-hooks.ts
+++ b/packages/cli/src/repl/builtin-hooks.ts
@@ -118,7 +118,7 @@ export function registerPassiveRecallHook(
   registry: SbHookRegistry,
   callRecall: (query: string, limit: number) => Promise<RecallMemory[]>,
   config?: Partial<PassiveRecallConfig>
-): { getStats: () => PassiveRecallStats } {
+): { getStats: () => PassiveRecallStats; seedBootstrapIds: (ids: string[]) => void } {
   const cfg = { ...DEFAULT_PASSIVE_RECALL_CONFIG, ...config };
   const injectedMemoryIds = new Set<string>();
   const evictedMemoryIds = new Map<string, number>(); // memoryId → turn evicted
@@ -247,6 +247,9 @@ export function registerPassiveRecallHook(
       turnsSinceLastInjection,
       currentTurn: turnCounter,
     }),
+    seedBootstrapIds: (ids: string[]) => {
+      for (const id of ids) injectedMemoryIds.add(id);
+    },
   };
 }
 
@@ -307,7 +310,9 @@ export function registerBuiltinHooks(
     passiveRecallConfig?: Partial<PassiveRecallConfig>;
     budgetThresholds?: number[];
   }
-): { passiveRecall: { getStats: () => PassiveRecallStats } } {
+): {
+  passiveRecall: { getStats: () => PassiveRecallStats; seedBootstrapIds: (ids: string[]) => void };
+} {
   const passiveRecall = registerPassiveRecallHook(
     registry,
     options.callRecall,

--- a/packages/cli/src/repl/ink/ChatApp.tsx
+++ b/packages/cli/src/repl/ink/ChatApp.tsx
@@ -68,6 +68,7 @@ export const ChatApp = React.forwardRef<ChatAppHandle, ChatAppProps>(function Ch
   const [ctrlCTimer, setCtrlCTimer] = useState<ReturnType<typeof setTimeout> | null>(null);
 
   const [commandOutput, setCommandOutput] = useState<string[] | null>(null);
+  const [inputHistory, setInputHistory] = useState<string[]>([]);
 
   // Abort handler — set by orchestrator when a backend turn is running
   const abortHandlerRef = useRef<(() => void) | null>(null);
@@ -114,6 +115,10 @@ export const ChatApp = React.forwardRef<ChatAppHandle, ChatAppProps>(function Ch
 
   const handleSubmit = useCallback(
     (value: string) => {
+      setInputHistory((prev) => {
+        if (prev[prev.length - 1] === value) return prev;
+        return [...prev, value];
+      });
       onUserInput(value);
     },
     [onUserInput]
@@ -126,6 +131,8 @@ export const ChatApp = React.forwardRef<ChatAppHandle, ChatAppProps>(function Ch
     }
   }, []);
 
+  const [ctrlCHint, setCtrlCHint] = useState(false);
+
   // Handle Ctrl+C for double-tap exit
   useEffect(() => {
     const handler = () => {
@@ -135,7 +142,11 @@ export const ChatApp = React.forwardRef<ChatAppHandle, ChatAppProps>(function Ch
         return;
       }
       setCtrlCCount(1);
-      const timer = setTimeout(() => setCtrlCCount(0), 1500);
+      setCtrlCHint(true);
+      const timer = setTimeout(() => {
+        setCtrlCCount(0);
+        setCtrlCHint(false);
+      }, 1500);
       setCtrlCTimer(timer);
     };
     process.on('SIGINT', handler);
@@ -174,6 +185,8 @@ export const ChatApp = React.forwardRef<ChatAppHandle, ChatAppProps>(function Ch
         onAbort={handleAbort}
         commandOutput={commandOutput}
         onCommandOutputClear={() => setCommandOutput(null)}
+        inputHistory={inputHistory}
+        ctrlCHint={ctrlCHint}
         waitingElement={
           waiting ? (
             <Box paddingX={1}>

--- a/packages/cli/src/repl/ink/Dock.tsx
+++ b/packages/cli/src/repl/ink/Dock.tsx
@@ -17,6 +17,8 @@ interface DockProps {
   commandOutput?: string[] | null;
   onCommandOutputClear?: () => void;
   waitingElement?: React.ReactNode;
+  inputHistory?: string[];
+  ctrlCHint?: boolean;
 }
 
 /**
@@ -39,6 +41,8 @@ export function Dock({
   commandOutput,
   onCommandOutputClear,
   waitingElement,
+  inputHistory,
+  ctrlCHint,
 }: DockProps): React.ReactElement {
   const { stdout } = useStdout();
   const [, setResizeCounter] = useState(0);
@@ -77,7 +81,9 @@ export function Dock({
         onSubmit={onSubmit}
         isActive={isPromptActive}
         onAbort={onAbort}
+        onEscape={onCommandOutputClear}
         onInputChange={handleInputChange}
+        history={inputHistory}
       />
       {showAutocomplete && <SlashAutocomplete input={inputValue} />}
       {showCommandOutput && (
@@ -90,7 +96,15 @@ export function Dock({
         </Box>
       )}
       <Separator />
-      <InfoBar items={infoItems} />
+      {ctrlCHint ? (
+        <Box paddingX={1}>
+          <Text dimColor>Press </Text>
+          <Text color="yellow">ctrl+c</Text>
+          <Text dimColor> again to quit</Text>
+        </Box>
+      ) : (
+        <InfoBar items={infoItems} />
+      )}
     </Box>
   );
 }

--- a/packages/cli/src/repl/ink/PromptInput.tsx
+++ b/packages/cli/src/repl/ink/PromptInput.tsx
@@ -7,10 +7,14 @@ interface PromptInputProps {
   isActive?: boolean;
   /** Called when Escape is pressed while waiting (not active). */
   onAbort?: () => void;
+  /** Called when Escape is pressed with empty input (e.g. dismiss dock panel). */
+  onEscape?: () => void;
   /** Called on every keystroke with the current input value. */
   onInputChange?: (value: string) => void;
   /** Scroll callback for page up/down from within the prompt. */
   onScroll?: (direction: 'up' | 'down') => void;
+  /** Input history for up/down arrow recall. */
+  history?: string[];
 }
 
 /** Find the position of the previous word boundary (start of current/previous word). */
@@ -42,11 +46,15 @@ export function PromptInput({
   onSubmit,
   isActive = true,
   onAbort,
+  onEscape,
   onInputChange,
   onScroll,
+  history = [],
 }: PromptInputProps): React.ReactElement {
   const [value, setValue] = useState('');
   const [cursor, setCursor] = useState(0);
+  const [historyIndex, setHistoryIndex] = useState(-1);
+  const [savedInput, setSavedInput] = useState('');
 
   useEffect(() => {
     onInputChange?.(value);
@@ -58,6 +66,8 @@ export function PromptInput({
       if (!submitted) return;
       setValue('');
       setCursor(0);
+      setHistoryIndex(-1);
+      setSavedInput('');
       onSubmit(submitted);
       return;
     }
@@ -173,20 +183,57 @@ export function PromptInput({
       return;
     }
 
-    // Escape: abort current turn if waiting, clear input if typing
+    // Escape: abort current turn if waiting, clear input if typing, dismiss panel if empty
     if (key.escape) {
       if (!isActive && onAbort) {
         onAbort();
       } else if (value.length > 0) {
         setValue('');
         setCursor(0);
+        setHistoryIndex(-1);
+        setSavedInput('');
+      } else {
+        onEscape?.();
+      }
+      return;
+    }
+
+    // Up arrow: navigate input history (most recent first)
+    if (key.upArrow) {
+      if (history.length === 0) return;
+      if (historyIndex === -1) {
+        setSavedInput(value);
+        const newIndex = history.length - 1;
+        setHistoryIndex(newIndex);
+        setValue(history[newIndex]!);
+        setCursor(history[newIndex]!.length);
+      } else if (historyIndex > 0) {
+        const newIndex = historyIndex - 1;
+        setHistoryIndex(newIndex);
+        setValue(history[newIndex]!);
+        setCursor(history[newIndex]!.length);
+      }
+      return;
+    }
+
+    // Down arrow: navigate forward in history, restore saved input at end
+    if (key.downArrow) {
+      if (historyIndex === -1) return;
+      if (historyIndex < history.length - 1) {
+        const newIndex = historyIndex + 1;
+        setHistoryIndex(newIndex);
+        setValue(history[newIndex]!);
+        setCursor(history[newIndex]!.length);
+      } else {
+        setHistoryIndex(-1);
+        setValue(savedInput);
+        setCursor(savedInput.length);
       }
       return;
     }
 
     // Ignore other control sequences
     if (key.ctrl) return;
-    if (key.upArrow || key.downArrow) return;
     if (key.tab) return;
 
     // Regular character input


### PR DESCRIPTION
## Summary

### REPL UX polish
- **Up/down arrow input history**: Previously submitted messages can be recalled with up arrow and navigated with down arrow, matching behavior in Claude Code and other terminal UIs
- **Escape dismisses dock panel**: Pressing Escape with an empty prompt clears command output (e.g., `/help` list, `/mcp-servers` output) instead of doing nothing
- **Ctrl+C "again to quit" hint**: First Ctrl+C shows a temporary yellow "press ctrl+c again to quit" message in the info bar area (auto-clears after 1.5s), instead of the permanent `ctrl+c ×2 quit` text that was always visible
- **Suppress signal exit noise**: `[claude] exit=143` no longer displayed on Escape abort — signal-based exits (exit code >= 128) are silently handled since they're user-initiated
- **Cleaned info bar**: Removed permanent `/help`, `esc cancel`, `ctrl+c ×2 quit` items from the info bar — only shows working directory and git branch

### Memory dedup — bootstrap → passive recall
- **Bootstrap now returns `memoryIds`**: The IDs of memories included in `knowledgeSummary` are returned alongside the formatted text
- **Passive recall seeds from bootstrap**: On startup and `/refresh`, bootstrap memory IDs are seeded into the passive recall hook's `injectedMemoryIds` set, preventing re-injection of the same memories
- First piece of the broader "pointer system" for context chunk tracking

## Test plan

- [ ] Type a message, submit it, press up arrow — previous message appears in prompt
- [ ] Submit multiple messages, navigate up/down through history
- [ ] Run `/help`, see output panel, press Escape — panel clears
- [ ] Press Ctrl+C once — "press ctrl+c again to quit" appears in info bar
- [ ] Wait 1.5s — hint disappears, info bar returns to normal
- [ ] Press Ctrl+C twice quickly — exits cleanly
- [ ] Start a backend turn, press Escape to abort — no `exit=143` displayed
- [ ] Verify info bar only shows cwd and git branch (no help/esc/ctrl+c hints)
- [ ] Start a chat session, observe bootstrap logs — memoryIds seeded count
- [ ] Converse on a bootstrap-loaded topic — passive recall should not re-inject the same memories

🤖 Generated with [Claude Code](https://claude.com/claude-code)