### PR TITLE
fix: ink wait no longer races push delivery — fullHistory thread polling (by Wren)

### DIFF
--- a/packages/api/src/mcp/tools/index.ts
+++ b/packages/api/src/mcp/tools/index.ts
@@ -4137,7 +4137,9 @@ User can be identified by ONE of: userId, email, phone, or platform + platformId
   server.registerTool(
     'get_thread_messages',
     {
-      description: `Get the full message timeline of a thread. Requires participant membership. Automatically marks the thread as read for the requesting agent.
+      // Description derived from the canonical definition so the MCP catalog
+      // can't drift from the handler's documented behavior again
+      description: `${threadToolDefinitions[0].description}
 
 Use to read conversation history in a group thread before replying.
 

--- a/packages/api/src/mcp/tools/thread-handlers.integration.test.ts
+++ b/packages/api/src/mcp/tools/thread-handlers.integration.test.ts
@@ -212,6 +212,47 @@ describe('Thread Handlers Integration — read cursor + monotonic markRead', () 
     expect(second.messages.map((m) => m.id)).toEqual([messageIds[3], messageIds[4]]);
   });
 
+  it('fullHistory bypasses the read-state fallback (ink wait race regression)', async () => {
+    const threadKey = 'thread:test-cursor-fullhistory-' + Date.now();
+    const { threadId, messageIds } = await createThreadWithMessages(threadKey, 'lumen', 'wren', [
+      { sender: 'wren', content: 'review request' },
+      { sender: 'lumen', content: 'review posted' },
+    ]);
+
+    // Simulate push-channel delivery: the trigger pipeline reads the thread
+    // and advances last_read_at past everything
+    await handleGetThreadMessages(
+      { userId, threadKey, agentId: 'wren', limit: 50, markRead: true },
+      dataComposer
+    );
+    const pointerAfterDelivery = await readPointer(threadId, 'wren');
+    expect(pointerAfterDelivery).not.toBeNull();
+
+    // The ink wait failure mode: a cursor-less poll after delivery sees an
+    // empty thread (read-state fallback hides everything already read)...
+    const raced = await parseResult(
+      await handleGetThreadMessages(
+        { userId, threadKey, agentId: 'wren', limit: 50, markRead: false },
+        dataComposer
+      )
+    );
+    expect(raced.messageCount).toBe(0);
+
+    // ...while fullHistory returns the true timeline so a watcher can
+    // anchor and detect the reply regardless of read state
+    const full = await parseResult(
+      await handleGetThreadMessages(
+        { userId, threadKey, agentId: 'wren', limit: 50, markRead: false, fullHistory: true },
+        dataComposer
+      )
+    );
+    expect(full.messages.map((m) => m.content)).toEqual(['review request', 'review posted']);
+    expect(full.messages.map((m) => m.id)).toEqual(messageIds);
+
+    // fullHistory + markRead:false must not move the read pointer
+    expect(await readPointer(threadId, 'wren')).toBe(pointerAfterDelivery);
+  });
+
   it('fallback returns full thread when the caller has no prior read status', async () => {
     const threadKey = 'thread:test-cursor-no-pointer-' + Date.now();
     await createThreadWithMessages(threadKey, 'lumen', 'wren', [

--- a/packages/api/src/mcp/tools/thread-handlers.ts
+++ b/packages/api/src/mcp/tools/thread-handlers.ts
@@ -42,6 +42,13 @@ const getThreadMessagesSchema = userIdentifierBaseSchema.extend({
   afterMessageId: z.string().uuid().optional().describe('Cursor: get messages after this ID'),
   includeSystemEvents: z.boolean().optional().default(true),
   markRead: z.boolean().optional().default(true),
+  fullHistory: z
+    .boolean()
+    .optional()
+    .default(false)
+    .describe(
+      'Return the full timeline regardless of read state. Without this (and without an explicit cursor), results fall back to messages newer than the last-read pointer — which hides already-delivered messages from watchers/pollers that manage their own cursor (e.g., ink wait).'
+    ),
 });
 
 const addThreadParticipantSchema = userIdentifierBaseSchema.extend({
@@ -327,9 +334,12 @@ export async function handleGetThreadMessages(args: unknown, dataComposer: DataC
     if (cursor) {
       query = query.gt('created_at', cursor.created_at);
     }
-  } else if (!beforeMessageId) {
+  } else if (!beforeMessageId && !parsed.fullHistory) {
     // No explicit cursor — fall back to stored read state so a client whose
     // in-memory cursor was reset doesn't replay the full thread history.
+    // Skipped when fullHistory is set: watchers (ink wait) need the true
+    // timeline to anchor on, or push-delivery read-marking races them into
+    // seeing an eternally-empty thread.
     // Baseline priority:
     //   1. last_read_at (explicit read pointer from prior reads)
     //   2. joined_at (participant join time — no replay of pre-join history)
@@ -793,7 +803,7 @@ export const threadToolDefinitions = [
   {
     name: 'get_thread_messages',
     description:
-      'Get the full message timeline of a thread. Requires participant membership. Automatically marks the thread as read for the requesting agent.',
+      'Get the message timeline of a thread. Requires participant membership. By default returns messages newer than your last-read pointer and advances it (markRead); pass fullHistory: true for the complete timeline regardless of read state, or an explicit before/afterMessageId cursor.',
     schema: getThreadMessagesSchema,
     handler: handleGetThreadMessages,
   },

--- a/packages/cli/src/commands/wait.ts
+++ b/packages/cli/src/commands/wait.ts
@@ -75,6 +75,11 @@ export function registerWaitCommand(program: Command): void {
       if (threadKey) {
         try {
           // Fetch recent messages to find the latest message ID as anchor.
+          // fullHistory is load-bearing: without it (and without a cursor)
+          // the server falls back to the last-read pointer, and push-channel
+          // delivery marks threads read — so the watcher would baseline on
+          // 0 messages and then race the push pipeline on every poll (the
+          // pr:404/pr:408 watchers timed out through live replies this way).
           // Known limitation: threads with >200 messages will anchor on #200,
           // not the true latest. Needs server-side "latest message" support
           // or descending order in get_thread_messages to fix properly.
@@ -83,6 +88,7 @@ export function registerWaitCommand(program: Command): void {
             agentId,
             threadKey,
             markRead: false,
+            fullHistory: true,
             limit: 200,
           })) as Record<string, unknown>;
           const messages = (threadResult.messages as Array<Record<string, unknown>>) || [];
@@ -166,12 +172,17 @@ export function registerWaitCommand(program: Command): void {
           }
 
           if (threadKey) {
-            // Watch specific thread — use afterMessageId to only get NEW messages
+            // Watch specific thread — use afterMessageId to only get NEW
+            // messages. fullHistory keeps anchor-less polls (thread empty at
+            // baseline) immune to the read-state fallback: a reply that the
+            // push channel already delivered-and-marked-read must still
+            // trigger the watcher.
             const pollArgs: Record<string, unknown> = {
               email: config.email,
               agentId,
               threadKey,
               markRead: false,
+              fullHistory: true,
               limit: 10,
             };
             if (baselineLastMessageId) {


### PR DESCRIPTION
## The stale-watcher mystery, solved

Every `ink wait --thread pr:<n>` watcher tonight timed out (exit 1) *through* live replies, firing stale failure notifications minutes after the reply had already arrived via the inkmail push channel. Conor asked if the watchers could drain themselves once the response is in — turns out they were designed to, and a server-side read-state race broke it.

## Root cause

`get_thread_messages` without an explicit cursor falls back to the caller's `last_read_at` pointer — and **push-channel delivery marks threads read**. So:

1. Watcher baselines → everything already read → `Baseline: 0 messages` → no anchor
2. Every cursor-less poll uses the read-state fallback again
3. Reply lands → push delivers it and advances `last_read_at` → the watcher's next poll sees an empty thread, forever → timeout

The one watcher that ever fired won the poll-vs-push race by seconds. Reproduced live: `get_thread_messages(pr:408)` returned `messageCount: 0` on a 6-message thread.

## Fix

- **`get_thread_messages` gains `fullHistory: true`** — skips the read-state fallback, returns the true timeline. Zod strips unknown keys, so the new CLI degrades gracefully against a not-yet-restarted server (old behavior, no error)
- **`ink wait`** passes `fullHistory` on the baseline fetch (anchors on the true latest message) and on anchor-less polls (threads empty at baseline stay immune to read-marking)
- **Tool description corrected** — it claimed "full message timeline" while defaulting to unread-since-last-read

Net effect: watchers self-drain — exit 0 within one poll interval of any reply, even when the push channel already delivered and read-marked it. The wake becomes a confirmation, not a stale failure.

## Tests

Integration regression (real Supabase, 6/6 green) modeled on the exact failure: simulated push delivery → cursor-less poll sees 0 (the race, asserted) → `fullHistory` sees the full timeline with correct ids → read pointer unmoved by `fullHistory` + `markRead: false`.

Existing cursor/monotonicity suite untouched and green.

## Known-unrelated CI

DB integration job red repo-wide (local Supabase drift, task `03fcdb56`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)