### PR TITLE
feat(cli): add interactive session picker to ink chat REPL (by Wren)

### DIFF
--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -70,7 +70,13 @@ import {
   separator,
   startWaitingIndicator,
 } from '../repl/tui-components.js';
-import { renderInkChat, InkExitSignal, type InkRepl } from '../repl/ink/index.js';
+import {
+  renderInkChat,
+  renderSessionPicker,
+  InkExitSignal,
+  type InkRepl,
+  type SessionPickerEntry,
+} from '../repl/ink/index.js';
 import {
   classifyError,
   decodeDelegationToken,
@@ -2187,26 +2193,75 @@ export async function runChat(options: ChatOptions): Promise<void> {
       toolPolicy,
       'attach'
     );
-    const selected = pickLatestSession(sessions, undefined, { studioId: runtime.studioId });
-    if (selected) {
-      attachedSessionSummary = selected;
-      runtime.sessionId = selected.id;
-      if (selected.studioId) {
-        runtime.studioId = selected.studioId;
+
+    const isInteractiveInk = useInk && !options.message && !options.nonInteractive;
+
+    if (isInteractiveInk && sessions.length > 0) {
+      // Show interactive session picker
+      const pickerEntries: SessionPickerEntry[] = sessions
+        .sort((a, b) => {
+          const aStudioMatch = runtime.studioId && a.studioId === runtime.studioId ? 1 : 0;
+          const bStudioMatch = runtime.studioId && b.studioId === runtime.studioId ? 1 : 0;
+          if (aStudioMatch !== bStudioMatch) return bStudioMatch - aStudioMatch;
+          const ams = a.startedAt ? Date.parse(a.startedAt) : 0;
+          const bms = b.startedAt ? Date.parse(b.startedAt) : 0;
+          return bms - ams;
+        })
+        .map((session) => {
+          const transcriptMeta = getSessionTranscriptMetadata(session.id);
+          return {
+            id: session.id,
+            label: session.id.slice(0, 8),
+            phase: session.currentPhase || session.status,
+            threadKey: session.threadKey,
+            studioName: sessionStudioLabel(session),
+            backend: sessionBackendLabel(session),
+            historyLabel: sessionHistoryLabel(transcriptMeta),
+            preview: sessionLatestMessagePreview(session, transcriptMeta) || undefined,
+          };
+        });
+
+      const picked = await renderSessionPicker(pickerEntries);
+      if (picked) {
+        const selected = sessions.find((s) => s.id === picked.id);
+        if (selected) {
+          attachedSessionSummary = selected;
+          runtime.sessionId = selected.id;
+          if (selected.studioId) {
+            runtime.studioId = selected.studioId;
+          }
+          if (!runtime.threadKey && selected.threadKey) {
+            runtime.threadKey = selected.threadKey;
+          }
+          toolPolicy.setContext({ agentId, studioId: runtime.studioId });
+          const currentScope = toolPolicy.getMutationScope();
+          if (currentScope.scope !== 'global') {
+            toolPolicy.setMutationScope(currentScope.scope);
+          }
+          runtime.toolMode = toolPolicy.getMode();
+        }
       }
-      if (!runtime.threadKey && selected.threadKey) {
-        runtime.threadKey = selected.threadKey;
+      // picked === null means "New session" — fall through to create one
+    } else {
+      // Non-interactive or no sessions — auto-attach to latest (existing behavior)
+      const selected = pickLatestSession(sessions, undefined, { studioId: runtime.studioId });
+      if (selected) {
+        attachedSessionSummary = selected;
+        runtime.sessionId = selected.id;
+        if (selected.studioId) {
+          runtime.studioId = selected.studioId;
+        }
+        if (!runtime.threadKey && selected.threadKey) {
+          runtime.threadKey = selected.threadKey;
+        }
+        autoAttachedLatest = true;
+        toolPolicy.setContext({ agentId, studioId: runtime.studioId });
+        const currentScope = toolPolicy.getMutationScope();
+        if (currentScope.scope !== 'global') {
+          toolPolicy.setMutationScope(currentScope.scope);
+        }
+        runtime.toolMode = toolPolicy.getMode();
       }
-      autoAttachedLatest = true;
-      toolPolicy.setContext({
-        agentId,
-        studioId: runtime.studioId,
-      });
-      const currentScope = toolPolicy.getMutationScope();
-      if (currentScope.scope !== 'global') {
-        toolPolicy.setMutationScope(currentScope.scope);
-      }
-      runtime.toolMode = toolPolicy.getMode();
     }
   }
 

--- a/packages/cli/src/repl/ink/SessionPicker.tsx
+++ b/packages/cli/src/repl/ink/SessionPicker.tsx
@@ -1,0 +1,98 @@
+import React, { useState } from 'react';
+import { Box, Text, useInput } from 'ink';
+
+export interface SessionPickerEntry {
+  id: string;
+  label: string;
+  phase?: string;
+  threadKey?: string;
+  studioName?: string;
+  backend?: string;
+  historyLabel?: string;
+  lastMessage?: string;
+  preview?: string;
+}
+
+interface SessionPickerProps {
+  entries: SessionPickerEntry[];
+  onSelect: (entry: SessionPickerEntry | null) => void;
+}
+
+export function SessionPicker({ entries, onSelect }: SessionPickerProps): React.ReactElement {
+  // Index 0 = "New session", 1..N = existing sessions
+  const totalItems = entries.length + 1;
+  const [selected, setSelected] = useState(0);
+
+  useInput((_input, key) => {
+    if (key.upArrow) {
+      setSelected((prev) => (prev > 0 ? prev - 1 : totalItems - 1));
+    } else if (key.downArrow) {
+      setSelected((prev) => (prev < totalItems - 1 ? prev + 1 : 0));
+    } else if (key.return) {
+      if (selected === 0) {
+        onSelect(null); // new session
+      } else {
+        onSelect(entries[selected - 1]!);
+      }
+    }
+  });
+
+  return (
+    <Box flexDirection="column" paddingX={1}>
+      <Box marginBottom={1}>
+        <Text bold>Select session</Text>
+        <Text dimColor> — ↑↓ navigate, Enter select</Text>
+      </Box>
+
+      {/* New session option */}
+      <Box>
+        <Text color={selected === 0 ? 'cyan' : undefined} bold={selected === 0}>
+          {selected === 0 ? '▸ ' : '  '}
+        </Text>
+        <Text color={selected === 0 ? 'cyan' : 'green'} bold={selected === 0}>
+          + New session
+        </Text>
+      </Box>
+
+      {entries.map((entry, i) => {
+        const idx = i + 1;
+        const isSelected = selected === idx;
+        const phase = entry.phase || 'active';
+        const parts = [
+          entry.historyLabel,
+          entry.threadKey ? `thread:${entry.threadKey}` : null,
+          entry.studioName,
+          entry.backend,
+        ].filter(Boolean);
+
+        return (
+          <Box key={entry.id} flexDirection="column">
+            <Box>
+              <Text color={isSelected ? 'cyan' : undefined} bold={isSelected}>
+                {isSelected ? '▸ ' : '  '}
+              </Text>
+              <Text color={isSelected ? 'cyan' : 'white'}>{entry.id.slice(0, 8)}</Text>
+              <Text dimColor>
+                {'  '}
+                {phase}
+              </Text>
+              {parts.length > 0 && (
+                <Text dimColor>
+                  {'  ·  '}
+                  {parts.join('  ·  ')}
+                </Text>
+              )}
+            </Box>
+            {entry.preview && (
+              <Box marginLeft={4}>
+                <Text dimColor wrap="truncate-end">
+                  ↳ {entry.preview}
+                </Text>
+              </Box>
+            )}
+          </Box>
+        );
+      })}
+    </Box>
+  );
+}

--- a/packages/cli/src/repl/ink/index.ts
+++ b/packages/cli/src/repl/ink/index.ts
@@ -13,5 +13,6 @@ export { StatusBar } from './StatusBar.js';
 export { InfoBar } from './InfoBar.js';
 export { PromptInput } from './PromptInput.js';
 export { Separator } from './Separator.js';
-export { renderInkChat, InkExitSignal, type InkRepl } from './renderApp.js';
+export { renderInkChat, renderSessionPicker, InkExitSignal, type InkRepl } from './renderApp.js';
 export { renderInkMission, type InkMission } from './renderMission.js';
+export { type SessionPickerEntry } from './SessionPicker.js';

--- a/packages/cli/src/repl/ink/renderApp.tsx
+++ b/packages/cli/src/repl/ink/renderApp.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render } from 'ink';
 import { ChatApp, type ChatAppHandle, type ChatMessage } from './ChatApp.js';
+import { SessionPicker, type SessionPickerEntry } from './SessionPicker.js';
 import type { MessageRole } from './MessageLine.js';
 import { formatNow } from '../tui-components.js';
 
@@ -199,6 +200,25 @@ export function renderInkChat(options: {
 
   return repl;
 }
+
+/**
+ * Show a session picker UI and return the user's selection.
+ * Returns the selected entry, or null for "new session".
+ */
+export function renderSessionPicker(
+  entries: SessionPickerEntry[]
+): Promise<SessionPickerEntry | null> {
+  return new Promise((resolve) => {
+    const onSelect = (entry: SessionPickerEntry | null) => {
+      unmount();
+      resolve(entry);
+    };
+
+    const { unmount } = render(<SessionPicker entries={entries} onSelect={onSelect} />);
+  });
+}
+
+export type { SessionPickerEntry };
 
 /**
  * Sentinel error thrown when the user requests exit (double Ctrl+C or /quit).


### PR DESCRIPTION
## Summary
- Adds an Ink-native session picker that shows when starting `ink chat` with active sessions available
- Arrow keys to navigate, Enter to select — "New session" is always the first option
- Non-interactive mode (`--message`, `--non-interactive`) and scroll UI mode fall back to existing auto-attach behavior
- Explicit flags (`--new`, `--attach`, `--session-id`, `--thread-key`) bypass the picker entirely

## What changed
- **New**: `SessionPicker.tsx` — Ink React component with keyboard navigation
- **Modified**: `renderApp.tsx` — added `renderSessionPicker()` that mounts/unmounts the picker as a standalone Ink app
- **Modified**: `chat.ts` — the auto-attach block now shows the picker in interactive ink mode instead of silently attaching to the latest session
- **Modified**: `index.ts` — re-exports

## Test plan
- [x] `yarn type-check` passes
- [x] 747/747 CLI tests pass
- [x] Non-interactive smoke test (`--non-interactive --message "ping"`) skips picker, auto-attaches correctly
- [ ] Interactive smoke test: `ink chat` shows picker with active sessions, arrow navigation works, Enter selects
- [ ] `ink chat --new` bypasses picker and starts fresh session
- [ ] `ink chat --attach` uses existing attach flow, not the new picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)