### PR TITLE
feat: token-budget compaction + stdin prompts — fix heartbeat session decay (by Wren)

### DIFF
--- a/packages/api/src/services/sessions/ink-runner.ts
+++ b/packages/api/src/services/sessions/ink-runner.ts
@@ -117,13 +117,19 @@ export class InkRunner implements IRunner {
       args.push('--model', config.model);
     }
 
-    args.push('--max-turns', '5');
+    // Turn backstop only — the real limit is the CLI's token budget
+    // (200K default), which auto-compacts the transcript when approached.
+    args.push('--max-turns', '15');
 
     // Auto-approve tools for non-interactive spawns. Without this, the CLI
     // defaults to auto-deny, which causes a slow deny→retry loop that easily
     // exceeds the process timeout. Uses --approval-mode (runtime-only) rather
     // than --profile full (which persists policy mutations to disk).
     args.push('--approval-mode', 'auto-approve');
+
+    // Label the delivered message with its originating channel so the
+    // transcript renders it as a system message (not "you").
+    args.push('--message-label', config.channel || 'server');
 
     return args;
   }
@@ -257,6 +263,7 @@ export class InkRunner implements IRunner {
     let exitPhase: string | undefined;
     let exitSignal: string | undefined;
     let exitReason: string | undefined;
+    let usage: { contextTokens: number; inputTokens: number; outputTokens: number } | undefined;
 
     // ink chat routes responses via MCP send_response — stdout may contain
     // CLI chrome, status lines, or other noise that must NOT be treated as
@@ -289,6 +296,16 @@ export class InkRunner implements IRunner {
           if (parsed.phase) exitPhase = parsed.phase;
           if (parsed.signal) exitSignal = parsed.signal;
           if (parsed.reason) exitReason = parsed.reason;
+          // Usage from the ink CLI's budget view (transcript + identity).
+          // Without this, sessions report contextTokens=0 and token-based
+          // lifecycle decisions never fire for the ink backend.
+          if (parsed.usage && typeof parsed.usage === 'object') {
+            usage = {
+              contextTokens: Number(parsed.usage.contextTokens) || 0,
+              inputTokens: Number(parsed.usage.inputTokens) || 0,
+              outputTokens: Number(parsed.usage.outputTokens) || 0,
+            };
+          }
         }
       } catch {
         // Non-JSON line — CLI noise, ignore
@@ -303,11 +320,13 @@ export class InkRunner implements IRunner {
         hasResponse: !!finalTextResponse,
         responseCount: responses.length,
         toolCallCount: toolCalls.length,
+        contextTokens: usage?.contextTokens,
       });
     }
 
     return {
       responses,
+      usage,
       finalTextResponse,
       toolCalls,
     };

