### PR TITLE
feat: transcript size in session picker + Telegram photo albums (by Wren)

### DIFF
--- a/packages/api/src/channels/gateway.test.ts
+++ b/packages/api/src/channels/gateway.test.ts
@@ -500,23 +500,21 @@ describe('isAgentMentioned', () => {
 
   it('returns true when mentioned username matches a known agent name', () => {
     gateway.setKnownAgentNames(['wren', 'myra', 'benson']);
-    expect(
-      isAgentMentioned(gateway, 'hello', { users: ['@wren'], botMentioned: false })
-    ).toBe(true);
+    expect(isAgentMentioned(gateway, 'hello', { users: ['@wren'], botMentioned: false })).toBe(
+      true
+    );
   });
 
   it('matches mentioned usernames case-insensitively', () => {
     gateway.setKnownAgentNames(['wren']);
-    expect(
-      isAgentMentioned(gateway, 'hello', { users: ['WREN'], botMentioned: false })
-    ).toBe(true);
+    expect(isAgentMentioned(gateway, 'hello', { users: ['WREN'], botMentioned: false })).toBe(true);
   });
 
   it('strips @ prefix from mentioned usernames', () => {
     gateway.setKnownAgentNames(['myra']);
-    expect(
-      isAgentMentioned(gateway, 'hello', { users: ['@myra'], botMentioned: false })
-    ).toBe(true);
+    expect(isAgentMentioned(gateway, 'hello', { users: ['@myra'], botMentioned: false })).toBe(
+      true
+    );
   });
 
   it('returns true when agent name appears in message text', () => {
@@ -544,9 +542,9 @@ describe('isAgentMentioned', () => {
 
   it('returns false when mentioned username does not match any agent', () => {
     gateway.setKnownAgentNames(['wren', 'myra']);
-    expect(
-      isAgentMentioned(gateway, 'hello', { users: ['someuser'], botMentioned: false })
-    ).toBe(false);
+    expect(isAgentMentioned(gateway, 'hello', { users: ['someuser'], botMentioned: false })).toBe(
+      false
+    );
   });
 
   it('handles multiple mentioned usernames', () => {
@@ -562,16 +560,16 @@ describe('isAgentMentioned', () => {
   it('safely handles agent names with regex metacharacters', () => {
     gateway.setKnownAgentNames(['agent+1', 'bot.v2']);
     // Should not throw, and should match literally
-    expect(
-      isAgentMentioned(gateway, 'hey agent+1!', { users: [], botMentioned: false })
-    ).toBe(true);
+    expect(isAgentMentioned(gateway, 'hey agent+1!', { users: [], botMentioned: false })).toBe(
+      true
+    );
     expect(
       isAgentMentioned(gateway, 'ask bot.v2 about it', { users: [], botMentioned: false })
     ).toBe(true);
     // "+" unescaped would match "agent1" — escaped should NOT
-    expect(
-      isAgentMentioned(gateway, 'hey agent1 help', { users: [], botMentioned: false })
-    ).toBe(false);
+    expect(isAgentMentioned(gateway, 'hey agent1 help', { users: [], botMentioned: false })).toBe(
+      false
+    );
   });
 });
 
@@ -869,5 +867,126 @@ describe('Activity Stream Integration', () => {
         })
       );
     });
+  });
+});
+
+describe('Telegram album batching', () => {
+  let gateway: ChannelGateway;
+  let sendMediaGroup: Mock;
+  let sendPhoto: Mock;
+  let sendVideo: Mock;
+  let sendDocument: Mock;
+
+  const img = (n: number) => ({
+    type: 'image' as const,
+    path: `/tmp/photo${n}.jpg`,
+    contentType: 'image/jpeg',
+  });
+
+  const sendMedia = (media: unknown[]) =>
+    (gateway as any).sendMediaAttachments('telegram', 'chat-album', media) as Promise<{
+      sent: number;
+      failed: number;
+      errors: string[];
+    }>;
+
+  beforeEach(() => {
+    gateway = new ChannelGateway({ enableTelegram: false, enableWhatsApp: false });
+    sendMediaGroup = vi.fn().mockResolvedValue(undefined);
+    sendPhoto = vi.fn().mockResolvedValue(undefined);
+    sendVideo = vi.fn().mockResolvedValue(undefined);
+    sendDocument = vi.fn().mockResolvedValue(undefined);
+    (gateway as any).telegramListener = { sendMediaGroup, sendPhoto, sendVideo, sendDocument };
+  });
+
+  it('groups multiple images into one sendMediaGroup album', async () => {
+    const result = await sendMedia([img(1), img(2), img(3)]);
+
+    expect(sendMediaGroup).toHaveBeenCalledTimes(1);
+    const [conversationId, items] = sendMediaGroup.mock.calls[0];
+    expect(conversationId).toBe('chat-album');
+    expect(items).toHaveLength(3);
+    expect(items.map((i: { filePath: string }) => i.filePath)).toEqual([
+      '/tmp/photo1.jpg',
+      '/tmp/photo2.jpg',
+      '/tmp/photo3.jpg',
+    ]);
+    expect(sendPhoto).not.toHaveBeenCalled();
+    expect(result.sent).toBe(3);
+    expect(result.failed).toBe(0);
+  });
+
+  it('sends a single image directly without an album', async () => {
+    const result = await sendMedia([img(1)]);
+
+    expect(sendMediaGroup).not.toHaveBeenCalled();
+    expect(sendPhoto).toHaveBeenCalledTimes(1);
+    expect(result.sent).toBe(1);
+  });
+
+  it('splits 12 images into albums of 10 and 2', async () => {
+    const result = await sendMedia(Array.from({ length: 12 }, (_, i) => img(i)));
+
+    expect(sendMediaGroup).toHaveBeenCalledTimes(2);
+    expect(sendMediaGroup.mock.calls[0][1]).toHaveLength(10);
+    expect(sendMediaGroup.mock.calls[1][1]).toHaveLength(2);
+    expect(sendPhoto).not.toHaveBeenCalled();
+    expect(result.sent).toBe(12);
+  });
+
+  it('sends a trailing remainder of one image singly (11 images)', async () => {
+    const result = await sendMedia(Array.from({ length: 11 }, (_, i) => img(i)));
+
+    expect(sendMediaGroup).toHaveBeenCalledTimes(1);
+    expect(sendMediaGroup.mock.calls[0][1]).toHaveLength(10);
+    expect(sendPhoto).toHaveBeenCalledTimes(1);
+    expect(result.sent).toBe(11);
+  });
+
+  it('mixes videos into albums alongside images', async () => {
+    const result = await sendMedia([
+      img(1),
+      { type: 'video', path: '/tmp/clip.mp4', contentType: 'video/mp4' },
+    ]);
+
+    expect(sendMediaGroup).toHaveBeenCalledTimes(1);
+    const items = sendMediaGroup.mock.calls[0][1];
+    expect(items.map((i: { type: string }) => i.type)).toEqual(['image', 'video']);
+    expect(sendVideo).not.toHaveBeenCalled();
+    expect(result.sent).toBe(2);
+  });
+
+  it('keeps non-groupable media on the per-item path', async () => {
+    const result = await sendMedia([
+      img(1),
+      img(2),
+      { type: 'document', path: '/tmp/report.pdf', contentType: 'application/pdf' },
+    ]);
+
+    expect(sendMediaGroup).toHaveBeenCalledTimes(1);
+    expect(sendMediaGroup.mock.calls[0][1]).toHaveLength(2);
+    expect(sendDocument).toHaveBeenCalledTimes(1);
+    expect(result.sent).toBe(3);
+  });
+
+  it('counts the whole batch as failed when the album send fails', async () => {
+    sendMediaGroup.mockRejectedValueOnce(new Error('flood control'));
+
+    const result = await sendMedia([img(1), img(2)]);
+
+    expect(result.sent).toBe(0);
+    expect(result.failed).toBe(2);
+    expect(result.errors.some((e) => e.includes('flood control'))).toBe(true);
+    // Album failure must not cascade into single sends
+    expect(sendPhoto).not.toHaveBeenCalled();
+  });
+
+  it('skips attachments missing both path and url without sinking the album', async () => {
+    const result = await sendMedia([img(1), img(2), { type: 'image' }]);
+
+    expect(sendMediaGroup).toHaveBeenCalledTimes(1);
+    expect(sendMediaGroup.mock.calls[0][1]).toHaveLength(2);
+    expect(result.sent).toBe(2);
+    expect(result.failed).toBe(1);
   });
 });

--- a/packages/api/src/channels/gateway.test.ts
+++ b/packages/api/src/channels/gateway.test.ts
@@ -989,4 +989,47 @@ describe('Telegram album batching', () => {
     expect(result.sent).toBe(2);
     expect(result.failed).toBe(1);
   });
+
+  it('downloads URL album items with the same filename to distinct temp paths', async () => {
+    // Two album items sharing a display filename must not overwrite each
+    // other's temp download — that uploaded duplicate bytes for one of them.
+    const fetchMock = vi.fn(async (url: string | URL) => {
+      const body = String(url).includes('first') ? 'AAAA' : 'BBBB';
+      return {
+        ok: true,
+        arrayBuffer: async () => new TextEncoder().encode(body).buffer,
+      } as unknown as Response;
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    // Read temp file contents inside the send, before batch cleanup runs
+    const { readFileSync } = await import('fs');
+    const capturedPaths: string[] = [];
+    const capturedContents: string[] = [];
+    sendMediaGroup.mockImplementation(async (_conv: string, items: Array<{ filePath: string }>) => {
+      for (const item of items) {
+        capturedPaths.push(item.filePath);
+        capturedContents.push(readFileSync(item.filePath, 'utf-8'));
+      }
+    });
+
+    try {
+      const result = await sendMedia([
+        { type: 'image', url: 'https://example.com/first/photo.jpg', filename: 'photo.jpg' },
+        { type: 'image', url: 'https://example.com/second/photo.jpg', filename: 'photo.jpg' },
+      ]);
+
+      expect(sendMediaGroup).toHaveBeenCalledTimes(1);
+      expect(capturedPaths).toHaveLength(2);
+      // Distinct temp paths, distinct bytes — the colliding implementation
+      // produced ['BBBB', 'BBBB'] here
+      expect(capturedPaths[0]).not.toBe(capturedPaths[1]);
+      expect(capturedContents).toEqual(['AAAA', 'BBBB']);
+      // Display filename preserved as the basename of both
+      expect(capturedPaths.every((p) => p.endsWith('photo.jpg'))).toBe(true);
+      expect(result.sent).toBe(2);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
 });

--- a/packages/api/src/channels/gateway.ts
+++ b/packages/api/src/channels/gateway.ts
@@ -1157,7 +1157,97 @@ export class ChannelGateway extends EventEmitter {
     let failed = 0;
     const errors: string[] = [];
 
-    for (const attachment of media) {
+    // Telegram albums: 2+ photos/videos batch into sendMediaGroup (10 per
+    // album) so they arrive as one grouped message instead of a stream of
+    // singles. Other media types fall through to the per-item loop below.
+    let queue = media;
+    if (channel === 'telegram' && this.telegramListener) {
+      const groupable = media.filter((m) => m.type === 'image' || m.type === 'video');
+      if (groupable.length >= 2) {
+        queue = media.filter((m) => m.type !== 'image' && m.type !== 'video');
+        const TELEGRAM_ALBUM_MAX = 10;
+        for (let i = 0; i < groupable.length; i += TELEGRAM_ALBUM_MAX) {
+          const batch = groupable.slice(i, i + TELEGRAM_ALBUM_MAX);
+          const resolved: Array<{
+            filePath: string;
+            type: 'image' | 'video';
+            caption?: string;
+            contentType?: string;
+            filename?: string;
+          }> = [];
+          const cleanups: Array<() => Promise<void>> = [];
+
+          for (const attachment of batch) {
+            let filePath = attachment.path;
+            if (!filePath && attachment.url) {
+              try {
+                const temp = await this.downloadToTempFile(attachment.url, attachment.filename);
+                filePath = temp.path;
+                cleanups.push(temp.cleanup);
+              } catch (error) {
+                const msg = `Failed to download media URL: ${attachment.url}`;
+                logger.error(msg, error);
+                errors.push(msg);
+                failed++;
+                continue;
+              }
+            }
+            if (!filePath) {
+              const msg = `Media attachment missing both path and url (type: ${attachment.type})`;
+              logger.warn(msg, { channel, attachment });
+              errors.push(msg);
+              failed++;
+              continue;
+            }
+            resolved.push({
+              filePath,
+              type: attachment.type === 'video' ? 'video' : 'image',
+              caption: attachment.caption,
+              contentType: attachment.contentType,
+              filename: attachment.filename,
+            });
+          }
+
+          try {
+            if (resolved.length >= 2) {
+              await this.telegramListener.sendMediaGroup(conversationId, resolved, {
+                replyToMessageId: options?.replyToMessageId,
+              });
+              sent += resolved.length;
+            } else if (resolved.length === 1) {
+              // Album collapsed to one item (trailing remainder or download
+              // failures) — sendMediaGroup needs 2+, send it singly.
+              const single = resolved[0];
+              const singleOpts = {
+                caption: single.caption,
+                filename: single.filename,
+                contentType: single.contentType,
+                replyToMessageId: options?.replyToMessageId,
+              };
+              if (single.type === 'video') {
+                await this.telegramListener.sendVideo(conversationId, single.filePath, singleOpts);
+              } else {
+                await this.telegramListener.sendPhoto(conversationId, single.filePath, singleOpts);
+              }
+              sent += 1;
+            }
+          } catch (error) {
+            const msg = `Failed to send telegram album (${resolved.length} items): ${
+              error instanceof Error ? error.message : String(error)
+            }`;
+            logger.error(msg);
+            errors.push(msg);
+            failed += resolved.length;
+          } finally {
+            for (const cleanup of cleanups) {
+              await cleanup().catch(() => undefined);
+            }
+          }
+        }
+      }
+    }
+
+    for (const attachment of queue) {
       let filePath = attachment.path;
       let tempCleanup: (() => Promise<void>) | null = null;
 

--- a/packages/api/src/channels/gateway.ts
+++ b/packages/api/src/channels/gateway.ts
@@ -1112,6 +1112,7 @@ export class ChannelGateway extends EventEmitter {
     const fs = await import('fs/promises');
     const pathMod = await import('path');
     const os = await import('os');
+    const { randomUUID } = await import('crypto');
 
     const response = await fetch(url);
     if (!response.ok) {
@@ -1119,10 +1120,15 @@ export class ChannelGateway extends EventEmitter {
     }
 
     const buffer = Buffer.from(await response.arrayBuffer());
-    const tmpDir = pathMod.join(os.tmpdir(), 'pcp-media');
+    // Each download gets its own unique subdirectory while the basename
+    // keeps the display filename. Naming the file directly from
+    // attachment.filename collided when two attachments shared a name
+    // (e.g. an album of two photo.jpg items) — the later download
+    // overwrote the earlier and the album uploaded duplicate bytes.
+    const tmpDir = pathMod.join(os.tmpdir(), 'pcp-media', randomUUID());
     await fs.mkdir(tmpDir, { recursive: true });
 
-    const safeName = (filename || `media_${Date.now()}`).replace(/[^a-zA-Z0-9._-]/g, '_');
+    const safeName = (filename || 'media').replace(/[^a-zA-Z0-9._-]/g, '_') || 'media';
     const tmpPath = pathMod.join(tmpDir, safeName);
     await fs.writeFile(tmpPath, buffer);
 
@@ -1131,6 +1137,7 @@ export class ChannelGateway extends EventEmitter {
       cleanup: async () => {
         try {
           await fs.unlink(tmpPath);
+          await fs.rmdir(tmpDir);
         } catch {
           // Best-effort cleanup
         }

--- a/packages/api/src/channels/telegram-listener.ts
+++ b/packages/api/src/channels/telegram-listener.ts
@@ -1209,6 +1209,72 @@ export class TelegramListener extends EventEmitter {
   }
 
   /**
+   * Send 2-10 photos/videos as a single album (sendMediaGroup).
+   * Telegram renders these as one grouped message — files are attached
+   * via multipart and referenced with attach://<name> in the media JSON.
+   * Captions are per-item; a caption on the first item displays under
+   * the album.
+   */
+  async sendMediaGroup(
+    conversationId: string,
+    items: Array<{
+      filePath: string;
+      type: 'image' | 'video';
+      caption?: string;
+      contentType?: string;
+      filename?: string;
+    }>,
+    options?: { replyToMessageId?: string }
+  ): Promise<void> {
+    if (items.length < 2 || items.length > 10) {
+      throw new Error(`sendMediaGroup requires 2-10 items, got ${items.length}`);
+    }
+
+    const chatId = conversationId.startsWith('telegram:')
+      ? conversationId.replace('telegram:', '')
+      : conversationId;
+
+    const fs = await import('fs/promises');
+    const pathMod = await import('path');
+
+    const form = new FormData();
+    form.append('chat_id', chatId);
+    if (options?.replyToMessageId) {
+      form.append('reply_to_message_id', String(parseInt(options.replyToMessageId, 10)));
+    }
+
+    const mediaSpec: Array<Record<string, string>> = [];
+    let totalBytes = 0;
+    for (let i = 0; i < items.length; i++) {
+      const item = items[i];
+      const bytes = await fs.readFile(item.filePath);
+      totalBytes += bytes.byteLength;
+      const attachName = `media${i}`;
+      const filename = item.filename || pathMod.basename(item.filePath) || attachName;
+      const contentType = item.contentType || (item.type === 'video' ? 'video/mp4' : 'image/jpeg');
+      form.append(attachName, new Blob([new Uint8Array(bytes)], { type: contentType }), filename);
+      mediaSpec.push({
+        type: item.type === 'video' ? 'video' : 'photo',
+        media: `attach://${attachName}`,
+        ...(item.caption ? { caption: item.caption } : {}),
+      });
+    }
+    form.append('media', JSON.stringify(mediaSpec));
+
+    const url = `${TELEGRAM_API}/bot${this.token}/sendMediaGroup`;
+    const response = await fetch(url, { method: 'POST', body: form });
+
+    const data = (await response.json()) as TelegramApiResponse<unknown>;
+    if (!data.ok) {
+      throw new Error(`Telegram API error: ${data.description}`);
+    }
+    logger.info(`Sent media group to Telegram chat ${chatId}`, {
+      items: items.length,
+      totalBytes,
+    });
+  }
+
+  /**
    * Send a document (file) to a Telegram chat
    */
   async sendDocument(

--- a/packages/api/src/channels/telegram-send-media-group.test.ts
+++ b/packages/api/src/channels/telegram-send-media-group.test.ts
@@ -1,0 +1,121 @@
+/**
+ * sendMediaGroup form construction
+ *
+ * Verifies the Telegram album payload: files attached via multipart with
+ * attach://<name> references in the media JSON, per the Bot API's
+ * sendMediaGroup contract (2-10 photos/videos per album).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtemp, writeFile, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+vi.mock('../utils/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('../config/env', () => ({
+  env: {
+    TELEGRAM_BOT_TOKEN: 'test-token',
+    LOG_LEVEL: 'info',
+    // Transitive: TelegramListener pulls in AuthorizationService, which
+    // constructs a Supabase client at module init
+    SUPABASE_URL: 'https://test.supabase.co',
+    SUPABASE_SECRET_KEY: 'test-secret-key',
+    SUPABASE_PUBLISHABLE_KEY: 'test-pub-key',
+  },
+}));
+
+import { createTelegramListener } from './telegram-listener.js';
+
+describe('TelegramListener.sendMediaGroup', () => {
+  let dir: string;
+  let photoA: string;
+  let photoB: string;
+  const fetchMock = vi.fn();
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'tg-album-test-'));
+    photoA = join(dir, 'a.jpg');
+    photoB = join(dir, 'b.png');
+    await writeFile(photoA, Buffer.alloc(64, 1));
+    await writeFile(photoB, Buffer.alloc(64, 2));
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue({
+      json: async () => ({ ok: true, result: [] }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(async () => {
+    vi.unstubAllGlobals();
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('posts to sendMediaGroup with attach:// references and per-item captions', async () => {
+    const listener = createTelegramListener({ token: 'test-token' });
+
+    await listener.sendMediaGroup('telegram:12345', [
+      { filePath: photoA, type: 'image', caption: 'first', contentType: 'image/jpeg' },
+      { filePath: photoB, type: 'image', contentType: 'image/png' },
+    ]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toContain('/sendMediaGroup');
+
+    const form = init.body as FormData;
+    expect(form.get('chat_id')).toBe('12345');
+    const mediaSpec = JSON.parse(String(form.get('media')));
+    expect(mediaSpec).toEqual([
+      { type: 'photo', media: 'attach://media0', caption: 'first' },
+      { type: 'photo', media: 'attach://media1' },
+    ]);
+    // The referenced files ride the same multipart form
+    expect(form.get('media0')).toBeInstanceOf(Blob);
+    expect(form.get('media1')).toBeInstanceOf(Blob);
+  });
+
+  it('maps video items to type video', async () => {
+    const listener = createTelegramListener({ token: 'test-token' });
+
+    await listener.sendMediaGroup('99', [
+      { filePath: photoA, type: 'image' },
+      { filePath: photoB, type: 'video', contentType: 'video/mp4' },
+    ]);
+
+    const form = fetchMock.mock.calls[0][1].body as FormData;
+    const mediaSpec = JSON.parse(String(form.get('media')));
+    expect(mediaSpec.map((m: { type: string }) => m.type)).toEqual(['photo', 'video']);
+  });
+
+  it('rejects item counts outside 2-10', async () => {
+    const listener = createTelegramListener({ token: 'test-token' });
+
+    await expect(
+      listener.sendMediaGroup('99', [{ filePath: photoA, type: 'image' }])
+    ).rejects.toThrow(/2-10/);
+    await expect(
+      listener.sendMediaGroup(
+        '99',
+        Array.from({ length: 11 }, () => ({ filePath: photoA, type: 'image' as const }))
+      )
+    ).rejects.toThrow(/2-10/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('surfaces Telegram API errors', async () => {
+    fetchMock.mockResolvedValue({
+      json: async () => ({ ok: false, description: 'flood control exceeded' }),
+    });
+    const listener = createTelegramListener({ token: 'test-token' });
+
+    await expect(
+      listener.sendMediaGroup('99', [
+        { filePath: photoA, type: 'image' },
+        { filePath: photoB, type: 'image' },
+      ])
+    ).rejects.toThrow(/flood control exceeded/);
+  });
+});

--- a/packages/cli/src/commands/chat-hydration.test.ts
+++ b/packages/cli/src/commands/chat-hydration.test.ts
@@ -3,7 +3,18 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { ContextLedger, entryRefHash } from '../repl/context-ledger.js';
-import { hydrateLedgerFromTranscript } from './chat.js';
+import { hydrateLedgerFromTranscript, formatTranscriptSize } from './chat.js';
+
+describe('formatTranscriptSize', () => {
+  it('formats KB below 1MB, one decimal below 10MB, whole MB above', () => {
+    expect(formatTranscriptSize(0)).toBe('');
+    expect(formatTranscriptSize(512)).toBe('1KB');
+    expect(formatTranscriptSize(420 * 1024)).toBe('420KB');
+    expect(formatTranscriptSize(1.2 * 1024 * 1024)).toBe('1.2MB');
+    expect(formatTranscriptSize(9.44 * 1024 * 1024)).toBe('9.4MB');
+    expect(formatTranscriptSize(24.6 * 1024 * 1024)).toBe('25MB');
+  });
+});
 
 describe('hydrateLedgerFromTranscript — compaction events', () => {
   let dir: string;

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -389,6 +389,8 @@ interface LocalToolCall {
 
 interface SessionTranscriptMetadata {
   transcriptPath: string;
+  /** Transcript file size in bytes — quick toxic-session indicator */
+  transcriptBytes: number;
   messageCount: number;
   userCount: number;
   assistantCount: number;
@@ -618,8 +620,15 @@ function getSessionTranscriptMetadata(sessionId: string): SessionTranscriptMetad
   }
 
   const messageCount = userCount + assistantCount + inboxCount;
+  let transcriptBytes = 0;
+  try {
+    transcriptBytes = statSync(path).size;
+  } catch {
+    // File raced away between read and stat — size stays 0
+  }
   return {
     transcriptPath: path,
+    transcriptBytes,
     messageCount,
     userCount,
     assistantCount,
@@ -1613,9 +1622,19 @@ function sessionBackendLabel(session: SessionSummary): string {
   return '-';
 }
 
+/** Human file size for transcript footprints: 412KB, 1.2MB, 24MB. Exported for tests. */
+export function formatTranscriptSize(bytes: number): string {
+  if (bytes <= 0) return '';
+  const mb = bytes / (1024 * 1024);
+  if (mb < 1) return `${Math.max(1, Math.round(bytes / 1024))}KB`;
+  if (mb < 10) return `${mb.toFixed(1)}MB`;
+  return `${Math.round(mb)}MB`;
+}
+
 function sessionHistoryLabel(meta: SessionTranscriptMetadata | null): string {
   if (!meta) return 'remote';
-  return `${meta.messageCount} msgs`;
+  const size = formatTranscriptSize(meta.transcriptBytes);
+  return size ? `${meta.messageCount} msgs · ${size}` : `${meta.messageCount} msgs`;
 }
 
 function sessionLatestMessagePreview(
@@ -1645,7 +1664,7 @@ function formatSessionsLines(
   }
   const lines = [
     'Active sessions',
-    'id       agent   status/phase            studio            thread        started   backend            history    last-msg',
+    'id       agent   status/phase            studio            thread        started   backend            history             last-msg',
   ];
   for (const session of sessions) {
     const transcriptMeta = getSessionTranscriptMetadata(session.id);
@@ -1656,7 +1675,7 @@ function formatSessionsLines(
     const thread = (session.threadKey || '-').slice(0, 12).padEnd(12);
     const started = formatStartedAt(session.startedAt);
     const backend = sessionBackendLabel(session).slice(0, 18).padEnd(18);
-    const history = sessionHistoryLabel(transcriptMeta).slice(0, 9).padEnd(9);
+    const history = sessionHistoryLabel(transcriptMeta).slice(0, 18).padEnd(18);
     const lastMessage = formatTimestampForSessionList(
       transcriptMeta?.lastMessageAt,
       options?.timezone


### PR DESCRIPTION
## Two quality-of-life upgrades

### 1. Transcript size in the session picker

The picker (and `/sessions` table) now shows the transcript file's footprint next to the message count:

```
▸ 95111fc0  idle:completed  ·  6m ago  ·  3118 msgs · 9.4MB  ·  ink
```

A glanceable toxic-session indicator — the 306K-token transcript that silently broke Myra's heartbeats for a month would have stood out immediately. Formatting: `412KB` under 1MB, `1.2MB` one-decimal under 10MB, `24MB` whole above. Flows through `sessionHistoryLabel` so both the interactive picker and the `/sessions` table get it; the table's history column widened to fit.

### 2. Telegram albums (`sendMediaGroup`)

`send_response` with 2+ images/videos now arrives as **one grouped album** instead of a stream of single messages:

- **`TelegramListener.sendMediaGroup`** — Bot API `sendMediaGroup` with `attach://` multipart references, per-item captions, and the 2–10 item contract enforced
- **Gateway batching** — `sendMediaAttachments` groups telegram images/videos into albums of 10; a trailing remainder of one falls back to `sendPhoto`/`sendVideo`; documents/audio keep the per-item path; an album failure counts the whole batch and doesn't cascade into duplicate single sends
- **Transparent to SBs** — no tool schema change; Myra's existing `send_response` media array just produces albums now

## Tests

- **Gateway batching (8 cases)**: multi-image grouping, single-image passthrough, 12→10+2 splits, 11→10+single fallback, image+video mixing, non-groupable fall-through, failure accounting, missing-path skips
- **Listener form construction (4 cases)**: `attach://` media JSON + multipart blobs, per-item captions, video type mapping, 2–10 bounds, API error surfacing (mocked fetch)
- **Size formatter**: KB/MB threshold coverage
- All green; NUL scan clean

## Verification still pending

Live album proof needs the dev server restart (Myra's listener runs on the main server) — after the restart, asking Myra for multiple photos exercises the album path, and Conor's planned screenshot-to-Myra test covers inbound media (#406) at the same time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)