### PR TITLE
feat: add provider column to agent_identities (by Wren)

### DIFF
--- a/packages/api/src/data/supabase/types.ts
+++ b/packages/api/src/data/supabase/types.ts
@@ -179,6 +179,7 @@ export type Database = {
           metadata: Json | null;
           name: string;
           permissions: Json;
+          provider: string | null;
           relationships: Json | null;
           role: string;
           sandbox_bypass: boolean;
@@ -203,6 +204,7 @@ export type Database = {
           metadata?: Json | null;
           name: string;
           permissions?: Json;
+          provider?: string | null;
           relationships?: Json | null;
           role: string;
           sandbox_bypass?: boolean;
@@ -227,6 +229,7 @@ export type Database = {
           metadata?: Json | null;
           name?: string;
           permissions?: Json;
+          provider?: string | null;
           relationships?: Json | null;
           role?: string;
           sandbox_bypass?: boolean;

--- a/packages/api/src/services/sessions/context-builder.ts
+++ b/packages/api/src/services/sessions/context-builder.ts
@@ -34,6 +34,7 @@ function mapAgentIdentity(row: DbAgentIdentity): AgentIdentity {
     role: row.role,
     description: row.description || undefined,
     backend: row.backend || undefined,
+    provider: row.provider || undefined,
     values: Array.isArray(row.values) ? (row.values as string[]) : [],
     capabilities: Array.isArray(row.capabilities) ? (row.capabilities as string[]) : [],
     soul: row.soul || undefined,
@@ -230,21 +231,27 @@ export class ContextBuilder implements IContextBuilder {
     };
   }
 
-  async getAgentBackend(userId: string, agentId: string): Promise<string | null> {
+  async getAgentBackend(
+    userId: string,
+    agentId: string
+  ): Promise<{ backend: string | null; provider: string | null }> {
     const { data, error } = await this.supabase
       .from('agent_identities')
-      .select('backend')
+      .select('backend, provider')
       .eq('user_id', userId)
       .eq('agent_id', agentId)
       .single();
 
     if (error) {
-      if (error.code === 'PGRST116') return null;
+      if (error.code === 'PGRST116') return { backend: null, provider: null };
       logger.error('Error fetching agent backend', { userId, agentId, error });
-      return null;
+      return { backend: null, provider: null };
     }
 
-    return data?.backend || null;
+    return {
+      backend: data?.backend || null,
+      provider: data?.provider || null,
+    };
   }
 
   private async getAgentIdentity(

--- a/packages/api/src/services/sessions/session-service.test.ts
+++ b/packages/api/src/services/sessions/session-service.test.ts
@@ -530,6 +530,30 @@ describe('SessionService', () => {
       );
     });
 
+    it('should use ink runner with claude model when backend=ink and provider=claude-code', async () => {
+      vi.mocked(mockRepository.findByUserAndAgent).mockResolvedValue(null);
+      vi.mocked(mockContextBuilder.getAgentBackend).mockResolvedValue({
+        backend: 'ink',
+        provider: 'claude-code',
+      });
+      vi.mocked(mockContextBuilder.buildContext).mockResolvedValue({
+        ...createMockInjectedContext(),
+        agent: { ...createMockInjectedContext().agent, backend: 'ink', provider: 'claude-code' },
+      });
+      const inkSession = createMockSession({ id: 'ink-session', backend: 'ink' });
+      vi.mocked(mockRepository.create).mockResolvedValue(inkSession);
+
+      const request = createMockRequest();
+      await sessionService.handleMessage(request);
+
+      expect(mockRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({ backend: 'ink' })
+      );
+      expect(mockInkRunner.run).toHaveBeenCalledTimes(1);
+      expect(mockClaudeRunner.run).not.toHaveBeenCalled();
+      expect(mockCodexRunner.run).not.toHaveBeenCalled();
+    });
+
     it('should increment messageCount after each processed message', async () => {
       const session = createMockSession({ messageCount: 5 });
       vi.mocked(mockRepository.findByUserAndAgent).mockResolvedValue(session);

--- a/packages/api/src/services/sessions/session-service.test.ts
+++ b/packages/api/src/services/sessions/session-service.test.ts
@@ -158,7 +158,7 @@ describe('SessionService', () => {
         temporal: createMockInjectedContext().temporal,
         agent: createMockInjectedContext().agent,
       }),
-      getAgentBackend: vi.fn().mockResolvedValue('claude'),
+      getAgentBackend: vi.fn().mockResolvedValue({ backend: 'claude', provider: null }),
     };
 
     mockClaudeRunner = {
@@ -492,7 +492,10 @@ describe('SessionService', () => {
 
     it('should resolve codex backend from agent identity when creating a new session', async () => {
       vi.mocked(mockRepository.findByUserAndAgent).mockResolvedValue(null);
-      vi.mocked(mockContextBuilder.getAgentBackend).mockResolvedValue('codex');
+      vi.mocked(mockContextBuilder.getAgentBackend).mockResolvedValue({
+        backend: 'codex',
+        provider: null,
+      });
       vi.mocked(mockRepository.create).mockResolvedValue(createMockSession({ id: 'new-session' }));
 
       const request = createMockRequest();

--- a/packages/api/src/services/sessions/session-service.ts
+++ b/packages/api/src/services/sessions/session-service.ts
@@ -457,10 +457,16 @@ export class SessionService implements ISessionService {
       session.backend,
       injectedContext.agent.backend
     );
+    // For ink, model selection is based on the provider (the LLM underneath),
+    // not the backend itself. For direct backends, backend === provider.
+    const modelKey =
+      resolvedBackend === 'ink'
+        ? this.normalizeBackend(injectedContext.agent.provider)
+        : resolvedBackend;
     const runtimeModel =
-      resolvedBackend === 'codex-cli'
+      modelKey === 'codex-cli'
         ? this.config.defaultCodexModel
-        : resolvedBackend === 'gemini'
+        : modelKey === 'gemini'
           ? this.config.defaultGeminiModel
           : this.config.defaultModel;
 
@@ -828,7 +834,7 @@ export class SessionService implements ISessionService {
   ): Promise<Session> {
     const type = options?.type || 'primary';
 
-    const backend = await this.resolveAgentBackend(userId, agentId);
+    const { backend } = await this.resolveAgentBackend(userId, agentId);
     const resolvedStudioId = await this.resolveStudioId(userId, agentId, {
       threadKey: options?.threadKey,
       explicitStudioId: options?.studioId,
@@ -1370,10 +1376,12 @@ This session will continue with a fresh context after compaction. Your identity,
       );
 
       const runtimeBackend = this.resolveRuntimeBackend(session.backend, context.agent.backend);
+      const compactionModelKey =
+        runtimeBackend === 'ink' ? this.normalizeBackend(context.agent.provider) : runtimeBackend;
       const runtimeModel =
-        runtimeBackend === 'codex-cli'
+        compactionModelKey === 'codex-cli'
           ? this.config.defaultCodexModel
-          : runtimeBackend === 'gemini'
+          : compactionModelKey === 'gemini'
             ? this.config.defaultGeminiModel
             : this.config.defaultModel;
 
@@ -1481,17 +1489,23 @@ This session will continue with a fresh context after compaction. Your identity,
   private async resolveAgentBackend(
     userId: string,
     agentId: string
-  ): Promise<'claude-code' | 'codex-cli' | 'gemini' | 'ink'> {
+  ): Promise<{
+    backend: 'claude-code' | 'codex-cli' | 'gemini' | 'ink';
+    provider: 'claude-code' | 'codex-cli' | 'gemini' | 'ink' | null;
+  }> {
     try {
-      const identityBackend = await this.contextBuilder.getAgentBackend(userId, agentId);
-      return this.normalizeBackend(identityBackend);
+      const { backend, provider } = await this.contextBuilder.getAgentBackend(userId, agentId);
+      return {
+        backend: this.normalizeBackend(backend),
+        provider: provider ? this.normalizeBackend(provider) : null,
+      };
     } catch (error) {
       logger.warn('Failed to resolve agent backend, falling back to claude-code', {
         userId,
         agentId,
         error: error instanceof Error ? error.message : String(error),
       });
-      return 'claude-code';
+      return { backend: 'claude-code', provider: null };
     }
   }
 

--- a/packages/api/src/services/sessions/types.ts
+++ b/packages/api/src/services/sessions/types.ts
@@ -220,6 +220,7 @@ export interface AgentIdentity {
   role: string;
   description?: string;
   backend?: string;
+  provider?: string;
   values: string[];
   capabilities: string[];
   soul?: string;
@@ -424,7 +425,10 @@ export interface IContextBuilder {
    * Resolve the preferred runtime backend for an agent identity.
    * Returns raw backend string from DB (e.g. "claude", "codex", "gemini").
    */
-  getAgentBackend(userId: string, agentId: string): Promise<string | null>;
+  getAgentBackend(
+    userId: string,
+    agentId: string
+  ): Promise<{ backend: string | null; provider: string | null }>;
 }
 
 // ─── Runner Interface ───

--- a/supabase/migrations/20260609000326_add_agent_provider_column.sql
+++ b/supabase/migrations/20260609000326_add_agent_provider_column.sql
@@ -1,0 +1,17 @@
+-- Add provider column to agent_identities.
+--
+-- backend  = the runtime/harness that runs the agent (ink, claude-code, codex-cli, gemini)
+-- provider = the LLM provider the runtime delegates to (claude-code, codex-cli, gemini)
+--
+-- For non-ink backends, provider is typically the same as backend.
+-- For ink, provider specifies which LLM the ink runtime uses underneath.
+
+ALTER TABLE agent_identities
+  ADD COLUMN IF NOT EXISTS provider text;
+
+-- Backfill: copy current backend values into provider.
+-- Today backend holds the LLM provider, not the runtime — this preserves that info
+-- before callers start setting backend='ink'.
+UPDATE agent_identities
+  SET provider = backend
+  WHERE provider IS NULL AND backend IS NOT NULL;


### PR DESCRIPTION
## Summary

Separates **runtime/harness** (`backend`) from **LLM provider** (`provider`) on `agent_identities`:

- `backend` = what runs the agent: `ink`, `claude-code`, `codex-cli`, `gemini`
- `provider` = which LLM the runtime delegates to: `claude-code`, `codex-cli`, `gemini`

This distinction matters for the ink runtime — when `backend='ink'`, the server needs to know which LLM provider ink is using underneath to select the right model config. Previously `backend` did double duty, which meant Myra (who should run on ink) was set to `backend='claude-code'` and trigger dispatch used claude-code directly instead of ink.

### Changes

- **Migration**: adds `provider` column, backfills from current `backend` values
- **Types**: `AgentIdentity` interface + `IContextBuilder.getAgentBackend()` return both fields
- **Model resolution**: when `backend='ink'`, model selection uses `provider` instead of `backend`
- **Tests**: updated mocks for new `getAgentBackend` return shape

### After merge

Update Myra's identity: `backend='ink'`, `provider='claude-code'`

## Test plan

- [x] Type-check passes (only pre-existing gateway/server errors)
- [x] `session-service.test.ts`: 65 passed, 4 failed (pre-existing multimodal image tests)
- [x] Codex backend resolution test updated and passing
- [ ] Manual: apply migration, update Myra's record, verify trigger dispatch uses ink

🤖 Generated with [Claude Code](https://claude.com/claude-code)