--- a/packages/api/src/services/sessions/session-service.ts
+++ b/packages/api/src/services/sessions/session-service.ts
@@ -534,6 +534,7 @@ export class SessionService implements ISessionService {
       ...(pcpAccessToken ? { pcpAccessToken } : {}),
       pcpSessionId: session.id,
       agentId,
+      channel: request.channel,
       ...(session.studioId ? { studioId: session.studioId } : {}),
       ...(sandboxBypass ? { sandboxBypass: true } : {}),
       ...(permissionOverlay ? { permissionOverlay } : {}),
@@ -749,7 +750,10 @@ export class SessionService implements ISessionService {
 
       // 6. Check if compaction is needed — only for claude-code backend where
       // PCP controls the context window (via sb chat). Native CLI backends
-      // (codex-cli, gemini) manage their own context lifecycle.
+      // (codex-cli, gemini) manage their own context lifecycle. The ink
+      // backend self-compacts inside ink chat (token-budget auto-compaction);
+      // its usage is persisted above for visibility but the server must NOT
+      // also trigger compaction — one compaction owner per backend.
       if (
         resolvedBackend === 'claude-code' &&
         result.usage.contextTokens >= this.config.compactionThreshold

--- a/packages/api/src/services/sessions/types.ts
+++ b/packages/api/src/services/sessions/types.ts
@@ -444,6 +444,8 @@ export interface ClaudeRunnerConfig {
   pcpSessionId?: string;
   /** Agent ID for this run — written to runtime hint files */
   agentId?: string;
+  /** Originating channel (heartbeat, telegram, agent, …) — used by runners that label delivered messages */
+  channel?: string;
   /** Studio/worktree scope — written to runtime hint so findRuntimeSessionByLinkId matches */
   studioId?: string;
   /** When true, bypass sandbox restrictions (e.g., Codex --dangerously-bypass-approvals-and-sandbox). Opt-in per studio. */

--- a/packages/cli/src/backends/claude.ts
+++ b/packages/cli/src/backends/claude.ts
@@ -37,11 +37,12 @@ export class ClaudeAdapter implements BackendAdapter {
 
     const args: string[] = [];
 
-    // Prompt mode vs interactive
+    // Prompt mode vs interactive. The prompt is passed via stdin (not argv):
+    // transcripts can exceed the OS argv limit (~256KB on macOS), which
+    // makes spawn fail with E2BIG. `claude -p` reads the prompt from piped
+    // stdin when no positional prompt is given.
     if (config.prompt) {
       args.push('-p');
-      // Claude expects print prompt immediately after -p/--print.
-      args.push(config.prompt);
     }
 
     // Model (only if explicitly specified)
@@ -106,6 +107,7 @@ export class ClaudeAdapter implements BackendAdapter {
         ...(config.studioId ? { INK_STUDIO_ID: config.studioId } : {}),
       },
       cleanup: mcpCleanup,
+      ...(config.prompt ? { stdinData: config.prompt } : {}),
     };
   }
 }

--- a/packages/cli/src/backends/types.ts
+++ b/packages/cli/src/backends/types.ts
@@ -24,6 +24,13 @@ export interface PreparedBackend {
   args: string[];
   env: Record<string, string>;
   cleanup: () => void;
+  /**
+   * Prompt data to pass via stdin instead of argv. Large transcripts exceed
+   * the OS argv limit (~256KB on macOS → spawn E2BIG), so adapters that
+   * support reading the prompt from stdin should set this and omit the
+   * prompt from args.
+   */
+  stdinData?: string;
 }
 
 export interface BackendAdapter {

--- a/packages/cli/src/commands/chat-hydration.test.ts
+++ b/packages/cli/src/commands/chat-hydration.test.ts
@@ -1,0 +1,161 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { ContextLedger } from '../repl/context-ledger.js';
+import { hydrateLedgerFromTranscript } from './chat.js';
+
+describe('hydrateLedgerFromTranscript — compaction events', () => {
+  let dir: string;
+  let transcriptPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'ink-hydration-test-'));
+    transcriptPath = join(dir, 'session-test.jsonl');
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  const writeTranscript = (events: Array<Record<string, unknown>>) => {
+    writeFileSync(transcriptPath, events.map((e) => JSON.stringify(e)).join('\n') + '\n');
+  };
+
+  it('rehydrates summary + kept tail from a compaction event (regression: tail was dropped)', () => {
+    // Simulates the live flow: 6 messages written, then compaction kept the
+    // last 2 verbatim. The tail's original events PRECEDE the marker in the
+    // file — hydration must restore the tail from the event's keptEntries.
+    writeTranscript([
+      { type: 'user', content: 'old question 1' },
+      { type: 'assistant', content: 'old answer 1', backend: 'claude' },
+      { type: 'user', content: 'old question 2' },
+      { type: 'assistant', content: 'old answer 2', backend: 'claude' },
+      { type: 'user', content: 'recent question' },
+      { type: 'assistant', content: 'recent answer', backend: 'claude' },
+      {
+        type: 'compaction',
+        summary: '[Conversation summary — compacted 4 earlier entries]\nKey facts here.',
+        keptEntries: [
+          { role: 'user', content: 'recent question', source: 'repl-history' },
+          { role: 'assistant', content: 'recent answer', source: 'claude' },
+        ],
+        removedCount: 4,
+      },
+    ]);
+
+    const ledger = new ContextLedger();
+    const result = hydrateLedgerFromTranscript(ledger, transcriptPath);
+
+    const entries = ledger.listEntries();
+    expect(entries).toHaveLength(3); // summary + 2-entry tail
+    expect(entries[0].role).toBe('system');
+    expect(entries[0].content).toContain('Key facts here');
+    expect(entries[0].source).toBe('compaction-history');
+    expect(entries[1].content).toBe('recent question');
+    expect(entries[1].role).toBe('user');
+    expect(entries[2].content).toBe('recent answer');
+    expect(entries[2].role).toBe('assistant');
+    expect(result.messageCount).toBe(2); // tail messages count; summary doesn't
+  });
+
+  it('replays events after the compaction marker on top of summary + tail', () => {
+    writeTranscript([
+      { type: 'user', content: 'pre-compaction' },
+      {
+        type: 'compaction',
+        summary: 'the summary',
+        keptEntries: [{ role: 'assistant', content: 'kept tail entry', source: 'claude' }],
+      },
+      { type: 'user', content: 'post-compaction question' },
+      { type: 'assistant', content: 'post-compaction answer', backend: 'claude' },
+    ]);
+
+    const ledger = new ContextLedger();
+    hydrateLedgerFromTranscript(ledger, transcriptPath);
+
+    const contents = ledger.listEntries().map((e) => e.content);
+    expect(contents).toEqual([
+      'the summary',
+      'kept tail entry',
+      'post-compaction question',
+      'post-compaction answer',
+    ]);
+    expect(contents).not.toContain('pre-compaction');
+  });
+
+  it('collapses repeatedly at the LAST compaction event', () => {
+    writeTranscript([
+      { type: 'user', content: 'era 1' },
+      { type: 'compaction', summary: 'summary 1', keptEntries: [] },
+      { type: 'user', content: 'era 2' },
+      {
+        type: 'compaction',
+        summary: 'summary 2',
+        keptEntries: [{ role: 'user', content: 'era 2', source: 'repl-history' }],
+      },
+      { type: 'user', content: 'era 3' },
+    ]);
+
+    const ledger = new ContextLedger();
+    hydrateLedgerFromTranscript(ledger, transcriptPath);
+
+    const contents = ledger.listEntries().map((e) => e.content);
+    expect(contents).toEqual(['summary 2', 'era 2', 'era 3']);
+  });
+
+  it('handles legacy compaction events without keptEntries', () => {
+    writeTranscript([
+      { type: 'user', content: 'old' },
+      { type: 'compaction', summary: 'summary only' },
+      { type: 'assistant', content: 'after', backend: 'claude' },
+    ]);
+
+    const ledger = new ContextLedger();
+    hydrateLedgerFromTranscript(ledger, transcriptPath);
+
+    const contents = ledger.listEntries().map((e) => e.content);
+    expect(contents).toEqual(['summary only', 'after']);
+  });
+
+  it('does not evict entries that predate hydration (e.g., bootstrap)', () => {
+    writeTranscript([
+      { type: 'user', content: 'old' },
+      { type: 'compaction', summary: 'the summary', keptEntries: [] },
+    ]);
+
+    const ledger = new ContextLedger();
+    ledger.addEntry('system', 'bootstrap identity block', 'bootstrap');
+
+    hydrateLedgerFromTranscript(ledger, transcriptPath);
+
+    const contents = ledger.listEntries().map((e) => e.content);
+    expect(contents).toEqual(['bootstrap identity block', 'the summary']);
+  });
+
+  it('skips malformed keptEntries without crashing', () => {
+    writeTranscript([
+      {
+        type: 'compaction',
+        summary: 'summary',
+        keptEntries: [
+          null,
+          'not-an-object',
+          { role: 'user' }, // missing content
+          { role: 'weird-role', content: 'falls back to system role', source: 'x' },
+          { role: 'user', content: 'valid entry' },
+        ],
+      },
+    ]);
+
+    const ledger = new ContextLedger();
+    hydrateLedgerFromTranscript(ledger, transcriptPath);
+
+    const entries = ledger.listEntries();
+    expect(entries).toHaveLength(3); // summary + fallback-role entry + valid entry
+    expect(entries[1].role).toBe('system'); // unknown role falls back
+    expect(entries[1].content).toBe('falls back to system role');
+    expect(entries[2].role).toBe('user');
+    expect(entries[2].content).toBe('valid entry');
+  });
+});

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -27,7 +27,7 @@ import {
   type BackendAuthBackend,
 } from '../lib/backend-auth.js';
 import { startBackendTurn, runBackendTurn } from '../repl/backend-runner.js';
-import { ContextLedger, estimateTokens } from '../repl/context-ledger.js';
+import { ContextLedger, estimateTokens, type LedgerRole } from '../repl/context-ledger.js';
 import { parseSlashCommand } from '../repl/slash.js';
 import { ToolMode, ToolPolicyScopeKind, ToolPolicyState } from '../repl/tool-policy.js';
 import { formatBackendTokenUsage, type BackendTokenUsage } from '../repl/token-usage.js';
@@ -591,7 +591,8 @@ function getSessionTranscriptMetadata(sessionId: string): SessionTranscriptMetad
   };
 }
 
