### PR TITLE
fix(cli): REPL UX polish — banner, cancellation, history hydration (by Wren)

### DIFF
--- a/packages/api/src/data/repositories/memory-repository.ts
+++ b/packages/api/src/data/repositories/memory-repository.ts
@@ -1712,6 +1712,7 @@ export class MemoryRepository {
       agentId?: string;
       studioId?: string;
       filterNullStudio?: boolean;
+      backend?: string;
     } = {}
   ): Promise<Session[]> {
     let query = this.supabase
@@ -1728,6 +1729,10 @@ export class MemoryRepository {
       query = query.is('studio_id', null);
     } else if (options.studioId) {
       query = query.eq('studio_id', options.studioId);
+    }
+
+    if (options.backend) {
+      query = query.eq('backend', options.backend);
     }
 
     const limit = options.limit || 20;

--- a/packages/api/src/mcp/tools/index.ts
+++ b/packages/api/src/mcp/tools/index.ts
@@ -2004,7 +2004,7 @@ User can be identified by ONE of: userId, email, phone, or platform + platformId
   server.registerTool(
     'list_sessions',
     {
-      description: `List past sessions, optionally filtered by agent.
+      description: `List past sessions, optionally filtered by agent and/or backend.
 
 User can be identified by ONE of: userId, email, phone, or platform + platformId`,
       inputSchema: {
@@ -2014,6 +2014,10 @@ User can be identified by ONE of: userId, email, phone, or platform + platformId
           .string()
           .optional()
           .describe('Filter by studio (UUID or "main" for the main studio)'),
+        backend: z
+          .string()
+          .optional()
+          .describe('Filter by backend runtime (e.g., "ink", "claude-code")'),
         limit: z.number().min(1).max(100).optional().describe('Max results (default: 20)'),
       },
     },

--- a/packages/api/src/mcp/tools/memory-handlers.ts
+++ b/packages/api/src/mcp/tools/memory-handlers.ts
@@ -511,6 +511,7 @@ export const listSessionsSchema = userIdentifierBaseSchema.extend({
         message: 'Must be a UUID or "main"',
       }
     ),
+  backend: z.string().optional().describe('Filter by backend runtime (e.g., "ink", "claude-code")'),
   limit: z.number().min(1).max(100).optional().describe('Max results (default: 20)'),
 });
 
@@ -1363,6 +1364,7 @@ export async function handleListSessions(args: unknown, dataComposer: DataCompos
     agentId: params.agentId,
     studioId,
     filterNullStudio,
+    backend: params.backend,
     limit: params.limit,
   });
 
@@ -1402,6 +1404,7 @@ export async function handleListSessions(args: unknown, dataComposer: DataCompos
               currentPhase: s.currentPhase || null,
               status: s.status || null,
               backend: s.backend || null,
+              provider: (s.metadata?.provider as string) || null,
               model: s.model || null,
               backendSessionId: s.backendSessionId || null,
               /** @deprecated Use backendSessionId */

--- a/packages/cli/src/commands/chat.integration.test.ts
+++ b/packages/cli/src/commands/chat.integration.test.ts
@@ -257,7 +257,7 @@ describe('runChat integration', () => {
     expect(backendRequest.prompt).toContain('old assistant reply');
 
     const logText = stripAnsi(logSpy.mock.calls.flat().join('\n'));
-    expect(logText).toContain('History: 2 prior message(s) loaded');
+    expect(logText).toContain('history: 2 prior message(s) loaded');
   });
 
   it('hydrates ledger context from PCP session context when no local transcript exists', async () => {
@@ -299,7 +299,7 @@ describe('runChat integration', () => {
     });
 
     const logText = stripAnsi(logSpy.mock.calls.flat().join('\n'));
-    expect(logText).toContain('History: 2 prior message(s) loaded');
+    expect(logText).toContain('history: 2 prior message(s) loaded');
   });
 
   it('supports interactive attach picker from active sessions', async () => {
@@ -353,7 +353,7 @@ describe('runChat integration', () => {
 
     const sessionStatusLine = stripAnsi(logSpy.mock.calls.flat().join('\n'));
     expect(sessionStatusLine).toContain('sess-b222');
-    expect(sessionStatusLine).toContain('Thread: spec:cli-session-hooks');
+    expect(sessionStatusLine).toContain('thread spec:cli-session-hooks');
   });
 
   it('renders latest transcript message previews in attach picker', async () => {
@@ -475,7 +475,7 @@ describe('runChat integration', () => {
     const sessionStatusLine = stripAnsi(logSpy.mock.calls.flat().join('\n'));
     expect(sessionStatusLine).not.toContain('Select session to attach');
     expect(sessionStatusLine).toContain('sess-new');
-    expect(sessionStatusLine).toContain('Thread: pr:2');
+    expect(sessionStatusLine).toContain('thread pr:2');
   });
 
   it('falls back gracefully when attach-latest cannot list sessions', async () => {
@@ -552,9 +552,9 @@ describe('runChat integration', () => {
 
     expect(testState.pcpCalls.some((call) => call.tool === 'start_session')).toBe(false);
     const sessionStatusLine = stripAnsi(logSpy.mock.calls.flat().join('\n'));
-    expect(sessionStatusLine).toContain('Auto-attached to latest session');
+    expect(sessionStatusLine).toContain('auto-attached to latest session');
     expect(sessionStatusLine).toContain('sess-latest');
-    expect(sessionStatusLine).toContain('Thread: pr:10');
+    expect(sessionStatusLine).toContain('thread pr:10');
   });
 
   it('filters cross-agent sessions during auto-attach by default visibility policy', async () => {
@@ -681,11 +681,11 @@ describe('runChat integration', () => {
       expect(logText, `visibility=${row.visibility}`).toContain(row.expectedSession);
       if (row.expectsAutoAttach) {
         expect(logText, `visibility=${row.visibility}`).toContain(
-          'Auto-attached to latest session'
+          'auto-attached to latest session'
         );
       } else {
         expect(logText, `visibility=${row.visibility}`).not.toContain(
-          'Auto-attached to latest session'
+          'auto-attached to latest session'
         );
       }
     }

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -2940,9 +2940,22 @@ export async function runChat(options: ChatOptions): Promise<void> {
         activitySince = activity.createdAt;
       }
 
-      const type = activity.subtype
+      const rawType = activity.subtype
         ? `${activity.type}:${activity.subtype}`
         : activity.type || 'activity';
+      const ACTIVITY_LABELS: Record<string, string> = {
+        message_in: 'received',
+        message_out: 'sent',
+        agent_spawn: 'spawned',
+        agent_complete: 'completed',
+        state_change: 'state change',
+        tool_call: 'tool call',
+        tool_result: 'tool result',
+        inkmail_dispatch: 'mail sent',
+        inkmail_deliver: 'mail delivered',
+        inkmail_fail: 'mail failed',
+      };
+      const type = ACTIVITY_LABELS[rawType] || rawType;
       const actor = activity.agentId || 'system';
       const preview = (activity.content || '').replace(/\\s+/g, ' ').trim().slice(0, 200);
       const rendered = `⚡ ${actor} ${type}${preview ? ` — ${preview}` : ''}`;

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -3344,13 +3344,18 @@ export async function runChat(options: ChatOptions): Promise<void> {
       }
     }
 
+    const isAbortedTurn =
+      !runResult.success && runResult.exitCode !== undefined && runResult.exitCode >= 128;
+
     if (inkRepl) {
-      const usageMeta = runResult.usage ? formatBackendTokenUsage(runResult.usage) : undefined;
-      const trailingParts = [`${turnDurationSeconds}s`, usageMeta].filter(Boolean).join('  ·  ');
-      inkRepl.addMessage('assistant', assistantDisplayText, {
-        label: agentId,
-        trailingMeta: trailingParts,
-      });
+      if (!isAbortedTurn) {
+        const usageMeta = runResult.usage ? formatBackendTokenUsage(runResult.usage) : undefined;
+        const trailingParts = [`${turnDurationSeconds}s`, usageMeta].filter(Boolean).join('  ·  ');
+        inkRepl.addMessage('assistant', assistantDisplayText, {
+          label: agentId,
+          trailingMeta: trailingParts,
+        });
+      }
     } else {
       printLine('');
       printLine(

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -607,6 +607,7 @@ function hydrateLedgerFromTranscript(
       continue;
     }
     if (type === 'assistant' && typeof event.content === 'string') {
+      if (event.content === '(no output)') continue;
       const source = typeof event.backend === 'string' ? event.backend : 'backend-history';
       ledger.addEntry('assistant', event.content, source);
       loaded += 1;

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -2240,6 +2240,10 @@ export async function runChat(options: ChatOptions): Promise<void> {
         });
 
       const picked = await renderSessionPicker(pickerEntries);
+      if (picked === undefined) {
+        // Cancel — exit without creating a session
+        return;
+      }
       if (picked) {
         const selected = sessions.find((s) => s.id === picked.id);
         if (selected) {

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -606,8 +606,9 @@ function hydrateLedgerFromTranscript(
       pushPreview('user', event.content, typeof event.ts === 'string' ? event.ts : undefined);
       continue;
     }
-    if (type === 'assistant' && typeof event.content === 'string') {
-      if (event.content === '(no output)') continue;
+    if (type === 'assistant') {
+      if (event.cancelled === true || event.content === '(no output)') continue;
+      if (typeof event.content !== 'string') continue;
       const source = typeof event.backend === 'string' ? event.backend : 'backend-history';
       ledger.addEntry('assistant', event.content, source);
       loaded += 1;
@@ -3542,8 +3543,12 @@ export async function runChat(options: ChatOptions): Promise<void> {
       if (!runResult.success) break;
     }
 
-    const assistantDisplayText =
-      runtime.toolRouting === 'local'
+    const isAbortedTurn =
+      !runResult.success && runResult.exitCode !== undefined && runResult.exitCode >= 128;
+
+    const assistantDisplayText = isAbortedTurn
+      ? ''
+      : runtime.toolRouting === 'local'
         ? (() => {
             const stripped = stripLocalToolBlocks(responseText);
             if (stripped) return stripped;
@@ -3553,20 +3558,35 @@ export async function runChat(options: ChatOptions): Promise<void> {
           })()
         : responseText;
 
-    ledger.addEntry('assistant', assistantDisplayText, runtime.backend);
-    appendTranscript(runtime.transcriptPath, {
-      type: 'assistant',
-      backend: runtime.backend,
-      model: runtime.model || null,
-      success: runResult.success,
-      exitCode: runResult.exitCode,
-      durationMs: runResult.durationMs,
-      stderr: runResult.stderr || null,
-      content: assistantDisplayText,
-      rawContent: responseText,
-      approxTokens: estimateTokens(assistantDisplayText),
-      usage: runResult.usage || null,
-    });
+    if (isAbortedTurn) {
+      appendTranscript(runtime.transcriptPath, {
+        type: 'assistant',
+        backend: runtime.backend,
+        model: runtime.model || null,
+        success: false,
+        exitCode: runResult.exitCode,
+        durationMs: runResult.durationMs,
+        stderr: runResult.stderr || null,
+        content: null,
+        cancelled: true,
+        usage: runResult.usage || null,
+      });
+    } else {
+      ledger.addEntry('assistant', assistantDisplayText, runtime.backend);
+      appendTranscript(runtime.transcriptPath, {
+        type: 'assistant',
+        backend: runtime.backend,
+        model: runtime.model || null,
+        success: runResult.success,
+        exitCode: runResult.exitCode,
+        durationMs: runResult.durationMs,
+        stderr: runResult.stderr || null,
+        content: assistantDisplayText,
+        rawContent: responseText,
+        approxTokens: estimateTokens(assistantDisplayText),
+        usage: runResult.usage || null,
+      });
+    }
     lastBackendUsage = runResult.usage;
 
     // ── Fire turn_end hooks (passive recall, etc.) ──
@@ -3644,18 +3664,12 @@ export async function runChat(options: ChatOptions): Promise<void> {
       })
       .catch(() => undefined); // never block the REPL
 
-    if (!runResult.success) {
-      const isSignalExit = runResult.exitCode !== undefined && runResult.exitCode >= 128;
-      if (!isSignalExit) {
-        printLine(chalk.red(`\n[${runtime.backend}] exit=${runResult.exitCode}`));
-        if (runResult.stderr) {
-          printLine(chalk.dim(runResult.stderr));
-        }
+    if (!runResult.success && !isAbortedTurn) {
+      printLine(chalk.red(`\n[${runtime.backend}] exit=${runResult.exitCode}`));
+      if (runResult.stderr) {
+        printLine(chalk.dim(runResult.stderr));
       }
     }
-
-    const isAbortedTurn =
-      !runResult.success && runResult.exitCode !== undefined && runResult.exitCode >= 128;
 
     if (inkRepl) {
       if (!isAbortedTurn) {
@@ -3666,7 +3680,7 @@ export async function runChat(options: ChatOptions): Promise<void> {
           trailingMeta: trailingParts,
         });
       }
-    } else {
+    } else if (!isAbortedTurn) {
       printLine('');
       printLine(
         renderMessageLine('assistant', assistantDisplayText, {

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -2771,13 +2771,29 @@ export async function runChat(options: ChatOptions): Promise<void> {
         .filter((e) => e.source === 'budget-monitor')
         .slice(-promptHookResult.injected);
 
-      for (const entry of recallEntries) {
-        const preview = entry.content.replace(/^\[passive-recall\]\s*/, '').slice(0, 120);
-        printLine(
-          chalk.dim(
-            `  💡 memory surfaced: "${preview}${entry.content.length > 120 ? '...' : ''}" (${entry.approxTokens} tok)`
-          )
-        );
+      if (recallEntries.length > 0) {
+        const totalTok = recallEntries.reduce((sum, e) => sum + e.approxTokens, 0);
+        if (inkRepl) {
+          const details = recallEntries.map((entry) => {
+            const preview = entry.content.replace(/^\[passive-recall\]\s*/, '').slice(0, 120);
+            return `  💡 ${preview}${entry.content.length > 120 ? '...' : ''} (${entry.approxTokens} tok)`;
+          });
+          inkRepl.setSurfacedMemories(details);
+          printLine(
+            chalk.dim(
+              `  💡 ${recallEntries.length} ${recallEntries.length === 1 ? 'memory' : 'memories'} surfaced (${totalTok} tok) — ctrl+o to expand`
+            )
+          );
+        } else {
+          for (const entry of recallEntries) {
+            const preview = entry.content.replace(/^\[passive-recall\]\s*/, '').slice(0, 120);
+            printLine(
+              chalk.dim(
+                `  💡 memory surfaced: "${preview}${entry.content.length > 120 ? '...' : ''}" (${entry.approxTokens} tok)`
+              )
+            );
+          }
+        }
       }
 
       if (budgetEntries.length > 0) {
@@ -3287,14 +3303,29 @@ export async function runChat(options: ChatOptions): Promise<void> {
             .filter((e) => e.source === 'passive-recall')
             .slice(-hookResult.injected);
 
-          for (const entry of recallEntries) {
-            const preview = entry.content.replace(/^\[passive-recall\]\s*/, '').slice(0, 120);
-            const tokens = entry.approxTokens;
-            printLine(
-              chalk.dim(
-                `  💡 memory surfaced: "${preview}${entry.content.length > 120 ? '...' : ''}" (${tokens} tok)`
-              )
-            );
+          if (recallEntries.length > 0) {
+            const totalTok = recallEntries.reduce((sum, e) => sum + e.approxTokens, 0);
+            if (inkRepl) {
+              const details = recallEntries.map((entry) => {
+                const preview = entry.content.replace(/^\[passive-recall\]\s*/, '').slice(0, 120);
+                return `  💡 ${preview}${entry.content.length > 120 ? '...' : ''} (${entry.approxTokens} tok)`;
+              });
+              inkRepl.setSurfacedMemories(details);
+              printLine(
+                chalk.dim(
+                  `  💡 ${recallEntries.length} ${recallEntries.length === 1 ? 'memory' : 'memories'} surfaced (${totalTok} tok) — ctrl+o to expand`
+                )
+              );
+            } else {
+              for (const entry of recallEntries) {
+                const preview = entry.content.replace(/^\[passive-recall\]\s*/, '').slice(0, 120);
+                printLine(
+                  chalk.dim(
+                    `  💡 memory surfaced: "${preview}${entry.content.length > 120 ? '...' : ''}" (${entry.approxTokens} tok)`
+                  )
+                );
+              }
+            }
           }
         }
         if (hookResult.evicted > 0) {

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -2346,6 +2346,138 @@ export async function runChat(options: ChatOptions): Promise<void> {
     const centerText = (s: string) =>
       ' '.repeat(Math.max(0, Math.floor((bannerWidth - s.length) / 2))) + s;
 
+    // ── Dawn Skyline ASCII art ──
+    const artWidth = Math.min(bannerWidth, 56);
+    const artPad = ' '.repeat(Math.max(0, Math.floor((bannerWidth - artWidth) / 2)));
+
+    const _lerp = (a: number, b: number, t: number) => Math.round(a + (b - a) * t);
+    const _lerpHex = (h1: string, h2: string, t: number) => {
+      const p = (s: string, o: number) => parseInt(s.slice(o, o + 2), 16);
+      const r = _lerp(p(h1, 1), p(h2, 1), t);
+      const g = _lerp(p(h1, 3), p(h2, 3), t);
+      const b = _lerp(p(h1, 5), p(h2, 5), t);
+      return '#' + [r, g, b].map((v) => v.toString(16).padStart(2, '0')).join('');
+    };
+
+    const skyStops = [
+      '#0a0a1a',
+      '#1a1040',
+      '#2d1b69',
+      '#5c3d8f',
+      '#8b5fbf',
+      '#c490d1',
+      '#e8b4b8',
+      '#f5d0a9',
+      '#ffeebb',
+    ];
+    const _skyAt = (t: number) => {
+      const idx = Math.floor(t * (skyStops.length - 1));
+      const idx2 = Math.min(idx + 1, skyStops.length - 1);
+      const frac = t * (skyStops.length - 1) - idx;
+      return _lerpHex(skyStops[idx]!, skyStops[idx2]!, frac);
+    };
+
+    // Seeded PRNG for deterministic art per session
+    let _seed = Date.now() & 0xffff;
+    const _rand = () => {
+      _seed = (_seed * 16807 + 0) % 2147483647;
+      return (_seed & 0xffff) / 0x10000;
+    };
+
+    // Sky rows
+    for (let r = 0; r < 4; r++) {
+      const rc = _skyAt(r / 8);
+      const rc2 = _skyAt((r + 1) / 8);
+      let row = '';
+      for (let i = 0; i < artWidth; i++) {
+        const c = _lerpHex(rc, rc2, (i / (artWidth - 1)) * 0.15);
+        if (r < 2 && _rand() < 0.03) row += chalk.hex('#ffffff')('·');
+        else if (r < 1 && _rand() < 0.02) row += chalk.hex('#ccccff')('✦');
+        else row += chalk.hex(c).bgHex(c)('▄');
+      }
+      console.log(artPad + row);
+    }
+
+    // Buildings — chaotic variety with four styles
+    type BldgStyle = 'tower' | 'thin' | 'wide' | 'squat';
+    interface Bldg {
+      s: number;
+      w: number;
+      h: number;
+      st: BldgStyle;
+    }
+    const bldgs: Bldg[] = [
+      { s: 0, w: 4, h: 5, st: 'squat' },
+      { s: 3, w: 2, h: 3, st: 'thin' },
+      { s: 4, w: 7, h: 8, st: 'tower' },
+      { s: 10, w: 3, h: 4, st: 'squat' },
+      { s: 12, w: 2, h: 6, st: 'thin' },
+      { s: 13, w: 5, h: 5, st: 'wide' },
+      { s: 17, w: 3, h: 3, st: 'squat' },
+      { s: 19, w: 8, h: 10, st: 'tower' },
+      { s: 26, w: 2, h: 4, st: 'thin' },
+      { s: 27, w: 5, h: 6, st: 'wide' },
+      { s: 31, w: 3, h: 3, st: 'squat' },
+      { s: 33, w: 6, h: 7, st: 'tower' },
+      { s: 38, w: 2, h: 5, st: 'thin' },
+      { s: 39, w: 4, h: 4, st: 'squat' },
+      { s: 42, w: 3, h: 8, st: 'thin' },
+      { s: 44, w: 5, h: 6, st: 'wide' },
+      { s: 48, w: 2, h: 3, st: 'thin' },
+      { s: 49, w: 7, h: 9, st: 'tower' },
+    ];
+    const bldgMaxH = 10;
+    const bldgColor = '#12122a';
+    const winPalette = ['#ffdd44', '#ff9944', '#ffcc33', '#44aaff', '#ffffff', '#88ddff'];
+
+    for (let row = 0; row < bldgMaxH; row++) {
+      let line = '';
+      for (let x = 0; x < artWidth; x++) {
+        let drawn = false;
+        for (const b of bldgs) {
+          if (x >= b.s && x < b.s + b.w && row >= bldgMaxH - b.h) {
+            const lx = x - b.s;
+            const ly = row - (bldgMaxH - b.h);
+            let isWin = false;
+            if (b.st === 'tower')
+              isWin =
+                lx > 0 && lx < b.w - 1 && ly > 0 && ly % 2 === 1 && lx % 2 === 1 && _rand() < 0.55;
+            else if (b.st === 'thin')
+              isWin = lx === Math.floor(b.w / 2) && ly > 0 && ly % 2 === 0 && _rand() < 0.7;
+            else if (b.st === 'wide')
+              isWin = lx > 0 && lx < b.w - 1 && ly > 0 && (ly === 2 || ly === 4) && _rand() < 0.5;
+            else isWin = lx > 0 && lx < b.w - 1 && ly > 0 && _rand() < 0.25;
+            if (isWin) {
+              line += chalk.hex(winPalette[Math.floor(_rand() * winPalette.length)]!)('▪');
+            } else {
+              line += chalk.hex(bldgColor).bgHex(bldgColor)('█');
+            }
+            drawn = true;
+            break;
+          }
+        }
+        if (!drawn) {
+          const bgC = _skyAt(0.6 + (row / bldgMaxH) * 0.4);
+          line += chalk.hex(bgC).bgHex(bgC)('▄');
+        }
+      }
+      console.log(artPad + line);
+    }
+
+    // Horizon glow
+    let horizonLine = '';
+    for (let i = 0; i < artWidth; i++) {
+      const t = Math.abs(i / (artWidth - 1) - 0.5) * 2;
+      const c = _lerpHex('#ffeebb', '#e8b4b8', t);
+      horizonLine += chalk.hex(c).bgHex(c)('▀');
+    }
+    console.log(artPad + horizonLine);
+
+    console.log('');
+    console.log(centerText(chalk.bold.white('i n k w e l l')));
+    console.log('');
+
+    // ── Quote ──
     const quote = INKWELL_QUOTES[Math.floor(Math.random() * INKWELL_QUOTES.length)]!;
     const maxQW = bannerWidth - 8;
     const qWords = quote.text.split(' ');
@@ -2368,11 +2500,6 @@ export async function runChat(options: ChatOptions): Promise<void> {
     const blockW = Math.max(...qLines.map((l) => l.length), attrText.length);
     const blockPad = Math.max(0, Math.floor((bannerWidth - blockW) / 2));
 
-    console.log('');
-    console.log(centerText(chalk.white('✦')));
-    console.log('');
-    console.log(centerText(chalk.bold.white('i n k w e l l')));
-    console.log('');
     for (const line of qLines) {
       console.log(' '.repeat(blockPad) + chalk.dim(line));
     }

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -169,6 +169,7 @@ interface SessionSummary {
   threadKey?: string;
   startedAt?: string;
   backend?: string;
+  provider?: string;
   model?: string;
   backendSessionId?: string;
   claudeSessionId?: string;
@@ -958,6 +959,7 @@ function extractSessionSummaries(
             : typeof row.backend_name === 'string'
               ? row.backend_name
               : undefined,
+        provider: typeof row.provider === 'string' ? row.provider : undefined,
         model:
           typeof row.model === 'string'
             ? row.model
@@ -1181,7 +1183,7 @@ function buildContextStatusSummary(params: {
       : `${total.toLocaleString()}`;
   return `${breakdown} / ${params.maxContextTokens.toLocaleString()} (${pct.toFixed(
     1
-  )}%) ${queue} backend:${params.backend}`;
+  )}%) ${queue} provider:${params.backend}`;
 }
 
 function formatUsageLines(
@@ -2200,7 +2202,7 @@ export async function runChat(options: ChatOptions): Promise<void> {
     !runtime.threadKey
   ) {
     const sessionsResult = (await pcp
-      .callTool('list_sessions', { agentId, status: 'active', limit: 30 })
+      .callTool('list_sessions', { agentId, status: 'active', backend: 'ink', limit: 30 })
       .catch(() => null)) as Record<string, unknown> | null;
     const sessions = filterSessionsByPolicy(
       extractSessionSummaries(sessionsResult),
@@ -2283,7 +2285,11 @@ export async function runChat(options: ChatOptions): Promise<void> {
 
   const attachedToExistingSession = Boolean(runtime.sessionId);
   if (!runtime.sessionId) {
-    const startArgs: Record<string, unknown> = { agentId };
+    const startArgs: Record<string, unknown> = {
+      agentId,
+      backend: 'ink',
+      metadata: { provider: runtime.backend },
+    };
     if (runtime.threadKey) startArgs.threadKey = runtime.threadKey;
     if (identity?.studioId) {
       startArgs.studioId = identity.studioId;
@@ -2604,11 +2610,8 @@ export async function runChat(options: ChatOptions): Promise<void> {
     (identity?.studioId ? formatStudioForDisplay(identity.studioId, 'short') : undefined);
   const bannerParts = [
     chip('inkling', agentId, chalk.cyan),
-    chip(
-      'backend',
-      `${runtime.backend}${runtime.model ? ` (${runtime.model})` : ''}`,
-      chalk.yellow
-    ),
+    chip('backend', 'ink', chalk.yellow),
+    chip('provider', runtime.backend, chalk.yellow),
     studioSlug ? chip('studio', studioSlug, chalk.cyan) : null,
     chip('window', `${formatTokenCount(runtime.backendTokenWindow)} tok`, chalk.green),
     chip('time', formatNow(runtime.userTimezone), chalk.magenta),

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -2519,7 +2519,7 @@ export async function runChat(options: ChatOptions): Promise<void> {
     // ── Quote (inline attribution) ──
     const quote = INKWELL_QUOTES[Math.floor(Math.random() * INKWELL_QUOTES.length)]!;
     const fullQuote = `”${quote.text}” ${quote.attr}`;
-    const maxQW = bannerWidth - 4;
+    const maxQW = Math.min(termW - 4, 80);
     const qWords = fullQuote.split(' ');
     const qLines: string[] = [];
     let qCur = '';

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -70,7 +70,13 @@ import {
   separator,
   startWaitingIndicator,
 } from '../repl/tui-components.js';
-import { renderInkChat, InkExitSignal, type InkRepl } from '../repl/ink/index.js';
+import {
+  renderInkChat,
+  renderSessionPicker,
+  InkExitSignal,
+  type InkRepl,
+  type SessionPickerEntry,
+} from '../repl/ink/index.js';
 import {
   classifyError,
   decodeDelegationToken,
@@ -2187,26 +2193,75 @@ export async function runChat(options: ChatOptions): Promise<void> {
       toolPolicy,
       'attach'
     );
-    const selected = pickLatestSession(sessions, undefined, { studioId: runtime.studioId });
-    if (selected) {
-      attachedSessionSummary = selected;
-      runtime.sessionId = selected.id;
-      if (selected.studioId) {
-        runtime.studioId = selected.studioId;
+
+    const isInteractiveInk = useInk && !options.message && !options.nonInteractive;
+
+    if (isInteractiveInk && sessions.length > 0) {
+      // Show interactive session picker
+      const pickerEntries: SessionPickerEntry[] = sessions
+        .sort((a, b) => {
+          const aStudioMatch = runtime.studioId && a.studioId === runtime.studioId ? 1 : 0;
+          const bStudioMatch = runtime.studioId && b.studioId === runtime.studioId ? 1 : 0;
+          if (aStudioMatch !== bStudioMatch) return bStudioMatch - aStudioMatch;
+          const ams = a.startedAt ? Date.parse(a.startedAt) : 0;
+          const bms = b.startedAt ? Date.parse(b.startedAt) : 0;
+          return bms - ams;
+        })
+        .map((session) => {
+          const transcriptMeta = getSessionTranscriptMetadata(session.id);
+          return {
+            id: session.id,
+            label: session.id.slice(0, 8),
+            phase: session.currentPhase || session.status,
+            threadKey: session.threadKey,
+            studioName: sessionStudioLabel(session),
+            backend: sessionBackendLabel(session),
+            historyLabel: sessionHistoryLabel(transcriptMeta),
+            preview: sessionLatestMessagePreview(session, transcriptMeta) || undefined,
+          };
+        });
+
+      const picked = await renderSessionPicker(pickerEntries);
+      if (picked) {
+        const selected = sessions.find((s) => s.id === picked.id);
+        if (selected) {
+          attachedSessionSummary = selected;
+          runtime.sessionId = selected.id;
+          if (selected.studioId) {
+            runtime.studioId = selected.studioId;
+          }
+          if (!runtime.threadKey && selected.threadKey) {
+            runtime.threadKey = selected.threadKey;
+          }
+          toolPolicy.setContext({ agentId, studioId: runtime.studioId });
+          const currentScope = toolPolicy.getMutationScope();
+          if (currentScope.scope !== 'global') {
+            toolPolicy.setMutationScope(currentScope.scope);
+          }
+          runtime.toolMode = toolPolicy.getMode();
+        }
       }
-      if (!runtime.threadKey && selected.threadKey) {
-        runtime.threadKey = selected.threadKey;
+      // picked === null means "New session" — fall through to create one
+    } else {
+      // Non-interactive or no sessions — auto-attach to latest (existing behavior)
+      const selected = pickLatestSession(sessions, undefined, { studioId: runtime.studioId });
+      if (selected) {
+        attachedSessionSummary = selected;
+        runtime.sessionId = selected.id;
+        if (selected.studioId) {
+          runtime.studioId = selected.studioId;
+        }
+        if (!runtime.threadKey && selected.threadKey) {
+          runtime.threadKey = selected.threadKey;
+        }
+        autoAttachedLatest = true;
+        toolPolicy.setContext({ agentId, studioId: runtime.studioId });
+        const currentScope = toolPolicy.getMutationScope();
+        if (currentScope.scope !== 'global') {
+          toolPolicy.setMutationScope(currentScope.scope);
+        }
+        runtime.toolMode = toolPolicy.getMode();
       }
-      autoAttachedLatest = true;
-      toolPolicy.setContext({
-        agentId,
-        studioId: runtime.studioId,
-      });
-      const currentScope = toolPolicy.getMutationScope();
-      if (currentScope.scope !== 'global') {
-        toolPolicy.setMutationScope(currentScope.scope);
-      }
-      runtime.toolMode = toolPolicy.getMode();
     }
   }
 

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -2694,6 +2694,7 @@ export async function runChat(options: ChatOptions): Promise<void> {
       if (inkRepl) {
         inkRepl.addMessage('activity', `${actor} ${type}${preview ? ` — ${preview}` : ''}`, {
           label: '⚡',
+          time: formatHumanTime(activity.createdAt, runtime.userTimezone),
         });
       } else {
         printLine('');

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -2518,7 +2518,7 @@ export async function runChat(options: ChatOptions): Promise<void> {
 
     // ── Quote (inline attribution) ──
     const quote = INKWELL_QUOTES[Math.floor(Math.random() * INKWELL_QUOTES.length)]!;
-    const fullQuote = `”${quote.text}” — ${quote.attr}`;
+    const fullQuote = `”${quote.text}” ${quote.attr}`;
     const maxQW = bannerWidth - 4;
     const qWords = fullQuote.split(' ');
     const qLines: string[] = [];

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -2326,7 +2326,6 @@ export async function runChat(options: ChatOptions): Promise<void> {
   // ── Banner (prints before Ink mounts, goes to terminal scrollback) ──
   {
     const INKWELL_QUOTES = [
-      { text: 'The palest ink is better than the best memory.', attr: 'Chinese proverb' },
       { text: 'A word after a word after a word is power.', attr: 'Margaret Atwood' },
       { text: 'We write to taste life twice.', attr: 'Anaïs Nin' },
       { text: "I write entirely to find out what I'm thinking.", attr: 'Joan Didion' },
@@ -2339,7 +2338,6 @@ export async function runChat(options: ChatOptions): Promise<void> {
         text: 'Either write something worth reading or do something worth writing.',
         attr: 'Benjamin Franklin',
       },
-      { text: 'The pen is the tongue of the mind.', attr: 'Miguel de Cervantes' },
     ];
 
     const bannerWidth = Math.min(process.stdout.columns || 80, 60);
@@ -2518,10 +2516,11 @@ export async function runChat(options: ChatOptions): Promise<void> {
     console.log('');
     console.log(bottomGlow);
 
-    // ── Quote ──
+    // ── Quote (inline attribution) ──
     const quote = INKWELL_QUOTES[Math.floor(Math.random() * INKWELL_QUOTES.length)]!;
-    const maxQW = bannerWidth - 8;
-    const qWords = quote.text.split(' ');
+    const fullQuote = `”${quote.text}” — ${quote.attr}`;
+    const maxQW = bannerWidth - 4;
+    const qWords = fullQuote.split(' ');
     const qLines: string[] = [];
     let qCur = '';
     for (const w of qWords) {
@@ -2534,19 +2533,14 @@ export async function runChat(options: ChatOptions): Promise<void> {
       }
     }
     if (qCur) qLines.push(qCur);
-    qLines[0] = `“${qLines[0]!}`;
-    qLines[qLines.length - 1] += `”`;
 
-    const attrText = `— ${quote.attr}`;
-    const blockW = Math.max(...qLines.map((l) => l.length), attrText.length);
-    const blockPad = Math.max(0, Math.floor((bannerWidth - blockW) / 2));
-
+    const qPad = ' '.repeat(
+      Math.max(0, Math.floor((bannerWidth - Math.max(...qLines.map((l) => l.length))) / 2))
+    );
     for (const line of qLines) {
-      console.log(' '.repeat(blockPad) + chalk.dim(line));
+      console.log(qPad + chalk.dim(line));
     }
-    console.log(' '.repeat(blockPad + Math.max(0, blockW - attrText.length)) + chalk.dim(attrText));
     console.log('');
-    console.log(chalk.dim('  ' + '─'.repeat(Math.max(0, bannerWidth - 4))));
   }
   const studioSlug =
     attachedSessionSummary?.studioName ||

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -2346,9 +2346,10 @@ export async function runChat(options: ChatOptions): Promise<void> {
     const centerText = (s: string) =>
       ' '.repeat(Math.max(0, Math.floor((bannerWidth - s.length) / 2))) + s;
 
-    // ── Dawn Skyline ASCII art ──
-    const artWidth = Math.min(bannerWidth, 56);
-    const artPad = ' '.repeat(Math.max(0, Math.floor((bannerWidth - artWidth) / 2)));
+    // ── Dawn Skyline ASCII art (full terminal width, centered buildings) ──
+    const termW = process.stdout.columns || 80;
+    const cityW = 56;
+    const cityOffset = Math.max(0, Math.floor((termW - cityW) / 2));
 
     const _lerp = (a: number, b: number, t: number) => Math.round(a + (b - a) * t);
     const _lerpHex = (h1: string, h2: string, t: number) => {
@@ -2377,28 +2378,27 @@ export async function runChat(options: ChatOptions): Promise<void> {
       return _lerpHex(skyStops[idx]!, skyStops[idx2]!, frac);
     };
 
-    // Seeded PRNG for deterministic art per session
     let _seed = Date.now() & 0xffff;
     const _rand = () => {
       _seed = (_seed * 16807 + 0) % 2147483647;
       return (_seed & 0xffff) / 0x10000;
     };
 
-    // Sky rows
+    // Sky rows — full terminal width
     for (let r = 0; r < 4; r++) {
       const rc = _skyAt(r / 8);
       const rc2 = _skyAt((r + 1) / 8);
       let row = '';
-      for (let i = 0; i < artWidth; i++) {
-        const c = _lerpHex(rc, rc2, (i / (artWidth - 1)) * 0.15);
+      for (let i = 0; i < termW; i++) {
+        const c = _lerpHex(rc, rc2, (i / Math.max(termW - 1, 1)) * 0.15);
         if (r < 2 && _rand() < 0.03) row += chalk.hex('#ffffff')('·');
         else if (r < 1 && _rand() < 0.02) row += chalk.hex('#ccccff')('✦');
         else row += chalk.hex(c).bgHex(c)('▄');
       }
-      console.log(artPad + row);
+      console.log(row);
     }
 
-    // Buildings — chaotic variety with four styles
+    // Buildings — chaotic variety, centered in full-width gradient
     type BldgStyle = 'tower' | 'thin' | 'wide' | 'squat';
     interface Bldg {
       s: number;
@@ -2432,28 +2432,36 @@ export async function runChat(options: ChatOptions): Promise<void> {
 
     for (let row = 0; row < bldgMaxH; row++) {
       let line = '';
-      for (let x = 0; x < artWidth; x++) {
+      for (let x = 0; x < termW; x++) {
+        const cx = x - cityOffset;
         let drawn = false;
-        for (const b of bldgs) {
-          if (x >= b.s && x < b.s + b.w && row >= bldgMaxH - b.h) {
-            const lx = x - b.s;
-            const ly = row - (bldgMaxH - b.h);
-            let isWin = false;
-            if (b.st === 'tower')
-              isWin =
-                lx > 0 && lx < b.w - 1 && ly > 0 && ly % 2 === 1 && lx % 2 === 1 && _rand() < 0.55;
-            else if (b.st === 'thin')
-              isWin = lx === Math.floor(b.w / 2) && ly > 0 && ly % 2 === 0 && _rand() < 0.7;
-            else if (b.st === 'wide')
-              isWin = lx > 0 && lx < b.w - 1 && ly > 0 && (ly === 2 || ly === 4) && _rand() < 0.5;
-            else isWin = lx > 0 && lx < b.w - 1 && ly > 0 && _rand() < 0.25;
-            if (isWin) {
-              line += chalk.hex(winPalette[Math.floor(_rand() * winPalette.length)]!)('▪');
-            } else {
-              line += chalk.hex(bldgColor).bgHex(bldgColor)('█');
+        if (cx >= 0 && cx < cityW) {
+          for (const b of bldgs) {
+            if (cx >= b.s && cx < b.s + b.w && row >= bldgMaxH - b.h) {
+              const lx = cx - b.s;
+              const ly = row - (bldgMaxH - b.h);
+              let isWin = false;
+              if (b.st === 'tower')
+                isWin =
+                  lx > 0 &&
+                  lx < b.w - 1 &&
+                  ly > 0 &&
+                  ly % 2 === 1 &&
+                  lx % 2 === 1 &&
+                  _rand() < 0.55;
+              else if (b.st === 'thin')
+                isWin = lx === Math.floor(b.w / 2) && ly > 0 && ly % 2 === 0 && _rand() < 0.7;
+              else if (b.st === 'wide')
+                isWin = lx > 0 && lx < b.w - 1 && ly > 0 && (ly === 2 || ly === 4) && _rand() < 0.5;
+              else isWin = lx > 0 && lx < b.w - 1 && ly > 0 && _rand() < 0.25;
+              if (isWin) {
+                line += chalk.hex(winPalette[Math.floor(_rand() * winPalette.length)]!)('▪');
+              } else {
+                line += chalk.hex(bldgColor).bgHex(bldgColor)('█');
+              }
+              drawn = true;
+              break;
             }
-            drawn = true;
-            break;
           }
         }
         if (!drawn) {
@@ -2461,21 +2469,51 @@ export async function runChat(options: ChatOptions): Promise<void> {
           line += chalk.hex(bgC).bgHex(bgC)('▄');
         }
       }
-      console.log(artPad + line);
+      console.log(line);
     }
 
-    // Horizon glow
+    // Horizon glow — full width, warm center fading to edges
     let horizonLine = '';
-    for (let i = 0; i < artWidth; i++) {
-      const t = Math.abs(i / (artWidth - 1) - 0.5) * 2;
+    for (let i = 0; i < termW; i++) {
+      const t = Math.abs(i / Math.max(termW - 1, 1) - 0.5) * 2;
       const c = _lerpHex('#ffeebb', '#e8b4b8', t);
       horizonLine += chalk.hex(c).bgHex(c)('▀');
     }
-    console.log(artPad + horizonLine);
+    console.log(horizonLine);
 
+    // Title — gradient text matching dawn palette
+    const titleText = 'i n k w e l l';
+    const titleStops = [
+      '#c490d1',
+      '#e8b4b8',
+      '#f5d0a9',
+      '#ffeebb',
+      '#f5d0a9',
+      '#e8b4b8',
+      '#c490d1',
+    ];
+    let titleStr = '';
+    for (let i = 0; i < titleText.length; i++) {
+      const t = titleText.length > 1 ? i / (titleText.length - 1) : 0;
+      const si = Math.floor(t * (titleStops.length - 1));
+      const si2 = Math.min(si + 1, titleStops.length - 1);
+      const sf = t * (titleStops.length - 1) - si;
+      const c = _lerpHex(titleStops[si]!, titleStops[si2]!, sf);
+      titleStr += chalk.bold.hex(c)(titleText[i]);
+    }
+    const titlePad = ' '.repeat(Math.max(0, Math.floor((bannerWidth - titleText.length) / 2)));
     console.log('');
-    console.log(centerText(chalk.bold.white('i n k w e l l')));
+    console.log(titlePad + titleStr);
+
+    // Bottom gradient accent — thin warm line mirroring the horizon
+    let bottomGlow = '';
+    for (let i = 0; i < termW; i++) {
+      const t = Math.abs(i / Math.max(termW - 1, 1) - 0.5) * 2;
+      const c = _lerpHex('#f5d0a9', '#c490d1', t);
+      bottomGlow += chalk.hex(c)('─');
+    }
     console.log('');
+    console.log(bottomGlow);
 
     // ── Quote ──
     const quote = INKWELL_QUOTES[Math.floor(Math.random() * INKWELL_QUOTES.length)]!;

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -2346,10 +2346,9 @@ export async function runChat(options: ChatOptions): Promise<void> {
     const centerText = (s: string) =>
       ' '.repeat(Math.max(0, Math.floor((bannerWidth - s.length) / 2))) + s;
 
-    // ── Dawn Skyline ASCII art (full terminal width, centered buildings) ──
+    // ── Dawn Skyline ASCII art (full width, tiling buildings) ──
     const termW = process.stdout.columns || 80;
     const cityW = 56;
-    const cityOffset = Math.max(0, Math.floor((termW - cityW) / 2));
 
     const _lerp = (a: number, b: number, t: number) => Math.round(a + (b - a) * t);
     const _lerpHex = (h1: string, h2: string, t: number) => {
@@ -2377,6 +2376,21 @@ export async function runChat(options: ChatOptions): Promise<void> {
       const frac = t * (skyStops.length - 1) - idx;
       return _lerpHex(skyStops[idx]!, skyStops[idx2]!, frac);
     };
+    const titleStops = [
+      '#c490d1',
+      '#e8b4b8',
+      '#f5d0a9',
+      '#ffeebb',
+      '#f5d0a9',
+      '#e8b4b8',
+      '#c490d1',
+    ];
+    const _titleAt = (t: number) => {
+      const idx = Math.floor(t * (titleStops.length - 1));
+      const idx2 = Math.min(idx + 1, titleStops.length - 1);
+      const frac = t * (titleStops.length - 1) - idx;
+      return _lerpHex(titleStops[idx]!, titleStops[idx2]!, frac);
+    };
 
     let _seed = Date.now() & 0xffff;
     const _rand = () => {
@@ -2398,7 +2412,7 @@ export async function runChat(options: ChatOptions): Promise<void> {
       console.log(row);
     }
 
-    // Buildings — chaotic variety, centered in full-width gradient
+    // Buildings — tiling across full terminal width
     type BldgStyle = 'tower' | 'thin' | 'wide' | 'squat';
     interface Bldg {
       s: number;
@@ -2433,35 +2447,28 @@ export async function runChat(options: ChatOptions): Promise<void> {
     for (let row = 0; row < bldgMaxH; row++) {
       let line = '';
       for (let x = 0; x < termW; x++) {
-        const cx = x - cityOffset;
+        const cx = ((x % cityW) + cityW) % cityW;
         let drawn = false;
-        if (cx >= 0 && cx < cityW) {
-          for (const b of bldgs) {
-            if (cx >= b.s && cx < b.s + b.w && row >= bldgMaxH - b.h) {
-              const lx = cx - b.s;
-              const ly = row - (bldgMaxH - b.h);
-              let isWin = false;
-              if (b.st === 'tower')
-                isWin =
-                  lx > 0 &&
-                  lx < b.w - 1 &&
-                  ly > 0 &&
-                  ly % 2 === 1 &&
-                  lx % 2 === 1 &&
-                  _rand() < 0.55;
-              else if (b.st === 'thin')
-                isWin = lx === Math.floor(b.w / 2) && ly > 0 && ly % 2 === 0 && _rand() < 0.7;
-              else if (b.st === 'wide')
-                isWin = lx > 0 && lx < b.w - 1 && ly > 0 && (ly === 2 || ly === 4) && _rand() < 0.5;
-              else isWin = lx > 0 && lx < b.w - 1 && ly > 0 && _rand() < 0.25;
-              if (isWin) {
-                line += chalk.hex(winPalette[Math.floor(_rand() * winPalette.length)]!)('▪');
-              } else {
-                line += chalk.hex(bldgColor).bgHex(bldgColor)('█');
-              }
-              drawn = true;
-              break;
+        for (const b of bldgs) {
+          if (cx >= b.s && cx < b.s + b.w && row >= bldgMaxH - b.h) {
+            const lx = cx - b.s;
+            const ly = row - (bldgMaxH - b.h);
+            let isWin = false;
+            if (b.st === 'tower')
+              isWin =
+                lx > 0 && lx < b.w - 1 && ly > 0 && ly % 2 === 1 && lx % 2 === 1 && _rand() < 0.55;
+            else if (b.st === 'thin')
+              isWin = lx === Math.floor(b.w / 2) && ly > 0 && ly % 2 === 0 && _rand() < 0.7;
+            else if (b.st === 'wide')
+              isWin = lx > 0 && lx < b.w - 1 && ly > 0 && (ly === 2 || ly === 4) && _rand() < 0.5;
+            else isWin = lx > 0 && lx < b.w - 1 && ly > 0 && _rand() < 0.25;
+            if (isWin) {
+              line += chalk.hex(winPalette[Math.floor(_rand() * winPalette.length)]!)('▪');
+            } else {
+              line += chalk.hex(bldgColor).bgHex(bldgColor)('█');
             }
+            drawn = true;
+            break;
           }
         }
         if (!drawn) {
@@ -2481,29 +2488,34 @@ export async function runChat(options: ChatOptions): Promise<void> {
     }
     console.log(horizonLine);
 
-    // Title — gradient text matching dawn palette
-    const titleText = 'i n k w e l l';
-    const titleStops = [
-      '#c490d1',
-      '#e8b4b8',
-      '#f5d0a9',
-      '#ffeebb',
-      '#f5d0a9',
-      '#e8b4b8',
-      '#c490d1',
-    ];
-    let titleStr = '';
-    for (let i = 0; i < titleText.length; i++) {
-      const t = titleText.length > 1 ? i / (titleText.length - 1) : 0;
-      const si = Math.floor(t * (titleStops.length - 1));
-      const si2 = Math.min(si + 1, titleStops.length - 1);
-      const sf = t * (titleStops.length - 1) - si;
-      const c = _lerpHex(titleStops[si]!, titleStops[si2]!, sf);
-      titleStr += chalk.bold.hex(c)(titleText[i]);
-    }
-    const titlePad = ' '.repeat(Math.max(0, Math.floor((bannerWidth - titleText.length) / 2)));
+    // Block-letter INKWELL with dawn gradient
+    const blockFont: Record<string, string[]> = {
+      I: ['█████', '  █  ', '  █  ', '  █  ', '█████'],
+      N: ['█   █', '██  █', '█ █ █', '█  ██', '█   █'],
+      K: ['█  █', '█ █ ', '██  ', '█ █ ', '█  █'],
+      W: ['█     █', '█  █  █', '█ █ █ █', '██   ██', '█     █'],
+      E: ['█████', '█    ', '████ ', '█    ', '█████'],
+      L: ['█   ', '█   ', '█   ', '█   ', '████'],
+    };
+    const blockWord = 'INKWELL';
+    const blockSpacing = 2;
+    const blockRows = [0, 1, 2, 3, 4].map((r) =>
+      [...blockWord].map((ch) => blockFont[ch]![r]).join(' '.repeat(blockSpacing))
+    );
+    const blockTotalW = blockRows[0]!.length;
+    const blockPadN = Math.max(0, Math.floor((termW - blockTotalW) / 2));
+
     console.log('');
-    console.log(titlePad + titleStr);
+    for (const bRow of blockRows) {
+      let line = ' '.repeat(blockPadN);
+      for (let i = 0; i < bRow.length; i++) {
+        const ch = bRow[i];
+        const t = bRow.length > 1 ? i / (bRow.length - 1) : 0;
+        const c = _titleAt(t);
+        line += ch === '█' ? chalk.hex(c)('█') : ' ';
+      }
+      console.log(line);
+    }
 
     // Bottom gradient accent — thin warm line mirroring the horizon
     let bottomGlow = '';

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -71,6 +71,7 @@ import {
   startWaitingIndicator,
 } from '../repl/tui-components.js';
 import { renderInkChat, InkExitSignal, type InkRepl } from '../repl/ink/index.js';
+import { formatContextLines, type ContextSections } from '../repl/ink/context-viewer.js';
 import {
   classifyError,
   decodeDelegationToken,
@@ -106,6 +107,7 @@ type ChatOptions = {
   sbDebug?: boolean;
   verbose?: boolean;
   fullscreen?: boolean;
+  dynamic?: boolean;
   approvalMode?: string;
 };
 
@@ -572,6 +574,7 @@ function hydrateLedgerFromTranscript(
   tailPreview: HistoryHydrationResult['tailPreview'];
   seenInboxIds: string[];
   seenActivityIds: string[];
+  recoveredMemoryIds: string[];
 } {
   const events = readTranscriptEvents(transcriptPath);
   let loaded = 0;
@@ -579,6 +582,7 @@ function hydrateLedgerFromTranscript(
   const preview: HistoryHydrationResult['tailPreview'] = [];
   const seenInboxIds = new Set<string>();
   const seenActivityIds = new Set<string>();
+  const recoveredMemoryIds: string[] = [];
 
   const pushPreview = (role: 'user' | 'assistant' | 'inbox', content: string, ts?: string) => {
     preview.push({ role, content: compactForHistoryPreview(role, content), ts });
@@ -614,6 +618,15 @@ function hydrateLedgerFromTranscript(
       }
       continue;
     }
+    if (type === 'hook_injection' && typeof event.content === 'string') {
+      const source = typeof event.source === 'string' ? event.source : 'hook-history';
+      ledger.addEntry('system', event.content, source);
+      loaded += 1;
+      if (typeof event.memoryId === 'string') {
+        recoveredMemoryIds.push(event.memoryId);
+      }
+      continue;
+    }
     if (type === 'activity' && typeof event.content === 'string') {
       const actor = typeof event.agentId === 'string' ? event.agentId : 'system';
       const activityType = typeof event.activityType === 'string' ? event.activityType : 'activity';
@@ -635,6 +648,7 @@ function hydrateLedgerFromTranscript(
     tailPreview: preview,
     seenInboxIds: Array.from(seenInboxIds),
     seenActivityIds: Array.from(seenActivityIds),
+    recoveredMemoryIds,
   };
 }
 
@@ -2265,6 +2279,9 @@ export async function runChat(options: ChatOptions): Promise<void> {
     for (const activityId of hydrated.seenActivityIds) {
       seenActivityIds.add(activityId);
     }
+    if (hydrated.recoveredMemoryIds.length > 0) {
+      passiveRecallHandle.seedBootstrapIds(hydrated.recoveredMemoryIds);
+    }
   } else if (attachedToExistingSession && runtime.sessionId) {
     const sessionContextResult = (await pcp
       .callTool('get_session_context', { sessionId: runtime.sessionId, limit: 120 })
@@ -2758,6 +2775,19 @@ export async function runChat(options: ChatOptions): Promise<void> {
         turnIndex: hookTurnCount + 1,
       },
     });
+
+    // Persist hook-injected entries to transcript so they survive reattach
+    if (promptHookResult.injectedEntries.length > 0) {
+      for (const entry of promptHookResult.injectedEntries) {
+        appendTranscript(runtime.transcriptPath, {
+          type: 'hook_injection',
+          role: entry.role,
+          content: entry.content,
+          source: entry.source,
+          memoryId: entry.memoryId,
+        });
+      }
+    }
 
     // Print notifications from prompt_build hooks
     if (promptHookResult.injected > 0) {
@@ -3296,6 +3326,19 @@ export async function runChat(options: ChatOptions): Promise<void> {
         },
       })
       .then((hookResult) => {
+        // Persist hook-injected entries to transcript so they survive reattach
+        if (hookResult.injectedEntries.length > 0) {
+          for (const entry of hookResult.injectedEntries) {
+            appendTranscript(runtime.transcriptPath, {
+              type: 'hook_injection',
+              role: entry.role,
+              content: entry.content,
+              source: entry.source,
+              memoryId: entry.memoryId,
+            });
+          }
+        }
+
         // Notify the user about passive recall injections
         if (hookResult.injected > 0) {
           const recallEntries = ledger
@@ -3538,6 +3581,30 @@ export async function runChat(options: ChatOptions): Promise<void> {
   let exitAfterTurnNoticeShown = false;
   let activePromptLabel = `${agentId}> `;
 
+  // Helper: build context view lines from current state
+  const buildContextViewLines = (): string[] => {
+    const recallStats = passiveRecallHandle.getStats();
+    const allEntries = ledger.listEntries();
+    const recallEntries = allEntries.filter((e) => e.source === 'passive-recall');
+    return formatContextLines({
+      bootstrapSummary: runtime.bootstrapContext || undefined,
+      passiveRecallEntries: recallEntries.map((e) => ({
+        content: e.content,
+        source: e.source,
+      })),
+      passiveRecallStats: {
+        totalInjected: recallStats.totalInjected,
+        uniqueMemories: recallStats.uniqueMemories,
+        currentTurn: recallStats.currentTurn,
+      },
+      ledgerStats: {
+        totalEntries: allEntries.length,
+        tokenEstimate: ledger.totalTokens(),
+        bootstrapTokens: runtime.bootstrapContext ? estimateTokens(runtime.bootstrapContext) : 0,
+      },
+    });
+  };
+
   if (useInk) {
     // ── Ink path ──
     inkRepl = renderInkChat({
@@ -3545,6 +3612,7 @@ export async function runChat(options: ChatOptions): Promise<void> {
       timezone: runtime.userTimezone,
       infoItems: initialInfoItems,
       fullscreen: !!options.fullscreen,
+      dynamicMessages: !!options.dynamic,
     });
     // Initial status update — ChatApp starts with 'waiting for input'
     // so push the real context budget summary immediately
@@ -3558,6 +3626,11 @@ export async function runChat(options: ChatOptions): Promise<void> {
     });
     inkRepl.setStatus(initialSummary);
     lastStatusSummary = initialSummary;
+
+    // Register Ctrl+O handler — opens context viewer via React state
+    inkRepl.handle.setCtrlOHandler(() => {
+      inkRepl!.showContextView(buildContextViewLines());
+    });
 
     // Push prior messages into Ink scrollback so user sees conversation history
     if (historyHydration && historyHydration.tailPreview.length > 0) {
@@ -4815,17 +4888,21 @@ export async function runChat(options: ChatOptions): Promise<void> {
           break;
         }
         case 'context': {
-          const entries = ledger.listEntries().slice(-12);
-          if (entries.length === 0) {
-            showInPanel(['Context is empty.']);
-            break;
+          if (inkRepl) {
+            inkRepl.showContextView(buildContextViewLines());
+          } else {
+            const entries = ledger.listEntries().slice(-12);
+            if (entries.length === 0) {
+              showInPanel(['Context is empty.']);
+              break;
+            }
+            showInPanel(
+              entries.map((entry) => {
+                const prefix = `${entry.role}${entry.source ? `/${entry.source}` : ''}`;
+                return `${prefix}: ${entry.content.slice(0, 180)}`;
+              })
+            );
           }
-          showInPanel(
-            entries.map((entry) => {
-              const prefix = `${entry.role}${entry.source ? `/${entry.source}` : ''}`;
-              return `${prefix}: ${entry.content.slice(0, 180)}`;
-            })
-          );
           break;
         }
         case 'usage': {
@@ -4947,6 +5024,7 @@ export function registerChatCommand(program: Command): void {
       )
       .option('-v, --verbose', 'Verbose backend passthrough output')
       .option('--fullscreen', 'Fullscreen alternate buffer mode (app-controlled scrolling)')
+      .option('--dynamic', 'Render messages dynamically (re-renderable, no terminal scrollback)')
       .action((options: ChatOptions) => runChat(options));
 
   register('chat', 'Start first-class Ink REPL (experimental)');

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -2325,18 +2325,66 @@ export async function runChat(options: ChatOptions): Promise<void> {
 
   // ── Banner (prints before Ink mounts, goes to terminal scrollback) ──
   {
+    const INKWELL_QUOTES = [
+      { text: 'The palest ink is better than the best memory.', attr: 'Chinese proverb' },
+      { text: 'A word after a word after a word is power.', attr: 'Margaret Atwood' },
+      { text: 'We write to taste life twice.', attr: 'Anaïs Nin' },
+      { text: "I write entirely to find out what I'm thinking.", attr: 'Joan Didion' },
+      { text: 'Memory is the diary we all carry about with us.', attr: 'Oscar Wilde' },
+      {
+        text: 'Fill your paper with the breathings of your heart.',
+        attr: 'William Wordsworth',
+      },
+      {
+        text: 'Either write something worth reading or do something worth writing.',
+        attr: 'Benjamin Franklin',
+      },
+      { text: 'The pen is the tongue of the mind.', attr: 'Miguel de Cervantes' },
+    ];
+
     const bannerWidth = Math.min(process.stdout.columns || 80, 60);
-    const bar = '━'.repeat(Math.max(0, bannerWidth - 2));
-    console.log(chalk.magentaBright(`\n✦${bar}✦`));
-    console.log(chalk.bold.white('  SB Chat'));
-    console.log(chalk.magentaBright(`✦${bar}✦`));
+    const centerText = (s: string) =>
+      ' '.repeat(Math.max(0, Math.floor((bannerWidth - s.length) / 2))) + s;
+
+    const quote = INKWELL_QUOTES[Math.floor(Math.random() * INKWELL_QUOTES.length)]!;
+    const maxQW = bannerWidth - 8;
+    const qWords = quote.text.split(' ');
+    const qLines: string[] = [];
+    let qCur = '';
+    for (const w of qWords) {
+      const test = qCur ? `${qCur} ${w}` : w;
+      if (test.length > maxQW && qCur) {
+        qLines.push(qCur);
+        qCur = w;
+      } else {
+        qCur = test;
+      }
+    }
+    if (qCur) qLines.push(qCur);
+    qLines[0] = `“${qLines[0]!}`;
+    qLines[qLines.length - 1] += `”`;
+
+    const attrText = `— ${quote.attr}`;
+    const blockW = Math.max(...qLines.map((l) => l.length), attrText.length);
+    const blockPad = Math.max(0, Math.floor((bannerWidth - blockW) / 2));
+
+    console.log('');
+    console.log(centerText(chalk.white('✦')));
+    console.log('');
+    console.log(centerText(chalk.bold.white('i n k w e l l')));
+    console.log('');
+    for (const line of qLines) {
+      console.log(' '.repeat(blockPad) + chalk.dim(line));
+    }
+    console.log(' '.repeat(blockPad + Math.max(0, blockW - attrText.length)) + chalk.dim(attrText));
+    console.log('');
+    console.log(chalk.dim('  ' + '─'.repeat(Math.max(0, bannerWidth - 4))));
   }
-  // Use studio slug/name where available, fall back to short ID
   const studioSlug =
     attachedSessionSummary?.studioName ||
     (identity?.studioId ? formatStudioForDisplay(identity.studioId, 'short') : undefined);
   const bannerParts = [
-    chip('agent', agentId, chalk.cyan),
+    chip('inkling', agentId, chalk.cyan),
     chip(
       'backend',
       `${runtime.backend}${runtime.model ? ` (${runtime.model})` : ''}`,
@@ -2346,20 +2394,20 @@ export async function runChat(options: ChatOptions): Promise<void> {
     chip('window', `${formatTokenCount(runtime.backendTokenWindow)} tok`, chalk.green),
     chip('time', formatNow(runtime.userTimezone), chalk.magenta),
   ].filter(Boolean);
-  console.log(bannerParts.join(chalk.dim('  •  ')));
-  if (runtime.sessionId) console.log(chalk.dim(`Session: ${runtime.sessionId}`));
-  if (runtime.threadKey) console.log(chalk.dim(`Thread: ${runtime.threadKey}`));
+  console.log('  ' + bannerParts.join(chalk.dim('  ·  ')));
+  if (runtime.sessionId) console.log(chalk.dim(`  session ${runtime.sessionId}`));
+  if (runtime.threadKey) console.log(chalk.dim(`  thread ${runtime.threadKey}`));
   if (attachedToExistingSession) {
     console.log(
       chalk.dim(
-        autoAttachedLatest ? 'Auto-attached to latest session' : 'Attached to existing session'
+        autoAttachedLatest ? '  auto-attached to latest session' : '  attached to existing session'
       )
     );
   }
   if (historyHydration && historyHydration.messageCount > 0) {
-    console.log(chalk.dim(`History: ${historyHydration.messageCount} prior message(s) loaded`));
+    console.log(chalk.dim(`  history: ${historyHydration.messageCount} prior message(s) loaded`));
   }
-  console.log(chalk.dim('Type /help for commands.\n'));
+  console.log(chalk.dim('  /help for commands\n'));
 
   const refreshSessionsSnapshot = async (force = false): Promise<SessionSummary[]> => {
     const stale = Date.now() - sessionsCacheAt > 15_000;

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -2479,15 +2479,6 @@ export async function runChat(options: ChatOptions): Promise<void> {
       console.log(line);
     }
 
-    // Horizon glow — full width, warm center fading to edges
-    let horizonLine = '';
-    for (let i = 0; i < termW; i++) {
-      const t = Math.abs(i / Math.max(termW - 1, 1) - 0.5) * 2;
-      const c = _lerpHex('#ffeebb', '#e8b4b8', t);
-      horizonLine += chalk.hex(c).bgHex(c)('▀');
-    }
-    console.log(horizonLine);
-
     // Block-letter INKWELL with dawn gradient
     const blockFont: Record<string, string[]> = {
       I: ['█████', '  █  ', '  █  ', '  █  ', '█████'],

--- a/packages/cli/src/repl/hook-registry.test.ts
+++ b/packages/cli/src/repl/hook-registry.test.ts
@@ -143,7 +143,7 @@ describe('SbHookRegistry: fire', () => {
   it('returns zero counts when no hooks match', async () => {
     const registry = new SbHookRegistry();
     const result = await registry.fire('turn_end', makeCtx());
-    expect(result).toEqual({ injected: 0, evicted: 0, blocked: false });
+    expect(result).toEqual({ injected: 0, evicted: 0, blocked: false, injectedEntries: [] });
   });
 
   it('records fire log entries', async () => {
@@ -399,7 +399,7 @@ describe('SbHookRegistry: error handling', () => {
     });
 
     const result = await registry.fire('turn_end', makeCtx());
-    expect(result).toEqual({ injected: 0, evicted: 0, blocked: false });
+    expect(result).toEqual({ injected: 0, evicted: 0, blocked: false, injectedEntries: [] });
   });
 });
 

--- a/packages/cli/src/repl/hook-registry.ts
+++ b/packages/cli/src/repl/hook-registry.ts
@@ -137,18 +137,20 @@ export class SbHookRegistry {
     ctx: Omit<HookContext, 'event'>
   ): Promise<{
     injected: number;
+    injectedEntries: InjectedLedgerEntry[];
     evicted: number;
     blocked: boolean;
     blockReason?: string;
   }> {
     const eventHooks = this.hooks.filter((h) => h.event === event);
     if (eventHooks.length === 0) {
-      return { injected: 0, evicted: 0, blocked: false };
+      return { injected: 0, injectedEntries: [], evicted: 0, blocked: false };
     }
 
     const fullCtx: HookContext = { event, ...ctx };
     let totalInjected = 0;
     let totalEvicted = 0;
+    const allInjected: InjectedLedgerEntry[] = [];
 
     for (const hook of eventHooks) {
       try {
@@ -165,6 +167,7 @@ export class SbHookRegistry {
         if (result.inject && result.inject.length > 0) {
           for (const entry of result.inject) {
             ctx.ledger.addEntry(entry.role, entry.content, entry.source);
+            allInjected.push(entry);
             totalInjected++;
           }
         }
@@ -179,6 +182,7 @@ export class SbHookRegistry {
         if (result.block && BLOCKING_EVENTS.has(event)) {
           return {
             injected: totalInjected,
+            injectedEntries: allInjected,
             evicted: totalEvicted,
             blocked: true,
             blockReason: result.blockReason || `Blocked by hook: ${hook.name}`,
@@ -191,6 +195,11 @@ export class SbHookRegistry {
       }
     }
 
-    return { injected: totalInjected, evicted: totalEvicted, blocked: false };
+    return {
+      injected: totalInjected,
+      injectedEntries: allInjected,
+      evicted: totalEvicted,
+      blocked: false,
+    };
   }
 }

--- a/packages/cli/src/repl/ink/ChatApp.tsx
+++ b/packages/cli/src/repl/ink/ChatApp.tsx
@@ -46,6 +46,7 @@ export interface ChatAppHandle {
   setInfoItems: (items: string[]) => void;
   setAbortHandler: (handler: (() => void) | null) => void;
   setCommandOutput: (lines: string[] | null) => void;
+  setSurfacedMemories: (lines: string[]) => void;
 }
 
 /**
@@ -69,6 +70,7 @@ export const ChatApp = React.forwardRef<ChatAppHandle, ChatAppProps>(function Ch
 
   const [commandOutput, setCommandOutput] = useState<string[] | null>(null);
   const [inputHistory, setInputHistory] = useState<string[]>([]);
+  const [lastSurfacedMemories, setLastSurfacedMemories] = useState<string[]>([]);
 
   // Abort handler — set by orchestrator when a backend turn is running
   const abortHandlerRef = useRef<(() => void) | null>(null);
@@ -111,6 +113,9 @@ export const ChatApp = React.forwardRef<ChatAppHandle, ChatAppProps>(function Ch
     setCommandOutput: (lines: string[] | null) => {
       setCommandOutput(lines);
     },
+    setSurfacedMemories: (lines: string[]) => {
+      setLastSurfacedMemories(lines);
+    },
   }));
 
   const handleSubmit = useCallback(
@@ -130,6 +135,12 @@ export const ChatApp = React.forwardRef<ChatAppHandle, ChatAppProps>(function Ch
       abortHandlerRef.current = null;
     }
   }, []);
+
+  const handleExpandMemories = useCallback(() => {
+    if (lastSurfacedMemories.length > 0) {
+      setCommandOutput(commandOutput ? null : lastSurfacedMemories);
+    }
+  }, [lastSurfacedMemories, commandOutput]);
 
   const [ctrlCHint, setCtrlCHint] = useState(false);
 
@@ -188,6 +199,7 @@ export const ChatApp = React.forwardRef<ChatAppHandle, ChatAppProps>(function Ch
         inputHistory={inputHistory}
         ctrlCHint={ctrlCHint}
         onCtrlC={handleCtrlC}
+        onExpandMemories={handleExpandMemories}
         waitingElement={
           waiting ? (
             <Box paddingX={1}>

--- a/packages/cli/src/repl/ink/ChatApp.tsx
+++ b/packages/cli/src/repl/ink/ChatApp.tsx
@@ -133,28 +133,28 @@ export const ChatApp = React.forwardRef<ChatAppHandle, ChatAppProps>(function Ch
 
   const [ctrlCHint, setCtrlCHint] = useState(false);
 
-  // Handle Ctrl+C for double-tap exit
+  const handleCtrlC = useCallback(() => {
+    if (ctrlCCount >= 1) {
+      if (ctrlCTimer) clearTimeout(ctrlCTimer);
+      onExit();
+      exit();
+      return;
+    }
+    setCtrlCCount(1);
+    setCtrlCHint(true);
+    const timer = setTimeout(() => {
+      setCtrlCCount(0);
+      setCtrlCHint(false);
+    }, 1500);
+    setCtrlCTimer(timer);
+  }, [ctrlCCount, ctrlCTimer, onExit, exit]);
+
+  // Clean up timer on unmount
   useEffect(() => {
-    const handler = () => {
-      if (ctrlCCount >= 1) {
-        onExit();
-        exit();
-        return;
-      }
-      setCtrlCCount(1);
-      setCtrlCHint(true);
-      const timer = setTimeout(() => {
-        setCtrlCCount(0);
-        setCtrlCHint(false);
-      }, 1500);
-      setCtrlCTimer(timer);
-    };
-    process.on('SIGINT', handler);
     return () => {
-      process.off('SIGINT', handler);
       if (ctrlCTimer) clearTimeout(ctrlCTimer);
     };
-  }, [ctrlCCount, ctrlCTimer, onExit, exit]);
+  }, [ctrlCTimer]);
 
   const now = formatNow(timezone);
   const promptLabel = '> ';
@@ -187,6 +187,7 @@ export const ChatApp = React.forwardRef<ChatAppHandle, ChatAppProps>(function Ch
         onCommandOutputClear={() => setCommandOutput(null)}
         inputHistory={inputHistory}
         ctrlCHint={ctrlCHint}
+        onCtrlC={handleCtrlC}
         waitingElement={
           waiting ? (
             <Box paddingX={1}>

--- a/packages/cli/src/repl/ink/ChatApp.tsx
+++ b/packages/cli/src/repl/ink/ChatApp.tsx
@@ -175,6 +175,12 @@ export const ChatApp = React.forwardRef<ChatAppHandle, ChatAppProps>(function Ch
   const [ctrlCHint, setCtrlCHint] = useState(false);
 
   const handleCtrlC = useCallback(() => {
+    // When a backend turn is active, first Ctrl+C aborts the turn
+    if (waiting && abortHandlerRef.current) {
+      abortHandlerRef.current();
+      abortHandlerRef.current = null;
+      return;
+    }
     if (ctrlCCount >= 1) {
       if (ctrlCTimer) clearTimeout(ctrlCTimer);
       onExit();
@@ -188,7 +194,7 @@ export const ChatApp = React.forwardRef<ChatAppHandle, ChatAppProps>(function Ch
       setCtrlCHint(false);
     }, 1500);
     setCtrlCTimer(timer);
-  }, [ctrlCCount, ctrlCTimer, onExit, exit]);
+  }, [waiting, ctrlCCount, ctrlCTimer, onExit, exit]);
 
   // Clean up timer on unmount
   useEffect(() => {

--- a/packages/cli/src/repl/ink/ChatApp.tsx
+++ b/packages/cli/src/repl/ink/ChatApp.tsx
@@ -213,58 +213,64 @@ export const ChatApp = React.forwardRef<ChatAppHandle, ChatAppProps>(function Ch
 
   return (
     <Box flexDirection="column">
-      {showingContext && (
+      {/* Context viewer — always mounted, toggled via display.
+          Keeps useInput lifecycle stable across open/close cycles. */}
+      <Box display={showingContext ? 'flex' : 'none'} flexDirection="column">
         <ContextViewer
-          lines={contextViewLines}
+          lines={contextViewLines ?? []}
           isActive={showingContext}
           onDismiss={() => setContextViewLines(null)}
         />
-      )}
-      {!showingContext && (
-        <>
-          {dynamicMessages ? (
-            <Box flexDirection="column">{messageElements}</Box>
-          ) : (
-            <Static items={messages}>
-              {(msg) => (
-                <MessageLine
-                  key={msg.id}
-                  id={msg.id}
-                  role={msg.role}
-                  content={msg.content}
-                  label={msg.label}
-                  time={msg.time}
-                  trailingMeta={msg.trailingMeta}
-                />
-              )}
-            </Static>
-          )}
+      </Box>
 
-          <Dock
-            statusSummary={statusSummary}
-            time={now}
-            infoItems={infoItems}
-            promptLabel={promptLabel}
-            onSubmit={handleSubmit}
-            isPromptActive={!waiting}
-            onAbort={handleAbort}
-            commandOutput={commandOutput}
-            onCommandOutputClear={() => setCommandOutput(null)}
-            inputHistory={inputHistory}
-            ctrlCHint={ctrlCHint}
-            onCtrlC={handleCtrlC}
-            onExpandMemories={handleExpandMemories}
-            waitingElement={
-              waiting ? (
-                <Box paddingX={1}>
-                  <Text color="cyan">{SPINNER_CHAR + ' '}</Text>
-                  <Text dimColor>{waitingVerb}...</Text>
-                </Box>
-              ) : undefined
-            }
-          />
-        </>
-      )}
+      {/* Chat messages — Static writes to scrollback regardless of display */}
+      {!showingContext &&
+        (dynamicMessages ? (
+          <Box flexDirection="column">{messageElements}</Box>
+        ) : (
+          <Static items={messages}>
+            {(msg) => (
+              <MessageLine
+                key={msg.id}
+                id={msg.id}
+                role={msg.role}
+                content={msg.content}
+                label={msg.label}
+                time={msg.time}
+                trailingMeta={msg.trailingMeta}
+              />
+            )}
+          </Static>
+        ))}
+
+      {/* Dock — always mounted, hidden when context viewer is active.
+          useInputActive=false yields stdin to ContextViewer's useInput. */}
+      <Box display={showingContext ? 'none' : 'flex'} flexDirection="column">
+        <Dock
+          statusSummary={statusSummary}
+          time={now}
+          infoItems={infoItems}
+          promptLabel={promptLabel}
+          onSubmit={handleSubmit}
+          isPromptActive={!waiting}
+          useInputActive={!showingContext}
+          onAbort={handleAbort}
+          commandOutput={commandOutput}
+          onCommandOutputClear={() => setCommandOutput(null)}
+          inputHistory={inputHistory}
+          ctrlCHint={ctrlCHint}
+          onCtrlC={handleCtrlC}
+          onExpandMemories={handleExpandMemories}
+          waitingElement={
+            waiting ? (
+              <Box paddingX={1}>
+                <Text color="cyan">{SPINNER_CHAR + ' '}</Text>
+                <Text dimColor>{waitingVerb}...</Text>
+              </Box>
+            ) : undefined
+          }
+        />
+      </Box>
     </Box>
   );
 });

--- a/packages/cli/src/repl/ink/ChatApp.tsx
+++ b/packages/cli/src/repl/ink/ChatApp.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useCallback, useEffect, useRef } from 'react';
 import { Box, Static, Text, useApp } from 'ink';
+import { ContextViewer } from './context-viewer.js';
 import { Dock } from './Dock.js';
 import { MessageLine, type MessageLineProps } from './MessageLine.js';
 import { formatNow } from '../tui-components.js';
@@ -30,6 +31,8 @@ export interface ChatAppProps {
   timezone?: string;
   infoItems: string[];
   fullscreen?: boolean;
+  /** Render all messages dynamically (re-renderable) instead of write-once Static. */
+  dynamicMessages?: boolean;
   /** Called when the user submits a message from the prompt. */
   onUserInput: (raw: string) => void;
   /** Called when the user requests exit (double Ctrl+C). */
@@ -47,6 +50,10 @@ export interface ChatAppHandle {
   setAbortHandler: (handler: (() => void) | null) => void;
   setCommandOutput: (lines: string[] | null) => void;
   setSurfacedMemories: (lines: string[]) => void;
+  /** Open the context viewer with the given lines. */
+  showContextView: (lines: string[]) => void;
+  /** Register callback for Ctrl+O (orchestrator builds context, calls showContextView). */
+  setCtrlOHandler: (handler: (() => void) | null) => void;
 }
 
 /**
@@ -56,7 +63,15 @@ export interface ChatAppHandle {
  * Only the dock (status | prompt | info) is dynamic (~6 lines).
  */
 export const ChatApp = React.forwardRef<ChatAppHandle, ChatAppProps>(function ChatApp(
-  { agentId, timezone, infoItems: initialInfoItems, fullscreen = false, onUserInput, onExit },
+  {
+    agentId,
+    timezone,
+    infoItems: initialInfoItems,
+    fullscreen = false,
+    dynamicMessages = false,
+    onUserInput,
+    onExit,
+  },
   ref
 ) {
   const { exit } = useApp();
@@ -74,6 +89,9 @@ export const ChatApp = React.forwardRef<ChatAppHandle, ChatAppProps>(function Ch
 
   // Abort handler — set by orchestrator when a backend turn is running
   const abortHandlerRef = useRef<(() => void) | null>(null);
+
+  // Context viewer state
+  const [contextViewLines, setContextViewLines] = useState<string[] | null>(null);
 
   // Waiting indicator state — verb rotates every 3s
   const [waitingVerb, setWaitingVerb] = useState('');
@@ -116,6 +134,12 @@ export const ChatApp = React.forwardRef<ChatAppHandle, ChatAppProps>(function Ch
     setSurfacedMemories: (lines: string[]) => {
       setLastSurfacedMemories(lines);
     },
+    showContextView: (lines: string[]) => {
+      setContextViewLines(lines);
+    },
+    setCtrlOHandler: (handler: (() => void) | null) => {
+      ctrlOHandlerRef.current = handler;
+    },
   }));
 
   const handleSubmit = useCallback(
@@ -136,11 +160,14 @@ export const ChatApp = React.forwardRef<ChatAppHandle, ChatAppProps>(function Ch
     }
   }, []);
 
+  // Ctrl+O callback — set by orchestrator to build context and call showContextView
+  const ctrlOHandlerRef = useRef<(() => void) | null>(null);
+
   const handleExpandMemories = useCallback(() => {
-    if (lastSurfacedMemories.length > 0) {
-      setCommandOutput(commandOutput ? null : lastSurfacedMemories);
+    if (ctrlOHandlerRef.current) {
+      ctrlOHandlerRef.current();
     }
-  }, [lastSurfacedMemories, commandOutput]);
+  }, []);
 
   const [ctrlCHint, setCtrlCHint] = useState(false);
 
@@ -170,45 +197,74 @@ export const ChatApp = React.forwardRef<ChatAppHandle, ChatAppProps>(function Ch
   const now = formatNow(timezone);
   const promptLabel = '> ';
 
+  const showingContext = contextViewLines !== null;
+
+  const messageElements = messages.map((msg) => (
+    <MessageLine
+      key={msg.id}
+      id={msg.id}
+      role={msg.role}
+      content={msg.content}
+      label={msg.label}
+      time={msg.time}
+      trailingMeta={msg.trailingMeta}
+    />
+  ));
+
   return (
     <Box flexDirection="column">
-      <Static items={messages}>
-        {(msg) => (
-          <MessageLine
-            key={msg.id}
-            id={msg.id}
-            role={msg.role}
-            content={msg.content}
-            label={msg.label}
-            time={msg.time}
-            trailingMeta={msg.trailingMeta}
-          />
-        )}
-      </Static>
+      {showingContext && (
+        <ContextViewer
+          lines={contextViewLines}
+          isActive={showingContext}
+          onDismiss={() => setContextViewLines(null)}
+        />
+      )}
+      {!showingContext && (
+        <>
+          {dynamicMessages ? (
+            <Box flexDirection="column">{messageElements}</Box>
+          ) : (
+            <Static items={messages}>
+              {(msg) => (
+                <MessageLine
+                  key={msg.id}
+                  id={msg.id}
+                  role={msg.role}
+                  content={msg.content}
+                  label={msg.label}
+                  time={msg.time}
+                  trailingMeta={msg.trailingMeta}
+                />
+              )}
+            </Static>
+          )}
 
-      <Dock
-        statusSummary={statusSummary}
-        time={now}
-        infoItems={infoItems}
-        promptLabel={promptLabel}
-        onSubmit={handleSubmit}
-        isPromptActive={!waiting}
-        onAbort={handleAbort}
-        commandOutput={commandOutput}
-        onCommandOutputClear={() => setCommandOutput(null)}
-        inputHistory={inputHistory}
-        ctrlCHint={ctrlCHint}
-        onCtrlC={handleCtrlC}
-        onExpandMemories={handleExpandMemories}
-        waitingElement={
-          waiting ? (
-            <Box paddingX={1}>
-              <Text color="cyan">{SPINNER_CHAR + ' '}</Text>
-              <Text dimColor>{waitingVerb}...</Text>
-            </Box>
-          ) : undefined
-        }
-      />
+          <Dock
+            statusSummary={statusSummary}
+            time={now}
+            infoItems={infoItems}
+            promptLabel={promptLabel}
+            onSubmit={handleSubmit}
+            isPromptActive={!waiting}
+            onAbort={handleAbort}
+            commandOutput={commandOutput}
+            onCommandOutputClear={() => setCommandOutput(null)}
+            inputHistory={inputHistory}
+            ctrlCHint={ctrlCHint}
+            onCtrlC={handleCtrlC}
+            onExpandMemories={handleExpandMemories}
+            waitingElement={
+              waiting ? (
+                <Box paddingX={1}>
+                  <Text color="cyan">{SPINNER_CHAR + ' '}</Text>
+                  <Text dimColor>{waitingVerb}...</Text>
+                </Box>
+              ) : undefined
+            }
+          />
+        </>
+      )}
     </Box>
   );
 });

--- a/packages/cli/src/repl/ink/ChatApp.tsx
+++ b/packages/cli/src/repl/ink/ChatApp.tsx
@@ -92,6 +92,9 @@ export const ChatApp = React.forwardRef<ChatAppHandle, ChatAppProps>(function Ch
 
   // Context viewer state
   const [contextViewLines, setContextViewLines] = useState<string[] | null>(null);
+  // Brief intermediate state: both views hidden so Ink renders a zero-height
+  // frame, erasing the tall context viewer before showing the shorter dock.
+  const [dismissingContext, setDismissingContext] = useState(false);
 
   // Waiting indicator state — verb rotates every 3s
   const [waitingVerb, setWaitingVerb] = useState('');
@@ -198,6 +201,16 @@ export const ChatApp = React.forwardRef<ChatAppHandle, ChatAppProps>(function Ch
   const promptLabel = '> ';
 
   const showingContext = contextViewLines !== null;
+  const dockVisible = !showingContext && !dismissingContext;
+
+  const handleContextDismiss = useCallback(() => {
+    // Two-phase dismiss: hide both views for one frame so Ink renders a
+    // zero-height dynamic area (erasing the tall context viewer), then
+    // show the dock fresh on the next tick.
+    setDismissingContext(true);
+    setContextViewLines(null);
+    setTimeout(() => setDismissingContext(false), 0);
+  }, []);
 
   const messageElements = messages.map((msg) => (
     <MessageLine
@@ -219,12 +232,12 @@ export const ChatApp = React.forwardRef<ChatAppHandle, ChatAppProps>(function Ch
         <ContextViewer
           lines={contextViewLines ?? []}
           isActive={showingContext}
-          onDismiss={() => setContextViewLines(null)}
+          onDismiss={handleContextDismiss}
         />
       </Box>
 
       {/* Chat messages — Static writes to scrollback regardless of display */}
-      {!showingContext &&
+      {dockVisible &&
         (dynamicMessages ? (
           <Box flexDirection="column">{messageElements}</Box>
         ) : (
@@ -245,7 +258,7 @@ export const ChatApp = React.forwardRef<ChatAppHandle, ChatAppProps>(function Ch
 
       {/* Dock — always mounted, hidden when context viewer is active.
           useInputActive=false yields stdin to ContextViewer's useInput. */}
-      <Box display={showingContext ? 'none' : 'flex'} flexDirection="column">
+      <Box display={dockVisible ? 'flex' : 'none'} flexDirection="column">
         <Dock
           statusSummary={statusSummary}
           time={now}
@@ -253,7 +266,7 @@ export const ChatApp = React.forwardRef<ChatAppHandle, ChatAppProps>(function Ch
           promptLabel={promptLabel}
           onSubmit={handleSubmit}
           isPromptActive={!waiting}
-          useInputActive={!showingContext}
+          useInputActive={dockVisible}
           onAbort={handleAbort}
           commandOutput={commandOutput}
           onCommandOutputClear={() => setCommandOutput(null)}

--- a/packages/cli/src/repl/ink/ChatApp.tsx
+++ b/packages/cli/src/repl/ink/ChatApp.tsx
@@ -226,17 +226,14 @@ export const ChatApp = React.forwardRef<ChatAppHandle, ChatAppProps>(function Ch
 
   return (
     <Box flexDirection="column">
-      {/* Context viewer — always mounted, toggled via display.
-          Keeps useInput lifecycle stable across open/close cycles. */}
-      <Box display={showingContext ? 'flex' : 'none'} flexDirection="column">
-        <ContextViewer
-          lines={contextViewLines ?? []}
-          isActive={showingContext}
-          onDismiss={handleContextDismiss}
-        />
-      </Box>
+      {/* Context viewer — conditionally rendered so each open gets fresh
+          scroll state. The useInput lifecycle issue only affects the Dock
+          (PromptInput), not the ContextViewer, so mount/unmount is safe. */}
+      {showingContext && (
+        <ContextViewer lines={contextViewLines!} isActive onDismiss={handleContextDismiss} />
+      )}
 
-      {/* Chat messages — Static writes to scrollback regardless of display */}
+      {/* Chat messages — Static writes to scrollback */}
       {dockVisible &&
         (dynamicMessages ? (
           <Box flexDirection="column">{messageElements}</Box>

--- a/packages/cli/src/repl/ink/ChatApp.tsx
+++ b/packages/cli/src/repl/ink/ChatApp.tsx
@@ -57,7 +57,7 @@ export interface ChatAppHandle {
 }
 
 /**
- * Root Ink component for the SB Chat REPL.
+ * Root Ink component for the Inkwell Chat REPL.
  *
  * Uses <Static> for completed messages (written once to terminal scrollback).
  * Only the dock (status | prompt | info) is dynamic (~6 lines).

--- a/packages/cli/src/repl/ink/Dock.tsx
+++ b/packages/cli/src/repl/ink/Dock.tsx
@@ -13,6 +13,9 @@ interface DockProps {
   promptLabel: string;
   onSubmit: (value: string) => void;
   isPromptActive: boolean;
+  /** When false, PromptInput's useInput unsubscribes from stdin entirely
+   *  (e.g. when ContextViewer is active and needs exclusive key handling). */
+  useInputActive?: boolean;
   onAbort?: () => void;
   commandOutput?: string[] | null;
   onCommandOutputClear?: () => void;
@@ -39,6 +42,7 @@ export function Dock({
   promptLabel,
   onSubmit,
   isPromptActive,
+  useInputActive = true,
   onAbort,
   commandOutput,
   onCommandOutputClear,
@@ -84,6 +88,7 @@ export function Dock({
         label={promptLabel}
         onSubmit={onSubmit}
         isActive={isPromptActive}
+        useInputActive={useInputActive}
         onAbort={onAbort}
         onEscape={onCommandOutputClear}
         onCtrlC={onCtrlC}

--- a/packages/cli/src/repl/ink/Dock.tsx
+++ b/packages/cli/src/repl/ink/Dock.tsx
@@ -19,6 +19,7 @@ interface DockProps {
   waitingElement?: React.ReactNode;
   inputHistory?: string[];
   ctrlCHint?: boolean;
+  onCtrlC?: () => void;
 }
 
 /**
@@ -43,6 +44,7 @@ export function Dock({
   waitingElement,
   inputHistory,
   ctrlCHint,
+  onCtrlC,
 }: DockProps): React.ReactElement {
   const { stdout } = useStdout();
   const [, setResizeCounter] = useState(0);
@@ -82,6 +84,7 @@ export function Dock({
         isActive={isPromptActive}
         onAbort={onAbort}
         onEscape={onCommandOutputClear}
+        onCtrlC={onCtrlC}
         onInputChange={handleInputChange}
         history={inputHistory}
       />

--- a/packages/cli/src/repl/ink/Dock.tsx
+++ b/packages/cli/src/repl/ink/Dock.tsx
@@ -20,6 +20,7 @@ interface DockProps {
   inputHistory?: string[];
   ctrlCHint?: boolean;
   onCtrlC?: () => void;
+  onExpandMemories?: () => void;
 }
 
 /**
@@ -45,6 +46,7 @@ export function Dock({
   inputHistory,
   ctrlCHint,
   onCtrlC,
+  onExpandMemories,
 }: DockProps): React.ReactElement {
   const { stdout } = useStdout();
   const [, setResizeCounter] = useState(0);
@@ -85,6 +87,7 @@ export function Dock({
         onAbort={onAbort}
         onEscape={onCommandOutputClear}
         onCtrlC={onCtrlC}
+        onExpandMemories={onExpandMemories}
         onInputChange={handleInputChange}
         history={inputHistory}
       />

--- a/packages/cli/src/repl/ink/PromptInput.tsx
+++ b/packages/cli/src/repl/ink/PromptInput.tsx
@@ -9,6 +9,8 @@ interface PromptInputProps {
   onAbort?: () => void;
   /** Called when Escape is pressed with empty input (e.g. dismiss dock panel). */
   onEscape?: () => void;
+  /** Called when Ctrl+C is pressed. */
+  onCtrlC?: () => void;
   /** Called on every keystroke with the current input value. */
   onInputChange?: (value: string) => void;
   /** Scroll callback for page up/down from within the prompt. */
@@ -47,6 +49,7 @@ export function PromptInput({
   isActive = true,
   onAbort,
   onEscape,
+  onCtrlC,
   onInputChange,
   onScroll,
   history = [],
@@ -89,8 +92,10 @@ export function PromptInput({
       return;
     }
 
-    // Ctrl+C is handled by Ink at the app level
-    if (key.ctrl && input === 'c') return;
+    if (key.ctrl && input === 'c') {
+      onCtrlC?.();
+      return;
+    }
 
     // Ctrl+U: clear line
     if (key.ctrl && input === 'u') {

--- a/packages/cli/src/repl/ink/PromptInput.tsx
+++ b/packages/cli/src/repl/ink/PromptInput.tsx
@@ -5,6 +5,10 @@ interface PromptInputProps {
   label: string;
   onSubmit: (value: string) => void;
   isActive?: boolean;
+  /** Controls whether useInput subscribes to stdin. Separate from isActive so
+   *  the prompt can still handle Escape-to-abort while waiting, but fully
+   *  yield stdin when another component (e.g. ContextViewer) needs it. */
+  useInputActive?: boolean;
   /** Called when Escape is pressed while waiting (not active). */
   onAbort?: () => void;
   /** Called when Escape is pressed with empty input (e.g. dismiss dock panel). */
@@ -49,6 +53,7 @@ export function PromptInput({
   label,
   onSubmit,
   isActive = true,
+  useInputActive = true,
   onAbort,
   onEscape,
   onCtrlC,
@@ -66,196 +71,199 @@ export function PromptInput({
     onInputChange?.(value);
   }, [value, onInputChange]);
 
-  useInput((input, key) => {
-    if (key.return) {
-      const submitted = value.trim();
-      if (!submitted) return;
-      setValue('');
-      setCursor(0);
-      setHistoryIndex(-1);
-      setSavedInput('');
-      onSubmit(submitted);
-      return;
-    }
-
-    // Option+Backspace: delete word before cursor
-    if ((key.backspace || key.delete) && key.meta) {
-      const boundary = prevWordBoundary(value, cursor);
-      setValue((prev) => prev.slice(0, boundary) + prev.slice(cursor));
-      setCursor(boundary);
-      return;
-    }
-
-    // Regular backspace: delete one character
-    if (key.backspace || key.delete) {
-      if (cursor > 0) {
-        setValue((prev) => prev.slice(0, cursor - 1) + prev.slice(cursor));
-        setCursor((prev) => prev - 1);
-      }
-      return;
-    }
-
-    if (key.ctrl && input === 'c') {
-      onCtrlC?.();
-      return;
-    }
-
-    // Ctrl+O: expand collapsed memories in dock panel
-    if (key.ctrl && input === 'o') {
-      onExpandMemories?.();
-      return;
-    }
-
-    // Ctrl+U: clear line
-    if (key.ctrl && input === 'u') {
-      setValue('');
-      setCursor(0);
-      return;
-    }
-
-    // Ctrl+W: delete word before cursor (Unix convention)
-    if (key.ctrl && input === 'w') {
-      const boundary = prevWordBoundary(value, cursor);
-      setValue((prev) => prev.slice(0, boundary) + prev.slice(cursor));
-      setCursor(boundary);
-      return;
-    }
-
-    // Ctrl+A: beginning of line
-    if (key.ctrl && input === 'a') {
-      setCursor(0);
-      return;
-    }
-
-    // Ctrl+E: end of line
-    if (key.ctrl && input === 'e') {
-      setCursor(value.length);
-      return;
-    }
-
-    // Ctrl+K: kill to end of line
-    if (key.ctrl && input === 'k') {
-      setValue((prev) => prev.slice(0, cursor));
-      return;
-    }
-
-    // Option+Left / Meta+b: move to previous word boundary
-    if ((key.leftArrow && key.meta) || (key.meta && input === 'b')) {
-      setCursor((prev) => prevWordBoundary(value, prev));
-      return;
-    }
-
-    // Option+Right / Meta+f: move to next word boundary
-    if ((key.rightArrow && key.meta) || (key.meta && input === 'f')) {
-      setCursor((prev) => nextWordBoundary(value, prev));
-      return;
-    }
-
-    // Meta+d: delete word forward
-    if (key.meta && input === 'd') {
-      const boundary = nextWordBoundary(value, cursor);
-      setValue((prev) => prev.slice(0, cursor) + prev.slice(boundary));
-      return;
-    }
-
-    // Regular left/right arrow
-    if (key.leftArrow) {
-      setCursor((prev) => Math.max(0, prev - 1));
-      return;
-    }
-
-    if (key.rightArrow) {
-      setCursor((prev) => Math.min(value.length, prev + 1));
-      return;
-    }
-
-    // Shift+Up/Down: scroll messages (page up/down)
-    if (key.shift && key.upArrow) {
-      onScroll?.('up');
-      return;
-    }
-    if (key.shift && key.downArrow) {
-      onScroll?.('down');
-      return;
-    }
-
-    // macOS Option+key without "Option as Meta" produces Unicode chars
-    if (input === '∫') {
-      // Option+b → word left
-      setCursor((prev) => prevWordBoundary(value, prev));
-      return;
-    }
-    if (input === 'ƒ') {
-      // Option+f → word right
-      setCursor((prev) => nextWordBoundary(value, prev));
-      return;
-    }
-    if (input === '∂') {
-      // Option+d → delete word forward
-      const boundary = nextWordBoundary(value, cursor);
-      setValue((prev) => prev.slice(0, cursor) + prev.slice(boundary));
-      return;
-    }
-
-    // Escape: abort current turn if waiting, clear input if typing, dismiss panel if empty
-    if (key.escape) {
-      if (!isActive && onAbort) {
-        onAbort();
-      } else if (value.length > 0) {
+  useInput(
+    (input, key) => {
+      if (key.return) {
+        const submitted = value.trim();
+        if (!submitted) return;
         setValue('');
         setCursor(0);
         setHistoryIndex(-1);
         setSavedInput('');
-      } else {
-        onEscape?.();
+        onSubmit(submitted);
+        return;
       }
-      return;
-    }
 
-    // Up arrow: navigate input history (most recent first)
-    if (key.upArrow) {
-      if (history.length === 0) return;
-      if (historyIndex === -1) {
-        setSavedInput(value);
-        const newIndex = history.length - 1;
-        setHistoryIndex(newIndex);
-        setValue(history[newIndex]!);
-        setCursor(history[newIndex]!.length);
-      } else if (historyIndex > 0) {
-        const newIndex = historyIndex - 1;
-        setHistoryIndex(newIndex);
-        setValue(history[newIndex]!);
-        setCursor(history[newIndex]!.length);
+      // Option+Backspace: delete word before cursor
+      if ((key.backspace || key.delete) && key.meta) {
+        const boundary = prevWordBoundary(value, cursor);
+        setValue((prev) => prev.slice(0, boundary) + prev.slice(cursor));
+        setCursor(boundary);
+        return;
       }
-      return;
-    }
 
-    // Down arrow: navigate forward in history, restore saved input at end
-    if (key.downArrow) {
-      if (historyIndex === -1) return;
-      if (historyIndex < history.length - 1) {
-        const newIndex = historyIndex + 1;
-        setHistoryIndex(newIndex);
-        setValue(history[newIndex]!);
-        setCursor(history[newIndex]!.length);
-      } else {
-        setHistoryIndex(-1);
-        setValue(savedInput);
-        setCursor(savedInput.length);
+      // Regular backspace: delete one character
+      if (key.backspace || key.delete) {
+        if (cursor > 0) {
+          setValue((prev) => prev.slice(0, cursor - 1) + prev.slice(cursor));
+          setCursor((prev) => prev - 1);
+        }
+        return;
       }
-      return;
-    }
 
-    // Ignore other control sequences
-    if (key.ctrl) return;
-    if (key.tab) return;
+      if (key.ctrl && input === 'c') {
+        onCtrlC?.();
+        return;
+      }
 
-    // Regular character input
-    if (input) {
-      setValue((prev) => prev.slice(0, cursor) + input + prev.slice(cursor));
-      setCursor((prev) => prev + input.length);
-    }
-  }, {});
+      // Ctrl+O: expand collapsed memories in dock panel
+      if (key.ctrl && input === 'o') {
+        onExpandMemories?.();
+        return;
+      }
+
+      // Ctrl+U: clear line
+      if (key.ctrl && input === 'u') {
+        setValue('');
+        setCursor(0);
+        return;
+      }
+
+      // Ctrl+W: delete word before cursor (Unix convention)
+      if (key.ctrl && input === 'w') {
+        const boundary = prevWordBoundary(value, cursor);
+        setValue((prev) => prev.slice(0, boundary) + prev.slice(cursor));
+        setCursor(boundary);
+        return;
+      }
+
+      // Ctrl+A: beginning of line
+      if (key.ctrl && input === 'a') {
+        setCursor(0);
+        return;
+      }
+
+      // Ctrl+E: end of line
+      if (key.ctrl && input === 'e') {
+        setCursor(value.length);
+        return;
+      }
+
+      // Ctrl+K: kill to end of line
+      if (key.ctrl && input === 'k') {
+        setValue((prev) => prev.slice(0, cursor));
+        return;
+      }
+
+      // Option+Left / Meta+b: move to previous word boundary
+      if ((key.leftArrow && key.meta) || (key.meta && input === 'b')) {
+        setCursor((prev) => prevWordBoundary(value, prev));
+        return;
+      }
+
+      // Option+Right / Meta+f: move to next word boundary
+      if ((key.rightArrow && key.meta) || (key.meta && input === 'f')) {
+        setCursor((prev) => nextWordBoundary(value, prev));
+        return;
+      }
+
+      // Meta+d: delete word forward
+      if (key.meta && input === 'd') {
+        const boundary = nextWordBoundary(value, cursor);
+        setValue((prev) => prev.slice(0, cursor) + prev.slice(boundary));
+        return;
+      }
+
+      // Regular left/right arrow
+      if (key.leftArrow) {
+        setCursor((prev) => Math.max(0, prev - 1));
+        return;
+      }
+
+      if (key.rightArrow) {
+        setCursor((prev) => Math.min(value.length, prev + 1));
+        return;
+      }
+
+      // Shift+Up/Down: scroll messages (page up/down)
+      if (key.shift && key.upArrow) {
+        onScroll?.('up');
+        return;
+      }
+      if (key.shift && key.downArrow) {
+        onScroll?.('down');
+        return;
+      }
+
+      // macOS Option+key without "Option as Meta" produces Unicode chars
+      if (input === '∫') {
+        // Option+b → word left
+        setCursor((prev) => prevWordBoundary(value, prev));
+        return;
+      }
+      if (input === 'ƒ') {
+        // Option+f → word right
+        setCursor((prev) => nextWordBoundary(value, prev));
+        return;
+      }
+      if (input === '∂') {
+        // Option+d → delete word forward
+        const boundary = nextWordBoundary(value, cursor);
+        setValue((prev) => prev.slice(0, cursor) + prev.slice(boundary));
+        return;
+      }
+
+      // Escape: abort current turn if waiting, clear input if typing, dismiss panel if empty
+      if (key.escape) {
+        if (!isActive && onAbort) {
+          onAbort();
+        } else if (value.length > 0) {
+          setValue('');
+          setCursor(0);
+          setHistoryIndex(-1);
+          setSavedInput('');
+        } else {
+          onEscape?.();
+        }
+        return;
+      }
+
+      // Up arrow: navigate input history (most recent first)
+      if (key.upArrow) {
+        if (history.length === 0) return;
+        if (historyIndex === -1) {
+          setSavedInput(value);
+          const newIndex = history.length - 1;
+          setHistoryIndex(newIndex);
+          setValue(history[newIndex]!);
+          setCursor(history[newIndex]!.length);
+        } else if (historyIndex > 0) {
+          const newIndex = historyIndex - 1;
+          setHistoryIndex(newIndex);
+          setValue(history[newIndex]!);
+          setCursor(history[newIndex]!.length);
+        }
+        return;
+      }
+
+      // Down arrow: navigate forward in history, restore saved input at end
+      if (key.downArrow) {
+        if (historyIndex === -1) return;
+        if (historyIndex < history.length - 1) {
+          const newIndex = historyIndex + 1;
+          setHistoryIndex(newIndex);
+          setValue(history[newIndex]!);
+          setCursor(history[newIndex]!.length);
+        } else {
+          setHistoryIndex(-1);
+          setValue(savedInput);
+          setCursor(savedInput.length);
+        }
+        return;
+      }
+
+      // Ignore other control sequences
+      if (key.ctrl) return;
+      if (key.tab) return;
+
+      // Regular character input
+      if (input) {
+        setValue((prev) => prev.slice(0, cursor) + input + prev.slice(cursor));
+        setCursor((prev) => prev + input.length);
+      }
+    },
+    { isActive: useInputActive }
+  );
 
   // Render the prompt with a visible cursor
   const before = value.slice(0, cursor);

--- a/packages/cli/src/repl/ink/PromptInput.tsx
+++ b/packages/cli/src/repl/ink/PromptInput.tsx
@@ -11,6 +11,8 @@ interface PromptInputProps {
   onEscape?: () => void;
   /** Called when Ctrl+C is pressed. */
   onCtrlC?: () => void;
+  /** Called when Ctrl+O is pressed (expand collapsed memories). */
+  onExpandMemories?: () => void;
   /** Called on every keystroke with the current input value. */
   onInputChange?: (value: string) => void;
   /** Scroll callback for page up/down from within the prompt. */
@@ -50,6 +52,7 @@ export function PromptInput({
   onAbort,
   onEscape,
   onCtrlC,
+  onExpandMemories,
   onInputChange,
   onScroll,
   history = [],
@@ -94,6 +97,12 @@ export function PromptInput({
 
     if (key.ctrl && input === 'c') {
       onCtrlC?.();
+      return;
+    }
+
+    // Ctrl+O: expand collapsed memories in dock panel
+    if (key.ctrl && input === 'o') {
+      onExpandMemories?.();
       return;
     }
 

--- a/packages/cli/src/repl/ink/SessionPicker.tsx
+++ b/packages/cli/src/repl/ink/SessionPicker.tsx
@@ -16,9 +16,14 @@ export interface SessionPickerEntry {
 interface SessionPickerProps {
   entries: SessionPickerEntry[];
   onSelect: (entry: SessionPickerEntry | null) => void;
+  onCancel: () => void;
 }
 
-export function SessionPicker({ entries, onSelect }: SessionPickerProps): React.ReactElement {
+export function SessionPicker({
+  entries,
+  onSelect,
+  onCancel,
+}: SessionPickerProps): React.ReactElement {
   // Index 0 = "New session", 1..N = existing sessions
   const totalItems = entries.length + 1;
   const [selected, setSelected] = useState(0);
@@ -35,7 +40,7 @@ export function SessionPicker({ entries, onSelect }: SessionPickerProps): React.
         onSelect(entries[selected - 1]!);
       }
     } else if (key.escape || (input === 'q' && !key.shift) || (key.ctrl && input === 'c')) {
-      onSelect(null); // cancel → fall through to new session
+      onCancel();
     }
   });
 
@@ -43,7 +48,7 @@ export function SessionPicker({ entries, onSelect }: SessionPickerProps): React.
     <Box flexDirection="column" paddingX={1}>
       <Box marginBottom={1}>
         <Text bold>Select session</Text>
-        <Text dimColor> — ↑↓ navigate, Enter select, Esc new session</Text>
+        <Text dimColor> — ↑↓ navigate, Enter select, Esc cancel</Text>
       </Box>
 
       {/* New session option */}

--- a/packages/cli/src/repl/ink/SessionPicker.tsx
+++ b/packages/cli/src/repl/ink/SessionPicker.tsx
@@ -1,0 +1,98 @@
+import React, { useState } from 'react';
+import { Box, Text, useInput } from 'ink';
+
+export interface SessionPickerEntry {
+  id: string;
+  label: string;
+  phase?: string;
+  threadKey?: string;
+  studioName?: string;
+  backend?: string;
+  historyLabel?: string;
+  lastMessage?: string;
+  preview?: string;
+}
+
+interface SessionPickerProps {
+  entries: SessionPickerEntry[];
+  onSelect: (entry: SessionPickerEntry | null) => void;
+}
+
+export function SessionPicker({ entries, onSelect }: SessionPickerProps): React.ReactElement {
+  // Index 0 = "New session", 1..N = existing sessions
+  const totalItems = entries.length + 1;
+  const [selected, setSelected] = useState(0);
+
+  useInput((_input, key) => {
+    if (key.upArrow) {
+      setSelected((prev) => (prev > 0 ? prev - 1 : totalItems - 1));
+    } else if (key.downArrow) {
+      setSelected((prev) => (prev < totalItems - 1 ? prev + 1 : 0));
+    } else if (key.return) {
+      if (selected === 0) {
+        onSelect(null); // new session
+      } else {
+        onSelect(entries[selected - 1]!);
+      }
+    }
+  });
+
+  return (
+    <Box flexDirection="column" paddingX={1}>
+      <Box marginBottom={1}>
+        <Text bold>Select session</Text>
+        <Text dimColor> — ↑↓ navigate, Enter select</Text>
+      </Box>
+
+      {/* New session option */}
+      <Box>
+        <Text color={selected === 0 ? 'cyan' : undefined} bold={selected === 0}>
+          {selected === 0 ? '▸ ' : '  '}
+        </Text>
+        <Text color={selected === 0 ? 'cyan' : 'green'} bold={selected === 0}>
+          + New session
+        </Text>
+      </Box>
+
+      {entries.map((entry, i) => {
+        const idx = i + 1;
+        const isSelected = selected === idx;
+        const phase = entry.phase || 'active';
+        const parts = [
+          entry.historyLabel,
+          entry.threadKey ? `thread:${entry.threadKey}` : null,
+          entry.studioName,
+          entry.backend,
+        ].filter(Boolean);
+
+        return (
+          <Box key={entry.id} flexDirection="column">
+            <Box>
+              <Text color={isSelected ? 'cyan' : undefined} bold={isSelected}>
+                {isSelected ? '▸ ' : '  '}
+              </Text>
+              <Text color={isSelected ? 'cyan' : 'white'}>{entry.id.slice(0, 8)}</Text>
+              <Text dimColor>
+                {'  '}
+                {phase}
+              </Text>
+              {parts.length > 0 && (
+                <Text dimColor>
+                  {'  ·  '}
+                  {parts.join('  ·  ')}
+                </Text>
+              )}
+            </Box>
+            {entry.preview && (
+              <Box marginLeft={4}>
+                <Text dimColor wrap="truncate-end">
+                  ↳ {entry.preview}
+                </Text>
+              </Box>
+            )}
+          </Box>
+        );
+      })}
+    </Box>
+  );
+}

--- a/packages/cli/src/repl/ink/SessionPicker.tsx
+++ b/packages/cli/src/repl/ink/SessionPicker.tsx
@@ -23,7 +23,7 @@ export function SessionPicker({ entries, onSelect }: SessionPickerProps): React.
   const totalItems = entries.length + 1;
   const [selected, setSelected] = useState(0);
 
-  useInput((_input, key) => {
+  useInput((input, key) => {
     if (key.upArrow) {
       setSelected((prev) => (prev > 0 ? prev - 1 : totalItems - 1));
     } else if (key.downArrow) {
@@ -34,6 +34,8 @@ export function SessionPicker({ entries, onSelect }: SessionPickerProps): React.
       } else {
         onSelect(entries[selected - 1]!);
       }
+    } else if (key.escape || (input === 'q' && !key.shift)) {
+      onSelect(null); // cancel → fall through to new session
     }
   });
 
@@ -41,7 +43,7 @@ export function SessionPicker({ entries, onSelect }: SessionPickerProps): React.
     <Box flexDirection="column" paddingX={1}>
       <Box marginBottom={1}>
         <Text bold>Select session</Text>
-        <Text dimColor> — ↑↓ navigate, Enter select</Text>
+        <Text dimColor> — ↑↓ navigate, Enter select, Esc new session</Text>
       </Box>
 
       {/* New session option */}

--- a/packages/cli/src/repl/ink/SessionPicker.tsx
+++ b/packages/cli/src/repl/ink/SessionPicker.tsx
@@ -34,7 +34,7 @@ export function SessionPicker({ entries, onSelect }: SessionPickerProps): React.
       } else {
         onSelect(entries[selected - 1]!);
       }
-    } else if (key.escape || (input === 'q' && !key.shift)) {
+    } else if (key.escape || (input === 'q' && !key.shift) || (key.ctrl && input === 'c')) {
       onSelect(null); // cancel → fall through to new session
     }
   });

--- a/packages/cli/src/repl/ink/context-viewer.tsx
+++ b/packages/cli/src/repl/ink/context-viewer.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useEffect } from 'react';
+import React, { useState, useCallback } from 'react';
 import { Box, Text, useInput, useStdout } from 'ink';
 
 export interface ContextSections {
@@ -75,11 +75,6 @@ export function ContextViewer({
   const viewportHeight = Math.max(5, (stdout?.rows || 24) - 4);
   const [scrollOffset, setScrollOffset] = useState(0);
   const maxScroll = Math.max(0, lines.length - viewportHeight);
-
-  // Reset scroll when lines change (new content or viewer reopened)
-  useEffect(() => {
-    setScrollOffset(0);
-  }, [lines]);
 
   const scrollUp = useCallback(
     (amount = 1) => setScrollOffset((prev) => Math.max(0, prev - amount)),

--- a/packages/cli/src/repl/ink/context-viewer.tsx
+++ b/packages/cli/src/repl/ink/context-viewer.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import { Box, Text, useInput, useStdout } from 'ink';
 
 export interface ContextSections {
@@ -75,6 +75,11 @@ export function ContextViewer({
   const viewportHeight = Math.max(5, (stdout?.rows || 24) - 4);
   const [scrollOffset, setScrollOffset] = useState(0);
   const maxScroll = Math.max(0, lines.length - viewportHeight);
+
+  // Reset scroll when lines change (new content or viewer reopened)
+  useEffect(() => {
+    setScrollOffset(0);
+  }, [lines]);
 
   const scrollUp = useCallback(
     (amount = 1) => setScrollOffset((prev) => Math.max(0, prev - amount)),

--- a/packages/cli/src/repl/ink/context-viewer.tsx
+++ b/packages/cli/src/repl/ink/context-viewer.tsx
@@ -1,0 +1,171 @@
+import React, { useState, useCallback } from 'react';
+import { Box, Text, useInput, useStdout } from 'ink';
+
+export interface ContextSections {
+  bootstrapSummary?: string;
+  passiveRecallEntries: Array<{ content: string; source?: string }>;
+  passiveRecallStats: {
+    totalInjected: number;
+    uniqueMemories: number;
+    currentTurn: number;
+  };
+  ledgerStats: {
+    totalEntries: number;
+    tokenEstimate: number;
+    bootstrapTokens: number;
+  };
+}
+
+export function formatContextLines(sections: ContextSections): string[] {
+  const lines: string[] = [];
+
+  lines.push('');
+  lines.push('Context Inspector');
+  lines.push('');
+
+  lines.push('── Ledger ──');
+  lines.push(`Entries: ${sections.ledgerStats.totalEntries}`);
+  lines.push(`Transcript tokens: ~${sections.ledgerStats.tokenEstimate.toLocaleString()}`);
+  lines.push(`Bootstrap tokens: ~${sections.ledgerStats.bootstrapTokens.toLocaleString()}`);
+  lines.push('');
+
+  lines.push('── Passive Recall ──');
+  lines.push(`Injected: ${sections.passiveRecallStats.totalInjected} total`);
+  lines.push(`Unique memories: ${sections.passiveRecallStats.uniqueMemories}`);
+  lines.push(`Current turn: ${sections.passiveRecallStats.currentTurn}`);
+  lines.push('');
+
+  if (sections.passiveRecallEntries.length > 0) {
+    lines.push('── Memories in Context ──');
+    lines.push('');
+    for (const entry of sections.passiveRecallEntries) {
+      const content = entry.content.replace(/^\[passive-recall\]\s*/, '');
+      lines.push(`• ${content}`);
+      lines.push('');
+    }
+  } else {
+    lines.push('No passive recall memories currently in context.');
+    lines.push('');
+  }
+
+  if (sections.bootstrapSummary) {
+    lines.push('── Bootstrap Context ──');
+    lines.push('');
+    for (const line of sections.bootstrapSummary.split('\n')) {
+      lines.push(line);
+    }
+    lines.push('');
+  }
+
+  return lines;
+}
+
+interface ContextViewerProps {
+  lines: string[];
+  isActive: boolean;
+  onDismiss: () => void;
+}
+
+export function ContextViewer({
+  lines,
+  isActive,
+  onDismiss,
+}: ContextViewerProps): React.ReactElement {
+  const { stdout } = useStdout();
+  const viewportHeight = Math.max(5, (stdout?.rows || 24) - 4);
+  const [scrollOffset, setScrollOffset] = useState(0);
+  const maxScroll = Math.max(0, lines.length - viewportHeight);
+
+  const scrollUp = useCallback(
+    (amount = 1) => setScrollOffset((prev) => Math.max(0, prev - amount)),
+    []
+  );
+  const scrollDown = useCallback(
+    (amount = 1) => setScrollOffset((prev) => Math.min(maxScroll, prev + amount)),
+    [maxScroll]
+  );
+
+  useInput(
+    (input, key) => {
+      if (key.escape || input === 'q' || input === 'Q') {
+        onDismiss();
+        return;
+      }
+      if (key.upArrow) {
+        scrollUp();
+        return;
+      }
+      if (key.downArrow) {
+        scrollDown();
+        return;
+      }
+      if (input === 'k') {
+        scrollUp();
+        return;
+      }
+      if (input === 'j') {
+        scrollDown();
+        return;
+      }
+      // Page up/down via shift+arrows
+      if (key.shift && key.upArrow) {
+        scrollUp(viewportHeight);
+        return;
+      }
+      if (key.shift && key.downArrow) {
+        scrollDown(viewportHeight);
+        return;
+      }
+      // Ctrl+U / Ctrl+D for half-page
+      if (key.ctrl && input === 'u') {
+        scrollUp(Math.floor(viewportHeight / 2));
+        return;
+      }
+      if (key.ctrl && input === 'd') {
+        scrollDown(Math.floor(viewportHeight / 2));
+        return;
+      }
+    },
+    { isActive }
+  );
+
+  const visible = lines.slice(scrollOffset, scrollOffset + viewportHeight);
+  const scrollPct = maxScroll > 0 ? Math.round((scrollOffset / maxScroll) * 100) : 100;
+  const position = `${scrollOffset + 1}-${Math.min(scrollOffset + viewportHeight, lines.length)} of ${lines.length}`;
+
+  return (
+    <Box flexDirection="column">
+      <Box paddingX={1}>
+        <Text bold inverse>
+          {' '}
+          Context Inspector{' '}
+        </Text>
+      </Box>
+      <Box flexDirection="column" paddingX={1}>
+        {visible.map((line, i) => {
+          if (line.startsWith('──')) {
+            return (
+              <Text key={scrollOffset + i} color="cyan">
+                {line}
+              </Text>
+            );
+          }
+          if (line === 'Context Inspector') {
+            return (
+              <Text key={scrollOffset + i} bold>
+                {line}
+              </Text>
+            );
+          }
+          return <Text key={scrollOffset + i}>{line || ' '}</Text>;
+        })}
+      </Box>
+      <Box paddingX={1} justifyContent="space-between">
+        <Text dimColor>q/esc: close · ↑↓/j/k: scroll · ctrl+u/d: page</Text>
+        <Text dimColor>
+          {position} {scrollPct}%
+        </Text>
+      </Box>
+    </Box>
+  );
+}

--- a/packages/cli/src/repl/ink/index.ts
+++ b/packages/cli/src/repl/ink/index.ts
@@ -13,5 +13,6 @@ export { StatusBar } from './StatusBar.js';
 export { InfoBar } from './InfoBar.js';
 export { PromptInput } from './PromptInput.js';
 export { Separator } from './Separator.js';
-export { renderInkChat, InkExitSignal, type InkRepl } from './renderApp.js';
+export { renderInkChat, renderSessionPicker, InkExitSignal, type InkRepl } from './renderApp.js';
 export { renderInkMission, type InkMission } from './renderMission.js';
+export { type SessionPickerEntry } from './SessionPicker.js';

--- a/packages/cli/src/repl/ink/renderApp.tsx
+++ b/packages/cli/src/repl/ink/renderApp.tsx
@@ -58,6 +58,8 @@ export interface InkRepl {
   setAbortHandler: (handler: (() => void) | null) => void;
   /** Show command output in the dock panel (below prompt, above info bar). */
   setCommandOutput: (lines: string[] | null) => void;
+  /** Store surfaced memory details for Ctrl+O expansion. */
+  setSurfacedMemories: (lines: string[]) => void;
   /** Signal exit from the orchestrator side (makes waitForInput reject). */
   requestExit: () => void;
   /** Unmount the Ink app and restore terminal. */
@@ -182,6 +184,10 @@ export function renderInkChat(options: {
 
     setCommandOutput: (lines) => {
       getHandle().setCommandOutput(lines);
+    },
+
+    setSurfacedMemories: (lines) => {
+      getHandle().setSurfacedMemories(lines);
     },
 
     requestExit: () => {

--- a/packages/cli/src/repl/ink/renderApp.tsx
+++ b/packages/cli/src/repl/ink/renderApp.tsx
@@ -60,6 +60,8 @@ export interface InkRepl {
   setCommandOutput: (lines: string[] | null) => void;
   /** Store surfaced memory details for Ctrl+O expansion. */
   setSurfacedMemories: (lines: string[]) => void;
+  /** Open the context viewer with formatted lines. */
+  showContextView: (lines: string[]) => void;
   /** Signal exit from the orchestrator side (makes waitForInput reject). */
   requestExit: () => void;
   /** Unmount the Ink app and restore terminal. */
@@ -85,6 +87,7 @@ export function renderInkChat(options: {
   timezone?: string;
   infoItems: string[];
   fullscreen?: boolean;
+  dynamicMessages?: boolean;
 }): InkRepl {
   const handleRef =
     React.createRef<ChatAppHandle>() as React.MutableRefObject<ChatAppHandle | null>;
@@ -123,6 +126,7 @@ export function renderInkChat(options: {
       timezone={options.timezone}
       infoItems={options.infoItems}
       fullscreen={fullscreen}
+      dynamicMessages={!!options.dynamicMessages}
       onUserInput={onUserInput}
       onExit={onExit}
     />,
@@ -188,6 +192,10 @@ export function renderInkChat(options: {
 
     setSurfacedMemories: (lines) => {
       getHandle().setSurfacedMemories(lines);
+    },
+
+    showContextView: (lines) => {
+      getHandle().showContextView(lines);
     },
 
     requestExit: () => {

--- a/packages/cli/src/repl/ink/renderApp.tsx
+++ b/packages/cli/src/repl/ink/renderApp.tsx
@@ -221,14 +221,20 @@ export function renderInkChat(options: {
  */
 export function renderSessionPicker(
   entries: SessionPickerEntry[]
-): Promise<SessionPickerEntry | null> {
+): Promise<SessionPickerEntry | null | undefined> {
   return new Promise((resolve) => {
     const onSelect = (entry: SessionPickerEntry | null) => {
       unmount();
       resolve(entry);
     };
+    const onCancel = () => {
+      unmount();
+      resolve(undefined);
+    };
 
-    const { unmount } = render(<SessionPicker entries={entries} onSelect={onSelect} />);
+    const { unmount } = render(
+      <SessionPicker entries={entries} onSelect={onSelect} onCancel={onCancel} />
+    );
   });
 }
 

--- a/packages/cli/src/repl/ink/renderApp.tsx
+++ b/packages/cli/src/repl/ink/renderApp.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render } from 'ink';
 import { ChatApp, type ChatAppHandle, type ChatMessage } from './ChatApp.js';
+import { SessionPicker, type SessionPickerEntry } from './SessionPicker.js';
 import type { MessageRole } from './MessageLine.js';
 import { formatNow } from '../tui-components.js';
 
@@ -199,6 +200,25 @@ export function renderInkChat(options: {
 
   return repl;
 }
+
+/**
+ * Show a session picker UI and return the user's selection.
+ * Returns the selected entry, or null for "new session".
+ */
+export function renderSessionPicker(
+  entries: SessionPickerEntry[]
+): Promise<SessionPickerEntry | null> {
+  return new Promise((resolve) => {
+    const onSelect = (entry: SessionPickerEntry | null) => {
+      unmount();
+      resolve(entry);
+    };
+
+    const { unmount } = render(<SessionPicker entries={entries} onSelect={onSelect} />);
+  });
+}
+
+export type { SessionPickerEntry };
 
 /**
  * Sentinel error thrown when the user requests exit (double Ctrl+C or /quit).

--- a/packages/cli/src/repl/ink/renderApp.tsx
+++ b/packages/cli/src/repl/ink/renderApp.tsx
@@ -124,7 +124,7 @@ export function renderInkChat(options: {
       onUserInput={onUserInput}
       onExit={onExit}
     />,
-    { alternateScreen: fullscreen, incrementalRendering: true }
+    { alternateScreen: fullscreen, incrementalRendering: true, exitOnCtrlC: false }
   );
 
   // Get the handle (available synchronously after render)

--- a/packages/cli/src/repl/slash-commands.ts
+++ b/packages/cli/src/repl/slash-commands.ts
@@ -49,7 +49,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { name: 'bookmarks', description: 'List bookmarks' },
   { name: 'eject', description: 'Eject context to bookmark' },
   { name: 'trim', description: 'Trim oldest context entries' },
-  { name: 'context', description: 'Show recent context entries' },
+  { name: 'context', description: 'Open context inspector (bootstrap, memories, ledger)' },
   { name: 'usage', description: 'Show context token estimate' },
 ];
 

--- a/packages/shared/src/runner/spawn-backend.ts
+++ b/packages/shared/src/runner/spawn-backend.ts
@@ -236,7 +236,11 @@ export function spawnBackend(options: SpawnBackendOptions): {
       finalize(1);
     });
 
-    child.on('close', (code) => finalize(code ?? 1));
+    child.on('close', (code, signal) => {
+      if (code !== null) return finalize(code);
+      const SIG_CODES: Record<string, number> = { SIGTERM: 15, SIGKILL: 9, SIGINT: 2 };
+      finalize(signal ? 128 + (SIG_CODES[signal] ?? 15) : 1);
+    });
   });
 
   return { child, result };


### PR DESCRIPTION
## Summary

- **Startup banner**: Dawn skyline ASCII art with truecolor gradients, big block-letter INKWELL title, tiling cityscape across full terminal width, rotating quotes with inline attribution
- **Cancellation semantics**: Aborted turns (exit code >= 128 / SIGTERM) now write `cancelled: true` and `content: null` to JSONL transcript instead of sentinel string `"(no output)"`
- **History hydration**: Cancelled turns are skipped on session resume (checks `cancelled` flag, falls back to legacy string match for old transcripts)
- **Context inspector**: Ctrl+O expands passive recall memories in a scrollable viewer, with two-phase dismiss to prevent Ink rendering artifacts
- **Session picker**: Interactive session picker merged from `wren/feat/ink-chat-session-picker` — arrow key navigation, session preview, "New session" first option
- **Misc fixes**: Correct `createdAt` timestamps on activity events, suppressed aborted turn display in both Ink and legacy paths

## Test plan

- [ ] Run `ink chat` — verify dawn skyline banner renders with gradient, block letters, and quote
- [ ] Resize terminal — skyline tiles correctly across width
- [ ] Start a backend turn, Ctrl+C to cancel — verify JSONL entry has `cancelled: true, content: null` (not `"(no output)"`)
- [ ] Reattach to a session with cancelled turns — verify they're skipped in history hydration
- [ ] Ctrl+O to open context viewer, Esc to dismiss — no rendering artifacts
- [ ] Session picker appears on `ink chat` with existing sessions — arrow keys navigate, Enter selects