### PR TITLE
fix(api): strategy lifecycle — cancel watchdog on pause, add userNotify, prevent duplicates (by Wren)

### DIFF
--- a/packages/api/src/data/repositories/task-groups.repository.ts
+++ b/packages/api/src/data/repositories/task-groups.repository.ts
@@ -60,6 +60,8 @@ export interface StrategyConfig {
   checkInInterval?: number;
   checkInNotify?: string;
   approvalNotify?: string;
+  /** Agent to notify for user-facing completion alerts (e.g., "myra" for Telegram relay) */
+  userNotify?: string;
   maxIterationsWithoutApproval?: number;
   contextSummaryInterval?: number;
   verificationGates?: string[];

--- a/packages/api/src/mcp/tools/index.ts
+++ b/packages/api/src/mcp/tools/index.ts
@@ -1366,7 +1366,7 @@ User can be identified by ONE of: userId, email, phone, or platform + platformId
     {
       description: `Modify strategy configuration on a running or paused strategy without tearing it down. Avoids cancel + start which loses session continuity.
 
-Mutable: checkInInterval, verificationGates, maxIterationsWithoutApproval, verificationMode, supervisorId, watchdogIntervalMinutes, contextSummaryInterval, approvalNotify, checkInNotify.
+Mutable: checkInInterval, verificationGates, maxIterationsWithoutApproval, verificationMode, supervisorId, watchdogIntervalMinutes, contextSummaryInterval, approvalNotify, checkInNotify, userNotify.
 
 User can be identified by ONE of: userId, email, phone, or platform + platformId`,
       inputSchema: updateStrategySchema.shape,

--- a/packages/api/src/mcp/tools/strategy-handlers.test.ts
+++ b/packages/api/src/mcp/tools/strategy-handlers.test.ts
@@ -153,6 +153,7 @@ describe('handleStartStrategy', () => {
         checkInNotify: 'myra',
         supervisorId: 'supervisor-uuid',
         verificationGates: ['tests', 'build'],
+        userNotify: 'myra',
       },
       dc
     );
@@ -164,6 +165,7 @@ describe('handleStartStrategy', () => {
           checkInNotify: 'myra',
           supervisorId: 'supervisor-uuid',
           verificationGates: ['tests', 'build'],
+          userNotify: 'myra',
         }),
       })
     );

--- a/packages/api/src/mcp/tools/strategy-handlers.ts
+++ b/packages/api/src/mcp/tools/strategy-handlers.ts
@@ -193,6 +193,7 @@ export async function handleStartStrategy(
         studioSlug: args.studioSlug,
         requireFinalApproval: args.requireFinalApproval,
         approvalCriteria: args.approvalCriteria,
+        userNotify: args.userNotify,
       },
     });
 

