### PR TITLE
fix(api): rewrite InkRunner to spawn ink chat as subprocess (by Wren)

### DIFF
--- a/packages/api/src/services/sessions/ink-runner.test.ts
+++ b/packages/api/src/services/sessions/ink-runner.test.ts
@@ -127,5 +127,45 @@ describe('InkRunner', () => {
       expect(result.toolCalls).toHaveLength(1);
       expect(result.finalTextResponse).toBeUndefined();
     });
+
+    it('extracts finalTextResponse from type=result JSON line', () => {
+      const runner = new InkRunner();
+      const stdout = [
+        JSON.stringify({
+          type: 'result',
+          text: 'Your appointment is confirmed for Thursday at 2pm.',
+          sessionId: 'sess-123',
+        }),
+        '\x1b[2m\nSession completed.\x1b[22m',
+        '\x1b[36m  Resume with: ink chat --attach-latest myra\n\x1b[39m',
+      ].join('\n');
+
+      const result = (runner as any).parseOutput(stdout, '');
+
+      expect(result.finalTextResponse).toBe('Your appointment is confirmed for Thursday at 2pm.');
+      expect(result.responses).toHaveLength(0);
+    });
+
+    it('prefers send_response over result for channel routing', () => {
+      const runner = new InkRunner();
+      const stdout = [
+        JSON.stringify({
+          type: 'send_response',
+          channel: 'telegram',
+          conversationId: '456',
+          content: 'Routed via MCP',
+        }),
+        JSON.stringify({
+          type: 'result',
+          text: 'Fallback text from ledger',
+        }),
+      ].join('\n');
+
+      const result = (runner as any).parseOutput(stdout, '');
+
+      expect(result.responses).toHaveLength(1);
+      expect(result.responses[0].content).toBe('Routed via MCP');
+      expect(result.finalTextResponse).toBe('Fallback text from ledger');
+    });
   });
 });

--- a/packages/api/src/services/sessions/ink-runner.test.ts
+++ b/packages/api/src/services/sessions/ink-runner.test.ts
@@ -1,95 +1,141 @@
 import { describe, it, expect, vi } from 'vitest';
 import { InkRunner } from './ink-runner';
