### PR TITLE
feat(cli): replay tool calls in transcript history (by Wren)

### DIFF
--- a/packages/cli/src/commands/chat-hydration.test.ts
+++ b/packages/cli/src/commands/chat-hydration.test.ts
@@ -5,6 +5,87 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { ContextLedger, entryRefHash } from '../repl/context-ledger.js';
 import { hydrateLedgerFromTranscript, formatTranscriptSize } from './chat.js';
 
+describe('hydrateLedgerFromTranscript — tool call replay', () => {
+  let dir: string;
+  let transcriptPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'ink-hydration-tools-test-'));
+    transcriptPath = join(dir, 'session-tools.jsonl');
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('replays local_tool_call events as dim event rows (regression: send_response receipts vanished)', () => {
+    writeFileSync(
+      transcriptPath,
+      [
+        {
+          eid: 1,
+          type: 'system_turn',
+          content: '[HEARTBEAT TRIGGER] check email',
+          label: 'heartbeat',
+        },
+        {
+          eid: 2,
+          type: 'local_tool_call',
+          tool: 'send_response',
+          args: { channel: 'telegram', conversationId: '726555973', content: 'heads-up!' },
+          status: 'executed',
+        },
+        {
+          eid: 3,
+          type: 'assistant',
+          content: 'Sent Conor a heads-up via Telegram.',
+          backend: 'claude',
+        },
+      ]
+        .map((e) => JSON.stringify(e))
+        .join('\n') + '\n'
+    );
+
+    const ledger = new ContextLedger();
+    const result = hydrateLedgerFromTranscript(ledger, transcriptPath);
+
+    // The tool call shows in the replay as an event row...
+    const eventRows = result.tailPreview.filter((p) => p.role === 'event');
+    expect(eventRows).toHaveLength(1);
+    expect(eventRows[0].content).toContain('send_response');
+    expect(eventRows[0].content).toContain('(executed)');
+    expect(eventRows[0].content).toContain('telegram');
+    expect(eventRows[0].eid).toBe(2);
+
+    // ...in order, between the trigger and the assistant's claim
+    const roles = result.tailPreview.map((p) => p.role);
+    expect(roles).toEqual(['system', 'event', 'assistant']);
+
+    // ...but is not counted as a message and not added to the ledger
+    expect(result.messageCount).toBe(2);
+    expect(ledger.listEntries().some((e) => e.content.includes('send_response'))).toBe(false);
+  });
+
+  it('caps long tool args in the replay preview', () => {
+    writeFileSync(
+      transcriptPath,
+      JSON.stringify({
+        eid: 1,
+        type: 'local_tool_call',
+        tool: 'remember',
+        args: { content: 'x'.repeat(500) },
+        status: 'executed',
+      }) + '\n'
+    );
+
+    const ledger = new ContextLedger();
+    const result = hydrateLedgerFromTranscript(ledger, transcriptPath);
+    const row = result.tailPreview.find((p) => p.role === 'event');
+    expect(row).toBeDefined();
+    expect(row!.content.length).toBeLessThan(150);
+  });
+});
+
 describe('formatTranscriptSize', () => {
   it('formats KB below 1MB, one decimal below 10MB, whole MB above', () => {
     expect(formatTranscriptSize(0)).toBe('');

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -406,7 +406,8 @@ interface HistoryHydrationResult {
   source: 'repl-transcript' | 'pcp-session-context' | 'none';
   transcriptPath?: string;
   tailPreview: Array<{
-    role: 'user' | 'assistant' | 'inbox' | 'system';
+    /** 'event' rows are dim progress lines (tool calls) — not messages */
+    role: 'user' | 'assistant' | 'inbox' | 'system' | 'event';
     content: string;
     ts?: string;
     /** Display label for system entries (e.g., "heartbeat", "continuation") */
@@ -671,7 +672,7 @@ export function hydrateLedgerFromTranscript(
   const hydratedEntryIds: number[] = [];
 
   const pushPreview = (
-    role: 'user' | 'assistant' | 'inbox' | 'system',
+    role: 'user' | 'assistant' | 'inbox' | 'system' | 'event',
     content: string,
     ts?: string,
     label?: string,
@@ -897,6 +898,24 @@ export function hydrateLedgerFromTranscript(
       }
       continue;
     }
+    if (type === 'local_tool_call' && typeof event.tool === 'string') {
+      // Tool calls are part of the story — when the assistant says "I sent
+      // him a heads-up via Telegram", the send_response call is the receipt.
+      // Replay them as dim event lines (display only — tool RESULTS are not
+      // reconstructed into the ledger here).
+      const status = typeof event.status === 'string' ? event.status : 'executed';
+      const argsPreview = event.args
+        ? JSON.stringify(event.args).replace(/\s+/g, ' ').slice(0, 100)
+        : '';
+      pushPreview(
+        'event',
+        `🛠 ${event.tool} (${status})${argsPreview ? ` — ${argsPreview}` : ''}`,
+        typeof event.ts === 'string' ? event.ts : undefined,
+        undefined,
+        eid
+      );
+      continue;
+    }
     if (type === 'activity' && typeof event.content === 'string') {
       const actor = typeof event.agentId === 'string' ? event.agentId : 'system';
       const activityType = typeof event.activityType === 'string' ? event.activityType : 'activity';
@@ -1040,7 +1059,7 @@ const INTERNAL_SYSTEM_SOURCES = new Set([
 ]);
 
 function compactForHistoryPreview(
-  role: 'user' | 'assistant' | 'inbox' | 'system',
+  role: 'user' | 'assistant' | 'inbox' | 'system' | 'event',
   content: string
 ): string {
   if (role === 'inbox') {
@@ -4681,6 +4700,11 @@ export async function runChat(options: ChatOptions): Promise<void> {
     // Push prior messages into Ink scrollback so user sees conversation history
     if (historyHydration && historyHydration.tailPreview.length > 0) {
       for (const entry of historyHydration.tailPreview) {
+        if (entry.role === 'event') {
+          // Tool calls and other progress lines — dim, unlabeled
+          inkRepl.printEvent(`  ${entry.content}`);
+          continue;
+        }
         const role =
           entry.role === 'user'
             ? ('user' as const)


### PR DESCRIPTION
## What

Conor's catch reviewing the heartbeat replay: Myra says *"I sent him a heads-up via Telegram"* — but the `send_response` call that proves it no longer renders. `local_tool_call` transcript events were skipped entirely by hydration, so reattach/replay showed **claims without receipts**.

Now the replay includes them as dim event lines, in stream order:

```
heartbeat  12:00 PM
[HEARTBEAT TRIGGER] ...

  🛠 send_response (executed) — {"channel":"telegram","conversationId":"726555973","content":"heads-up…

myra  12:01 PM
The noon email/calendar heartbeat cycle is complete. ... so I sent him a heads-up via Telegram.
```

## How

- `hydrateLedgerFromTranscript` pushes `local_tool_call` events into `tailPreview` as a new `'event'` row type — `🛠 <tool> (<status>) — <args…>`, args capped at 100 chars
- Ink replay renders event rows via the existing `printEvent` (dim, unlabeled — same treatment live tool lines get)
- **Display-only**: event rows don't count as messages and tool *results* are not reconstructed into the ledger (that's a context-fidelity question with token-budget implications — deliberately out of scope)
- Event rows carry eids, so eviction preview-filtering stays precise (they can never be spuriously matched since they have no ledger counterpart)

## Tests

- Regression: ordered `system → event → assistant` replay; the event row carries tool name, status, args slice, and eid; `messageCount` unaffected; nothing leaks into the ledger
- Long-args capping
- Hydration suite 19/19; full CLI repl+commands sweep 334/334

## Known-unrelated CI

DB integration drift (task `03fcdb56`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)