### PR TITLE
feat(cli,api,web): session picker, credential resolver, Keychain secrets (by Wren)

### DIFF
--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -7099,13 +7099,11 @@ router.post('/secrets', async (req: Request, res: Response) => {
     res.status(400).json({ error: 'name and value are required' });
     return;
   }
-  if (!/^[a-zA-Z][a-zA-Z0-9_-]*$/.test(name)) {
-    res
-      .status(400)
-      .json({
-        error:
-          'name must start with a letter and contain only letters, numbers, hyphens, underscores',
-      });
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
+    res.status(400).json({
+      error:
+        'name must match env-var format: start with a letter or underscore, then letters, numbers, underscores (e.g., GFIBER_PASSWORD)',
+    });
     return;
   }
   try {

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -7075,4 +7075,61 @@ router.get('/approval-requests/:requestId/status', async (req: Request, res: Res
 // platform identity — no HTTP endpoint means no client-asserted trust boundary.
 // See ink://specs/2fa-permission-grants for the security invariant.
 
+// ─── Secrets (Keychain) ────────────────────────────────────────
+
+import { listCredentials, saveCredential, deleteCredential } from '../services/keychain.js';
+
+router.get('/secrets', async (_req: Request, res: Response) => {
+  try {
+    const credentials = await listCredentials();
+    res.json({ secrets: credentials });
+  } catch (error) {
+    logger.error('Failed to list secrets:', error);
+    res.status(500).json(errorJson('Failed to list secrets', error));
+  }
+});
+
+router.post('/secrets', async (req: Request, res: Response) => {
+  const { name, value, label } = req.body as {
+    name?: string;
+    value?: string;
+    label?: string;
+  };
+  if (!name || !value) {
+    res.status(400).json({ error: 'name and value are required' });
+    return;
+  }
+  if (!/^[a-zA-Z][a-zA-Z0-9_-]*$/.test(name)) {
+    res
+      .status(400)
+      .json({
+        error:
+          'name must start with a letter and contain only letters, numbers, hyphens, underscores',
+      });
+    return;
+  }
+  try {
+    await saveCredential(name, value, label);
+    res.json({ success: true, name });
+  } catch (error) {
+    logger.error('Failed to save secret:', error);
+    res.status(500).json(errorJson('Failed to save secret', error));
+  }
+});
+
+router.delete('/secrets/:name', async (req: Request, res: Response) => {
+  const { name } = req.params;
+  try {
+    const deleted = await deleteCredential(name);
+    if (!deleted) {
+      res.status(404).json({ error: 'Secret not found' });
+      return;
+    }
+    res.json({ success: true, name });
+  } catch (error) {
+    logger.error('Failed to delete secret:', error);
+    res.status(500).json(errorJson('Failed to delete secret', error));
+  }
+});
+
 export default router;

--- a/packages/api/src/services/keychain.ts
+++ b/packages/api/src/services/keychain.ts
@@ -1,0 +1,131 @@
+/**
+ * macOS Keychain Credential Storage
+ *
+ * Stores and retrieves credentials using the macOS Keychain via the
+ * `security` CLI. All items use the service prefix "ink:" for namespacing.
+ *
+ * Credentials are stored as generic passwords with:
+ * - service: "ink:<name>" (the credential name, e.g., "ink:gfiber")
+ * - account: the label/description
+ * - password: the actual secret value
+ */
+
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
+const SERVICE_PREFIX = 'ink:';
+
+export interface KeychainCredential {
+  name: string;
+  label: string;
+  createdAt: string | null;
+  modifiedAt: string | null;
+}
+
+export interface KeychainCredentialWithValue extends KeychainCredential {
+  value: string;
+}
+
+function serviceName(name: string): string {
+  return `${SERVICE_PREFIX}${name}`;
+}
+
+/**
+ * Save a credential to the Keychain. Updates if it already exists.
+ */
+export async function saveCredential(name: string, value: string, label?: string): Promise<void> {
+  const svc = serviceName(name);
+  const acct = label || name;
+  await execFileAsync('security', [
+    'add-generic-password',
+    '-s',
+    svc,
+    '-a',
+    acct,
+    '-w',
+    value,
+    '-U',
+  ]);
+}
+
+/**
+ * Retrieve a credential value from the Keychain.
+ * Returns null if not found.
+ */
+export async function getCredentialValue(name: string): Promise<string | null> {
+  const svc = serviceName(name);
+  try {
+    const { stdout } = await execFileAsync('security', ['find-generic-password', '-s', svc, '-w']);
+    return stdout.trimEnd();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Delete a credential from the Keychain.
+ * Returns true if deleted, false if not found.
+ */
+export async function deleteCredential(name: string): Promise<boolean> {
+  const svc = serviceName(name);
+  try {
+    await execFileAsync('security', ['delete-generic-password', '-s', svc]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * List all ink-namespaced credentials in the Keychain.
+ * Returns metadata only — never the actual secret values.
+ */
+export async function listCredentials(): Promise<KeychainCredential[]> {
+  try {
+    const { stdout } = await execFileAsync('security', ['dump-keychain']);
+    return parseKeychainDump(stdout);
+  } catch {
+    return [];
+  }
+}
+
+function parseKeychainDump(dump: string): KeychainCredential[] {
+  const results: KeychainCredential[] = [];
+  const entries = dump.split(/^keychain:/gm);
+
+  for (const entry of entries) {
+    if (!entry.includes('class: "genp"')) continue;
+
+    const svcMatch = entry.match(/"svce"<blob>="([^"]+)"/);
+    if (!svcMatch) continue;
+
+    const svc = svcMatch[1];
+    if (!svc.startsWith(SERVICE_PREFIX)) continue;
+
+    const name = svc.slice(SERVICE_PREFIX.length);
+    const acctMatch = entry.match(/"acct"<blob>="([^"]+)"/);
+    const label = acctMatch ? acctMatch[1] : name;
+
+    const cdatMatch = entry.match(
+      /"cdat"<timedate>=0x[0-9A-Fa-f]+\s+"(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})Z/
+    );
+    const mdatMatch = entry.match(
+      /"mdat"<timedate>=0x[0-9A-Fa-f]+\s+"(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})Z/
+    );
+
+    const parseKeychainDate = (m: RegExpMatchArray | null): string | null => {
+      if (!m) return null;
+      return `${m[1]}-${m[2]}-${m[3]}T${m[4]}:${m[5]}:${m[6]}Z`;
+    };
+
+    results.push({
+      name,
+      label,
+      createdAt: parseKeychainDate(cdatMatch),
+      modifiedAt: parseKeychainDate(mdatMatch),
+    });
+  }
+
+  return results;
+}

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -35,7 +35,11 @@ import { discoverSkills, loadSkillInstruction, type SkillInstruction } from '../
 import { applyToolApprovalChoice, parseToolApprovalInput } from '../repl/tool-approval.js';
 import { ensurePcpToolAllowed } from '../repl/tool-gate.js';
 import { executeToolCalls, type ToolCallResult } from '../repl/tool-call-executor.js';
-import { resolveCredentialRefs } from '../repl/credential-resolver.js';
+import {
+  resolveCredentialRefs,
+  loadKeychainCredentials,
+  buildResolverEnv,
+} from '../repl/credential-resolver.js';
 import {
   isClientLocalTool,
   handleClientLocalTool,
@@ -2145,6 +2149,13 @@ export async function runChat(options: ChatOptions): Promise<void> {
       );
     }
 
+    // Pre-load Keychain credentials for the credential resolver.
+    // Runs once at session start; the cache persists for the session lifetime.
+    const keychainCreds = await loadKeychainCredentials();
+    if (Object.keys(keychainCreds).length > 0) {
+      console.log(chalk.dim(`Keychain: ${Object.keys(keychainCreds).length} credential(s) loaded`));
+    }
+
     // Seed passive recall dedup with memory IDs already in bootstrap context
     const bootstrapMemoryIds = bootstrapResult.memoryIds as string[] | undefined;
     if (bootstrapMemoryIds && bootstrapMemoryIds.length > 0) {
@@ -3353,7 +3364,10 @@ export async function runChat(options: ChatOptions): Promise<void> {
           // Resolve credential references ($VAR / ${VAR}) in tool args.
           // The LLM emits references; actual values are injected here at the
           // execution layer so credentials never enter transcripts or context.
-          const { args: resolvedArgs, resolutions } = resolveCredentialRefs(args);
+          const { args: resolvedArgs, resolutions } = resolveCredentialRefs(
+            args,
+            buildResolverEnv()
+          );
           if (resolutions.length > 0 && runtime.verbose) {
             const refs = resolutions.map((r) => `${r.name} at ${r.path}`).join(', ');
             printLine(

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -35,6 +35,7 @@ import { discoverSkills, loadSkillInstruction, type SkillInstruction } from '../
 import { applyToolApprovalChoice, parseToolApprovalInput } from '../repl/tool-approval.js';
 import { ensurePcpToolAllowed } from '../repl/tool-gate.js';
 import { executeToolCalls, type ToolCallResult } from '../repl/tool-call-executor.js';
+import { resolveCredentialRefs } from '../repl/credential-resolver.js';
 import {
   isClientLocalTool,
   handleClientLocalTool,
@@ -1273,6 +1274,28 @@ function formatTimestampForSessionList(value?: string, timezone?: string): strin
   }
 }
 
+function formatRelativeTime(ms: number, timezone?: string): string {
+  const now = Date.now();
+  const diffMs = now - ms;
+  if (diffMs < 0) return 'just now';
+  const mins = Math.floor(diffMs / 60_000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  try {
+    return new Date(ms).toLocaleDateString([], {
+      month: 'short',
+      day: 'numeric',
+      timeZone: timezone,
+    });
+  } catch {
+    return new Date(ms).toLocaleDateString([], { month: 'short', day: 'numeric' });
+  }
+}
+
 function safeDateMs(value?: string): number {
   if (!value) return 0;
   const ms = Date.parse(value);
@@ -2216,28 +2239,38 @@ export async function runChat(options: ChatOptions): Promise<void> {
 
     if (isInteractiveInk) {
       // Show interactive session picker
-      const pickerEntries: SessionPickerEntry[] = sessions
-        .sort((a, b) => {
-          const aStudioMatch = runtime.studioId && a.studioId === runtime.studioId ? 1 : 0;
-          const bStudioMatch = runtime.studioId && b.studioId === runtime.studioId ? 1 : 0;
-          if (aStudioMatch !== bStudioMatch) return bStudioMatch - aStudioMatch;
-          const ams = a.startedAt ? Date.parse(a.startedAt) : 0;
-          const bms = b.startedAt ? Date.parse(b.startedAt) : 0;
-          return bms - ams;
+      const sessionsWithMeta = sessions.map((session) => {
+        const transcriptMeta = getSessionTranscriptMetadata(session.id);
+        const lastActivityMs = transcriptMeta?.lastMessageAt
+          ? Date.parse(transcriptMeta.lastMessageAt)
+          : session.startedAt
+            ? Date.parse(session.startedAt)
+            : 0;
+        return { session, transcriptMeta, lastActivityMs };
+      });
+
+      sessionsWithMeta.sort((a, b) => {
+        const aStudioMatch = runtime.studioId && a.session.studioId === runtime.studioId ? 1 : 0;
+        const bStudioMatch = runtime.studioId && b.session.studioId === runtime.studioId ? 1 : 0;
+        if (aStudioMatch !== bStudioMatch) return bStudioMatch - aStudioMatch;
+        return b.lastActivityMs - a.lastActivityMs;
+      });
+
+      const pickerEntries: SessionPickerEntry[] = sessionsWithMeta.map(
+        ({ session, transcriptMeta, lastActivityMs }) => ({
+          id: session.id,
+          label: session.id.slice(0, 8),
+          phase: session.currentPhase || session.status,
+          threadKey: session.threadKey,
+          studioName: sessionStudioLabel(session),
+          backend: sessionBackendLabel(session),
+          historyLabel: sessionHistoryLabel(transcriptMeta),
+          lastMessage: lastActivityMs
+            ? formatRelativeTime(lastActivityMs, runtime.userTimezone)
+            : undefined,
+          preview: sessionLatestMessagePreview(session, transcriptMeta) || undefined,
         })
-        .map((session) => {
-          const transcriptMeta = getSessionTranscriptMetadata(session.id);
-          return {
-            id: session.id,
-            label: session.id.slice(0, 8),
-            phase: session.currentPhase || session.status,
-            threadKey: session.threadKey,
-            studioName: sessionStudioLabel(session),
-            backend: sessionBackendLabel(session),
-            historyLabel: sessionHistoryLabel(transcriptMeta),
-            preview: sessionLatestMessagePreview(session, transcriptMeta) || undefined,
-          };
-        });
+      );
 
       const picked = await renderSessionPicker(pickerEntries);
       if (picked === undefined) {
@@ -3317,10 +3350,20 @@ export async function runChat(options: ChatOptions): Promise<void> {
             const result = handleClientLocalTool(tool, args, ledger);
             if (result) return Promise.resolve(result);
           }
+          // Resolve credential references ($VAR / ${VAR}) in tool args.
+          // The LLM emits references; actual values are injected here at the
+          // execution layer so credentials never enter transcripts or context.
+          const { args: resolvedArgs, resolutions } = resolveCredentialRefs(args);
+          if (resolutions.length > 0 && runtime.verbose) {
+            const refs = resolutions.map((r) => `${r.name} at ${r.path}`).join(', ');
+            printLine(
+              chalk.dim(`credential-resolver: resolved ${resolutions.length} ref(s): ${refs}`)
+            );
+          }
           // Strip MCP namespace prefix — the SB may emit mcp__inkwell__tool_name
           // but PcpClient expects bare tool names (get_inbox, recall, etc.)
           const bareTool = tool.replace(/^mcp__inkwell__/, '');
-          return pcp.callTool(bareTool, args);
+          return pcp.callTool(bareTool, resolvedArgs);
         },
         sessionId: runtime.sessionId,
         promptForApproval: async (tool, reason) => {

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -2214,7 +2214,7 @@ export async function runChat(options: ChatOptions): Promise<void> {
 
     const isInteractiveInk = useInk && !options.message && !options.nonInteractive;
 
-    if (isInteractiveInk && sessions.length > 0) {
+    if (isInteractiveInk) {
       // Show interactive session picker
       const pickerEntries: SessionPickerEntry[] = sessions
         .sort((a, b) => {

--- a/packages/cli/src/repl/credential-resolver.test.ts
+++ b/packages/cli/src/repl/credential-resolver.test.ts
@@ -132,4 +132,18 @@ describe('resolveCredentialRefs', () => {
       delete process.env.INK_TEST_LIVE_CRED;
     }
   });
+
+  it('does NOT resolve $VAR references absent from the provided env', () => {
+    const keychainOnly: Record<string, string> = { GFIBER_PASSWORD: 'secret123' };
+    const { args, resolutions } = resolveCredentialRefs(
+      {
+        content: 'Please use $API_TOKEN in your config and set $HOME correctly',
+        password: '$GFIBER_PASSWORD',
+      },
+      keychainOnly
+    );
+    expect(args.content).toBe('Please use $API_TOKEN in your config and set $HOME correctly');
+    expect(args.password).toBe('secret123');
+    expect(resolutions).toEqual([{ name: 'GFIBER_PASSWORD', path: 'password' }]);
+  });
 });

--- a/packages/cli/src/repl/credential-resolver.test.ts
+++ b/packages/cli/src/repl/credential-resolver.test.ts
@@ -21,24 +21,30 @@ describe('resolveCredentialRefs', () => {
     expect(resolutions[1]).toEqual({ name: 'TEST_PASS', path: 'password' });
   });
 
-  it('resolves ${VAR} braced references', () => {
-    const { args } = resolveCredentialRefs(
+  it('resolves bare ${VAR} braced references', () => {
+    const { args } = resolveCredentialRefs({ host: '${TEST_HOST}' }, testEnv);
+    expect(args.host).toBe('example.com');
+  });
+
+  it('does NOT resolve embedded references in longer strings', () => {
+    const { args, resolutions } = resolveCredentialRefs(
       { url: 'https://${TEST_HOST}:${TEST_PORT}/api' },
       testEnv
     );
-    expect(args.url).toBe('https://example.com:8080/api');
+    expect(args.url).toBe('https://${TEST_HOST}:${TEST_PORT}/api');
+    expect(resolutions).toHaveLength(0);
   });
 
-  it('interpolates references embedded in strings', () => {
+  it('does NOT interpolate references embedded in text', () => {
     const { args, resolutions } = resolveCredentialRefs(
       { greeting: 'Hello $TEST_USER, welcome!' },
       testEnv
     );
-    expect(args.greeting).toBe('Hello alice, welcome!');
-    expect(resolutions).toHaveLength(1);
+    expect(args.greeting).toBe('Hello $TEST_USER, welcome!');
+    expect(resolutions).toHaveLength(0);
   });
 
-  it('leaves unresolvable references as-is', () => {
+  it('leaves unresolvable bare references as-is', () => {
     const { args, resolutions } = resolveCredentialRefs({ value: '$NONEXISTENT_VAR' }, testEnv);
     expect(args.value).toBe('$NONEXISTENT_VAR');
     expect(resolutions).toHaveLength(0);
@@ -84,18 +90,13 @@ describe('resolveCredentialRefs', () => {
     expect(resolutions).toEqual([{ name: 'TEST_HOST', path: 'hosts[0]' }]);
   });
 
-  it('resolves multiple references in a single string', () => {
+  it('does NOT resolve multi-reference strings (not bare)', () => {
     const { args, resolutions } = resolveCredentialRefs(
       { dsn: '$TEST_USER:$TEST_PASS@$TEST_HOST' },
       testEnv
     );
-    expect(args.dsn).toBe('alice:s3cret@example.com');
-    expect(resolutions).toHaveLength(3);
-  });
-
-  it('handles mixed resolved and unresolved in one string', () => {
-    const { args } = resolveCredentialRefs({ partial: '$TEST_USER@$UNKNOWN_DOMAIN' }, testEnv);
-    expect(args.partial).toBe('alice@$UNKNOWN_DOMAIN');
+    expect(args.dsn).toBe('$TEST_USER:$TEST_PASS@$TEST_HOST');
+    expect(resolutions).toHaveLength(0);
   });
 
   it('returns empty resolutions for args with no references', () => {
@@ -131,6 +132,20 @@ describe('resolveCredentialRefs', () => {
     } finally {
       delete process.env.INK_TEST_LIVE_CRED;
     }
+  });
+
+  it('does NOT resolve known credential names embedded in text fields', () => {
+    const keychainOnly: Record<string, string> = { GFIBER_PASSWORD: 'super-secret' };
+    const { args, resolutions } = resolveCredentialRefs(
+      {
+        content: 'Please use $GFIBER_PASSWORD literally',
+        password: '$GFIBER_PASSWORD',
+      },
+      keychainOnly
+    );
+    expect(args.content).toBe('Please use $GFIBER_PASSWORD literally');
+    expect(args.password).toBe('super-secret');
+    expect(resolutions).toEqual([{ name: 'GFIBER_PASSWORD', path: 'password' }]);
   });
 
   it('does NOT resolve $VAR references absent from the provided env', () => {

--- a/packages/cli/src/repl/credential-resolver.test.ts
+++ b/packages/cli/src/repl/credential-resolver.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest';
+import { resolveCredentialRefs } from './credential-resolver.js';
+
+const testEnv: Record<string, string> = {
+  TEST_USER: 'alice',
+  TEST_PASS: 's3cret',
+  TEST_HOST: 'example.com',
+  TEST_PORT: '8080',
+};
+
+describe('resolveCredentialRefs', () => {
+  it('resolves bare $VAR references', () => {
+    const { args, resolutions } = resolveCredentialRefs(
+      { username: '$TEST_USER', password: '$TEST_PASS' },
+      testEnv
+    );
+    expect(args.username).toBe('alice');
+    expect(args.password).toBe('s3cret');
+    expect(resolutions).toHaveLength(2);
+    expect(resolutions[0]).toEqual({ name: 'TEST_USER', path: 'username' });
+    expect(resolutions[1]).toEqual({ name: 'TEST_PASS', path: 'password' });
+  });
+
+  it('resolves ${VAR} braced references', () => {
+    const { args } = resolveCredentialRefs(
+      { url: 'https://${TEST_HOST}:${TEST_PORT}/api' },
+      testEnv
+    );
+    expect(args.url).toBe('https://example.com:8080/api');
+  });
+
+  it('interpolates references embedded in strings', () => {
+    const { args, resolutions } = resolveCredentialRefs(
+      { greeting: 'Hello $TEST_USER, welcome!' },
+      testEnv
+    );
+    expect(args.greeting).toBe('Hello alice, welcome!');
+    expect(resolutions).toHaveLength(1);
+  });
+
+  it('leaves unresolvable references as-is', () => {
+    const { args, resolutions } = resolveCredentialRefs({ value: '$NONEXISTENT_VAR' }, testEnv);
+    expect(args.value).toBe('$NONEXISTENT_VAR');
+    expect(resolutions).toHaveLength(0);
+  });
+
+  it('passes through non-string values unchanged', () => {
+    const { args, resolutions } = resolveCredentialRefs(
+      { count: 42, enabled: true, data: null },
+      testEnv
+    );
+    expect(args.count).toBe(42);
+    expect(args.enabled).toBe(true);
+    expect(args.data).toBe(null);
+    expect(resolutions).toHaveLength(0);
+  });
+
+  it('walks nested objects recursively', () => {
+    const { args, resolutions } = resolveCredentialRefs(
+      {
+        credentials: {
+          user: '$TEST_USER',
+          auth: { password: '$TEST_PASS' },
+        },
+      },
+      testEnv
+    );
+    const creds = args.credentials as Record<string, unknown>;
+    expect(creds.user).toBe('alice');
+    const auth = creds.auth as Record<string, unknown>;
+    expect(auth.password).toBe('s3cret');
+    expect(resolutions).toEqual([
+      { name: 'TEST_USER', path: 'credentials.user' },
+      { name: 'TEST_PASS', path: 'credentials.auth.password' },
+    ]);
+  });
+
+  it('walks arrays recursively', () => {
+    const { args, resolutions } = resolveCredentialRefs(
+      { hosts: ['$TEST_HOST', 'static.example.com'] },
+      testEnv
+    );
+    expect(args.hosts).toEqual(['example.com', 'static.example.com']);
+    expect(resolutions).toEqual([{ name: 'TEST_HOST', path: 'hosts[0]' }]);
+  });
+
+  it('resolves multiple references in a single string', () => {
+    const { args, resolutions } = resolveCredentialRefs(
+      { dsn: '$TEST_USER:$TEST_PASS@$TEST_HOST' },
+      testEnv
+    );
+    expect(args.dsn).toBe('alice:s3cret@example.com');
+    expect(resolutions).toHaveLength(3);
+  });
+
+  it('handles mixed resolved and unresolved in one string', () => {
+    const { args } = resolveCredentialRefs({ partial: '$TEST_USER@$UNKNOWN_DOMAIN' }, testEnv);
+    expect(args.partial).toBe('alice@$UNKNOWN_DOMAIN');
+  });
+
+  it('returns empty resolutions for args with no references', () => {
+    const { args, resolutions } = resolveCredentialRefs(
+      { url: 'https://example.com', count: 5 },
+      testEnv
+    );
+    expect(args.url).toBe('https://example.com');
+    expect(resolutions).toHaveLength(0);
+  });
+
+  it('does not mutate the original args object', () => {
+    const original = { user: '$TEST_USER', nested: { pass: '$TEST_PASS' } };
+    const originalJson = JSON.stringify(original);
+    resolveCredentialRefs(original, testEnv);
+    expect(JSON.stringify(original)).toBe(originalJson);
+  });
+
+  it('handles empty args', () => {
+    const { args, resolutions } = resolveCredentialRefs({}, testEnv);
+    expect(args).toEqual({});
+    expect(resolutions).toHaveLength(0);
+  });
+
+  it('resolves from real process.env when no env override', () => {
+    process.env.INK_TEST_LIVE_CRED = 'live-value-123';
+    try {
+      const { args, resolutions } = resolveCredentialRefs({
+        token: '$INK_TEST_LIVE_CRED',
+      });
+      expect(args.token).toBe('live-value-123');
+      expect(resolutions).toEqual([{ name: 'INK_TEST_LIVE_CRED', path: 'token' }]);
+    } finally {
+      delete process.env.INK_TEST_LIVE_CRED;
+    }
+  });
+});

--- a/packages/cli/src/repl/credential-resolver.ts
+++ b/packages/cli/src/repl/credential-resolver.ts
@@ -12,15 +12,19 @@
  * Resolution scope:
  * ONLY resolves references that match known Keychain credential names
  * (loaded at session start via `loadKeychainCredentials()`). Arbitrary
- * process.env vars like $HOME or $PATH are never resolved. This prevents
- * accidental secret injection in text fields like send_to_inbox.content
- * where "$API_TOKEN" should stay literal.
+ * process.env vars like $HOME or $PATH are never resolved.
+ *
+ * Safety invariant:
+ * Only BARE references are resolved — the entire string value must be
+ * exactly `$VAR` or `${VAR}` with no surrounding text. This prevents
+ * credential leakage into text fields: `send_to_inbox({ content:
+ * "use $GFIBER_PASSWORD" })` stays literal, while `{ password:
+ * "$GFIBER_PASSWORD" }` resolves correctly.
  *
  * Resolution rules:
  * - Only string values are scanned (numbers, booleans, objects pass through)
- * - Pattern: `$VAR_NAME` or `${VAR_NAME}` anywhere in a string value
- * - A string that IS a bare reference (`$FOO`) resolves to just the value
- * - A string with embedded references (`user: $FOO`) does interpolation
+ * - Pattern: entire value must be `$VAR_NAME` or `${VAR_NAME}` (bare ref)
+ * - Embedded references (`user: $FOO`) are NOT resolved
  * - Unresolvable references are left as-is
  * - Nested objects/arrays are walked recursively
  */
@@ -44,14 +48,14 @@ export interface ResolveResult {
   resolutions: CredentialResolution[];
 }
 
-const REF_PATTERN = /\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*)/g;
+const BARE_REF_PATTERN = /^\$\{([A-Za-z_][A-Za-z0-9_]*)\}$|^\$([A-Za-z_][A-Za-z0-9_]*)$/;
 
 /**
  * Resolve credential references in tool call arguments.
  *
- * Walks all string values in `args`, replacing `$VAR` / `${VAR}` patterns
- * with their `process.env` values. Returns the resolved args and an audit
- * trail of which references were resolved (without the actual values).
+ * Only resolves bare references where the entire string value is a single
+ * `$VAR` or `${VAR}`. Embedded references in longer strings are left as-is
+ * to prevent credential leakage into text fields.
  */
 export function resolveCredentialRefs(
   args: Record<string, unknown>,
@@ -73,17 +77,14 @@ export function resolveCredentialRefs(
   }
 
   function resolveString(value: string, path: string): string {
-    return value.replace(
-      REF_PATTERN,
-      (match, braced: string | undefined, bare: string | undefined) => {
-        const varName = braced || bare;
-        if (!varName) return match;
-        const envValue = env[varName];
-        if (envValue === undefined) return match;
-        resolutions.push({ name: varName, path });
-        return envValue;
-      }
-    );
+    const m = value.trim().match(BARE_REF_PATTERN);
+    if (!m) return value;
+    const varName = m[1] || m[2];
+    if (!varName) return value;
+    const resolved = env[varName];
+    if (resolved === undefined) return value;
+    resolutions.push({ name: varName, path });
+    return resolved;
   }
 
   function resolveObject(

--- a/packages/cli/src/repl/credential-resolver.ts
+++ b/packages/cli/src/repl/credential-resolver.ts
@@ -1,0 +1,91 @@
+/**
+ * Credential Resolver
+ *
+ * Resolves environment variable references in tool call parameters before
+ * they reach MCP servers. This keeps credentials out of LLM context windows,
+ * conversation transcripts, and compaction summaries.
+ *
+ * The LLM generates `$GFIBER_PASSWORD` — this module resolves it to the
+ * actual value at the tool execution layer. The transcript only ever records
+ * the reference, not the secret.
+ *
+ * Resolution rules:
+ * - Only string values are scanned (numbers, booleans, objects pass through)
+ * - Pattern: `$VAR_NAME` or `${VAR_NAME}` anywhere in a string value
+ * - A string that IS a bare reference (`$FOO`) resolves to just the value
+ * - A string with embedded references (`user: $FOO`) does interpolation
+ * - Unresolvable references (env var not set) are left as-is
+ * - Nested objects/arrays are walked recursively
+ */
+
+export interface CredentialResolution {
+  /** Env var name that was resolved */
+  name: string;
+  /** Tool parameter path where it was found (e.g., "value", "options.password") */
+  path: string;
+}
+
+export interface ResolveResult {
+  /** The args with credential references resolved */
+  args: Record<string, unknown>;
+  /** Which credentials were resolved (for audit logging — never includes values) */
+  resolutions: CredentialResolution[];
+}
+
+const REF_PATTERN = /\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*)/g;
+
+/**
+ * Resolve credential references in tool call arguments.
+ *
+ * Walks all string values in `args`, replacing `$VAR` / `${VAR}` patterns
+ * with their `process.env` values. Returns the resolved args and an audit
+ * trail of which references were resolved (without the actual values).
+ */
+export function resolveCredentialRefs(
+  args: Record<string, unknown>,
+  env: Record<string, string | undefined> = process.env
+): ResolveResult {
+  const resolutions: CredentialResolution[] = [];
+
+  function resolveValue(value: unknown, path: string): unknown {
+    if (typeof value === 'string') {
+      return resolveString(value, path);
+    }
+    if (Array.isArray(value)) {
+      return value.map((item, i) => resolveValue(item, `${path}[${i}]`));
+    }
+    if (value !== null && typeof value === 'object') {
+      return resolveObject(value as Record<string, unknown>, path);
+    }
+    return value;
+  }
+
+  function resolveString(value: string, path: string): string {
+    return value.replace(
+      REF_PATTERN,
+      (match, braced: string | undefined, bare: string | undefined) => {
+        const varName = braced || bare;
+        if (!varName) return match;
+        const envValue = env[varName];
+        if (envValue === undefined) return match;
+        resolutions.push({ name: varName, path });
+        return envValue;
+      }
+    );
+  }
+
+  function resolveObject(
+    obj: Record<string, unknown>,
+    parentPath: string
+  ): Record<string, unknown> {
+    const resolved: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(obj)) {
+      const path = parentPath ? `${parentPath}.${key}` : key;
+      resolved[key] = resolveValue(value, path);
+    }
+    return resolved;
+  }
+
+  const resolvedArgs = resolveObject(args, '');
+  return { args: resolvedArgs, resolutions };
+}

--- a/packages/cli/src/repl/credential-resolver.ts
+++ b/packages/cli/src/repl/credential-resolver.ts
@@ -9,16 +9,19 @@
  * actual value at the tool execution layer. The transcript only ever records
  * the reference, not the secret.
  *
- * Resolution cascade:
- * 1. Keychain cache (loaded at session start via `loadKeychainCredentials()`)
- * 2. process.env (fallback)
+ * Resolution scope:
+ * ONLY resolves references that match known Keychain credential names
+ * (loaded at session start via `loadKeychainCredentials()`). Arbitrary
+ * process.env vars like $HOME or $PATH are never resolved. This prevents
+ * accidental secret injection in text fields like send_to_inbox.content
+ * where "$API_TOKEN" should stay literal.
  *
  * Resolution rules:
  * - Only string values are scanned (numbers, booleans, objects pass through)
  * - Pattern: `$VAR_NAME` or `${VAR_NAME}` anywhere in a string value
  * - A string that IS a bare reference (`$FOO`) resolves to just the value
  * - A string with embedded references (`user: $FOO`) does interpolation
- * - Unresolvable references (env var not set) are left as-is
+ * - Unresolvable references are left as-is
  * - Nested objects/arrays are walked recursively
  */
 
@@ -150,10 +153,11 @@ export async function loadKeychainCredentials(): Promise<Record<string, string>>
 }
 
 /**
- * Build the merged env map for credential resolution.
- * Keychain values take precedence over process.env.
+ * Return the Keychain-only credential map for resolution.
+ * Only explicitly stored secrets are resolvable — process.env is NOT
+ * included, preventing accidental injection of $HOME, $PATH, etc.
+ * into text fields.
  */
-export function buildResolverEnv(): Record<string, string | undefined> {
-  if (!keychainCache) return process.env;
-  return { ...process.env, ...keychainCache };
+export function buildResolverEnv(): Record<string, string> {
+  return keychainCache ?? {};
 }

--- a/packages/cli/src/repl/credential-resolver.ts
+++ b/packages/cli/src/repl/credential-resolver.ts
@@ -1,13 +1,17 @@
 /**
  * Credential Resolver
  *
- * Resolves environment variable references in tool call parameters before
- * they reach MCP servers. This keeps credentials out of LLM context windows,
- * conversation transcripts, and compaction summaries.
+ * Resolves credential references in tool call parameters before they reach
+ * MCP servers. This keeps credentials out of LLM context windows, conversation
+ * transcripts, and compaction summaries.
  *
  * The LLM generates `$GFIBER_PASSWORD` — this module resolves it to the
  * actual value at the tool execution layer. The transcript only ever records
  * the reference, not the secret.
+ *
+ * Resolution cascade:
+ * 1. Keychain cache (loaded at session start via `loadKeychainCredentials()`)
+ * 2. process.env (fallback)
  *
  * Resolution rules:
  * - Only string values are scanned (numbers, booleans, objects pass through)
@@ -17,6 +21,11 @@
  * - Unresolvable references (env var not set) are left as-is
  * - Nested objects/arrays are walked recursively
  */
+
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
 
 export interface CredentialResolution {
   /** Env var name that was resolved */
@@ -88,4 +97,63 @@ export function resolveCredentialRefs(
 
   const resolvedArgs = resolveObject(args, '');
   return { args: resolvedArgs, resolutions };
+}
+
+// ─── Keychain Integration ──────────────────────────────────────
+
+const SERVICE_PREFIX = 'ink:';
+let keychainCache: Record<string, string> | null = null;
+
+/**
+ * Load all ink-namespaced credentials from macOS Keychain into an
+ * in-memory cache. Call once at session start — the cache is used by
+ * `buildResolverEnv()` to merge Keychain values with process.env.
+ *
+ * On non-macOS or if the Keychain is inaccessible, silently returns
+ * an empty map (credentials fall back to process.env only).
+ */
+export async function loadKeychainCredentials(): Promise<Record<string, string>> {
+  const cache: Record<string, string> = {};
+  if (process.platform !== 'darwin') {
+    keychainCache = cache;
+    return cache;
+  }
+
+  try {
+    const { stdout } = await execFileAsync('security', ['dump-keychain']);
+    const entries = stdout.split(/^keychain:/gm);
+
+    for (const entry of entries) {
+      if (!entry.includes('class: "genp"')) continue;
+      const svcMatch = entry.match(/"svce"<blob>="([^"]+)"/);
+      if (!svcMatch || !svcMatch[1].startsWith(SERVICE_PREFIX)) continue;
+      const name = svcMatch[1].slice(SERVICE_PREFIX.length);
+
+      try {
+        const { stdout: pw } = await execFileAsync('security', [
+          'find-generic-password',
+          '-s',
+          svcMatch[1],
+          '-w',
+        ]);
+        cache[name] = pw.trimEnd();
+      } catch {
+        // Individual credential retrieval failed — skip it
+      }
+    }
+  } catch {
+    // Keychain inaccessible — proceed with empty cache
+  }
+
+  keychainCache = cache;
+  return cache;
+}
+
+/**
+ * Build the merged env map for credential resolution.
+ * Keychain values take precedence over process.env.
+ */
+export function buildResolverEnv(): Record<string, string | undefined> {
+  if (!keychainCache) return process.env;
+  return { ...process.env, ...keychainCache };
 }

--- a/packages/cli/src/repl/ink/SessionPicker.tsx
+++ b/packages/cli/src/repl/ink/SessionPicker.tsx
@@ -66,6 +66,7 @@ export function SessionPicker({
         const isSelected = selected === idx;
         const phase = entry.phase || 'active';
         const parts = [
+          entry.lastMessage,
           entry.historyLabel,
           entry.threadKey ? `thread:${entry.threadKey}` : null,
           entry.studioName,

--- a/packages/web/src/app/(auth)/login/login-form.tsx
+++ b/packages/web/src/app/(auth)/login/login-form.tsx
@@ -9,7 +9,7 @@ import { SocialButtons } from '@/components/auth/social-buttons';
 import { AuthDivider } from '@/components/auth/auth-divider';
 import { signInWithPassword, signInWithOtp } from '@/lib/auth/actions';
 import { getErrorMessage } from '@/lib/auth-utils';
-import { Loader2, Zap } from 'lucide-react';
+import { Eye, EyeOff, Loader2, Zap } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 type AuthMode = 'magic-link' | 'password';
@@ -22,6 +22,7 @@ export default function LoginForm() {
   const [authMode, setAuthMode] = useState<AuthMode>('password');
   const [isLoading, setIsLoading] = useState(false);
   const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+  const [showPassword, setShowPassword] = useState(false);
   const [mcpRedirecting, setMcpRedirecting] = useState(false);
 
   const mcpPendingId = searchParams.get('pending_id');
@@ -174,16 +175,26 @@ export default function LoginForm() {
                 Use magic link instead
               </button>
             </div>
-            <Input
-              id="password"
-              type="password"
-              placeholder="Enter your password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              required
-              autoComplete="current-password"
-              className="h-12 rounded-xl px-4 text-base"
-            />
+            <div className="relative">
+              <Input
+                id="password"
+                type={showPassword ? 'text' : 'password'}
+                placeholder="Enter your password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+                autoComplete="current-password"
+                className="h-12 rounded-xl px-4 pr-11 text-base"
+              />
+              <button
+                type="button"
+                onClick={() => setShowPassword(!showPassword)}
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 transition-colors"
+                tabIndex={-1}
+              >
+                {showPassword ? <EyeOff className="h-5 w-5" /> : <Eye className="h-5 w-5" />}
+              </button>
+            </div>
           </div>
         )}
 

--- a/packages/web/src/app/(dashboard)/secrets/page.tsx
+++ b/packages/web/src/app/(dashboard)/secrets/page.tsx
@@ -74,19 +74,19 @@ export default function SecretsPage() {
   const handleCreate = (e: React.FormEvent) => {
     e.preventDefault();
     setFormError('');
-    if (!name.trim() || !value.trim()) {
+    if (!name.trim() || !value) {
       setFormError('Name and value are required');
       return;
     }
-    if (!/^[a-zA-Z][a-zA-Z0-9_-]*$/.test(name)) {
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
       setFormError(
-        'Name must start with a letter and contain only letters, numbers, hyphens, underscores'
+        'Name must match env-var format: letters, numbers, underscores (e.g., GFIBER_PASSWORD)'
       );
       return;
     }
     createMutation.mutate({
       name: name.trim(),
-      value: value.trim(),
+      value,
       label: label.trim() || undefined,
     });
   };

--- a/packages/web/src/app/(dashboard)/secrets/page.tsx
+++ b/packages/web/src/app/(dashboard)/secrets/page.tsx
@@ -1,0 +1,287 @@
+'use client';
+
+import { useState, useMemo } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+import { Lock, Plus, Trash2, Eye, EyeOff, KeyRound, ShieldCheck } from 'lucide-react';
+import { useApiQuery, useApiPost, useApiDelete, useQueryClient } from '@/lib/api';
+
+interface Secret {
+  name: string;
+  label: string;
+  createdAt: string | null;
+  modifiedAt: string | null;
+}
+
+interface SecretsResponse {
+  secrets: Secret[];
+}
+
+function formatDate(iso: string | null): string {
+  if (!iso) return '-';
+  try {
+    return new Date(iso).toLocaleDateString(undefined, {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    });
+  } catch {
+    return iso;
+  }
+}
+
+export default function SecretsPage() {
+  const queryClient = useQueryClient();
+  const [showForm, setShowForm] = useState(false);
+  const [name, setName] = useState('');
+  const [value, setValue] = useState('');
+  const [label, setLabel] = useState('');
+  const [showValue, setShowValue] = useState(false);
+  const [formError, setFormError] = useState('');
+
+  const { data, isLoading, error } = useApiQuery<SecretsResponse>(
+    ['secrets'],
+    '/api/admin/secrets'
+  );
+
+  const createMutation = useApiPost<
+    { success: boolean; name: string },
+    { name: string; value: string; label?: string }
+  >('/api/admin/secrets', {
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['secrets'] });
+      setShowForm(false);
+      setName('');
+      setValue('');
+      setLabel('');
+      setFormError('');
+    },
+    onError: (err: Error) => {
+      setFormError(err.message || 'Failed to save secret');
+    },
+  });
+
+  const deleteMutation = useApiDelete<{ success: boolean }>('/api/admin/secrets', {
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['secrets'] });
+    },
+  });
+
+  const secrets = useMemo(() => data?.secrets ?? [], [data]);
+
+  const handleCreate = (e: React.FormEvent) => {
+    e.preventDefault();
+    setFormError('');
+    if (!name.trim() || !value.trim()) {
+      setFormError('Name and value are required');
+      return;
+    }
+    if (!/^[a-zA-Z][a-zA-Z0-9_-]*$/.test(name)) {
+      setFormError(
+        'Name must start with a letter and contain only letters, numbers, hyphens, underscores'
+      );
+      return;
+    }
+    createMutation.mutate({
+      name: name.trim(),
+      value: value.trim(),
+      label: label.trim() || undefined,
+    });
+  };
+
+  return (
+    <div className="max-w-4xl">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-3xl font-bold text-gray-900 flex items-center gap-3">
+            <Lock className="h-8 w-8 text-gray-400" />
+            Secrets
+          </h1>
+          <p className="mt-1 text-gray-500">
+            Credentials stored in macOS Keychain. Referenced as{' '}
+            <code className="rounded bg-gray-100 px-1.5 py-0.5 text-sm font-mono">$NAME</code> in
+            tool call parameters.
+          </p>
+        </div>
+        <Button
+          onClick={() => setShowForm(!showForm)}
+          size="sm"
+          variant={showForm ? 'outline' : 'default'}
+        >
+          <Plus className="mr-2 h-4 w-4" />
+          {showForm ? 'Cancel' : 'Add Secret'}
+        </Button>
+      </div>
+
+      {/* Stats */}
+      <div className="mt-6 grid grid-cols-2 gap-3 sm:grid-cols-3">
+        <Card>
+          <CardContent className="p-4">
+            <div className="flex items-center gap-2">
+              <KeyRound className="h-4 w-4 text-gray-400" />
+              <span className="text-sm text-gray-500">Total</span>
+            </div>
+            <p className="mt-1 text-2xl font-semibold">{secrets.length}</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-4">
+            <div className="flex items-center gap-2">
+              <ShieldCheck className="h-4 w-4 text-green-500" />
+              <span className="text-sm text-gray-500">Storage</span>
+            </div>
+            <p className="mt-1 text-sm font-medium text-green-700">macOS Keychain</p>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Create Form */}
+      {showForm && (
+        <Card className="mt-6">
+          <CardHeader>
+            <CardTitle className="text-lg">Add Secret</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <form onSubmit={handleCreate} className="space-y-4">
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">Name</label>
+                  <Input
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                    placeholder="GFIBER_PASSWORD"
+                    className="font-mono"
+                    autoFocus
+                  />
+                  <p className="mt-1 text-xs text-gray-400">
+                    Referenced as{' '}
+                    <code className="bg-gray-100 px-1 rounded">${name || 'NAME'}</code> in tool
+                    calls
+                  </p>
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">Label</label>
+                  <Input
+                    value={label}
+                    onChange={(e) => setLabel(e.target.value)}
+                    placeholder="Google Fiber password (optional)"
+                  />
+                </div>
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Value</label>
+                <div className="relative">
+                  <Input
+                    type={showValue ? 'text' : 'password'}
+                    value={value}
+                    onChange={(e) => setValue(e.target.value)}
+                    placeholder="••••••••"
+                    className="pr-10 font-mono"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setShowValue(!showValue)}
+                    className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
+                  >
+                    {showValue ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                  </button>
+                </div>
+              </div>
+              {formError && <p className="text-sm text-red-600">{formError}</p>}
+              <div className="flex justify-end gap-2">
+                <Button type="button" variant="outline" onClick={() => setShowForm(false)}>
+                  Cancel
+                </Button>
+                <Button type="submit" disabled={createMutation.isPending}>
+                  {createMutation.isPending ? 'Saving...' : 'Save to Keychain'}
+                </Button>
+              </div>
+            </form>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Error */}
+      {error && (
+        <div className="mt-6 rounded-lg bg-red-50 border border-red-200 p-4 text-sm text-red-800">
+          Failed to load secrets: {error.message}
+        </div>
+      )}
+
+      {/* Secrets List */}
+      <div className="mt-6 space-y-2">
+        {isLoading && <p className="text-sm text-gray-400 py-8 text-center">Loading...</p>}
+        {!isLoading && secrets.length === 0 && !showForm && (
+          <div className="text-center py-12">
+            <Lock className="mx-auto h-12 w-12 text-gray-300" />
+            <p className="mt-3 text-sm text-gray-500">No secrets stored yet</p>
+            <p className="mt-1 text-xs text-gray-400">
+              Secrets are stored in macOS Keychain and referenced as $NAME in agent tool calls
+            </p>
+            <Button onClick={() => setShowForm(true)} size="sm" className="mt-4">
+              <Plus className="mr-2 h-4 w-4" />
+              Add your first secret
+            </Button>
+          </div>
+        )}
+        {secrets.map((secret) => (
+          <Card key={secret.name} className="group">
+            <CardContent className="flex items-center justify-between p-4">
+              <div className="flex items-center gap-3 min-w-0">
+                <KeyRound className="h-4 w-4 text-gray-400 shrink-0" />
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2">
+                    <code className="text-sm font-mono font-medium text-gray-900">
+                      {secret.name}
+                    </code>
+                    <Badge variant="outline" className="text-xs">
+                      ${secret.name}
+                    </Badge>
+                  </div>
+                  {secret.label !== secret.name && (
+                    <p className="text-xs text-gray-500 truncate">{secret.label}</p>
+                  )}
+                </div>
+              </div>
+              <div className="flex items-center gap-4">
+                <span className="text-xs text-gray-400">{formatDate(secret.createdAt)}</span>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => deleteMutation.mutate(secret.name)}
+                  disabled={deleteMutation.isPending}
+                  className="opacity-0 group-hover:opacity-100 text-gray-400 hover:text-red-600"
+                >
+                  <Trash2 className="h-4 w-4" />
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      {/* Info */}
+      {secrets.length > 0 && (
+        <div className="mt-8 rounded-lg bg-gray-50 border border-gray-200 p-4">
+          <h3 className="text-sm font-medium text-gray-700 flex items-center gap-2">
+            <ShieldCheck className="h-4 w-4 text-green-500" />
+            How credentials work
+          </h3>
+          <ul className="mt-2 space-y-1 text-xs text-gray-500">
+            <li>
+              Agents reference credentials as{' '}
+              <code className="bg-gray-100 px-1 rounded">$NAME</code> in tool call parameters
+            </li>
+            <li>
+              The actual value is injected at the Ink execution layer — it never enters the LLM
+              context or transcripts
+            </li>
+            <li>Credentials are stored in macOS Keychain with AES-256 encryption</li>
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/components/layout/sidebar.tsx
+++ b/packages/web/src/components/layout/sidebar.tsx
@@ -22,6 +22,7 @@ import {
   MessageSquare,
   ListTodo,
   Swords,
+  KeyRound,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useRouter } from 'next/navigation';
@@ -73,6 +74,7 @@ const mainNav: NavGroup[] = [
     items: [
       { name: 'Reminders', href: '/reminders', icon: Bell },
       { name: 'Connections', href: '/connected-accounts', icon: Link2 },
+      { name: 'Secrets', href: '/secrets', icon: KeyRound },
       { name: 'Routing', href: '/routing', icon: Route },
       { name: 'Sessions', href: '/sessions', icon: Activity },
     ],

--- a/packages/web/src/components/layout/sidebar.tsx
+++ b/packages/web/src/components/layout/sidebar.tsx
@@ -74,9 +74,9 @@ const mainNav: NavGroup[] = [
     items: [
       { name: 'Reminders', href: '/reminders', icon: Bell },
       { name: 'Connections', href: '/connected-accounts', icon: Link2 },
-      { name: 'Secrets', href: '/secrets', icon: KeyRound },
       { name: 'Routing', href: '/routing', icon: Route },
       { name: 'Sessions', href: '/sessions', icon: Activity },
+      { name: 'Secrets', href: '/secrets', icon: KeyRound },
     ],
   },
 ];


### PR DESCRIPTION
## Summary

- **Session picker improvements**: Always show picker (even 0 sessions), sort by last activity, relative timestamps ("5m ago", "3h ago")
- **Credential resolver**: Bare `$VAR`/`${VAR}` references in tool call args resolved at the Ink execution layer before reaching MCP servers. Only Keychain-stored credentials are resolved — process.env is not touched. Embedded references in text fields stay literal. 15 unit tests.
- **Keychain integration**: `loadKeychainCredentials()` loads all `ink:*` credentials from macOS Keychain at session start. Keychain-only resolution scope.
- **Secrets dashboard**: Full CRUD page at `/secrets` in the web UI backed by macOS Keychain storage via `security` CLI. API routes: GET/POST/DELETE `/api/admin/secrets`.
- **Keychain service**: `packages/api/src/services/keychain.ts` — macOS `security` CLI wrapper with `ink:` namespace prefix.
- **Login page**: Password visibility toggle (eye icon)
- **Sidebar**: Reordered nav items

## Test plan

- [x] 15 unit tests for credential resolver (bare refs, braced, embedded-stays-literal, nested, arrays, immutability, Keychain-only scope, regression for text field leakage)
- [ ] Manual: run `ink chat`, verify Keychain credentials load at startup
- [ ] Manual: visit `/secrets` in dashboard, create/delete a secret
- [ ] Manual: use `$SECRET_NAME` in a tool call arg, verify resolution in verbose mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)