### PR TITLE
fix(ink-runner): auto-approve tools and reduce turn/timeout limits (by Wren)

### DIFF
--- a/packages/api/src/services/sessions/ink-runner.ts
+++ b/packages/api/src/services/sessions/ink-runner.ts
@@ -119,10 +119,11 @@ export class InkRunner implements IRunner {
 
     args.push('--max-turns', '5');
 
-    // Full profile = auto-approve all tools. Without this, non-interactive
-    // mode defaults to auto-deny, which causes a slow deny→retry loop that
-    // easily exceeds the process timeout.
-    args.push('--profile', 'full');
+    // Auto-approve tools for non-interactive spawns. Without this, the CLI
+    // defaults to auto-deny, which causes a slow deny→retry loop that easily
+    // exceeds the process timeout. Uses --approval-mode (runtime-only) rather
+    // than --profile full (which persists policy mutations to disk).
+    args.push('--approval-mode', 'auto-approve');
 
     return args;
   }

--- a/packages/api/src/services/sessions/ink-runner.ts
+++ b/packages/api/src/services/sessions/ink-runner.ts
@@ -25,7 +25,7 @@ import { logger } from '../../utils/logger.js';
 import { resolveBinaryPath, buildSpawnPath } from './resolve-binary.js';
 import { injectSessionHeaders, buildSessionEnv, writeRuntimeSessionHint } from '@inklabs/shared';
 
-const PROCESS_TIMEOUT_MS = parseInt(process.env.INK_PROCESS_TIMEOUT_MS || '', 10) || 30 * 60 * 1000;
+const PROCESS_TIMEOUT_MS = parseInt(process.env.INK_PROCESS_TIMEOUT_MS || '', 10) || 15 * 60 * 1000;
 
 export class InkRunner implements IRunner {
   async run(
@@ -117,7 +117,12 @@ export class InkRunner implements IRunner {
       args.push('--model', config.model);
     }
 
-    args.push('--max-turns', '25');
+    args.push('--max-turns', '5');
+
+    // Full profile = auto-approve all tools. Without this, non-interactive
+    // mode defaults to auto-deny, which causes a slow deny→retry loop that
+    // easily exceeds the process timeout.
+    args.push('--profile', 'full');
 
     return args;
   }

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -3860,6 +3860,12 @@ export async function runChat(options: ChatOptions): Promise<void> {
   }
 
   if (options.nonInteractive || options.message) {
+    // Suppress MaxListenersExceeded for non-interactive spawns. Various
+    // libraries (Commander, Ink renderer, MCP clients) each add SIGINT
+    // handlers during init, easily exceeding the default limit of 10.
+    // These are benign — the handlers are paired with cleanup.
+    process.setMaxListeners(25);
+
     const message = options.message?.trim();
     if (!message) {
       throw new Error('--non-interactive requires --message "<text>"');


### PR DESCRIPTION
## Summary

Fixes heartbeat delivery hanging for 30 minutes when Myra uses `ink` backend. Two issues:

1. **Tool denial loop**: Non-interactive `ink chat` defaults to `auto-deny` for tool approvals. Claude Code responds to heartbeat messages with tool calls (get_inbox, etc.), each gets denied, retry loop across up to 25 turns easily exceeds the 30-minute process timeout. Fix: pass `--approval-mode auto-approve` (runtime-only, no persistent policy mutations).

2. **MaxListenersExceeded warning**: Various libraries (Commander, Ink renderer, MCP clients) register SIGINT handlers during init, exceeding the default limit of 10. Fix: `process.setMaxListeners(25)` in non-interactive block.

Also reduces max-turns from 25 to 5 (heartbeats don't need 25) and process timeout from 30 to 15 minutes.

## Changes

- `ink-runner.ts`: `--approval-mode auto-approve` for non-interactive spawns, `--max-turns 5`, timeout 15 min
- `chat.ts`: `process.setMaxListeners(25)` in non-interactive block

## Verified

- Simulated InkRunner spawn completes in ~23 seconds (vs 30-min timeout before)
- Tests: 38/38 InkRunner/tool-profile/approval tests pass, 3/3 chat integration non-interactive cases pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)