-import type { InkToolDefinition } from '../../agent/tools/pi-coding-tools';
-import type { ImageContent } from './types';
 
 vi.mock('../../utils/logger', () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
 }));
 
 describe('InkRunner', () => {
-  describe('buildUserContent', () => {
-    it('returns plain string when no images', () => {
-      const runner = new InkRunner({ apiKey: 'test-key' });
-      const result = (runner as any).buildUserContent('Hello world');
-      expect(result).toBe('Hello world');
-    });
-
-    it('returns plain string when images is empty array', () => {
-      const runner = new InkRunner({ apiKey: 'test-key' });
-      const result = (runner as any).buildUserContent('Hello world', []);
-      expect(result).toBe('Hello world');
-    });
-
-    it('returns multimodal content blocks when images are present', () => {
-      const runner = new InkRunner({ apiKey: 'test-key' });
-      const images: ImageContent[] = [
-        { type: 'image', source: 'base64', mediaType: 'image/jpeg', data: 'abc123' },
-      ];
-      const result = (runner as any).buildUserContent('Describe this', images);
-
-      expect(Array.isArray(result)).toBe(true);
-      expect(result).toHaveLength(2);
-      expect(result[0]).toEqual({
-        type: 'image',
-        source: { type: 'base64', media_type: 'image/jpeg', data: 'abc123' },
+  describe('buildArgs', () => {
+    it('builds base args for a new session', () => {
+      const runner = new InkRunner();
+      const args = (runner as any).buildArgs('session-123', false, {
+        workingDirectory: '/tmp',
+        agentId: 'myra',
       });
-      expect(result[1]).toEqual({ type: 'text', text: 'Describe this' });
+
+      expect(args).toContain('chat');
+      expect(args).toContain('--non-interactive');
+      expect(args).toContain('--agent');
+      expect(args).toContain('myra');
+      expect(args).toContain('--max-turns');
+      expect(args).not.toContain('--session-id');
     });
 
-    it('handles multiple images in a gallery', () => {
-      const runner = new InkRunner({ apiKey: 'test-key' });
-      const images: ImageContent[] = [
-        { type: 'image', source: 'base64', mediaType: 'image/jpeg', data: 'img1' },
-        { type: 'image', source: 'base64', mediaType: 'image/png', data: 'img2' },
-        { type: 'image', source: 'base64', mediaType: 'image/webp', data: 'img3' },
-      ];
-      const result = (runner as any).buildUserContent('Gallery caption', images);
+    it('adds --session-id for resumed sessions', () => {
+      const runner = new InkRunner();
+      const args = (runner as any).buildArgs('session-456', true, {
+        workingDirectory: '/tmp',
+        agentId: 'myra',
+      });
 
-      expect(result).toHaveLength(4);
-      expect(result[0].type).toBe('image');
-      expect(result[1].type).toBe('image');
-      expect(result[2].type).toBe('image');
-      expect(result[3]).toEqual({ type: 'text', text: 'Gallery caption' });
+      expect(args).toContain('--session-id');
+      expect(args).toContain('session-456');
+    });
+
+    it('includes --model when specified', () => {
+      const runner = new InkRunner();
+      const args = (runner as any).buildArgs('session-789', false, {
+        workingDirectory: '/tmp',
+        agentId: 'wren',
+        model: 'claude-sonnet-4-20250514',
+      });
+
+      expect(args).toContain('--model');
+      expect(args).toContain('claude-sonnet-4-20250514');
+    });
+
+    it('omits --agent when agentId is not provided', () => {
+      const runner = new InkRunner();
+      const args = (runner as any).buildArgs('session-000', false, {
+        workingDirectory: '/tmp',
+      });
+
+      expect(args).not.toContain('--agent');
     });
   });
 
-  describe('agentId propagation', () => {
-    it('creates guarded bash tools when agentId is provided', async () => {
-      const runner = new InkRunner({ apiKey: 'test-key' });
+  describe('parseOutput', () => {
+    it('captures plain text as finalTextResponse', () => {
+      const runner = new InkRunner();
+      const result = (runner as any).parseOutput(
+        'Hello! I checked and the appointment is still the same.\n',
+        ''
+      );
 
-      // Access private getTools to verify agentId propagation
-      const tools: InkToolDefinition[] = await (runner as any).getTools('/tmp', 'wren');
-      const bash = tools.find((t) => t.schema.name === 'bash')!;
-
-      // If agentId propagated, the guard blocks dangerous commands
-      const result = await bash.execute({ command: ':(){ :|:& };:' });
-      expect(result).toContain('fork bomb');
+      expect(result.finalTextResponse).toBe(
+        'Hello! I checked and the appointment is still the same.'
+      );
+      expect(result.responses).toHaveLength(0);
+      expect(result.toolCalls).toHaveLength(0);
     });
 
-    it('creates unguarded bash tools when agentId is absent', async () => {
-      const runner = new InkRunner({ apiKey: 'test-key' });
+    it('parses send_response JSON lines into responses', () => {
+      const runner = new InkRunner();
+      const stdout = [
+        JSON.stringify({
+          type: 'send_response',
+          channel: 'telegram',
+          conversationId: '123',
+          content: 'Done!',
+        }),
+        'Some trailing text',
+      ].join('\n');
 
-      const tools: InkToolDefinition[] = await (runner as any).getTools('/tmp');
-      const bash = tools.find((t) => t.schema.name === 'bash')!;
+      const result = (runner as any).parseOutput(stdout, '');
 
-      // Without agentId, guard is bypassed — command would execute
-      // (we test with a safe command to avoid actual execution of dangerous ones)
-      const result = await bash.execute({ command: 'echo hello' });
-      expect(result).toContain('hello');
+      expect(result.responses).toHaveLength(1);
+      expect(result.responses[0]).toEqual({
+        channel: 'telegram',
+        conversationId: '123',
+        content: 'Done!',
+        format: undefined,
+      });
+      expect(result.finalTextResponse).toBe('Some trailing text');
     });
 
-    it('caches tools by cwd+agentId combination', async () => {
-      const runner = new InkRunner({ apiKey: 'test-key' });
+    it('parses tool_call JSON lines', () => {
+      const runner = new InkRunner();
+      const stdout = JSON.stringify({
+        type: 'tool_call',
+        toolName: 'browser_navigate',
+        toolUseId: 'tc-1',
+        input: { url: 'https://example.com' },
+      });
 
-      const tools1 = await (runner as any).getTools('/tmp', 'wren');
-      const tools2 = await (runner as any).getTools('/tmp', 'wren');
-      const tools3 = await (runner as any).getTools('/tmp', 'lumen');
+      const result = (runner as any).parseOutput(stdout, '');
 
-      // Same cwd+agentId returns cached instance
-      expect(tools1).toBe(tools2);
-      // Different agentId returns different instance
-      expect(tools1).not.toBe(tools3);
+      expect(result.toolCalls).toHaveLength(1);
+      expect(result.toolCalls[0].toolName).toBe('browser_navigate');
+      expect(result.toolCalls[0].input).toEqual({ url: 'https://example.com' });
+    });
+
+    it('handles empty output', () => {
+      const runner = new InkRunner();
+      const result = (runner as any).parseOutput('', '');
+
+      expect(result.finalTextResponse).toBeUndefined();
+      expect(result.responses).toHaveLength(0);
+      expect(result.toolCalls).toHaveLength(0);
+    });
+
+    it('handles mixed JSON and plain text', () => {
+      const runner = new InkRunner();
+      const stdout = [
+        'Starting task...',
+        JSON.stringify({
+          type: 'tool_call',
+          toolName: 'bash',
+          id: 'tc-2',
+          input: { command: 'ls' },
+        }),
+        'All done.',
+      ].join('\n');
+
+      const result = (runner as any).parseOutput(stdout, '');
+
+      expect(result.toolCalls).toHaveLength(1);
+      expect(result.finalTextResponse).toBe('Starting task...\nAll done.');
     });
   });
 });

--- a/packages/api/src/services/sessions/ink-runner.test.ts
+++ b/packages/api/src/services/sessions/ink-runner.test.ts
@@ -7,9 +7,9 @@ vi.mock('../../utils/logger', () => ({
 
 describe('InkRunner', () => {
   describe('buildArgs', () => {
-    it('builds base args for a new session', () => {
+    it('always includes --session-id with the PCP session ID', () => {
       const runner = new InkRunner();
-      const args = (runner as any).buildArgs('session-123', false, {
+      const args = (runner as any).buildArgs('session-123', {
         workingDirectory: '/tmp',
         agentId: 'myra',
       });
@@ -19,23 +19,13 @@ describe('InkRunner', () => {
       expect(args).toContain('--agent');
       expect(args).toContain('myra');
       expect(args).toContain('--max-turns');
-      expect(args).not.toContain('--session-id');
-    });
-
-    it('adds --session-id for resumed sessions', () => {
-      const runner = new InkRunner();
-      const args = (runner as any).buildArgs('session-456', true, {
-        workingDirectory: '/tmp',
-        agentId: 'myra',
-      });
-
       expect(args).toContain('--session-id');
-      expect(args).toContain('session-456');
+      expect(args).toContain('session-123');
     });
 
     it('includes --model when specified', () => {
       const runner = new InkRunner();
-      const args = (runner as any).buildArgs('session-789', false, {
+      const args = (runner as any).buildArgs('session-789', {
         workingDirectory: '/tmp',
         agentId: 'wren',
         model: 'claude-sonnet-4-20250514',
@@ -47,25 +37,25 @@ describe('InkRunner', () => {
 
     it('omits --agent when agentId is not provided', () => {
       const runner = new InkRunner();
-      const args = (runner as any).buildArgs('session-000', false, {
+      const args = (runner as any).buildArgs('session-000', {
         workingDirectory: '/tmp',
       });
 
       expect(args).not.toContain('--agent');
+      expect(args).toContain('--session-id');
+      expect(args).toContain('session-000');
     });
   });
 
   describe('parseOutput', () => {
-    it('captures plain text as finalTextResponse', () => {
+    it('does not treat plain text stdout as finalTextResponse', () => {
       const runner = new InkRunner();
       const result = (runner as any).parseOutput(
         'Hello! I checked and the appointment is still the same.\n',
         ''
       );
 
-      expect(result.finalTextResponse).toBe(
-        'Hello! I checked and the appointment is still the same.'
-      );
+      expect(result.finalTextResponse).toBeUndefined();
       expect(result.responses).toHaveLength(0);
       expect(result.toolCalls).toHaveLength(0);
     });
@@ -79,7 +69,7 @@ describe('InkRunner', () => {
           conversationId: '123',
           content: 'Done!',
         }),
-        'Some trailing text',
+        'Some trailing CLI noise',
       ].join('\n');
 
       const result = (runner as any).parseOutput(stdout, '');
@@ -91,7 +81,7 @@ describe('InkRunner', () => {
         content: 'Done!',
         format: undefined,
       });
-      expect(result.finalTextResponse).toBe('Some trailing text');
+      expect(result.finalTextResponse).toBeUndefined();
     });
 
     it('parses tool_call JSON lines', () => {
@@ -119,7 +109,7 @@ describe('InkRunner', () => {
       expect(result.toolCalls).toHaveLength(0);
     });
 
-    it('handles mixed JSON and plain text', () => {
+    it('ignores non-JSON text lines (CLI noise)', () => {
       const runner = new InkRunner();
       const stdout = [
         'Starting task...',
@@ -135,7 +125,7 @@ describe('InkRunner', () => {
       const result = (runner as any).parseOutput(stdout, '');
 
       expect(result.toolCalls).toHaveLength(1);
-      expect(result.finalTextResponse).toBe('Starting task...\nAll done.');
+      expect(result.finalTextResponse).toBeUndefined();
     });
   });
 });

--- a/packages/api/src/services/sessions/ink-runner.ts
+++ b/packages/api/src/services/sessions/ink-runner.ts
@@ -39,7 +39,7 @@ export class InkRunner implements IRunner {
     const { backendSessionId, injectedContext, config } = options;
 
     const isResume = !!backendSessionId;
-    let sessionId = backendSessionId || randomUUID();
+    const sessionId = config.pcpSessionId || backendSessionId || randomUUID();
 
     let fullMessage = message;
     if (injectedContext && !isResume) {
@@ -47,10 +47,11 @@ export class InkRunner implements IRunner {
       fullMessage = `${contextBlock}\n\n---\n\n${message}`;
     }
 
-    let args = this.buildArgs(sessionId, isResume, config);
+    const args = this.buildArgs(sessionId, config);
 
     logger.info('Spawning ink chat (non-interactive)', {
       sessionId,
+      pcpSessionId: config.pcpSessionId,
       isResume,
       workingDirectory: config.workingDirectory,
       messageLength: fullMessage.length,
@@ -63,15 +64,14 @@ export class InkRunner implements IRunner {
         logger.warn('Resume failed - session not found locally. Starting fresh session.', {
           oldSessionId: sessionId,
         });
-        sessionId = randomUUID();
-        args = this.buildArgs(sessionId, false, config);
 
         if (injectedContext) {
           const contextBlock = formatInjectedContext(injectedContext);
           fullMessage = `${contextBlock}\n\n---\n\n${message}`;
         }
 
-        const retryResult = await this.spawnProcess(args, fullMessage, config);
+        const freshArgs = this.buildArgs(sessionId, config);
+        const retryResult = await this.spawnProcess(freshArgs, fullMessage, config);
         return {
           success: true,
           backendSessionId: sessionId,
@@ -104,22 +104,19 @@ export class InkRunner implements IRunner {
     }
   }
 
-  private buildArgs(sessionId: string, isResume: boolean, config: ClaudeRunnerConfig): string[] {
+  private buildArgs(sessionId: string, config: ClaudeRunnerConfig): string[] {
     const args: string[] = ['chat', '--non-interactive'];
 
     if (config.agentId) {
       args.push('--agent', config.agentId);
     }
 
-    if (isResume) {
-      args.push('--session-id', sessionId);
-    }
+    args.push('--session-id', sessionId);
 
     if (config.model) {
       args.push('--model', config.model);
     }
 
-    // Max turns: let the ink runtime handle multi-turn tool loops
     args.push('--max-turns', '25');
 
     return args;
@@ -248,12 +245,11 @@ export class InkRunner implements IRunner {
   } {
     const responses: ChannelResponse[] = [];
     const toolCalls: ToolCall[] = [];
-    let finalTextResponse = '';
 
-    // ink chat --non-interactive outputs the assistant's response to stdout.
-    // Parse any structured JSON lines if present, otherwise treat as plain text.
+    // ink chat routes responses via MCP send_response — stdout may contain
+    // CLI chrome, status lines, or other noise that must NOT be treated as
+    // routeable content. Only parse structured JSON lines.
     const lines = stdout.split('\n');
-    const textLines: string[] = [];
 
     for (const line of lines) {
       if (!line.trim()) continue;
@@ -273,21 +269,15 @@ export class InkRunner implements IRunner {
             toolName: parsed.toolName || parsed.name || '',
             input: parsed.input || {},
           });
-        } else if (parsed.type === 'usage') {
-          // Will be handled if present
-        } else {
-          textLines.push(line);
         }
       } catch {
-        textLines.push(line);
+        // Non-JSON line — CLI noise, ignore
       }
     }
 
-    finalTextResponse = textLines.join('\n').trim();
-
     return {
       responses,
-      finalTextResponse: finalTextResponse || undefined,
+      finalTextResponse: undefined,
       toolCalls,
     };
   }

--- a/packages/api/src/services/sessions/ink-runner.ts
+++ b/packages/api/src/services/sessions/ink-runner.ts
@@ -245,10 +245,14 @@ export class InkRunner implements IRunner {
   } {
     const responses: ChannelResponse[] = [];
     const toolCalls: ToolCall[] = [];
+    let finalTextResponse: string | undefined;
 
     // ink chat routes responses via MCP send_response — stdout may contain
     // CLI chrome, status lines, or other noise that must NOT be treated as
-    // routeable content. Only parse structured JSON lines.
+    // routeable content. Only parse structured JSON lines:
+    //   - type: "send_response" → explicit channel routing
+    //   - type: "tool_call"     → tool invocation tracking
+    //   - type: "result"        → assistant's final text (emitted by --non-interactive)
     const lines = stdout.split('\n');
 
     for (const line of lines) {
@@ -269,6 +273,8 @@ export class InkRunner implements IRunner {
             toolName: parsed.toolName || parsed.name || '',
             input: parsed.input || {},
           });
+        } else if (parsed.type === 'result' && parsed.text) {
+          finalTextResponse = parsed.text;
         }
       } catch {
         // Non-JSON line — CLI noise, ignore
@@ -277,7 +283,7 @@ export class InkRunner implements IRunner {
 
     return {
       responses,
-      finalTextResponse: undefined,
+      finalTextResponse,
       toolCalls,
     };
   }

--- a/packages/api/src/services/sessions/ink-runner.ts
+++ b/packages/api/src/services/sessions/ink-runner.ts
@@ -1,295 +1,294 @@
 /**
  * Ink Runner
  *
- * Implements IRunner using the Anthropic API directly with Ink coding tools.
- * Unlike CLI runners (Claude/Codex/Gemini), this calls the API in-process
- * with a proper tool execution loop — tool results are fed back to continue
- * the conversation until the model emits end_turn.
+ * Spawns `ink chat --non-interactive` as a subprocess. The ink runtime
+ * manages the full context window, tools, permissions, credential
+ * resolution, and skills — Claude Code is the LLM execution backend
+ * underneath, just like when a user runs `ink chat` interactively.
+ *
+ * This follows the same subprocess pattern as ClaudeRunner but points
+ * at the `ink` binary instead of `claude`.
  */
 
-import Anthropic from '@anthropic-ai/sdk';
+import { spawn, type ChildProcess } from 'child_process';
+import { randomUUID } from 'crypto';
 import type {
   InjectedContext,
   ClaudeRunnerConfig,
   RunnerResult,
   ChannelResponse,
-  ChannelType,
   IRunner,
   ToolCall,
-  ImageContent,
 } from './types.js';
 import { formatInjectedContext } from './context-builder.js';
-import { buildIdentityPrompt } from './claude-runner.js';
 import { logger } from '../../utils/logger.js';
-import {
-  createInkCodingTools,
-  type InkToolDefinition,
-  type PiCodingToolsConfig,
-} from '../../agent/tools/pi-coding-tools.js';
+import { resolveBinaryPath, buildSpawnPath } from './resolve-binary.js';
+import { injectSessionHeaders, buildSessionEnv, writeRuntimeSessionHint } from '@inklabs/shared';
 
-const MAX_TOOL_ITERATIONS = 50;
-const DEFAULT_MODEL = 'claude-sonnet-4-20250514';
-const DEFAULT_MAX_TOKENS = 16384;
-
-export interface InkRunnerConfig {
-  apiKey?: string;
-  model?: string;
-  maxTokens?: number;
-  /** Pi coding tools config — if omitted, tools are loaded with cwd from runner config */
-  piToolsConfig?: Partial<PiCodingToolsConfig>;
-  /** Additional tools to register alongside Pi coding tools */
-  extraTools?: Anthropic.Tool[];
-}
+const PROCESS_TIMEOUT_MS = parseInt(process.env.INK_PROCESS_TIMEOUT_MS || '', 10) || 30 * 60 * 1000;
 
 export class InkRunner implements IRunner {
-  private client: Anthropic | null = null;
-  private runnerConfig: InkRunnerConfig;
-  private toolsCache = new Map<string, InkToolDefinition[]>();
-
-  constructor(config: InkRunnerConfig = {}) {
-    this.runnerConfig = config;
-  }
-
   async run(
     message: string,
     options: {
       backendSessionId?: string;
       injectedContext?: InjectedContext;
       config: ClaudeRunnerConfig;
-      imageContents?: ImageContent[];
     }
   ): Promise<RunnerResult> {
-    const { injectedContext, config } = options;
+    const { backendSessionId, injectedContext, config } = options;
 
-    this.ensureClient();
+    const isResume = !!backendSessionId;
+    let sessionId = backendSessionId || randomUUID();
 
-    // Build system prompt
-    const systemPrompt = this.buildSystemPrompt(config, injectedContext);
-
-    // Build user message with context injection (first turn only)
     let fullMessage = message;
-    if (injectedContext && !options.backendSessionId) {
+    if (injectedContext && !isResume) {
       const contextBlock = formatInjectedContext(injectedContext);
       fullMessage = `${contextBlock}\n\n---\n\n${message}`;
     }
 
-    // Load Pi coding tools scoped to the working directory
-    const tools = await this.getTools(config.workingDirectory, config.agentId);
-    const toolSchemas: Anthropic.Tool[] = tools.map((t) => t.schema);
-    if (this.runnerConfig.extraTools) {
-      toolSchemas.push(...this.runnerConfig.extraTools);
-    }
+    let args = this.buildArgs(sessionId, isResume, config);
 
-    // Build executor map for fast lookup
-    const executorMap = new Map<string, InkToolDefinition['execute']>();
-    for (const tool of tools) {
-      executorMap.set(tool.schema.name, tool.execute);
-    }
+    logger.info('Spawning ink chat (non-interactive)', {
+      sessionId,
+      isResume,
+      workingDirectory: config.workingDirectory,
+      messageLength: fullMessage.length,
+    });
 
-    // Build first user message — multimodal when images present
-    const userContent = this.buildUserContent(fullMessage, options.imageContents);
+    try {
+      const result = await this.spawnProcess(args, fullMessage, config);
 
-    // Run the agentic loop
-    const messages: Anthropic.MessageParam[] = [{ role: 'user', content: userContent }];
-    const responses: ChannelResponse[] = [];
-    const toolCalls: ToolCall[] = [];
-    let totalInputTokens = 0;
-    let totalOutputTokens = 0;
-    let finalTextResponse = '';
-    let backendSessionId = options.backendSessionId || `ink-${Date.now()}`;
-
-    for (let iteration = 0; iteration < MAX_TOOL_ITERATIONS; iteration++) {
-      const response = await this.client!.messages.create({
-        model: this.runnerConfig.model || config.model || DEFAULT_MODEL,
-        max_tokens: this.runnerConfig.maxTokens || DEFAULT_MAX_TOKENS,
-        system: systemPrompt,
-        messages,
-        tools: toolSchemas.length > 0 ? toolSchemas : undefined,
-      });
-
-      totalInputTokens += response.usage.input_tokens;
-      totalOutputTokens += response.usage.output_tokens;
-
-      // Collect text and tool_use blocks
-      const textParts: string[] = [];
-      const toolUseBlocks: Anthropic.ToolUseBlock[] = [];
-
-      for (const block of response.content) {
-        if (block.type === 'text') {
-          textParts.push(block.text);
-        } else if (block.type === 'tool_use') {
-          toolUseBlocks.push(block);
-        }
-      }
-
-      if (textParts.length > 0) {
-        finalTextResponse = textParts.join('');
-      }
-
-      // Check for send_response in tool calls
-      for (const toolUse of toolUseBlocks) {
-        const input = toolUse.input as Record<string, unknown>;
-        toolCalls.push({
-          toolUseId: toolUse.id,
-          toolName: toolUse.name,
-          input,
+      if (result.resumeFailedNoSession && isResume) {
+        logger.warn('Resume failed - session not found locally. Starting fresh session.', {
+          oldSessionId: sessionId,
         });
+        sessionId = randomUUID();
+        args = this.buildArgs(sessionId, false, config);
 
-        if (toolUse.name === 'send_response' || toolUse.name === 'mcp__inkwell__send_response') {
-          const channel = (input.channel as ChannelType) || 'api';
-          const conversationId = input.conversationId as string | undefined;
-          const content = input.content as string | undefined;
-          if (content) {
-            responses.push({
-              channel,
-              conversationId: conversationId || '',
-              content,
-              format: input.format as ChannelResponse['format'],
-            });
-          }
-        }
-      }
-
-      // If no tool use, we're done
-      if (toolUseBlocks.length === 0 || response.stop_reason === 'end_turn') {
-        break;
-      }
-
-      // Execute tools and build tool_result messages
-      // Add assistant turn with the full content (text + tool_use)
-      messages.push({ role: 'assistant', content: response.content });
-
-      const toolResults: Anthropic.ToolResultBlockParam[] = [];
-      for (const toolUse of toolUseBlocks) {
-        const executor = executorMap.get(toolUse.name);
-        let resultText: string;
-
-        if (executor) {
-          try {
-            resultText = await executor(toolUse.input as Record<string, unknown>);
-          } catch (err) {
-            const errMsg = err instanceof Error ? err.message : String(err);
-            logger.error(`Ink runner: tool ${toolUse.name} threw`, { error: errMsg });
-            resultText = `Error: ${errMsg}`;
-          }
-        } else {
-          resultText = `Error: Tool "${toolUse.name}" not available in this runtime. Available tools: ${Array.from(executorMap.keys()).join(', ')}`;
-          logger.warn(`Ink runner: unknown tool "${toolUse.name}" requested`);
+        if (injectedContext) {
+          const contextBlock = formatInjectedContext(injectedContext);
+          fullMessage = `${contextBlock}\n\n---\n\n${message}`;
         }
 
-        toolResults.push({
-          type: 'tool_result',
-          tool_use_id: toolUse.id,
-          content: resultText,
-        });
+        const retryResult = await this.spawnProcess(args, fullMessage, config);
+        return {
+          success: true,
+          backendSessionId: sessionId,
+          responses: retryResult.responses,
+          usage: retryResult.usage,
+          finalTextResponse: retryResult.finalTextResponse,
+          toolCalls: retryResult.toolCalls,
+        };
       }
 
-      // Add tool results as user turn
-      messages.push({ role: 'user', content: toolResults });
-
-      logger.debug('Ink runner: tool iteration complete', {
-        iteration,
-        toolsExecuted: toolUseBlocks.map((t) => t.name),
+      return {
+        success: true,
+        backendSessionId: sessionId,
+        responses: result.responses,
+        usage: result.usage,
+        finalTextResponse: result.finalTextResponse,
+        toolCalls: result.toolCalls,
+      };
+    } catch (error) {
+      logger.error('ink chat process failed', {
+        sessionId,
+        error: error instanceof Error ? error.message : String(error),
       });
+      return {
+        success: false,
+        backendSessionId: sessionId,
+        responses: [],
+        error: error instanceof Error ? error.message : 'Unknown error',
+      };
     }
-
-    return {
-      success: true,
-      backendSessionId,
-      responses,
-      usage: {
-        contextTokens: 0,
-        inputTokens: totalInputTokens,
-        outputTokens: totalOutputTokens,
-      },
-      finalTextResponse: finalTextResponse || undefined,
-      toolCalls,
-    };
   }
 
-  private buildUserContent(
-    text: string,
-    imageContents?: ImageContent[]
-  ): string | Anthropic.ContentBlockParam[] {
-    if (!imageContents || imageContents.length === 0) return text;
+  private buildArgs(sessionId: string, isResume: boolean, config: ClaudeRunnerConfig): string[] {
+    const args: string[] = ['chat', '--non-interactive'];
 
-    const blocks: Anthropic.ContentBlockParam[] = [];
-    for (const img of imageContents) {
-      blocks.push({
-        type: 'image',
-        source: {
-          type: 'base64',
-          media_type: img.mediaType as Anthropic.Base64ImageSource['media_type'],
-          data: img.data,
-        },
-      });
-    }
-    blocks.push({ type: 'text', text });
-    return blocks;
-  }
-
-  private ensureClient(): void {
-    if (this.client) return;
-    const apiKey = this.runnerConfig.apiKey || process.env.ANTHROPIC_API_KEY;
-    if (!apiKey) {
-      throw new Error('ANTHROPIC_API_KEY is required for Ink runner');
-    }
-    this.client = new Anthropic({ apiKey });
-  }
-
-  private async getTools(cwd: string, agentId?: string): Promise<InkToolDefinition[]> {
-    const cacheKey = `${cwd}:${agentId ?? ''}`;
-    if (this.toolsCache.has(cacheKey)) {
-      return this.toolsCache.get(cacheKey)!;
+    if (config.agentId) {
+      args.push('--agent', config.agentId);
     }
 
-    const piConfig: PiCodingToolsConfig = {
-      cwd,
-      ...this.runnerConfig.piToolsConfig,
-      ...(agentId && { agentId }),
-    };
+    if (isResume) {
+      args.push('--session-id', sessionId);
+    }
 
-    const tools = await createInkCodingTools(piConfig);
-    this.toolsCache.set(cacheKey, tools);
-    return tools;
+    if (config.model) {
+      args.push('--model', config.model);
+    }
+
+    // Max turns: let the ink runtime handle multi-turn tool loops
+    args.push('--max-turns', '25');
+
+    return args;
   }
 
-  private buildSystemPrompt(config: ClaudeRunnerConfig, context?: InjectedContext): string {
-    const parts: string[] = [];
+  private async spawnProcess(
+    args: string[],
+    message: string,
+    config: ClaudeRunnerConfig
+  ): Promise<{
+    responses: ChannelResponse[];
+    usage?: { contextTokens: number; inputTokens: number; outputTokens: number };
+    resumeFailedNoSession?: boolean;
+    finalTextResponse?: string;
+    toolCalls: ToolCall[];
+  }> {
+    const inkBin = await resolveBinaryPath('ink');
 
-    // Identity prompt (same as CLI runners)
-    if (config.agentId && context?.agent) {
-      parts.push(
-        buildIdentityPrompt(
-          config.agentId,
-          context.agent.name,
-          context.agent.soul,
-          context.user?.timezone,
-          context.agent.heartbeat,
-          {
-            pcpSessionId: config.pcpSessionId,
-            studioId: config.studioId,
-          }
-        )
+    if (config.pcpSessionId && config.workingDirectory) {
+      writeRuntimeSessionHint(
+        config.workingDirectory,
+        config.pcpSessionId,
+        config.agentId || 'unknown',
+        'ink',
+        randomUUID(),
+        config.studioId
       );
     }
 
-    // System prompt from config
-    if (config.systemPrompt) {
-      parts.push(config.systemPrompt);
+    const mcpInjection =
+      config.mcpConfigPath && config.pcpSessionId
+        ? injectSessionHeaders({
+            mcpConfigPath: config.mcpConfigPath,
+            pcpSessionId: config.pcpSessionId,
+            studioId: config.studioId,
+            accessToken: config.pcpAccessToken,
+          })
+        : null;
+
+    // Pass --message via args (not stdin) so ink chat gets it directly
+    const fullArgs = [...args, '--message', message];
+
+    const spawnPath = buildSpawnPath(inkBin);
+    const sessionEnv = buildSessionEnv({
+      pcpSessionId: config.pcpSessionId,
+      studioId: config.studioId,
+      agentId: config.agentId,
+    });
+
+    const env: Record<string, string> = {
+      ...process.env,
+      ...sessionEnv,
+      PATH: spawnPath,
+      AGENT_ID: config.agentId || '',
+    } as Record<string, string>;
+
+    // Strip CLAUDECODE to prevent nested-session detection
+    delete env.CLAUDECODE;
+
+    return new Promise((resolve, reject) => {
+      const child: ChildProcess = spawn(inkBin, fullArgs, {
+        cwd: config.workingDirectory,
+        env,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+
+      let stdout = '';
+      let stderr = '';
+
+      child.stdout?.on('data', (chunk: Buffer) => {
+        stdout += chunk.toString();
+      });
+      child.stderr?.on('data', (chunk: Buffer) => {
+        stderr += chunk.toString();
+      });
+
+      const timeout = setTimeout(() => {
+        logger.warn('ink chat process timed out, killing', { timeout: PROCESS_TIMEOUT_MS });
+        child.kill('SIGTERM');
+        setTimeout(() => child.kill('SIGKILL'), 3000);
+      }, PROCESS_TIMEOUT_MS);
+
+      child.on('close', (code) => {
+        clearTimeout(timeout);
+        mcpInjection?.cleanup();
+
+        if (code !== 0) {
+          // Check for resume failure
+          if (stderr.includes('session not found') || stderr.includes('No such session')) {
+            resolve({
+              responses: [],
+              resumeFailedNoSession: true,
+              toolCalls: [],
+            });
+            return;
+          }
+
+          const errorText = stderr.trim() || stdout.trim() || `exit code ${code}`;
+          reject(new Error(`ink chat exited with code ${code}: ${errorText.slice(0, 1000)}`));
+          return;
+        }
+
+        const result = this.parseOutput(stdout, stderr);
+        resolve(result);
+      });
+
+      child.on('error', (err) => {
+        clearTimeout(timeout);
+        mcpInjection?.cleanup();
+        reject(new Error(`Failed to spawn ink: ${err.message}`));
+      });
+
+      // Close stdin — message is passed via --message arg
+      child.stdin?.end();
+    });
+  }
+
+  private parseOutput(
+    stdout: string,
+    _stderr: string
+  ): {
+    responses: ChannelResponse[];
+    usage?: { contextTokens: number; inputTokens: number; outputTokens: number };
+    finalTextResponse?: string;
+    toolCalls: ToolCall[];
+  } {
+    const responses: ChannelResponse[] = [];
+    const toolCalls: ToolCall[] = [];
+    let finalTextResponse = '';
+
+    // ink chat --non-interactive outputs the assistant's response to stdout.
+    // Parse any structured JSON lines if present, otherwise treat as plain text.
+    const lines = stdout.split('\n');
+    const textLines: string[] = [];
+
+    for (const line of lines) {
+      if (!line.trim()) continue;
+
+      try {
+        const parsed = JSON.parse(line);
+        if (parsed.type === 'send_response') {
+          responses.push({
+            channel: parsed.channel || 'api',
+            conversationId: parsed.conversationId || '',
+            content: parsed.content || '',
+            format: parsed.format,
+          });
+        } else if (parsed.type === 'tool_call') {
+          toolCalls.push({
+            toolUseId: parsed.toolUseId || parsed.id || '',
+            toolName: parsed.toolName || parsed.name || '',
+            input: parsed.input || {},
+          });
+        } else if (parsed.type === 'usage') {
+          // Will be handled if present
+        } else {
+          textLines.push(line);
+        }
+      } catch {
+        textLines.push(line);
+      }
     }
-    if (config.appendSystemPrompt) {
-      parts.push(config.appendSystemPrompt);
-    }
 
-    // Coding tools context
-    parts.push(`## Coding Tools
+    finalTextResponse = textLines.join('\n').trim();
 
-You have filesystem access scoped to: ${config.workingDirectory}
-
-Available tools: read, write, edit, bash, grep, find, ls
-All file paths are resolved relative to the working directory. Access outside this directory is blocked.`);
-
-    return parts.join('\n\n');
+    return {
+      responses,
+      finalTextResponse: finalTextResponse || undefined,
+      toolCalls,
+    };
   }
 }

--- a/packages/api/src/services/sessions/session-service.ts
+++ b/packages/api/src/services/sessions/session-service.ts
@@ -9,7 +9,7 @@
  */
 
 import { randomUUID } from 'crypto';
-import { access } from 'fs/promises';
+import { access, readFile, stat } from 'fs/promises';
 import path from 'path';
 import { SupabaseClient } from '@supabase/supabase-js';
 import jwt from 'jsonwebtoken';
@@ -27,6 +27,7 @@ import type {
   ISessionRepository,
   IContextBuilder,
   ToolCall,
+  ImageContent,
 } from './types.js';
 import type { Json } from '../../data/supabase/types.js';
 import { SessionRepository } from './session-repository.js';
@@ -34,6 +35,7 @@ import { ContextBuilder } from './context-builder.js';
 import { ClaudeRunner, buildIdentityPrompt } from './claude-runner.js';
 import { CodexRunner } from './codex-runner.js';
 import { GeminiRunner } from './gemini-runner.js';
+import { InkRunner } from './ink-runner.js';
 import { ActivityStreamRepository } from '../../data/repositories/activity-stream.repository.js';
 import { resolveIdentityId } from '../../auth/resolve-identity.js';
 import { classifyError } from '@inklabs/shared';
@@ -136,6 +138,7 @@ export class SessionService implements ISessionService {
   private claudeRunner: IRunner;
   private codexRunner: IRunner;
   private geminiRunner: IRunner;
+  private inkRunner: IRunner;
   private activityStream: IActivityStream;
   private config: SessionServiceConfig;
   private supabase: SupabaseClient<Database> | null;
@@ -168,13 +171,15 @@ export class SessionService implements ISessionService {
     config: Partial<SessionServiceConfig> = {},
     codexRunner?: IRunner,
     supabase?: SupabaseClient<Database>,
-    geminiRunner?: IRunner
+    geminiRunner?: IRunner,
+    inkRunner?: IRunner
   ) {
     this.repository = repository;
     this.contextBuilder = contextBuilder;
     this.claudeRunner = claudeRunner;
     this.codexRunner = codexRunner || claudeRunner;
     this.geminiRunner = geminiRunner || claudeRunner;
+    this.inkRunner = inkRunner || new InkRunner();
     this.activityStream = activityStream;
     this.config = { ...DEFAULT_CONFIG, ...config };
     this.supabase = supabase || null;
@@ -482,12 +487,24 @@ export class SessionService implements ISessionService {
     };
 
     // 5. Run with selected backend
+    // Ink runner executes tools in-process against the host filesystem —
+    // it cannot route to a Docker container. Reject the combination so a
+    // sandboxed strategy doesn't silently bypass containment.
+    if (resolvedBackend === 'ink' && runnerConfig.container) {
+      throw new Error(
+        'ink backend cannot run inside a sandbox container. ' +
+          'Use a CLI backend (claude-code, codex-cli, gemini) for sandboxed strategies.'
+      );
+    }
+
     const runner =
       resolvedBackend === 'codex-cli'
         ? this.codexRunner
         : resolvedBackend === 'gemini'
           ? this.geminiRunner
-          : this.claudeRunner;
+          : resolvedBackend === 'ink'
+            ? this.inkRunner
+            : this.claudeRunner;
 
     // 5a. Log backend spawn to activity stream (fire-and-forget)
     const triggerSource = metadata?.triggerType as string | undefined;
@@ -523,6 +540,10 @@ export class SessionService implements ISessionService {
     // Mark session as running before backend turn
     await this.repository.update(session.id, { lifecycle: 'running' });
 
+    // Read image attachments only for vision-capable backends (ink runner calls Anthropic API directly)
+    const imageContents =
+      resolvedBackend === 'ink' ? await this.readImageAttachments(request.metadata?.media) : [];
+
     let result;
     let turnDurationMs: number;
     const turnStartMs = Date.now();
@@ -531,6 +552,7 @@ export class SessionService implements ISessionService {
         backendSessionId: session.backendSessionId || undefined,
         injectedContext: session.backendSessionId ? undefined : injectedContext,
         config: runnerConfig,
+        imageContents: imageContents.length > 0 ? imageContents : undefined,
       });
       turnDurationMs = Date.now() - turnStartMs;
     } catch (runnerError) {
@@ -1312,7 +1334,9 @@ This session will continue with a fresh context after compaction. Your identity,
           ? this.codexRunner
           : runtimeBackend === 'gemini'
             ? this.geminiRunner
-            : this.claudeRunner;
+            : runtimeBackend === 'ink'
+              ? this.inkRunner
+              : this.claudeRunner;
 
       // Phase 1: Send compaction prompt — agent saves context, notifies users, ends session
       const result = await runner.run(compactionPrompt, {
@@ -1525,6 +1549,52 @@ This session will continue with a fresh context after compaction. Your identity,
         platformChatId: request.conversationId,
       });
     }
+  }
+
+  /**
+   * Format an incoming message with sender context.
+   * External channel messages are wrapped in <untrusted-data> tags following
+   * Supabase's proven pattern for prompt injection protection.
+   */
+  private async readImageAttachments(
+    media?: import('./types.js').MediaAttachment[]
+  ): Promise<ImageContent[]> {
+    if (!media || media.length === 0) return [];
+
+    const MAX_IMAGE_BYTES = 20 * 1024 * 1024;
+    const MAX_IMAGES = 10;
+    const SUPPORTED_TYPES = new Set(['image/jpeg', 'image/png', 'image/gif', 'image/webp']);
+
+    const images: ImageContent[] = [];
+
+    for (const attachment of media) {
+      if (images.length >= MAX_IMAGES) break;
+      if (attachment.type !== 'image') continue;
+      if (!attachment.path) continue;
+
+      const mimeType = attachment.contentType || attachment.mimeType || 'image/jpeg';
+      if (!SUPPORTED_TYPES.has(mimeType)) continue;
+
+      try {
+        const info = await stat(attachment.path);
+        if (info.size <= 0 || info.size > MAX_IMAGE_BYTES) continue;
+
+        const bytes = await readFile(attachment.path);
+        images.push({
+          type: 'image',
+          source: 'base64',
+          mediaType: mimeType,
+          data: bytes.toString('base64'),
+        });
+      } catch (error) {
+        logger.warn('Failed to read image attachment for multimodal', {
+          filePath: attachment.path,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    return images;
   }
 
   private formatMessage(request: SessionRequest, timezone?: string): string {
@@ -1743,6 +1813,7 @@ export function createSessionService(
     config,
     new CodexRunner(),
     supabase,
-    new GeminiRunner()
+    new GeminiRunner(),
+    new InkRunner()
   );
 }

--- a/packages/api/src/services/sessions/session-service.ts
+++ b/packages/api/src/services/sessions/session-service.ts
@@ -9,7 +9,7 @@
  */
 
 import { randomUUID } from 'crypto';
-import { access, readFile, stat } from 'fs/promises';
+import { access } from 'fs/promises';
 import path from 'path';
 import { SupabaseClient } from '@supabase/supabase-js';
 import jwt from 'jsonwebtoken';
@@ -27,7 +27,6 @@ import type {
   ISessionRepository,
   IContextBuilder,
   ToolCall,
-  ImageContent,
 } from './types.js';
 import type { Json } from '../../data/supabase/types.js';
 import { SessionRepository } from './session-repository.js';
@@ -35,7 +34,6 @@ import { ContextBuilder } from './context-builder.js';
 import { ClaudeRunner, buildIdentityPrompt } from './claude-runner.js';
 import { CodexRunner } from './codex-runner.js';
 import { GeminiRunner } from './gemini-runner.js';
-import { InkRunner } from './ink-runner.js';
 import { ActivityStreamRepository } from '../../data/repositories/activity-stream.repository.js';
 import { resolveIdentityId } from '../../auth/resolve-identity.js';
 import { classifyError } from '@inklabs/shared';
@@ -138,7 +136,6 @@ export class SessionService implements ISessionService {
   private claudeRunner: IRunner;
   private codexRunner: IRunner;
   private geminiRunner: IRunner;
-  private inkRunner: IRunner;
   private activityStream: IActivityStream;
   private config: SessionServiceConfig;
   private supabase: SupabaseClient<Database> | null;
@@ -171,15 +168,13 @@ export class SessionService implements ISessionService {
     config: Partial<SessionServiceConfig> = {},
     codexRunner?: IRunner,
     supabase?: SupabaseClient<Database>,
-    geminiRunner?: IRunner,
-    inkRunner?: IRunner
+    geminiRunner?: IRunner
   ) {
     this.repository = repository;
     this.contextBuilder = contextBuilder;
     this.claudeRunner = claudeRunner;
     this.codexRunner = codexRunner || claudeRunner;
     this.geminiRunner = geminiRunner || claudeRunner;
-    this.inkRunner = inkRunner || new InkRunner();
     this.activityStream = activityStream;
     this.config = { ...DEFAULT_CONFIG, ...config };
     this.supabase = supabase || null;
@@ -487,24 +482,12 @@ export class SessionService implements ISessionService {
     };
 
     // 5. Run with selected backend
-    // Ink runner executes tools in-process against the host filesystem —
-    // it cannot route to a Docker container. Reject the combination so a
-    // sandboxed strategy doesn't silently bypass containment.
-    if (resolvedBackend === 'ink' && runnerConfig.container) {
-      throw new Error(
-        'ink backend cannot run inside a sandbox container. ' +
-          'Use a CLI backend (claude-code, codex-cli, gemini) for sandboxed strategies.'
-      );
-    }
-
     const runner =
       resolvedBackend === 'codex-cli'
         ? this.codexRunner
         : resolvedBackend === 'gemini'
           ? this.geminiRunner
-          : resolvedBackend === 'ink'
-            ? this.inkRunner
-            : this.claudeRunner;
+          : this.claudeRunner;
 
     // 5a. Log backend spawn to activity stream (fire-and-forget)
     const triggerSource = metadata?.triggerType as string | undefined;
@@ -540,10 +523,6 @@ export class SessionService implements ISessionService {
     // Mark session as running before backend turn
     await this.repository.update(session.id, { lifecycle: 'running' });
 
-    // Read image attachments only for vision-capable backends (ink runner calls Anthropic API directly)
-    const imageContents =
-      resolvedBackend === 'ink' ? await this.readImageAttachments(request.metadata?.media) : [];
-
     let result;
     let turnDurationMs: number;
     const turnStartMs = Date.now();
@@ -552,7 +531,6 @@ export class SessionService implements ISessionService {
         backendSessionId: session.backendSessionId || undefined,
         injectedContext: session.backendSessionId ? undefined : injectedContext,
         config: runnerConfig,
-        imageContents: imageContents.length > 0 ? imageContents : undefined,
       });
       turnDurationMs = Date.now() - turnStartMs;
     } catch (runnerError) {
@@ -1334,9 +1312,7 @@ This session will continue with a fresh context after compaction. Your identity,
           ? this.codexRunner
           : runtimeBackend === 'gemini'
             ? this.geminiRunner
-            : runtimeBackend === 'ink'
-              ? this.inkRunner
-              : this.claudeRunner;
+            : this.claudeRunner;
 
       // Phase 1: Send compaction prompt — agent saves context, notifies users, ends session
       const result = await runner.run(compactionPrompt, {
@@ -1549,52 +1525,6 @@ This session will continue with a fresh context after compaction. Your identity,
         platformChatId: request.conversationId,
       });
     }
-  }
-
-  /**
-   * Format an incoming message with sender context.
-   * External channel messages are wrapped in <untrusted-data> tags following
-   * Supabase's proven pattern for prompt injection protection.
-   */
-  private async readImageAttachments(
-    media?: import('./types.js').MediaAttachment[]
-  ): Promise<ImageContent[]> {
-    if (!media || media.length === 0) return [];
-
-    const MAX_IMAGE_BYTES = 20 * 1024 * 1024;
-    const MAX_IMAGES = 10;
-    const SUPPORTED_TYPES = new Set(['image/jpeg', 'image/png', 'image/gif', 'image/webp']);
-
-    const images: ImageContent[] = [];
-
-    for (const attachment of media) {
-      if (images.length >= MAX_IMAGES) break;
-      if (attachment.type !== 'image') continue;
-      if (!attachment.path) continue;
-
-      const mimeType = attachment.contentType || attachment.mimeType || 'image/jpeg';
-      if (!SUPPORTED_TYPES.has(mimeType)) continue;
-
-      try {
-        const info = await stat(attachment.path);
-        if (info.size <= 0 || info.size > MAX_IMAGE_BYTES) continue;
-
-        const bytes = await readFile(attachment.path);
-        images.push({
-          type: 'image',
-          source: 'base64',
-          mediaType: mimeType,
-          data: bytes.toString('base64'),
-        });
-      } catch (error) {
-        logger.warn('Failed to read image attachment for multimodal', {
-          filePath: attachment.path,
-          error: error instanceof Error ? error.message : String(error),
-        });
-      }
-    }
-
-    return images;
   }
 
   private formatMessage(request: SessionRequest, timezone?: string): string {
@@ -1813,7 +1743,6 @@ export function createSessionService(
     config,
     new CodexRunner(),
     supabase,
-    new GeminiRunner(),
-    new InkRunner()
+    new GeminiRunner()
   );
 }

--- a/packages/api/src/services/sessions/session-service.ts
+++ b/packages/api/src/services/sessions/session-service.ts
@@ -540,9 +540,14 @@ export class SessionService implements ISessionService {
     // Mark session as running before backend turn
     await this.repository.update(session.id, { lifecycle: 'running' });
 
-    // Read image attachments only for vision-capable backends (ink runner calls Anthropic API directly)
+    // Read image attachments for backends that accept them via the runner interface.
+    // Currently only ClaudeRunner supports inline base64 images via --image flags.
+    // InkRunner spawns ink chat which manages its own backend — images are not
+    // passed through the runner interface for ink.
     const imageContents =
-      resolvedBackend === 'ink' ? await this.readImageAttachments(request.metadata?.media) : [];
+      resolvedBackend === 'claude-code'
+        ? await this.readImageAttachments(request.metadata?.media)
+        : [];
 
     let result;
     let turnDurationMs: number;

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -3918,6 +3918,23 @@ export async function runChat(options: ChatOptions): Promise<void> {
       signal: finalSignal || undefined,
     });
 
+    // Emit structured result for machine consumers (InkRunner, etc.).
+    // Must come before human-readable status lines so parsers can
+    // distinguish the assistant's response from CLI chrome.
+    const lastAssistant = ledger
+      .listEntries()
+      .filter((e) => e.role === 'assistant')
+      .pop();
+    if (lastAssistant) {
+      console.log(
+        JSON.stringify({
+          type: 'result',
+          text: lastAssistant.content,
+          sessionId: runtime.sessionId || null,
+        })
+      );
+    }
+
     if (finalSignal?.status === 'blocked') {
       console.log(chalk.yellow(`\nSession blocked: ${finalSignal.reason || 'needs input'}`));
     } else if (finalSignal?.status === 'completed') {


### PR DESCRIPTION
## Summary

- **InkRunner rewritten** to spawn `ink chat --non-interactive --message` as a subprocess instead of calling the Anthropic API directly. The ink runtime manages the full context window, tools, permissions, credential resolution, and skills — Claude Code is the LLM execution backend underneath, consistent with how `ink chat` works interactively.
- **No ANTHROPIC_API_KEY required** — the ink runtime handles auth through Claude Code's native auth, just like interactive `ink chat`.
- **Fixes Myra spawn failures** — heartbeat was triggering Myra with `backend: 'ink'` but the old InkRunner required an API key that wasn't in the server's env.

### Architecture

| Before | After |
|--------|-------|
| InkRunner called Anthropic API directly in-process | InkRunner spawns `ink chat --non-interactive` subprocess |
| Required `ANTHROPIC_API_KEY` in server env | No API key needed — CC handles auth |
| Own tool execution loop with Pi coding tools | Full ink runtime (tools, skills, credentials, permissions) |
| Separate code path from `ink chat` | Same runtime as interactive `ink chat` |

## Test plan

- [x] 9 unit tests for InkRunner (buildArgs, parseOutput — plain text, JSON, mixed, empty, resume)
- [ ] Integration: trigger Myra with `backend: 'ink'` and verify she spawns successfully
- [ ] Live: verify Myra can execute a multi-turn task (e.g., GFiber appointment check) via ink runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)