### PR TITLE
test(cli): add unit + integration tests for ink wait --group (by Wren)

### DIFF
--- a/packages/cli/src/commands/wait.test.ts
+++ b/packages/cli/src/commands/wait.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
+import { validateStrategyResult } from './wait.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -29,15 +30,22 @@ async function runWait(
 describe('sb wait', () => {
   it('shows help text', async () => {
     const result = await runWait(['--help']);
-    // Commander may write help to stdout or stderr depending on environment.
-    // On CI, tsx may not be available — skip gracefully if the process crashed.
     const output = result.stdout + result.stderr;
     if (output.includes('triggerUncaughtException') || output.includes('Cannot find module')) {
-      return; // tsx not available in this environment — skip gracefully
+      return;
     }
     expect(output).toContain('Wait for new inbox or thread messages');
     expect(output).toContain('--thread');
     expect(output).toContain('--timeout');
+  });
+
+  it('shows --group in help', async () => {
+    const result = await runWait(['--help']);
+    const output = result.stdout + result.stderr;
+    if (output.includes('triggerUncaughtException') || output.includes('Cannot find module')) {
+      return;
+    }
+    expect(output).toContain('--group');
   });
 
   // Integration tests — require running PCP server
@@ -58,4 +66,67 @@ describe('sb wait', () => {
       expect(result.stdout).toContain('new message(s)');
     }
   );
+
+  it.skipIf(!process.env.INK_INTEGRATION)('exits 2 for invalid group UUID', async () => {
+    const result = await runWait(['--group', 'not-a-uuid', '--timeout', '10', '--interval', '5']);
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain('Failed to fetch initial strategy status');
+  });
+
+  it.skipIf(!process.env.INK_INTEGRATION)('exits 2 for nonexistent group UUID', async () => {
+    const result = await runWait([
+      '--group',
+      '00000000-0000-4000-8000-000000000000',
+      '--timeout',
+      '10',
+      '--interval',
+      '5',
+    ]);
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain('Failed to fetch initial strategy status');
+  });
+});
+
+describe('validateStrategyResult', () => {
+  it('passes for a valid strategy response', () => {
+    expect(() =>
+      validateStrategyResult({ status: 'active', progress: { total: 3, completed: 1 } }, 'test')
+    ).not.toThrow();
+  });
+
+  it('throws on { success: false } with error message', () => {
+    expect(() =>
+      validateStrategyResult({ success: false, error: 'Task group not found' }, 'test')
+    ).toThrow('Task group not found');
+  });
+
+  it('throws on { success: false } without error message', () => {
+    expect(() => validateStrategyResult({ success: false }, 'test')).toThrow(
+      'test: server returned failure'
+    );
+  });
+
+  it('throws on text-shaped MCP error', () => {
+    expect(() =>
+      validateStrategyResult(
+        { text: 'MCP error -32602: Invalid params: groupId must be a UUID' },
+        'test'
+      )
+    ).toThrow('MCP error -32602');
+  });
+
+  it('does not throw on valid result that happens to have a text field', () => {
+    expect(() =>
+      validateStrategyResult(
+        { status: 'active', progress: { total: 3 }, text: 'some note' },
+        'test'
+      )
+    ).not.toThrow();
+  });
+
+  it('throws on text error even when success is undefined', () => {
+    expect(() => validateStrategyResult({ text: 'something went wrong' }, 'test')).toThrow(
+      'something went wrong'
+    );
+  });
 });

--- a/packages/cli/src/commands/wait.ts
+++ b/packages/cli/src/commands/wait.ts
@@ -284,7 +284,7 @@ interface StrategyStatus {
   };
 }
 
-function validateStrategyResult(result: Record<string, unknown>, context: string): void {
+export function validateStrategyResult(result: Record<string, unknown>, context: string): void {
   if (result.success === false) {
     throw new Error((result.error as string) || `${context}: server returned failure`);
   }


### PR DESCRIPTION
## Summary
- Export `validateStrategyResult` for direct unit testing
- 6 unit tests covering both error shapes (`success: false`, `text` MCP errors) and valid responses
- 2 integration tests for invalid/nonexistent group UUIDs (exit 2)
- 1 smoke test for `--group` in help output

Follows up on #393 which shipped without test coverage.

## Test plan
- [x] `npx vitest run packages/cli/src/commands/wait.test.ts` — 8 passed, 4 skipped
- [x] Type-check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)