### PR TITLE
test: align multimodal tests with claude-code-only image gating (by Wren)

### DIFF
--- a/packages/api/src/services/sessions/session-service.test.ts
+++ b/packages/api/src/services/sessions/session-service.test.ts
@@ -1940,8 +1940,8 @@ describe('SessionService', () => {
   });
 
   describe('Multimodal Image Handling', () => {
-    it('passes imageContents to ink runner when image media is present', async () => {
-      const session = createMockSession({ lifecycle: 'idle', backend: 'ink' });
+    it('passes imageContents to claude runner when image media is present', async () => {
+      const session = createMockSession({ lifecycle: 'idle', backend: 'claude-code' });
       vi.mocked(mockRepository.findByUserAndAgent).mockResolvedValue(session);
 
       const request = createMockRequest({
@@ -1952,8 +1952,8 @@ describe('SessionService', () => {
 
       await sessionService.handleMessage(request);
 
-      expect(mockInkRunner.run).toHaveBeenCalledTimes(1);
-      const runOptions = vi.mocked(mockInkRunner.run).mock.calls[0][1];
+      expect(mockClaudeRunner.run).toHaveBeenCalledTimes(1);
+      const runOptions = vi.mocked(mockClaudeRunner.run).mock.calls[0][1];
       expect(runOptions.imageContents).toBeDefined();
       expect(runOptions.imageContents).toHaveLength(1);
       expect(runOptions.imageContents![0]).toEqual({
@@ -1965,7 +1965,7 @@ describe('SessionService', () => {
     });
 
     it('passes multiple images from a gallery', async () => {
-      const session = createMockSession({ lifecycle: 'idle', backend: 'ink' });
+      const session = createMockSession({ lifecycle: 'idle', backend: 'claude-code' });
       vi.mocked(mockRepository.findByUserAndAgent).mockResolvedValue(session);
 
       const request = createMockRequest({
@@ -1980,15 +1980,15 @@ describe('SessionService', () => {
 
       await sessionService.handleMessage(request);
 
-      const runOptions = vi.mocked(mockInkRunner.run).mock.calls[0][1];
+      const runOptions = vi.mocked(mockClaudeRunner.run).mock.calls[0][1];
       expect(runOptions.imageContents).toHaveLength(3);
       expect(runOptions.imageContents![0].mediaType).toBe('image/jpeg');
       expect(runOptions.imageContents![1].mediaType).toBe('image/png');
       expect(runOptions.imageContents![2].mediaType).toBe('image/webp');
     });
 
-    it('skips image reading for CLI backends', async () => {
-      const session = createMockSession({ lifecycle: 'idle', backend: 'claude-code' });
+    it('does not pass imageContents to ink runner (ink chat manages its own backend)', async () => {
+      const session = createMockSession({ lifecycle: 'idle', backend: 'ink' });
       vi.mocked(mockRepository.findByUserAndAgent).mockResolvedValue(session);
 
       const request = createMockRequest({
@@ -1999,12 +1999,12 @@ describe('SessionService', () => {
 
       await sessionService.handleMessage(request);
 
-      const runOptions = vi.mocked(mockClaudeRunner.run).mock.calls[0][1];
+      const runOptions = vi.mocked(mockInkRunner.run).mock.calls[0][1];
       expect(runOptions.imageContents).toBeUndefined();
     });
 
     it('skips non-image media attachments', async () => {
-      const session = createMockSession({ lifecycle: 'idle', backend: 'ink' });
+      const session = createMockSession({ lifecycle: 'idle', backend: 'claude-code' });
       vi.mocked(mockRepository.findByUserAndAgent).mockResolvedValue(session);
 
       const request = createMockRequest({
@@ -2018,7 +2018,7 @@ describe('SessionService', () => {
 
       await sessionService.handleMessage(request);
 
-      const runOptions = vi.mocked(mockInkRunner.run).mock.calls[0][1];
+      const runOptions = vi.mocked(mockClaudeRunner.run).mock.calls[0][1];
       expect(runOptions.imageContents).toBeUndefined();
     });
 
@@ -2026,7 +2026,7 @@ describe('SessionService', () => {
       const { stat } = await import('fs/promises');
       vi.mocked(stat).mockResolvedValue({ size: 1024 } as any);
 
-      const session = createMockSession({ lifecycle: 'idle', backend: 'ink' });
+      const session = createMockSession({ lifecycle: 'idle', backend: 'claude-code' });
       vi.mocked(mockRepository.findByUserAndAgent).mockResolvedValue(session);
 
       const request = createMockRequest({
@@ -2037,12 +2037,12 @@ describe('SessionService', () => {
 
       await sessionService.handleMessage(request);
 
-      const runOptions = vi.mocked(mockInkRunner.run).mock.calls[0][1];
+      const runOptions = vi.mocked(mockClaudeRunner.run).mock.calls[0][1];
       expect(runOptions.imageContents).toBeUndefined();
     });
 
     it('respects MAX_IMAGES limit of 10', async () => {
-      const session = createMockSession({ lifecycle: 'idle', backend: 'ink' });
+      const session = createMockSession({ lifecycle: 'idle', backend: 'claude-code' });
       vi.mocked(mockRepository.findByUserAndAgent).mockResolvedValue(session);
 
       const media = Array.from({ length: 15 }, (_, i) => ({
@@ -2054,7 +2054,7 @@ describe('SessionService', () => {
       const request = createMockRequest({ metadata: { media } });
       await sessionService.handleMessage(request);
 
-      const runOptions = vi.mocked(mockInkRunner.run).mock.calls[0][1];
+      const runOptions = vi.mocked(mockClaudeRunner.run).mock.calls[0][1];
       expect(runOptions.imageContents).toHaveLength(10);
     });
 
@@ -2062,7 +2062,7 @@ describe('SessionService', () => {
       const { stat } = await import('fs/promises');
       vi.mocked(stat).mockResolvedValue({ size: 25 * 1024 * 1024 } as any);
 
-      const session = createMockSession({ lifecycle: 'idle', backend: 'ink' });
+      const session = createMockSession({ lifecycle: 'idle', backend: 'claude-code' });
       vi.mocked(mockRepository.findByUserAndAgent).mockResolvedValue(session);
 
       const request = createMockRequest({
@@ -2073,7 +2073,7 @@ describe('SessionService', () => {
 
       await sessionService.handleMessage(request);
 
-      const runOptions = vi.mocked(mockInkRunner.run).mock.calls[0][1];
+      const runOptions = vi.mocked(mockClaudeRunner.run).mock.calls[0][1];
       expect(runOptions.imageContents).toBeUndefined();
     });
   });


### PR DESCRIPTION
## What

Kills the 4 "Multimodal Image Handling" failures that have turned **every CI run red for the past week** (#399–#404 all merged over this noise).

## Root cause — stale tests, not a regression

`8153008b` (June 3) deliberately made image attachments **claude-code-only**:

> Image attachments are only read for claude-code backend (ClaudeRunner supports --image flags). InkRunner spawns ink chat which manages its own backend.

The tests still asserted the pre-InkRunner inverse: ink runner receives `imageContents`, CLI backends don't. Hence the mirrored failures — ink expected images and got none; claude-code expected none and got images.

## Changes (test-only, one file)

- Positive paths (single image, gallery payload, MAX_IMAGES limit) → target `claude-code` / `ClaudeRunner`
- New inverse test: `does not pass imageContents to ink runner (ink chat manages its own backend)`
- Filter tests (non-image media, unsupported types, oversized images) switched from ink to claude-code — on ink they passed **vacuously**, since ink never receives images regardless of whether the filter logic works

## Verification

- `session-service.test.ts`: **70/70 green** — first time this file fully passes in weeks
- NUL-byte scan clean
- No production code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)