-function hydrateLedgerFromTranscript(
+// Exported for tests — verifies compaction events rehydrate summary + kept tail
+export function hydrateLedgerFromTranscript(
   ledger: ContextLedger,
   transcriptPath: string
 ): {
@@ -624,13 +625,44 @@ function hydrateLedgerFromTranscript(
     const type = typeof event.type === 'string' ? event.type : '';
     if (type === 'compaction' && typeof event.summary === 'string') {
       // Compaction marks a new start state: everything replayed before this
-      // point is superseded by the summary. Evict it and seed the summary.
+      // point is superseded by the event's summary + kept tail. The tail's
+      // original events precede this marker in the file, so they were just
+      // evicted — re-seed them from the event to match the live session's
+      // post-compaction ledger exactly.
       ledger.evictEntries(hydratedEntryIds);
       hydratedEntryIds.length = 0;
       const summaryEntry = ledger.addEntry('system', event.summary, 'compaction-history');
       hydratedEntryIds.push(summaryEntry.id);
       loaded = 1;
       messageCount = 0;
+      const keptEntries = Array.isArray(event.keptEntries) ? event.keptEntries : [];
+      for (const kept of keptEntries) {
+        if (!kept || typeof kept !== 'object') continue;
+        const keptRecord = kept as Record<string, unknown>;
+        if (typeof keptRecord.content !== 'string') continue;
+        const role: LedgerRole =
+          keptRecord.role === 'user' ||
+          keptRecord.role === 'assistant' ||
+          keptRecord.role === 'inbox' ||
+          keptRecord.role === 'system'
+            ? keptRecord.role
+            : 'system';
+        const entry = ledger.addEntry(
+          role,
+          keptRecord.content,
+          typeof keptRecord.source === 'string' ? keptRecord.source : 'compaction-tail'
+        );
+        hydratedEntryIds.push(entry.id);
+        loaded += 1;
+        if (role === 'user' || role === 'assistant' || role === 'inbox') {
+          messageCount += 1;
+          pushPreview(
+            role,
+            keptRecord.content,
+            typeof event.ts === 'string' ? event.ts : undefined
+          );
+        }
+      }
       continue;
     }
     if (type === 'user' && typeof event.content === 'string') {
@@ -2828,10 +2860,20 @@ export async function runChat(options: ChatOptions): Promise<void> {
 
         const summary = `[Conversation summary — compacted ${oldest.length} earlier entries]\n${summaryText}`;
         const result = ledger.compactToSummary(summary, AUTO_COMPACT_KEEP_RECENT_ENTRIES);
+        // The compaction event is the COMPLETE new start state: summary plus
+        // the verbatim recent tail. The tail's original events precede this
+        // marker in the file, so hydration must get the tail from here —
+        // otherwise reattach would keep only the summary and lose the
+        // protected recent entries the live session still has.
+        const keptEntries = ledger
+          .listEntries()
+          .slice(1) // entry 0 is the summary itself
+          .map((e) => ({ role: e.role, content: e.content, source: e.source }));
         appendTranscript(runtime.transcriptPath, {
           type: 'compaction',
           reason,
           summary,
+          keptEntries,
           removedCount: result.removedEntries.length,
           removedTokens: result.removedTokens,
           summaryTokens: result.summaryTokens,

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -110,6 +110,7 @@ type ChatOptions = {
   tools?: string;
   profile?: string;
   message?: string;
+  messageLabel?: string;
   nonInteractive?: boolean;
   maxTurns?: string;
   backendTimeoutSeconds?: string;
@@ -402,10 +403,23 @@ const AUTO_TRIM_KEEP_RECENT_ENTRIES = 6;
 const DEFAULT_TRIM_TARGET_PCT = 70;
 const CTRL_C_EXIT_WINDOW_MS = 3000;
 const DEFAULT_BACKEND_TOKEN_WINDOW = 1_000_000;
+// Our working context budget — deliberately smaller than the backend's raw
+// window. When the transcript approaches this, we compact (summarize the
+// oldest entries into a new start state) rather than letting it grow until
+// turns degrade or argv/window limits bite. Override with --max-context-tokens.
+const DEFAULT_MAX_CONTEXT_TOKENS = 200_000;
+// Compact when transcript+identity utilization crosses this fraction of budget
+const AUTO_COMPACT_THRESHOLD_PCT = 0.8;
+// Entries kept verbatim after the compaction summary (the working tail)
+const AUTO_COMPACT_KEEP_RECENT_ENTRIES = 12;
 const HISTORY_PREVIEW_MAX = 200;
 function resolveBackendTokenWindow(_backend: string, _model?: string): number {
   // Current policy: claude/codex/gemini all default to 1M effective context window.
   return DEFAULT_BACKEND_TOKEN_WINDOW;
+}
+
+function defaultContextBudget(backendTokenWindow: number): number {
+  return Math.min(backendTokenWindow, DEFAULT_MAX_CONTEXT_TOKENS);
 }
 
 function formatTokenCount(value: number): string {
@@ -595,6 +609,9 @@ function hydrateLedgerFromTranscript(
   const seenInboxIds = new Set<string>();
   const seenActivityIds = new Set<string>();
   const recoveredMemoryIds: string[] = [];
+  // Entries added by THIS hydration pass — a compaction event collapses them
+  // (and only them; entries that pre-date hydration are left alone).
+  const hydratedEntryIds: number[] = [];
 
   const pushPreview = (role: 'user' | 'assistant' | 'inbox', content: string, ts?: string) => {
     preview.push({ role, content: compactForHistoryPreview(role, content), ts });
@@ -605,8 +622,20 @@ function hydrateLedgerFromTranscript(
 
   for (const event of events) {
     const type = typeof event.type === 'string' ? event.type : '';
+    if (type === 'compaction' && typeof event.summary === 'string') {
+      // Compaction marks a new start state: everything replayed before this
+      // point is superseded by the summary. Evict it and seed the summary.
+      ledger.evictEntries(hydratedEntryIds);
+      hydratedEntryIds.length = 0;
+      const summaryEntry = ledger.addEntry('system', event.summary, 'compaction-history');
+      hydratedEntryIds.push(summaryEntry.id);
+      loaded = 1;
+      messageCount = 0;
+      continue;
+    }
     if (type === 'user' && typeof event.content === 'string') {
-      ledger.addEntry('user', event.content, 'repl-history');
+      const entry = ledger.addEntry('user', event.content, 'repl-history');
+      hydratedEntryIds.push(entry.id);
       loaded += 1;
       messageCount += 1;
       pushPreview('user', event.content, typeof event.ts === 'string' ? event.ts : undefined);
@@ -616,14 +645,16 @@ function hydrateLedgerFromTranscript(
       if (event.cancelled === true || event.content === '(no output)') continue;
       if (typeof event.content !== 'string') continue;
       const source = typeof event.backend === 'string' ? event.backend : 'backend-history';
-      ledger.addEntry('assistant', event.content, source);
+      const entry = ledger.addEntry('assistant', event.content, source);
+      hydratedEntryIds.push(entry.id);
       loaded += 1;
       messageCount += 1;
       pushPreview('assistant', event.content, typeof event.ts === 'string' ? event.ts : undefined);
       continue;
     }
     if (type === 'inbox' && typeof event.rendered === 'string') {
-      ledger.addEntry('inbox', compactForLedger(event.rendered), 'inkmail-history');
+      const entry = ledger.addEntry('inbox', compactForLedger(event.rendered), 'inkmail-history');
+      hydratedEntryIds.push(entry.id);
       loaded += 1;
       messageCount += 1;
       pushPreview('inbox', event.rendered, typeof event.ts === 'string' ? event.ts : undefined);
@@ -632,9 +663,19 @@ function hydrateLedgerFromTranscript(
       }
       continue;
     }
+    if (type === 'system_turn' && typeof event.content === 'string') {
+      // Synthetic turn input (heartbeat trigger, continuation prompt, etc.)
+      const label = typeof event.label === 'string' ? event.label : 'system';
+      const entry = ledger.addEntry('system', event.content, label);
+      hydratedEntryIds.push(entry.id);
+      loaded += 1;
+      messageCount += 1;
+      continue;
+    }
     if (type === 'hook_injection' && typeof event.content === 'string') {
       const source = typeof event.source === 'string' ? event.source : 'hook-history';
-      ledger.addEntry('system', event.content, source);
+      const entry = ledger.addEntry('system', event.content, source);
+      hydratedEntryIds.push(entry.id);
       loaded += 1;
       if (typeof event.memoryId === 'string') {
         recoveredMemoryIds.push(event.memoryId);
@@ -644,11 +685,12 @@ function hydrateLedgerFromTranscript(
     if (type === 'activity' && typeof event.content === 'string') {
       const actor = typeof event.agentId === 'string' ? event.agentId : 'system';
       const activityType = typeof event.activityType === 'string' ? event.activityType : 'activity';
-      ledger.addEntry(
+      const entry = ledger.addEntry(
         'system',
         compactForLedger(`⚡ ${actor} ${activityType} — ${event.content}`, 320),
         'pcp-activity-history'
       );
+      hydratedEntryIds.push(entry.id);
       loaded += 1;
       if (typeof event.activityId === 'string') {
         seenActivityIds.add(event.activityId);
@@ -1883,7 +1925,7 @@ export async function runChat(options: ChatOptions): Promise<void> {
   const initialBackend = options.backend || 'claude';
   const initialBackendTokenWindow = resolveBackendTokenWindow(initialBackend, options.model);
   const configuredMaxContextTokens = Number.parseInt(
-    options.maxContextTokens || String(initialBackendTokenWindow),
+    options.maxContextTokens || String(defaultContextBudget(initialBackendTokenWindow)),
     10
   );
   const parsedBackendTimeoutSeconds =
@@ -1918,7 +1960,7 @@ export async function runChat(options: ChatOptions): Promise<void> {
     backendTokenWindow: initialBackendTokenWindow,
     sessionId: options.sessionId?.trim() || undefined,
     maxContextTokens: Number.isNaN(configuredMaxContextTokens)
-      ? initialBackendTokenWindow
+      ? defaultContextBudget(initialBackendTokenWindow)
       : configuredMaxContextTokens,
     pollSeconds: Number.parseInt(options.pollSeconds || '20', 10),
     showSessionsWatch: false,
@@ -2723,6 +2765,93 @@ export async function runChat(options: ChatOptions): Promise<void> {
     return { removed: trim.removedEntries.length, removedTokens: trim.removedTokens };
   };
 
+  // ── Token-budget auto-compaction ──
+  // When the transcript approaches the context budget, summarize the oldest
+  // entries into a dense brief via the backend and replace them with it. The
+  // `compaction` transcript event is the pointer to the new start state —
+  // hydration collapses everything before it on reattach. If summarization
+  // fails, fall back to a hard trim so the turn can still proceed.
+  let compactionInFlight = false;
+
+  const buildCompactionPrompt = (chunk: string): string =>
+    [
+      'You are compacting a conversation transcript into a dense continuation brief.',
+      'Summarize the conversation below, preserving: decisions and their rationale,',
+      'completed and in-progress work, key facts and constraints, open questions,',
+      'commitments made, and any identifiers (PR numbers, session IDs, file paths, URLs).',
+      'Write compact bullet points. Output ONLY the summary — no preamble.',
+      '',
+      '<conversation>',
+      chunk,
+      '</conversation>',
+    ].join('\n');
+
+  const maybeCompactContext = async (reason: string): Promise<void> => {
+    if (compactionInFlight) return;
+    const bootstrapReserve = runtime.bootstrapContext
+      ? estimateTokens(runtime.bootstrapContext)
+      : 0;
+    const effectiveBudget = Math.max(1, runtime.maxContextTokens - bootstrapReserve);
+    const threshold = Math.floor(effectiveBudget * AUTO_COMPACT_THRESHOLD_PCT);
+    if (ledger.totalTokens() <= threshold) return;
+
+    const entries = ledger.listEntries();
+    const cutoff = Math.max(0, entries.length - AUTO_COMPACT_KEEP_RECENT_ENTRIES);
+    if (cutoff === 0) return; // only the protected tail remains — nothing to compact
+
+    compactionInFlight = true;
+    try {
+      const oldest = entries.slice(0, cutoff);
+      const chunk = oldest
+        .map((e) => `${e.role.toUpperCase()}${e.source ? ` [${e.source}]` : ''}: ${e.content}`)
+        .join('\n\n');
+      const before = ledger.totalTokens();
+      printLine(
+        chalk.yellow(
+          `  ⛁ Context at ${formatTokenCount(before)} tok (> ${formatTokenCount(threshold)} threshold) — compacting (${reason})`
+        )
+      );
+
+      try {
+        const turn = await runBackendTurn({
+          backend: runtime.backend,
+          agentId,
+          model: runtime.model,
+          prompt: buildCompactionPrompt(chunk),
+          // Summarizing a large chunk takes longer than a normal turn
+          timeoutMs: Math.max(runtime.backendTurnTimeoutMs ?? 0, 5 * 60 * 1000),
+        });
+        const summaryText = turn.success ? turn.stdout.trim() : '';
+        if (!summaryText) {
+          throw new Error(turn.stderr.trim().slice(0, 200) || `exit code ${turn.exitCode}`);
+        }
+
+        const summary = `[Conversation summary — compacted ${oldest.length} earlier entries]\n${summaryText}`;
+        const result = ledger.compactToSummary(summary, AUTO_COMPACT_KEEP_RECENT_ENTRIES);
+        appendTranscript(runtime.transcriptPath, {
+          type: 'compaction',
+          reason,
+          summary,
+          removedCount: result.removedEntries.length,
+          removedTokens: result.removedTokens,
+          summaryTokens: result.summaryTokens,
+          totalAfter: result.totalAfter,
+        });
+        printLine(
+          chalk.green(
+            `  ⛁ Compacted ${result.removedEntries.length} entries: ${formatTokenCount(before)} → ${formatTokenCount(result.totalAfter)} tok`
+          )
+        );
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        printLine(chalk.yellow(`  ⛁ Compaction summarization failed (${msg}) — hard-trimming`));
+        await trimContextToPercent(DEFAULT_TRIM_TARGET_PCT, `${reason} (compaction fallback)`);
+      }
+    } finally {
+      compactionInFlight = false;
+    }
+  };
+
   const pollInbox = async (force = false): Promise<number> => {
     const inboxResult = (await pcp
       .callTool('get_inbox', { agentId, status: 'unread', limit: 10 })
@@ -3050,7 +3179,11 @@ export async function runChat(options: ChatOptions): Promise<void> {
     return activities.length;
   };
 
-  const runUserTurn = async (raw: string, source: 'user' | 'inbox-auto' = 'user') => {
+  const runUserTurn = async (
+    raw: string,
+    source: 'user' | 'inbox-auto' | 'system' = 'user',
+    displayLabel?: string
+  ) => {
     if (!raw.trim()) return;
     if (source === 'user') {
       // Echo the user's message
@@ -3067,6 +3200,24 @@ export async function runChat(options: ChatOptions): Promise<void> {
       }
       ledger.addEntry('user', raw, 'repl');
       appendTranscript(runtime.transcriptPath, { type: 'user', content: raw });
+    } else if (source === 'system') {
+      // Synthetic turn input: heartbeat triggers, server-delivered messages,
+      // continuation prompts. Rendered as system (not "you") so transcripts
+      // distinguish harness prompts from the human's words.
+      const label = displayLabel || 'system';
+      if (inkRepl) {
+        inkRepl.addMessage('system', raw, { label });
+      } else {
+        printLine(
+          renderMessageLine('system', raw, {
+            label,
+            timezone: runtime.userTimezone,
+          })
+        );
+        printLine('');
+      }
+      ledger.addEntry('system', raw, label);
+      appendTranscript(runtime.transcriptPath, { type: 'system_turn', content: raw, label });
     } else {
       ledger.addEntry('system', compactForLedger(`[auto-run inbox] ${raw}`, 500), 'auto-run');
       appendTranscript(runtime.transcriptPath, { type: 'auto_turn', content: raw });
@@ -3082,6 +3233,11 @@ export async function runChat(options: ChatOptions): Promise<void> {
         })
         .catch(() => undefined);
     }
+
+    // ── Token-budget enforcement: compact before building the prompt ──
+    // If the transcript has grown past the compaction threshold, summarize
+    // the oldest entries into a new start state before this turn spends them.
+    await maybeCompactContext('pre-turn budget check');
 
     // ── Fire prompt_build hooks (budget monitor, etc.) ──
     // Budget utilization must account for bootstrap tokens — the ledger only
@@ -3806,7 +3962,11 @@ export async function runChat(options: ChatOptions): Promise<void> {
       statusLane.markPromptRefreshed();
     }
   };
-  const enqueueTurn = (raw: string, source: 'user' | 'inbox-auto' = 'user'): Promise<void> => {
+  const enqueueTurn = (
+    raw: string,
+    source: 'user' | 'inbox-auto' | 'system' = 'user',
+    displayLabel?: string
+  ): Promise<void> => {
     pendingTurns += 1;
     emitStatusLaneIfChanged();
     const run = async () => {
@@ -3816,7 +3976,7 @@ export async function runChat(options: ChatOptions): Promise<void> {
         statusLane.setTurnActive(true);
       }
       try {
-        await runUserTurn(raw, source);
+        await runUserTurn(raw, source, displayLabel);
       } catch (error) {
         printLine(chalk.red(`Turn failed: ${String(error)}`));
       } finally {
@@ -3872,9 +4032,12 @@ export async function runChat(options: ChatOptions): Promise<void> {
     }
     const maxTurns = parseInt(options.maxTurns || '1', 10);
 
-    // Turn 1: user-provided message
+    // Turn 1: the delivered message. When --message-label is set (server
+    // spawns pass the originating channel, e.g. "heartbeat"), render as a
+    // system message — it's harness-delivered, not typed by the human.
+    const messageLabel = options.messageLabel?.trim();
     clearLastSignal();
-    await enqueueTurn(message);
+    await enqueueTurn(message, messageLabel ? 'system' : 'user', messageLabel);
 
     // Check for signal or failure after turn 1
     let exitReason: string | undefined;
@@ -3891,7 +4054,9 @@ export async function runChat(options: ChatOptions): Promise<void> {
       for (let turn = 2; turn <= maxTurns; turn++) {
         clearLastSignal();
         await enqueueTurn(
-          'Continue working. Use signal_status to indicate when you are completed, blocked, or continuing.'
+          'Continue working. Use signal_status to indicate when you are completed, blocked, or continuing.',
+          'system',
+          'continuation'
         );
 
         const signal = getLastSignal();
@@ -3946,6 +4111,13 @@ export async function runChat(options: ChatOptions): Promise<void> {
       .listEntries()
       .filter((e) => e.role === 'assistant')
       .pop();
+    // Context utilization from our budget's view: transcript + identity.
+    // The server (InkRunner) persists this so session-level token tracking
+    // works for the ink backend — without it, sessions report 0 context
+    // tokens and grow unbounded.
+    const reportedContextTokens =
+      ledger.totalTokens() +
+      (runtime.bootstrapContext ? estimateTokens(runtime.bootstrapContext) : 0);
     console.log(
       JSON.stringify({
         type: 'result',
@@ -3954,6 +4126,11 @@ export async function runChat(options: ChatOptions): Promise<void> {
         phase,
         signal: finalSignal?.status || null,
         reason: finalSignal?.reason || (isBackendFailure ? 'backend_failure' : null),
+        usage: {
+          contextTokens: reportedContextTokens,
+          inputTokens: lastBackendUsage?.inputTokens || 0,
+          outputTokens: lastBackendUsage?.outputTokens || 0,
+        },
         ...(isBackendFailure ? { backendFailure: true } : {}),
       })
     );
@@ -3984,8 +4161,11 @@ export async function runChat(options: ChatOptions): Promise<void> {
       await turnQueue;
     }
     // Unref stdio so lingering streams (e.g. piped stdin from InkRunner)
-    // don't prevent the event loop from draining.
-    process.stdin.unref();
+    // don't prevent the event loop from draining. Guarded: some stdin
+    // stream types (already-closed pipes) don't implement unref.
+    if (typeof process.stdin.unref === 'function') {
+      process.stdin.unref();
+    }
     return;
   }
 
@@ -4469,7 +4649,7 @@ export async function runChat(options: ChatOptions): Promise<void> {
           runtime.backend = next;
           runtime.backendTokenWindow = resolveBackendTokenWindow(runtime.backend, runtime.model);
           if (contextBudgetAuto) {
-            runtime.maxContextTokens = runtime.backendTokenWindow;
+            runtime.maxContextTokens = defaultContextBudget(runtime.backendTokenWindow);
           }
           const backendLines = [`Switched backend to ${next}`];
           if (contextBudgetAuto) {
@@ -4485,7 +4665,7 @@ export async function runChat(options: ChatOptions): Promise<void> {
           runtime.model = next || undefined;
           runtime.backendTokenWindow = resolveBackendTokenWindow(runtime.backend, runtime.model);
           if (contextBudgetAuto) {
-            runtime.maxContextTokens = runtime.backendTokenWindow;
+            runtime.maxContextTokens = defaultContextBudget(runtime.backendTokenWindow);
           }
           showInPanel([
             `Model override: ${runtime.model || '(backend default)'}`,
@@ -5420,6 +5600,10 @@ export function registerChatCommand(program: Command): void {
       .option('--profile <name>', 'Apply security profile: minimal|safe|collaborative|full')
       .option('--auto-run', 'Automatically execute backend turns for new inbox task messages')
       .option('--message <text>', 'Single-turn message for non-interactive mode')
+      .option(
+        '--message-label <label>',
+        'Render the --message as a system message with this label (e.g., heartbeat, telegram). Used by server spawns.'
+      )
       .option('--non-interactive', 'Run one turn and exit (requires --message)')
       .option('--max-turns <n>', 'Run up to N conversational turns then exit (requires --message)')
       .option(

--- a/packages/cli/src/commands/claude.ts
+++ b/packages/cli/src/commands/claude.ts
@@ -3555,8 +3555,10 @@ export async function runClaude(
     }
   };
 
+  // Adapters that pass the prompt via stdin (Claude — avoids argv E2BIG on
+  // large prompts) need a piped stdin we write to; otherwise inherit the TTY.
   const child = spawn(prepared.binary, prepared.args, {
-    stdio: ['inherit', 'pipe', 'pipe'],
+    stdio: [prepared.stdinData !== undefined ? 'pipe' : 'inherit', 'pipe', 'pipe'],
     env: {
       ...process.env,
       ...authEnv,
@@ -3568,6 +3570,12 @@ export async function runClaude(
       ...(runtimeLinkId ? { INK_RUNTIME_LINK_ID: runtimeLinkId } : {}),
     },
   });
+
+  if (prepared.stdinData !== undefined && child.stdin) {
+    child.stdin.on('error', () => {});
+    child.stdin.write(prepared.stdinData);
+    child.stdin.end();
+  }
 
   child.stdout?.on('data', (chunk) => {
     process.stdout.write(chunk);

--- a/packages/cli/src/repl/backend-runner.ts
+++ b/packages/cli/src/repl/backend-runner.ts
@@ -44,6 +44,7 @@ export function startBackendTurn(request: BackendRunRequest): BackendTurnHandle 
     binary: prepared.binary,
     args: prepared.args,
     env: prepared.env,
+    stdinData: prepared.stdinData,
     timeoutMs: request.timeoutMs || 20 * 60 * 1000,
     onStdout: request.verbose ? (chunk) => process.stdout.write(chunk) : undefined,
     onStderr: request.verbose ? (chunk) => process.stderr.write(chunk) : undefined,

--- a/packages/cli/src/repl/context-ledger.test.ts
+++ b/packages/cli/src/repl/context-ledger.test.ts
@@ -172,4 +172,82 @@ describe('ContextLedger', () => {
       expect(summary[1].source).toBe('ink-tool');
     });
   });
+
+  describe('compactToSummary', () => {
+    it('replaces oldest entries with a summary, keeping the recent tail', () => {
+      const ledger = new ContextLedger();
+      for (let i = 0; i < 10; i++) {
+        ledger.addEntry(i % 2 === 0 ? 'user' : 'assistant', `message ${i} ${'x'.repeat(50)}`);
+      }
+      const before = ledger.totalTokens();
+
+      const result = ledger.compactToSummary('summary of 0-6', 3);
+
+      expect(result.removedEntries).toHaveLength(7);
+      expect(result.totalAfter).toBeLessThan(before);
+      const entries = ledger.listEntries();
+      expect(entries).toHaveLength(4); // summary + 3 kept
+      expect(entries[0].role).toBe('system');
+      expect(entries[0].content).toBe('summary of 0-6');
+      expect(entries[0].source).toBe('compaction');
+      expect(entries[1].content).toContain('message 7');
+      expect(entries[3].content).toContain('message 9');
+    });
+
+    it('compacts everything when keepRecentEntries is 0', () => {
+      const ledger = new ContextLedger();
+      ledger.addEntry('user', 'one');
+      ledger.addEntry('assistant', 'two');
+
+      const result = ledger.compactToSummary('the summary', 0);
+
+      expect(result.removedEntries).toHaveLength(2);
+      expect(ledger.listEntries()).toHaveLength(1);
+      expect(ledger.listEntries()[0].content).toBe('the summary');
+    });
+
+    it('keeps all entries when keepRecentEntries exceeds entry count', () => {
+      const ledger = new ContextLedger();
+      ledger.addEntry('user', 'only message');
+
+      const result = ledger.compactToSummary('summary', 5);
+
+      expect(result.removedEntries).toHaveLength(0);
+      const entries = ledger.listEntries();
+      expect(entries).toHaveLength(2); // summary prepended + original
+      expect(entries[0].content).toBe('summary');
+      expect(entries[1].content).toBe('only message');
+    });
+
+    it('drops bookmarks in the compacted region and shifts survivors', () => {
+      const ledger = new ContextLedger();
+      ledger.addEntry('user', 'old 1');
+      ledger.createBookmark('old-mark'); // index 0 — inside compacted region
+      ledger.addEntry('user', 'old 2');
+      ledger.addEntry('user', 'recent 1');
+      ledger.createBookmark('recent-mark'); // index 2 — survives
+      ledger.addEntry('user', 'recent 2');
+
+      ledger.compactToSummary('summary', 2);
+
+      const bookmarks = ledger.listBookmarks();
+      expect(bookmarks).toHaveLength(1);
+      expect(bookmarks[0].label).toBe('recent-mark');
+      // recent 1 is now at index 1 (after the summary entry)
+      expect(ledger.listEntries()[bookmarks[0].entryIndex].content).toBe('recent 1');
+    });
+
+    it('reduces total tokens when summary is smaller than removed content', () => {
+      const ledger = new ContextLedger();
+      for (let i = 0; i < 20; i++) {
+        ledger.addEntry('user', 'long content '.repeat(100));
+      }
+      const before = ledger.totalTokens();
+
+      const result = ledger.compactToSummary('short summary', 4);
+
+      expect(result.totalAfter).toBeLessThan(before / 2);
+      expect(result.summaryTokens).toBe(estimateTokens('short summary'));
+    });
+  });
 });

--- a/packages/cli/src/repl/context-ledger.ts
+++ b/packages/cli/src/repl/context-ledger.ts
@@ -36,6 +36,13 @@ export interface LedgerEvictResult {
   totalAfter: number;
 }
 
+export interface LedgerCompactResult {
+  removedEntries: LedgerEntry[];
+  removedTokens: number;
+  summaryTokens: number;
+  totalAfter: number;
+}
+
 export interface PromptBuildOptions {
   maxTokens?: number;
   includeSources?: boolean;
@@ -185,6 +192,47 @@ export class ContextLedger {
 
     runningTotal = this.totalTokens();
     return { removedEntries, removedTokens, totalAfter: runningTotal };
+  }
+
+  /**
+   * Replace the oldest entries with a single summary entry, keeping the most
+   * recent `keepRecentEntries` verbatim. This is the in-memory half of
+   * transcript compaction: the summary becomes the new start state and the
+   * recent tail preserves working context.
+   */
+  public compactToSummary(
+    summary: string,
+    keepRecentEntries: number,
+    source = 'compaction'
+  ): LedgerCompactResult {
+    const keep = Math.max(0, Math.floor(keepRecentEntries));
+    const cutoff = Math.max(0, this.entries.length - keep);
+    const removedEntries = this.entries.slice(0, cutoff);
+    const removedTokens = removedEntries.reduce((sum, entry) => sum + entry.approxTokens, 0);
+    const kept = this.entries.slice(cutoff);
+
+    const summaryEntry: LedgerEntry = {
+      id: this.entrySeq++,
+      role: 'system',
+      content: summary,
+      source,
+      createdAt: new Date().toISOString(),
+      approxTokens: estimateTokens(summary),
+    };
+
+    this.entries = [summaryEntry, ...kept];
+    // Bookmarks inside the compacted region are gone; survivors shift to
+    // account for removed entries plus the prepended summary.
+    this.bookmarks = this.bookmarks
+      .filter((bookmark) => bookmark.entryIndex >= cutoff)
+      .map((bookmark) => ({ ...bookmark, entryIndex: bookmark.entryIndex - cutoff + 1 }));
+
+    return {
+      removedEntries,
+      removedTokens,
+      summaryTokens: summaryEntry.approxTokens,
+      totalAfter: this.totalTokens(),
+    };
   }
 
   /**

--- a/packages/shared/src/runner/spawn-backend.ts
+++ b/packages/shared/src/runner/spawn-backend.ts
@@ -40,6 +40,12 @@ export interface SpawnBackendOptions {
   cwd?: string;
   /** Whether to pipe stdin (default: false — stdin is 'ignore') */
   pipeStdin?: boolean;
+  /**
+   * Data to write to the child's stdin (then close it). Implies pipeStdin.
+   * Used to pass large prompts via stdin instead of argv — argv has an OS
+   * limit (~256KB on macOS) and large transcripts trigger spawn E2BIG.
+   */
+  stdinData?: string;
   /** Hard timeout in ms (default: 30 minutes) */
   timeoutMs?: number;
   /** Idle timeout in ms — kill if no output for this long (default: none) */
@@ -153,6 +159,10 @@ export function spawnBackend(options: SpawnBackendOptions): {
   result: Promise<SpawnBackendResult>;
 } {
   const started = Date.now();
+  // stdinData implies pipeStdin (resolveSpawnTarget also checks it for docker -i)
+  if (options.stdinData !== undefined && !options.pipeStdin) {
+    options = { ...options, pipeStdin: true };
+  }
   const target = resolveSpawnTarget(options);
 
   const child = spawn(target.binary, target.args, {
@@ -160,6 +170,14 @@ export function spawnBackend(options: SpawnBackendOptions): {
     cwd: target.cwd,
     env: target.env,
   });
+
+  if (options.stdinData !== undefined && child.stdin) {
+    // EPIPE if the child exits before consuming stdin — swallow, the close
+    // handler reports the real exit
+    child.stdin.on('error', () => {});
+    child.stdin.write(options.stdinData);
+    child.stdin.end();
+  }
 
   let stdout = '';
   let stderr = '';


### PR DESCRIPTION
## Why

PR #399 fixed the tool-denial loop, but Myra's heartbeats kept failing. Root cause analysis of the toxic session (3,090 messages / 306K tokens, zero compactions over a month) revealed three structural gaps:

1. **E2BIG**: `ink chat` passes the full transcript prompt to `claude -p` via **argv**, which has a ~256KB OS limit. At 306K tokens (~1.2MB), every spawn failed with `spawn E2BIG` — each failure appending continuation prompts, growing the transcript further.
2. **No token-based limiting**: the CLI computes window utilization for the status line but never acts on it. Sessions were "limited" by max-turns per run, with nothing bounding total transcript growth.
3. **Server blindness**: InkRunner never parsed usage from the CLI result, so ink sessions reported `contextTokens: 0` forever and no token-based lifecycle could fire.

Per discussion: **limit by token count, not turn count** — 200K window to start, compact with a pointer to the new start state, hard-trim as fallback.

## What

### `fix(cli): pass claude prompt via stdin instead of argv`
- `spawnBackend` gains `stdinData` (implies pipeStdin, writes then closes)
- `ClaudeAdapter` returns the prompt as `stdinData` — no size limit, E2BIG is structurally impossible
- Verified: `echo "..." | claude -p` works; full e2e through `ink chat` works

### `feat(cli): token-budget auto-compaction with 200K default window`
- `maxContextTokens` defaults to `min(backend window, 200K)` (override: `--max-context-tokens`)
- Pre-turn check: if transcript+identity > 80% of budget, the oldest entries (all but the last 12) are summarized into a dense brief via the backend (`ContextLedger.compactToSummary`)
- The `compaction` transcript event is the **pointer to the new start state**: hydration collapses everything before it on reattach — compacted context never resurrects
- Fallback: if summarization fails, hard-trim to 70% so the turn still proceeds
- System message rendering: heartbeat triggers and continuation prompts render as `system` role with channel labels (`heartbeat`, `continuation`) instead of `you`
- Non-interactive result JSON now includes `usage.contextTokens`
- Guard `process.stdin.unref` crash at non-interactive exit

### `feat(ink-runner): parse usage, label delivered messages, raise turn backstop`
- Parses usage from result JSON → sessions get real `contextTokens`
- Passes `--message-label <channel>` (channel plumbed through `ClaudeRunnerConfig`)
- `--max-turns` 5 → 15: a backstop, not the limit — the token budget is the real bound
- Server-side compaction stays gated to claude-code: **one compaction owner per backend** (ink self-compacts)

## Verification

- Unit: 18/18 context-ledger (5 new `compactToSummary` tests), 72/72 backend-runner + shared, 10/10 ink-runner
- Full CLI suite: 773 passed (1 pre-existing gemini adapter failure from uncommitted WIP on main, verified by stashing)
- API type-check: clean except known `channels/gateway.ts` / `mcp/server.ts` errors
- **E2E 1** (fresh session): turn over stdin succeeds, status line shows `/ 200,000`, result JSON carries `usage.contextTokens`, `heartbeat` label renders
- **E2E 2** (synthetic 80-message over-budget session): compaction fired pre-turn — `27,870 → 1,512 tok`, and the agent correctly answered a question whose answer existed **only in the compacted summary**
- **E2E 3** (reattach): `history: 1 prior message(s) loaded` — hydration collapsed at the compaction event; answer still served from summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)