### PR TITLE
feat: REPL rendering polish — event lines, context cutoff, tool visibility (by Wren)

### DIFF
--- a/packages/cli/src/commands/chat-hydration.test.ts
+++ b/packages/cli/src/commands/chat-hydration.test.ts
@@ -133,6 +133,42 @@ describe('hydrateLedgerFromTranscript — compaction events', () => {
     expect(contents).toEqual(['bootstrap identity block', 'the summary']);
   });
 
+  it('resets tailPreview at the compaction marker (regression: stale pre-compaction preview)', () => {
+    // Pre-compaction turns must NOT appear in the visible replay below the
+    // cutoff divider, and kept tail entries must not duplicate.
+    writeTranscript([
+      { type: 'user', content: 'ancient question' },
+      { type: 'assistant', content: 'ancient answer', backend: 'claude' },
+      { type: 'user', content: 'kept question' },
+      { type: 'assistant', content: 'kept answer', backend: 'claude' },
+      {
+        type: 'compaction',
+        summary: 'the summary',
+        keptEntries: [
+          { role: 'user', content: 'kept question', source: 'repl-history' },
+          { role: 'assistant', content: 'kept answer', source: 'claude' },
+        ],
+      },
+      { type: 'user', content: 'post-marker question' },
+      { type: 'assistant', content: 'post-marker answer', backend: 'claude' },
+    ]);
+
+    const ledger = new ContextLedger();
+    const result = hydrateLedgerFromTranscript(ledger, transcriptPath);
+
+    const previewContents = result.tailPreview.map((p) => p.content);
+    // Exactly: kept tail + post-marker — no pre-compaction turns, no duplicates
+    expect(previewContents).toEqual([
+      'kept question',
+      'kept answer',
+      'post-marker question',
+      'post-marker answer',
+    ]);
+    expect(previewContents).not.toContain('ancient question');
+    expect(previewContents).not.toContain('ancient answer');
+    expect(previewContents.filter((c) => c === 'kept question')).toHaveLength(1);
+  });
+
   it('skips malformed keptEntries without crashing', () => {
     writeTranscript([
       {

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -70,6 +70,7 @@ import {
   isOlderThan5Days,
   LiveStatusLane,
   renderCollapsedInbox,
+  renderContextCutoff,
   renderMessageLine,
   renderTimedBlock,
   separator,
@@ -389,6 +390,8 @@ interface HistoryHydrationResult {
   tailPreview: Array<{ role: 'user' | 'assistant' | 'inbox'; content: string; ts?: string }>;
   seenInboxIds?: string[];
   seenActivityIds?: string[];
+  /** True when hydration collapsed history at a compaction event */
+  compactionCollapsed?: boolean;
 }
 
 interface SessionContextMessage {
@@ -602,10 +605,12 @@ export function hydrateLedgerFromTranscript(
   seenInboxIds: string[];
   seenActivityIds: string[];
   recoveredMemoryIds: string[];
+  compactionCollapsed: boolean;
 } {
   const events = readTranscriptEvents(transcriptPath);
   let loaded = 0;
   let messageCount = 0;
+  let compactionCollapsed = false;
   const preview: HistoryHydrationResult['tailPreview'] = [];
   const seenInboxIds = new Set<string>();
   const seenActivityIds = new Set<string>();
@@ -635,6 +640,7 @@ export function hydrateLedgerFromTranscript(
       hydratedEntryIds.push(summaryEntry.id);
       loaded = 1;
       messageCount = 0;
+      compactionCollapsed = true;
       const keptEntries = Array.isArray(event.keptEntries) ? event.keptEntries : [];
       for (const kept of keptEntries) {
         if (!kept || typeof kept !== 'object') continue;
@@ -737,6 +743,7 @@ export function hydrateLedgerFromTranscript(
     seenInboxIds: Array.from(seenInboxIds),
     seenActivityIds: Array.from(seenActivityIds),
     recoveredMemoryIds,
+    compactionCollapsed,
   };
 }
 
@@ -2150,9 +2157,26 @@ export async function runChat(options: ChatOptions): Promise<void> {
     restorePromptAfterWrite?.();
   };
 
+  // Compact progress/status lines (tool runs, signals, dividers, surfaced
+  // memories): rendered as dim unlabeled events in Ink mode rather than
+  // "system"-labeled message blocks. Legacy mode prints them as-is.
+  const printEvent = (line: string) => {
+    if (inkRepl) {
+      if (line.trim()) {
+        inkRepl.printEvent(line);
+      }
+      return;
+    }
+    statusLane.printLine(line);
+    restorePromptAfterWrite?.();
+  };
+
   const ledger = new ContextLedger();
   const hookRegistry = new SbHookRegistry();
   let hookTurnCount = 0;
+
+  // Session-level tool call log — surfaced in the Ctrl+O context inspector
+  const recentToolCalls: Array<{ tool: string; status: string; at: string }> = [];
 
   // Register built-in hooks (passive recall + budget monitor).
   // callRecall wraps pcp.callTool('recall', ...) into the shape hooks expect.
@@ -2457,6 +2481,7 @@ export async function runChat(options: ChatOptions): Promise<void> {
       tailPreview: hydrated.tailPreview,
       seenInboxIds: hydrated.seenInboxIds,
       seenActivityIds: hydrated.seenActivityIds,
+      compactionCollapsed: hydrated.compactionCollapsed,
     };
     for (const inboxId of hydrated.seenInboxIds) {
       seenInboxIds.add(inboxId);
@@ -2749,6 +2774,14 @@ export async function runChat(options: ChatOptions): Promise<void> {
     );
   }
   if (historyHydration && historyHydration.messageCount > 0) {
+    if (historyHydration.compactionCollapsed) {
+      // Earlier history was compacted — mark where the loaded window begins
+      console.log(
+        renderContextCutoff(
+          `earlier history compacted · ${formatTokenCount(ledger.totalTokens())} tok loaded`
+        )
+      );
+    }
     console.log(chalk.dim(`  history: ${historyHydration.messageCount} prior message(s) loaded`));
   }
   console.log(chalk.dim('  /help for commands\n'));
@@ -2838,7 +2871,7 @@ export async function runChat(options: ChatOptions): Promise<void> {
         .map((e) => `${e.role.toUpperCase()}${e.source ? ` [${e.source}]` : ''}: ${e.content}`)
         .join('\n\n');
       const before = ledger.totalTokens();
-      printLine(
+      printEvent(
         chalk.yellow(
           `  ⛁ Context at ${formatTokenCount(before)} tok (> ${formatTokenCount(threshold)} threshold) — compacting (${reason})`
         )
@@ -2879,14 +2912,16 @@ export async function runChat(options: ChatOptions): Promise<void> {
           summaryTokens: result.summaryTokens,
           totalAfter: result.totalAfter,
         });
-        printLine(
-          chalk.green(
-            `  ⛁ Compacted ${result.removedEntries.length} entries: ${formatTokenCount(before)} → ${formatTokenCount(result.totalAfter)} tok`
+        // Cutoff divider: everything above this line in the scrollback is
+        // now out of the context window (replaced by the summary).
+        printEvent(
+          renderContextCutoff(
+            `compacted ${result.removedEntries.length} entries · ${formatTokenCount(before)} → ${formatTokenCount(result.totalAfter)} tok`
           )
         );
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
-        printLine(chalk.yellow(`  ⛁ Compaction summarization failed (${msg}) — hard-trimming`));
+        printEvent(chalk.yellow(`  ⛁ Compaction summarization failed (${msg}) — hard-trimming`));
         await trimContextToPercent(DEFAULT_TRIM_TARGET_PCT, `${reason} (compaction fallback)`);
       }
     } finally {
@@ -3193,7 +3228,21 @@ export async function runChat(options: ChatOptions): Promise<void> {
         createdAt: activity.createdAt || null,
         content: activity.content || null,
       });
-      if (inkRepl) {
+      // This agent's own bookkeeping (session state updates, tool call
+      // echoes) is progress, not conversation — render as a dim event line
+      // instead of a full activity block.
+      const isOwnBookkeeping =
+        activity.agentId === agentId &&
+        (rawType.startsWith('state_change') ||
+          rawType.startsWith('tool_call') ||
+          rawType.startsWith('tool_result'));
+      if (isOwnBookkeeping) {
+        printEvent(
+          chalk.dim(
+            `  ⚡ ${type}${preview ? ` — ${preview}` : ''} · ${formatHumanTime(activity.createdAt, runtime.userTimezone)}`
+          )
+        );
+      } else if (inkRepl) {
         inkRepl.addMessage('activity', `${actor} ${type}${preview ? ` — ${preview}` : ''}`, {
           label: '⚡',
           time: formatHumanTime(activity.createdAt, runtime.userTimezone),
@@ -3339,7 +3388,7 @@ export async function runChat(options: ChatOptions): Promise<void> {
             return `  💡 ${preview}${entry.content.length > 120 ? '...' : ''} (${entry.approxTokens} tok)`;
           });
           inkRepl.setSurfacedMemories(details);
-          printLine(
+          printEvent(
             chalk.dim(
               `  💡 ${recallEntries.length} ${recallEntries.length === 1 ? 'memory' : 'memories'} surfaced (${totalTok} tok) — ctrl+o to expand`
             )
@@ -3347,7 +3396,7 @@ export async function runChat(options: ChatOptions): Promise<void> {
         } else {
           for (const entry of recallEntries) {
             const preview = entry.content.replace(/^\[passive-recall\]\s*/, '').slice(0, 120);
-            printLine(
+            printEvent(
               chalk.dim(
                 `  💡 memory surfaced: "${preview}${entry.content.length > 120 ? '...' : ''}" (${entry.approxTokens} tok)`
               )
@@ -3358,7 +3407,7 @@ export async function runChat(options: ChatOptions): Promise<void> {
 
       if (budgetEntries.length > 0) {
         const util = Math.round((ledger.totalTokens() / effectiveBudget) * 100);
-        printLine(
+        printEvent(
           chalk.yellow(
             `  ⚠ Context at ${util}% — ${ledger.totalTokens().toLocaleString()} / ${effectiveBudget.toLocaleString()} tok (bootstrap: ${bootstrapReserve.toLocaleString()} reserved)`
           )
@@ -3705,7 +3754,7 @@ export async function runChat(options: ChatOptions): Promise<void> {
                       : signal.status === 'blocked'
                         ? '🚫'
                         : '➡️';
-                  printLine(
+                  printEvent(
                     chalk.dim(
                       `  ${icon} signal: ${signal.status}${signal.reason ? ` — ${signal.reason}` : ''}`
                     )
@@ -3754,6 +3803,12 @@ export async function runChat(options: ChatOptions): Promise<void> {
       });
 
       allToolResults.push(...iterationResults);
+      for (const r of iterationResults) {
+        recentToolCalls.push({ tool: r.tool, status: r.status, at: new Date().toISOString() });
+      }
+      if (recentToolCalls.length > 100) {
+        recentToolCalls.splice(0, recentToolCalls.length - 100);
+      }
       toolLoopIteration++;
 
       // Check if we should continue the loop
@@ -3783,10 +3838,12 @@ export async function runChat(options: ChatOptions): Promise<void> {
         `[Tool results from previous turn]\n${toolResultsSummary}\n\nContinue your response based on these tool results. If you need more tools, emit ink-tool blocks. Otherwise, provide your final answer.`
       );
 
-      // Show continuation indicator
-      printLine(
+      // Show continuation indicator naming the tools that just ran — this is
+      // the SB working, not a system message
+      const ranTools = Array.from(new Set(iterationResults.map((r) => r.tool))).join(', ');
+      printEvent(
         chalk.dim(
-          `  ↳ continuing with tool results (${toolLoopIteration}/${MAX_TOOL_LOOP_ITERATIONS})…`
+          `  ⋯ ran ${ranTools} — continuing (${toolLoopIteration}/${MAX_TOOL_LOOP_ITERATIONS})…`
         )
       );
       const stopContinuation = inkRepl
@@ -4242,6 +4299,7 @@ export async function runChat(options: ChatOptions): Promise<void> {
         tokenEstimate: ledger.totalTokens(),
         bootstrapTokens: runtime.bootstrapContext ? estimateTokens(runtime.bootstrapContext) : 0,
       },
+      toolCalls: recentToolCalls,
     });
   };
 

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -640,6 +640,10 @@ export function hydrateLedgerFromTranscript(
       hydratedEntryIds.push(summaryEntry.id);
       loaded = 1;
       messageCount = 0;
+      // Reset the visible replay too — pre-compaction turns are out of
+      // context and must not appear below the cutoff divider. The kept
+      // tail is re-added below from the event's keptEntries.
+      preview.length = 0;
       compactionCollapsed = true;
       const keptEntries = Array.isArray(event.keptEntries) ? event.keptEntries : [];
       for (const kept of keptEntries) {

--- a/packages/cli/src/repl/ink/MessageLine.tsx
+++ b/packages/cli/src/repl/ink/MessageLine.tsx
@@ -1,7 +1,14 @@
 import React from 'react';
 import { Box, Text } from 'ink';
 
-export type MessageRole = 'user' | 'assistant' | 'inbox' | 'activity' | 'system' | 'grant';
+export type MessageRole =
+  | 'user'
+  | 'assistant'
+  | 'inbox'
+  | 'activity'
+  | 'system'
+  | 'grant'
+  | 'event';
 
 export interface MessageLineProps {
   id: string;
@@ -19,6 +26,7 @@ const LABEL_COLORS: Record<MessageRole, string> = {
   activity: 'magenta',
   system: 'gray',
   grant: 'green',
+  event: 'gray',
 };
 
 const CONTENT_COLORS: Record<MessageRole, string | undefined> = {
@@ -28,6 +36,7 @@ const CONTENT_COLORS: Record<MessageRole, string | undefined> = {
   activity: undefined,
   system: 'gray',
   grant: 'green',
+  event: 'gray',
 };
 
 /**
@@ -60,9 +69,23 @@ export const MessageLine = React.memo(function MessageLine({
   const meta = [time, trailingMeta].filter(Boolean).join('  ·  ');
   const displayContent = collapseImagePaths(content);
 
+  // Events are compact progress/status lines (tool runs, signals, dividers):
+  // a single dim line at the content column — no label row, no spacing.
+  if (role === 'event') {
+    return (
+      <Box paddingLeft={3}>
+        <Text dimColor wrap="wrap">
+          {displayContent}
+          {meta ? `  ·  ${meta}` : ''}
+        </Text>
+      </Box>
+    );
+  }
+
   return (
     <Box flexDirection="column" paddingLeft={1} marginTop={1}>
-      <Box>
+      {/* Label is padded to sit flush with the content text below it */}
+      <Box paddingLeft={2}>
         <Text bold color={labelColor}>
           {displayLabel}
         </Text>

--- a/packages/cli/src/repl/ink/context-viewer.tsx
+++ b/packages/cli/src/repl/ink/context-viewer.tsx
@@ -14,6 +14,8 @@ export interface ContextSections {
     tokenEstimate: number;
     bootstrapTokens: number;
   };
+  /** Tool calls executed this session (most recent last) */
+  toolCalls?: Array<{ tool: string; status: string; at: string }>;
 }
 
 export function formatContextLines(sections: ContextSections): string[] {
@@ -34,6 +36,18 @@ export function formatContextLines(sections: ContextSections): string[] {
   lines.push(`Unique memories: ${sections.passiveRecallStats.uniqueMemories}`);
   lines.push(`Current turn: ${sections.passiveRecallStats.currentTurn}`);
   lines.push('');
+
+  if (sections.toolCalls && sections.toolCalls.length > 0) {
+    lines.push('── Recent Tool Calls ──');
+    lines.push('');
+    // Most recent first, capped for readability
+    const recent = sections.toolCalls.slice(-25).reverse();
+    for (const call of recent) {
+      const time = call.at ? new Date(call.at).toLocaleTimeString() : '';
+      lines.push(`• ${call.tool} (${call.status})${time ? ` · ${time}` : ''}`);
+    }
+    lines.push('');
+  }
 
   if (sections.passiveRecallEntries.length > 0) {
     lines.push('── Memories in Context ──');

--- a/packages/cli/src/repl/ink/renderApp.tsx
+++ b/packages/cli/src/repl/ink/renderApp.tsx
@@ -49,6 +49,11 @@ export interface InkRepl {
   ) => void;
   /** Print a system/info line (replaces printLine for non-message output). */
   printSystem: (content: string) => void;
+  /**
+   * Print a compact progress/status event line (tool runs, signals,
+   * dividers). Renders as a single dim line without a label row.
+   */
+  printEvent: (content: string) => void;
   /** Update the status bar summary. */
   setStatus: (summary: string) => void;
   /** Show/hide the waiting indicator. */
@@ -168,6 +173,14 @@ export function renderInkChat(options: {
         role: 'system',
         content,
         time: formatNow(options.timezone),
+      });
+    },
+
+    printEvent: (content) => {
+      getHandle().addMessage({
+        id: nextMessageId(),
+        role: 'event',
+        content,
       });
     },
 

--- a/packages/cli/src/repl/tui-components.ts
+++ b/packages/cli/src/repl/tui-components.ts
@@ -58,7 +58,9 @@ export function renderMessageLine(
     trailingMeta?: string;
   } = {}
 ): string {
-  const clock = options.ts ? formatClock(options.ts, options.timezone) : formatNow(options.timezone);
+  const clock = options.ts
+    ? formatClock(options.ts, options.timezone)
+    : formatNow(options.timezone);
   const meta = options.trailingMeta ? `  ·  ${options.trailingMeta}` : '';
   const timeStr = chalk.dim(`${clock}${meta}`);
 
@@ -105,6 +107,18 @@ export function renderCollapsedInbox(count: number): string {
   return chalk.dim(`${'┄'.repeat(side)}${label}${'┄'.repeat(side)}`);
 }
 
+/**
+ * Context-window cutoff divider. Marks the boundary in the scrollback where
+ * the loaded context begins: everything above it has been compacted or
+ * trimmed out of the prompt window; everything below is what the SB sees.
+ */
+export function renderContextCutoff(detail: string): string {
+  const label = ` ⌃ out of context · ${detail} · in context ⌄ `;
+  const w = process.stdout.columns || 80;
+  const side = Math.max(2, Math.floor((w - label.length) / 2));
+  return chalk.dim(`${'─'.repeat(side)}${label}${'─'.repeat(side)}`);
+}
+
 /** Check if a timestamp is older than 5 days. */
 export function isOlderThan5Days(createdAt?: string): boolean {
   if (!createdAt) return false;
@@ -142,7 +156,11 @@ export function formatHumanTime(value?: string, timezone?: string): string {
 
   try {
     if (sameDay) {
-      return date.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit', timeZone: timezone });
+      return date.toLocaleTimeString([], {
+        hour: 'numeric',
+        minute: '2-digit',
+        timeZone: timezone,
+      });
     }
     // Older — show short date + time
     return date.toLocaleDateString([], {
@@ -345,19 +363,11 @@ export class LiveStatusLane {
       chalk.dim(` ${this.statusLine}`),
       chalk.dim(formatNow(this.timezone))
     );
-    const info = this.infoItems.length > 0
-      ? ` ${infoBar(this.infoItems)}`
-      : chalk.dim(` ${this.hintLine}`);
+    const info =
+      this.infoItems.length > 0 ? ` ${infoBar(this.infoItems)}` : chalk.dim(` ${this.hintLine}`);
     // Prompt MUST be the last line so readline places the cursor there.
     // Layout: sep | status | sep | info | sep | prompt
-    return [
-      sep,
-      statusWithTime,
-      sep,
-      info,
-      sep,
-      ` ${promptLabel}`,
-    ].join('\n');
+    return [sep, statusWithTime, sep, info, sep, ` ${promptLabel}`].join('\n');
   }
 }
 


### PR DESCRIPTION
## Why

Conor's observations from watching Myra's live transcript after the PR #400 heartbeat fixes:
1. Message labels (`you`, `myra`) hang to the left of their content — misaligned
2. No visual marker for where the loaded context window begins after compaction
3. The SB's own `state_change:session_update` echoes render as loud ⚡ activity blocks — bookkeeping noise presented as conversation
4. Tool calls are invisible: `↳ continuing with tool results (1/5)` doesn't say *which* tools ran, was mislabeled as a "system" message, and Ctrl+O didn't show tool history

## What

**1. Labels flush with content** — `MessageLine.tsx` label row now shares the content's left edge.

**2. Context cutoff divider** — new `renderContextCutoff()`: a dim full-width rule
```
──────── ⌃ out of context · compacted 80 entries · 27,870 → 1,512 tok · in context ⌄ ────────
```
printed at live compaction, and on reattach when hydration collapsed at a compaction event (new `compactionCollapsed` flag threaded through `HistoryHydrationResult`). Everything above the line is out of the prompt window.

**3. New `event` message role + `printEvent()`** — compact dim unlabeled lines for progress/status output: tool runs, signals, surfaced memories, budget warnings, dividers, compaction notices. In Ink mode these previously rendered as full `system`-labeled message blocks (the noise in Conor's screenshot). Legacy mode unchanged (plain dim lines).

**4. Tool visibility**
- Continuation indicator names the tools: `⋯ ran get_inbox, signal_status — continuing (1/5)…`
- Ctrl+O context inspector gains a **Recent Tool Calls** section (last 25, status + time) fed by a session-level tool-call log
- Own-agent bookkeeping activities (`state_change`, `tool_call`/`tool_result` echoes) render as dim event lines instead of ⚡ activity blocks; other agents' activities unchanged

## Verification

- Full CLI suite: 779 passed (1 pre-existing gemini adapter failure from uncommitted WIP on main)
- CLI type-check clean
- E2E (non-interactive, fresh session): `⋯ ran get_timezone — continuing (1/5)…` renders with tool names; signal + result JSON paths unchanged
- CLI-only build — deliberately did NOT rebuild `shared/dist` (it restarts the dev server and kills in-flight SB runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)