--- a/packages/api/src/mcp/tools/strategy-handlers.ts
+++ b/packages/api/src/mcp/tools/strategy-handlers.ts
@@ -78,6 +78,10 @@ export const startStrategySchema = z.object({
     .describe('Post progress check-in every N tasks'),
   checkInNotify: z.string().optional().describe('Agent ID to notify on check-ins (e.g., "myra")'),
   approvalNotify: z.string().optional().describe('Agent ID to notify when approval is needed'),
+  userNotify: z
+    .string()
+    .optional()
+    .describe('Agent to relay user-facing completion alerts (e.g., "myra" for Telegram)'),
   maxIterationsWithoutApproval: z
     .number()
     .int()
@@ -401,6 +405,10 @@ export const updateStrategySchema = z.object({
     .max(1440)
     .optional()
     .describe('How often (minutes) the watchdog checks for stuck strategies'),
+  userNotify: z
+    .string()
+    .optional()
+    .describe('Agent to relay user-facing completion alerts (e.g., "myra" for Telegram)'),
 });
 
 export async function handleUpdateStrategy(
@@ -454,6 +462,7 @@ export async function handleUpdateStrategy(
     if (args.watchdogIntervalMinutes !== undefined)
       configUpdates.watchdogIntervalMinutes = args.watchdogIntervalMinutes;
     if (args.supervisorId !== undefined) configUpdates.supervisorId = args.supervisorId;
+    if (args.userNotify !== undefined) configUpdates.userNotify = args.userNotify;
 
     if (Object.keys(configUpdates).length === 0 && args.verificationMode === undefined) {
       return mcpResponse(

--- a/packages/api/src/services/strategy.service.test.ts
+++ b/packages/api/src/services/strategy.service.test.ts
@@ -1555,12 +1555,13 @@ describe('StrategyService', () => {
       // Watchdog chains, then getTaskByOrder (not found), getGroupTasks, cleanup
       let idx = 0;
       const chains = [
+        noopChain, // cancelWatchdog (called before create to prevent duplicates)
         noopChain, // watchdog: sessions
         noopChain, // watchdog: insert (sb_id resolved directly, no identity lookup)
         taskNotFoundChain, // getTaskByOrder: exact match (fails)
         taskNotFoundChain, // getTaskByOrder: fallback (empty)
         groupTasksChain, // getGroupTasks for finalization
-        noopChain, // cancelWatchdog
+        noopChain, // cancelWatchdog (cleanup in finalizeStrategy)
       ];
       mockClient.from.mockImplementation(() => chains[idx++] || noopChain);
 

--- a/packages/api/src/services/strategy.service.test.ts
+++ b/packages/api/src/services/strategy.service.test.ts
@@ -1857,27 +1857,34 @@ describe('StrategyService', () => {
       expect((payload.metadata as Record<string, unknown>).reason).toBe('watchdog');
     });
 
-    it('triggerWatchdog returns false when group is not active', async () => {
+    it('triggerWatchdog returns false and cancels watchdog when group is not active', async () => {
       const { handleSendToInbox: sendMock } = await import('../mcp/tools/inbox-handlers');
 
       const group = createMockGroup({ strategy: 'persistence', status: 'paused' });
       dc.repositories.taskGroups.findById.mockResolvedValue(group);
+      setupChains(dc, [chainNoop()]); // cancelWatchdogReminder
 
       const fired = await service.triggerWatchdog('group-1');
 
       expect(fired).toBe(false);
       expect(sendMock).not.toHaveBeenCalled();
+      // Verify the watchdog cancelled itself
+      const client = dc.getClient();
+      expect(client.from).toHaveBeenCalledWith('scheduled_reminders');
     });
 
-    it('triggerWatchdog returns false when group is not found', async () => {
+    it('triggerWatchdog returns false and cancels watchdog when group is not found', async () => {
       const { handleSendToInbox: sendMock } = await import('../mcp/tools/inbox-handlers');
 
       dc.repositories.taskGroups.findById.mockResolvedValue(null);
+      setupChains(dc, [chainNoop()]); // cancelWatchdogReminder
 
       const fired = await service.triggerWatchdog('group-missing');
 
       expect(fired).toBe(false);
       expect(sendMock).not.toHaveBeenCalled();
+      const client = dc.getClient();
+      expect(client.from).toHaveBeenCalledWith('scheduled_reminders');
     });
 
     it('triggerWatchdog falls back to current_task_index when no in-progress task', async () => {

--- a/packages/api/src/services/strategy.service.ts
+++ b/packages/api/src/services/strategy.service.ts
@@ -1508,7 +1508,8 @@ export class StrategyService {
   async triggerWatchdog(groupId: string): Promise<boolean> {
     const group = await this.dataComposer.repositories.taskGroups.findById(groupId);
     if (!group) {
-      logger.warn(`Strategy watchdog: group ${groupId} not found, skipping`);
+      logger.warn(`Strategy watchdog: group ${groupId} not found, cancelling orphaned watchdog`);
+      await this.cancelWatchdogReminder(groupId);
       return false;
     }
 
@@ -1523,12 +1524,13 @@ export class StrategyService {
 
     if (group.status !== 'active' || !group.strategy) {
       logger.info(
-        `Strategy watchdog: group ${groupId} is ${group.status} (strategy=${group.strategy ?? 'null'}), skipping`
+        `Strategy watchdog: group ${groupId} is ${group.status} (strategy=${group.strategy ?? 'null'}), cancelling stale watchdog`
       );
+      await this.cancelWatchdogReminder(groupId);
       await this.logStrategyEvent(
         group,
         'watchdog_skip',
-        `Watchdog skipped: group is ${group.status}`,
+        `Watchdog skipped and self-cancelled: group is ${group.status}`,
         { reason: 'inactive_group' }
       );
       return false;
@@ -1543,12 +1545,13 @@ export class StrategyService {
     }
     if (!currentTask) {
       logger.info(
-        `Strategy watchdog: group ${groupId} has no in_progress or pending task, skipping`
+        `Strategy watchdog: group ${groupId} has no in_progress or pending task, cancelling stale watchdog`
       );
+      await this.cancelWatchdogReminder(groupId);
       await this.logStrategyEvent(
         group,
         'watchdog_skip',
-        `Watchdog skipped: no pending/in-progress task`,
+        `Watchdog skipped and self-cancelled: no pending/in-progress task`,
         {
           reason: 'no_current_task',
           currentTaskIndex: group.current_task_index,
@@ -1573,6 +1576,7 @@ export class StrategyService {
           `Watchdog aborted: sandbox required but spin-up failed — ${sandboxResult.error}`,
           { error: sandboxResult.error, policy: 'required', trigger: 'watchdog' }
         );
+        await this.cancelWatchdogReminder(groupId);
         await this.dataComposer.repositories.taskGroups.update(groupId, {
           status: 'paused',
           strategy_paused_at: new Date().toISOString(),

--- a/packages/api/src/services/strategy.service.ts
+++ b/packages/api/src/services/strategy.service.ts
@@ -416,6 +416,7 @@ export class StrategyService {
             ? `\n\nAcceptance criteria:\n${criteria.map((c) => `• ${c}`).join('\n')}`
             : '';
 
+        await this.cancelWatchdogReminder(groupId);
         await this.dataComposer.repositories.taskGroups.update(groupId, {
           strategy_paused_at: new Date().toISOString(),
           status: 'paused',
@@ -451,6 +452,15 @@ export class StrategyService {
           }
         }
 
+        if (config.userNotify) {
+          await this.notifyDispatcher(
+            group,
+            config.userNotify,
+            `All tasks complete on "${group.title}" (${completed}/${tasks.length}). Awaiting final review.`,
+            userId
+          );
+        }
+
         await this.logStrategyEvent(
           group,
           'final_review_requested',
@@ -461,6 +471,7 @@ export class StrategyService {
             approvalCriteria: criteria,
             notified,
             routedTo: config.approvalNotify || config.checkInNotify || null,
+            userNotified: config.userNotify || null,
           }
         );
 
@@ -492,6 +503,7 @@ export class StrategyService {
 
       // Pause for approval — set pauseReason so resumeStrategy can distinguish
       // approval-gate pauses from manual pauses (Lumen review, PR #338)
+      await this.cancelWatchdogReminder(groupId);
       await this.dataComposer.repositories.taskGroups.update(groupId, {
         strategy_paused_at: new Date().toISOString(),
         status: 'paused',
@@ -1585,6 +1597,9 @@ export class StrategyService {
     const intervalMinutes = config.watchdogIntervalMinutes || 10;
 
     try {
+      // Cancel any existing watchdog before creating a new one to prevent duplicates
+      await this.cancelWatchdogReminder(group.id);
+
       const nextRunAt = new Date();
       nextRunAt.setMinutes(nextRunAt.getMinutes() + intervalMinutes);
 
@@ -1703,6 +1718,15 @@ export class StrategyService {
           userId
         );
       }
+    }
+
+    if (config.userNotify) {
+      await this.notifyDispatcher(
+        group,
+        config.userNotify,
+        `Strategy complete: "${group.title}" — ${stats.completed}/${stats.total} tasks finished.${stats.hasIncomplete ? ` (${stats.pending} pending, ${stats.blocked} blocked)` : ''}`,
+        userId
+      );
     }
   }
 


### PR DESCRIPTION
## Summary
- **Cancel watchdog on pause**: `advanceToNextTask` set status='paused' at `final_review` and `approval_gate` without cancelling the watchdog reminder, causing it to fire every 5 min indefinitely on completed strategies (the trigger consolidation strategy has been firing for 5 days)
- **Add `userNotify` config field**: strategies can now specify a relay agent (e.g., `"myra"`) to ping the user via Telegram when work reaches `final_review` or completes — previously only the `approvalNotify` agent was notified
- **Prevent duplicate watchdog reminders**: `createWatchdogReminder` now cancels existing watchdogs before inserting, preventing the 2x-per-cycle duplicate events seen in the activity stream

## Test plan
- [x] 59/59 strategy service unit tests passing
- [x] Type-check clean (same 5 pre-existing errors as main)
- [ ] Verify the stale `cb25a24c` watchdog stops firing after deploy
- [ ] Test `userNotify: "myra"` on a new strategy to confirm Telegram relay

🤖 Generated with [Claude Code](https://claude.com/claude-code)