### PR TITLE
fix(cli): align event rows, ellipsis truncation, Ctrl+T tool-calls view (by Wren)

### DIFF
--- a/packages/cli/src/commands/chat-hydration.test.ts
+++ b/packages/cli/src/commands/chat-hydration.test.ts
@@ -64,6 +64,11 @@ describe('hydrateLedgerFromTranscript — tool call replay', () => {
     // ...but is not counted as a message and not added to the ledger
     expect(result.messageCount).toBe(2);
     expect(ledger.listEntries().some((e) => e.content.includes('send_response'))).toBe(false);
+
+    // ...and is collected for the context inspector's Tool Calls section
+    expect(result.toolCalls).toHaveLength(1);
+    expect(result.toolCalls[0].tool).toBe('send_response');
+    expect(result.toolCalls[0].args).toContain('726555973');
   });
 
   it('caps long tool args in the replay preview', () => {
@@ -83,6 +88,11 @@ describe('hydrateLedgerFromTranscript — tool call replay', () => {
     const row = result.tailPreview.find((p) => p.role === 'event');
     expect(row).toBeDefined();
     expect(row!.content.length).toBeLessThan(150);
+    // Truncation is explicit, not a mid-word clip
+    expect(row!.content.endsWith('…')).toBe(true);
+    // The inspector record keeps a longer (but still capped) version
+    expect(result.toolCalls[0].args!.length).toBeLessThanOrEqual(401);
+    expect(result.toolCalls[0].args!.endsWith('…')).toBe(true);
   });
 });
 

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -654,6 +654,8 @@ export function hydrateLedgerFromTranscript(
   compactionCollapsed: boolean;
   /** Entries excluded by context_evict events — for evicted-content display */
   evictedEntries: EvictedEntryRecord[];
+  /** Tool calls replayed from the transcript (for the context inspector) */
+  toolCalls: Array<{ tool: string; status: string; at: string; args?: string }>;
   /** Highest event id seen — seeds the append counter so new eids continue */
   maxEid: number;
 } {
@@ -667,6 +669,7 @@ export function hydrateLedgerFromTranscript(
   const seenActivityIds = new Set<string>();
   const recoveredMemoryIds: string[] = [];
   const evictedEntries: EvictedEntryRecord[] = [];
+  const toolCalls: Array<{ tool: string; status: string; at: string; args?: string }> = [];
   // Entries added by THIS hydration pass — a compaction event collapses them
   // (and only them; entries that pre-date hydration are left alone).
   const hydratedEntryIds: number[] = [];
@@ -902,11 +905,12 @@ export function hydrateLedgerFromTranscript(
       // Tool calls are part of the story — when the assistant says "I sent
       // him a heads-up via Telegram", the send_response call is the receipt.
       // Replay them as dim event lines (display only — tool RESULTS are not
-      // reconstructed into the ledger here).
+      // reconstructed into the ledger here). The inline row is a one-line
+      // teaser; fuller args land in the context inspector's Tool Calls
+      // section (Ctrl+T) via the toolCalls collected here.
       const status = typeof event.status === 'string' ? event.status : 'executed';
-      const argsPreview = event.args
-        ? JSON.stringify(event.args).replace(/\s+/g, ' ').slice(0, 100)
-        : '';
+      const argsJson = event.args ? JSON.stringify(event.args).replace(/\s+/g, ' ') : '';
+      const argsPreview = argsJson.length > 100 ? `${argsJson.slice(0, 100)}…` : argsJson;
       pushPreview(
         'event',
         `🛠 ${event.tool} (${status})${argsPreview ? ` — ${argsPreview}` : ''}`,
@@ -914,6 +918,19 @@ export function hydrateLedgerFromTranscript(
         undefined,
         eid
       );
+      toolCalls.push({
+        tool: event.tool,
+        status,
+        at: typeof event.ts === 'string' ? event.ts : '',
+        args: argsJson
+          ? argsJson.length > 400
+            ? `${argsJson.slice(0, 400)}…`
+            : argsJson
+          : undefined,
+      });
+      if (toolCalls.length > 100) {
+        toolCalls.splice(0, toolCalls.length - 100);
+      }
       continue;
     }
     if (type === 'activity' && typeof event.content === 'string') {
@@ -942,6 +959,7 @@ export function hydrateLedgerFromTranscript(
     recoveredMemoryIds,
     compactionCollapsed,
     evictedEntries,
+    toolCalls,
     maxEid,
   };
 }
@@ -2416,7 +2434,7 @@ export async function runChat(options: ChatOptions): Promise<void> {
   let hookTurnCount = 0;
 
   // Session-level tool call log — surfaced in the Ctrl+O context inspector
-  const recentToolCalls: Array<{ tool: string; status: string; at: string }> = [];
+  const recentToolCalls: Array<{ tool: string; status: string; at: string; args?: string }> = [];
 
   // Entries evicted from the window (hydration replay + live evictions) —
   // out of context but never out of sight; surfaced in the inspector
@@ -2720,6 +2738,9 @@ export async function runChat(options: ChatOptions): Promise<void> {
     // Continue the event-id sequence from where the file left off
     seedTranscriptEidCounter(existingTranscript, hydrated.maxEid);
     sessionEvictedEntries.push(...hydrated.evictedEntries);
+    // Replayed tool calls populate the inspector's Tool Calls section so
+    // Ctrl+T shows the receipts behind prior turns, not just this session's
+    recentToolCalls.push(...hydrated.toolCalls);
     historyHydration = {
       loaded: hydrated.loaded,
       messageCount: hydrated.messageCount,
@@ -3926,7 +3947,8 @@ export async function runChat(options: ChatOptions): Promise<void> {
     let toolLoopIteration = 0;
     let responseText = '';
     let localToolCalls: ReturnType<typeof extractLocalToolCalls> = [];
-    let allToolResults: Array<{ tool: string; result: unknown; status: string }> = [];
+    let allToolResults: Array<{ tool: string; result: unknown; status: string; args?: unknown }> =
+      [];
 
     // eslint-disable-next-line no-constant-condition
     while (true) {
@@ -4144,6 +4166,7 @@ export async function runChat(options: ChatOptions): Promise<void> {
               tool: result.tool,
               result: result.result,
               status: result.status,
+              args: result.args,
             });
           } else if (result.status === 'error') {
             const msg = `Local tool error (${result.tool}): ${result.error}`;
@@ -4163,7 +4186,17 @@ export async function runChat(options: ChatOptions): Promise<void> {
 
       allToolResults.push(...iterationResults);
       for (const r of iterationResults) {
-        recentToolCalls.push({ tool: r.tool, status: r.status, at: new Date().toISOString() });
+        const liveArgsJson = r.args ? JSON.stringify(r.args).replace(/\s+/g, ' ') : '';
+        recentToolCalls.push({
+          tool: r.tool,
+          status: r.status,
+          at: new Date().toISOString(),
+          args: liveArgsJson
+            ? liveArgsJson.length > 400
+              ? `${liveArgsJson.slice(0, 400)}…`
+              : liveArgsJson
+            : undefined,
+        });
       }
       if (recentToolCalls.length > 100) {
         recentToolCalls.splice(0, recentToolCalls.length - 100);
@@ -4696,6 +4729,11 @@ export async function runChat(options: ChatOptions): Promise<void> {
     inkRepl.handle.setCtrlOHandler(() => {
       inkRepl!.showContextView(buildContextViewLines());
     });
+    // Ctrl+T — same viewer, opened at the Tool Calls section (expands the
+    // one-line 🛠 rows in the replay to full args)
+    inkRepl.handle.setCtrlTHandler(() => {
+      inkRepl!.showContextView(buildContextViewLines(), { initialSection: 't' });
+    });
 
     // Push prior messages into Ink scrollback so user sees conversation history
     if (historyHydration && historyHydration.tailPreview.length > 0) {
@@ -4915,6 +4953,8 @@ export async function runChat(options: ChatOptions): Promise<void> {
             '/evicted                   Show evicted-from-context entries',
             '/context                   Show recent entries',
             '/usage                     Token estimate',
+            'Ctrl+O                     Context inspector (e/t/m/b: jump sections)',
+            'Ctrl+T                     Context inspector at Tool Calls',
           ]);
           break;
         }

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -4739,8 +4739,9 @@ export async function runChat(options: ChatOptions): Promise<void> {
     if (historyHydration && historyHydration.tailPreview.length > 0) {
       for (const entry of historyHydration.tailPreview) {
         if (entry.role === 'event') {
-          // Tool calls and other progress lines — dim, unlabeled
-          inkRepl.printEvent(`  ${entry.content}`);
+          // Tool calls and other progress lines — dim, unlabeled.
+          // No manual indent: MessageLine's event role owns the column.
+          inkRepl.printEvent(entry.content);
           continue;
         }
         const role =

--- a/packages/cli/src/repl/ink/ChatApp.tsx
+++ b/packages/cli/src/repl/ink/ChatApp.tsx
@@ -50,10 +50,12 @@ export interface ChatAppHandle {
   setAbortHandler: (handler: (() => void) | null) => void;
   setCommandOutput: (lines: string[] | null) => void;
   setSurfacedMemories: (lines: string[]) => void;
-  /** Open the context viewer with the given lines. */
-  showContextView: (lines: string[]) => void;
+  /** Open the context viewer with the given lines (optionally at a section). */
+  showContextView: (lines: string[], opts?: { initialSection?: string }) => void;
   /** Register callback for Ctrl+O (orchestrator builds context, calls showContextView). */
   setCtrlOHandler: (handler: (() => void) | null) => void;
+  /** Register callback for Ctrl+T (orchestrator opens the viewer at Tool Calls). */
+  setCtrlTHandler: (handler: (() => void) | null) => void;
 }
 
 /**
@@ -92,6 +94,8 @@ export const ChatApp = React.forwardRef<ChatAppHandle, ChatAppProps>(function Ch
 
   // Context viewer state
   const [contextViewLines, setContextViewLines] = useState<string[] | null>(null);
+  // Section the viewer opens at ('t' for tools, undefined for top)
+  const [contextViewSection, setContextViewSection] = useState<string | undefined>(undefined);
   // Brief intermediate state: both views hidden so Ink renders a zero-height
   // frame, erasing the tall context viewer before showing the shorter dock.
   const [dismissingContext, setDismissingContext] = useState(false);
@@ -137,11 +141,15 @@ export const ChatApp = React.forwardRef<ChatAppHandle, ChatAppProps>(function Ch
     setSurfacedMemories: (lines: string[]) => {
       setLastSurfacedMemories(lines);
     },
-    showContextView: (lines: string[]) => {
+    showContextView: (lines: string[], opts?: { initialSection?: string }) => {
+      setContextViewSection(opts?.initialSection);
       setContextViewLines(lines);
     },
     setCtrlOHandler: (handler: (() => void) | null) => {
       ctrlOHandlerRef.current = handler;
+    },
+    setCtrlTHandler: (handler: (() => void) | null) => {
+      ctrlTHandlerRef.current = handler;
     },
   }));
 
@@ -165,10 +173,18 @@ export const ChatApp = React.forwardRef<ChatAppHandle, ChatAppProps>(function Ch
 
   // Ctrl+O callback — set by orchestrator to build context and call showContextView
   const ctrlOHandlerRef = useRef<(() => void) | null>(null);
+  // Ctrl+T callback — same, but opens the viewer at the Tool Calls section
+  const ctrlTHandlerRef = useRef<(() => void) | null>(null);
 
   const handleExpandMemories = useCallback(() => {
     if (ctrlOHandlerRef.current) {
       ctrlOHandlerRef.current();
+    }
+  }, []);
+
+  const handleShowToolCalls = useCallback(() => {
+    if (ctrlTHandlerRef.current) {
+      ctrlTHandlerRef.current();
     }
   }, []);
 
@@ -236,7 +252,13 @@ export const ChatApp = React.forwardRef<ChatAppHandle, ChatAppProps>(function Ch
           scroll state. The useInput lifecycle issue only affects the Dock
           (PromptInput), not the ContextViewer, so mount/unmount is safe. */}
       {showingContext && (
-        <ContextViewer lines={contextViewLines!} isActive onDismiss={handleContextDismiss} />
+        <ContextViewer
+          key={contextViewSection || 'top'}
+          lines={contextViewLines!}
+          isActive
+          onDismiss={handleContextDismiss}
+          initialSection={contextViewSection}
+        />
       )}
 
       {/* Chat messages — Static writes to scrollback */}
@@ -277,6 +299,7 @@ export const ChatApp = React.forwardRef<ChatAppHandle, ChatAppProps>(function Ch
           ctrlCHint={ctrlCHint}
           onCtrlC={handleCtrlC}
           onExpandMemories={handleExpandMemories}
+          onShowToolCalls={handleShowToolCalls}
           waitingElement={
             waiting ? (
               <Box paddingX={1}>

--- a/packages/cli/src/repl/ink/ChatApp.tsx
+++ b/packages/cli/src/repl/ink/ChatApp.tsx
@@ -251,9 +251,12 @@ export const ChatApp = React.forwardRef<ChatAppHandle, ChatAppProps>(function Ch
       {/* Context viewer — conditionally rendered so each open gets fresh
           scroll state. The useInput lifecycle issue only affects the Dock
           (PromptInput), not the ContextViewer, so mount/unmount is safe. */}
+      {/* Fresh mount per open (conditional render unmounts on dismiss), so
+          initialSection applies via useState initializer. Re-jumps while
+          open are handled INSIDE the viewer (it owns stdin): plain `t` or
+          Ctrl+T — no keyed remount needed. */}
       {showingContext && (
         <ContextViewer
-          key={contextViewSection || 'top'}
           lines={contextViewLines!}
           isActive
           onDismiss={handleContextDismiss}

--- a/packages/cli/src/repl/ink/Dock.tsx
+++ b/packages/cli/src/repl/ink/Dock.tsx
@@ -24,6 +24,7 @@ interface DockProps {
   ctrlCHint?: boolean;
   onCtrlC?: () => void;
   onExpandMemories?: () => void;
+  onShowToolCalls?: () => void;
 }
 
 /**
@@ -51,6 +52,7 @@ export function Dock({
   ctrlCHint,
   onCtrlC,
   onExpandMemories,
+  onShowToolCalls,
 }: DockProps): React.ReactElement {
   const { stdout } = useStdout();
   const [, setResizeCounter] = useState(0);
@@ -93,6 +95,7 @@ export function Dock({
         onEscape={onCommandOutputClear}
         onCtrlC={onCtrlC}
         onExpandMemories={onExpandMemories}
+        onShowToolCalls={onShowToolCalls}
         onInputChange={handleInputChange}
         history={inputHistory}
       />

--- a/packages/cli/src/repl/ink/MessageLine.test.ts
+++ b/packages/cli/src/repl/ink/MessageLine.test.ts
@@ -1,26 +1,22 @@
 import { describe, it, expect } from 'vitest';
-import { collapseImagePaths } from './MessageLine.js';
+import { collapseImagePaths, normalizeEventContent } from './MessageLine.js';
 
 describe('collapseImagePaths', () => {
   it('collapses absolute PNG path', () => {
-    expect(collapseImagePaths('/Users/conor/Desktop/screenshot.png'))
-      .toBe('[Image #1]');
+    expect(collapseImagePaths('/Users/conor/Desktop/screenshot.png')).toBe('[Image #1]');
   });
 
   it('collapses absolute JPG path', () => {
-    expect(collapseImagePaths('/tmp/photo.jpg'))
-      .toBe('[Image #1]');
+    expect(collapseImagePaths('/tmp/photo.jpg')).toBe('[Image #1]');
   });
 
   it('collapses file:// URI', () => {
-    expect(collapseImagePaths('file:///Users/conor/image.webp'))
-      .toBe('[Image #1]');
+    expect(collapseImagePaths('file:///Users/conor/image.webp')).toBe('[Image #1]');
   });
 
   it('numbers multiple images sequentially', () => {
     const input = 'Here is /tmp/a.png and also /tmp/b.jpg end';
-    expect(collapseImagePaths(input))
-      .toBe('Here is [Image #1] and also [Image #2] end');
+    expect(collapseImagePaths(input)).toBe('Here is [Image #1] and also [Image #2] end');
   });
 
   it('handles various extensions', () => {
@@ -33,32 +29,52 @@ describe('collapseImagePaths', () => {
   });
 
   it('is case-insensitive for extensions', () => {
-    expect(collapseImagePaths('/tmp/photo.PNG'))
-      .toBe('[Image #1]');
-    expect(collapseImagePaths('/tmp/photo.Jpeg'))
-      .toBe('[Image #1]');
+    expect(collapseImagePaths('/tmp/photo.PNG')).toBe('[Image #1]');
+    expect(collapseImagePaths('/tmp/photo.Jpeg')).toBe('[Image #1]');
   });
 
   it('leaves non-image paths alone', () => {
-    expect(collapseImagePaths('/tmp/file.txt'))
-      .toBe('/tmp/file.txt');
-    expect(collapseImagePaths('/tmp/data.json'))
-      .toBe('/tmp/data.json');
+    expect(collapseImagePaths('/tmp/file.txt')).toBe('/tmp/file.txt');
+    expect(collapseImagePaths('/tmp/data.json')).toBe('/tmp/data.json');
   });
 
   it('leaves plain text alone', () => {
-    expect(collapseImagePaths('Hello world'))
-      .toBe('Hello world');
+    expect(collapseImagePaths('Hello world')).toBe('Hello world');
   });
 
   it('handles paths with dots in directory names', () => {
-    expect(collapseImagePaths('/Users/my.name/Desktop/screenshot.png'))
-      .toBe('[Image #1]');
+    expect(collapseImagePaths('/Users/my.name/Desktop/screenshot.png')).toBe('[Image #1]');
   });
 
   it('handles mixed content with images and text', () => {
     const input = 'Check this /Users/me/Downloads/chart.png — it shows the data';
-    expect(collapseImagePaths(input))
-      .toBe('Check this [Image #1] — it shows the data');
+    expect(collapseImagePaths(input)).toBe('Check this [Image #1] — it shows the data');
+  });
+});
+
+describe('normalizeEventContent', () => {
+  it('strips plain leading indentation', () => {
+    expect(normalizeEventContent('  🛠 send_response (executed)')).toBe(
+      '🛠 send_response (executed)'
+    );
+    expect(normalizeEventContent('\t⚡ state change')).toBe('⚡ state change');
+  });
+
+  it('strips spaces hidden behind leading ANSI sequences (chalk-wrapped live events)', () => {
+    // chalk.dim('  🗑 evicted…') — SGR escape precedes the embedded spaces
+    const dim = '\u001b[2m  🗑 evicted 5 entries\u001b[22m';
+    expect(normalizeEventContent(dim)).toBe('\u001b[2m🗑 evicted 5 entries\u001b[22m');
+    // Stacked sequences (e.g. dim + yellow)
+    const stacked = '\u001b[2m\u001b[33m  ⛁ compacting\u001b[39m\u001b[22m';
+    expect(normalizeEventContent(stacked)).toBe(
+      '\u001b[2m\u001b[33m⛁ compacting\u001b[39m\u001b[22m'
+    );
+  });
+
+  it('leaves unindented content untouched', () => {
+    expect(normalizeEventContent('─── ⌃ out of context ───')).toBe('─── ⌃ out of context ───');
+    expect(normalizeEventContent('\u001b[2m🛠 already flush\u001b[22m')).toBe(
+      '\u001b[2m🛠 already flush\u001b[22m'
+    );
   });
 });

--- a/packages/cli/src/repl/ink/MessageLine.tsx
+++ b/packages/cli/src/repl/ink/MessageLine.tsx
@@ -71,11 +71,15 @@ export const MessageLine = React.memo(function MessageLine({
 
   // Events are compact progress/status lines (tool runs, signals, dividers):
   // a single dim line at the content column — no label row, no spacing.
+  // trimStart normalizes call sites that embed their own leading spaces so
+  // every event row aligns flush with message content (column 3), and
+  // truncate-end keeps them to ONE line with a terminal-width ellipsis —
+  // full details live in the context inspector (Ctrl+O / Ctrl+T).
   if (role === 'event') {
     return (
       <Box paddingLeft={3}>
-        <Text dimColor wrap="wrap">
-          {displayContent}
+        <Text dimColor wrap="truncate-end">
+          {displayContent.trimStart()}
           {meta ? `  ·  ${meta}` : ''}
         </Text>
       </Box>

--- a/packages/cli/src/repl/ink/MessageLine.tsx
+++ b/packages/cli/src/repl/ink/MessageLine.tsx
@@ -40,6 +40,20 @@ const CONTENT_COLORS: Record<MessageRole, string | undefined> = {
 };
 
 /**
+ * Strip leading indentation from event content, including spaces that hide
+ * BEHIND leading ANSI color sequences — live call sites wrap their strings
+ * in chalk (e.g. chalk.dim('  🗑 …')), so the first bytes are SGR escapes
+ * and a plain trimStart() never reaches the embedded spaces. The event
+ * role's paddingLeft owns the column; content must not add to it.
+ */
+// eslint-disable-next-line no-control-regex
+const LEADING_INDENT_RE = /^((?:\u001b\[[0-9;]*m)*)[ \t]+/;
+
+export function normalizeEventContent(content: string): string {
+  return content.replace(LEADING_INDENT_RE, '$1');
+}
+
+/**
  * Collapse image file paths to numbered [Image #N] tokens.
  * Matches absolute paths and file:// URIs ending in common image extensions.
  * Path segments use non-greedy matching and stop at whitespace boundaries.
@@ -71,15 +85,15 @@ export const MessageLine = React.memo(function MessageLine({
 
   // Events are compact progress/status lines (tool runs, signals, dividers):
   // a single dim line at the content column — no label row, no spacing.
-  // trimStart normalizes call sites that embed their own leading spaces so
-  // every event row aligns flush with message content (column 3), and
-  // truncate-end keeps them to ONE line with a terminal-width ellipsis —
-  // full details live in the context inspector (Ctrl+O / Ctrl+T).
+  // normalizeEventContent strips call-site indentation (even behind chalk's
+  // leading ANSI escapes) so every event row aligns flush with message
+  // content (column 3), and truncate-end keeps them to ONE line with a
+  // terminal-width ellipsis — full details live in the inspector (Ctrl+T).
   if (role === 'event') {
     return (
       <Box paddingLeft={3}>
         <Text dimColor wrap="truncate-end">
-          {displayContent.trimStart()}
+          {normalizeEventContent(displayContent)}
           {meta ? `  ·  ${meta}` : ''}
         </Text>
       </Box>

--- a/packages/cli/src/repl/ink/PromptInput.tsx
+++ b/packages/cli/src/repl/ink/PromptInput.tsx
@@ -17,6 +17,7 @@ interface PromptInputProps {
   onCtrlC?: () => void;
   /** Called when Ctrl+O is pressed (expand collapsed memories). */
   onExpandMemories?: () => void;
+  onShowToolCalls?: () => void;
   /** Called on every keystroke with the current input value. */
   onInputChange?: (value: string) => void;
   /** Scroll callback for page up/down from within the prompt. */
@@ -58,6 +59,7 @@ export function PromptInput({
   onEscape,
   onCtrlC,
   onExpandMemories,
+  onShowToolCalls,
   onInputChange,
   onScroll,
   history = [],
@@ -106,9 +108,16 @@ export function PromptInput({
         return;
       }
 
-      // Ctrl+O: expand collapsed memories in dock panel
+      // Ctrl+O: open the context inspector
       if (key.ctrl && input === 'o') {
         onExpandMemories?.();
+        return;
+      }
+
+      // Ctrl+T: open the context inspector at the Tool Calls section.
+      // (Ctrl+M is unavailable — it emits the same byte as Enter.)
+      if (key.ctrl && input === 't') {
+        onShowToolCalls?.();
         return;
       }
 

--- a/packages/cli/src/repl/ink/context-viewer.test.ts
+++ b/packages/cli/src/repl/ink/context-viewer.test.ts
@@ -34,6 +34,25 @@ describe('computeSectionJumps', () => {
     expect(jumps.has('b')).toBe(false); // no bootstrap summary
   });
 
+  it('tool calls section renders args beneath each call', () => {
+    const lines = formatContextLines({
+      ...baseSections,
+      toolCalls: [
+        {
+          tool: 'send_response',
+          status: 'executed',
+          at: new Date().toISOString(),
+          args: '{"channel":"telegram","content":"heads-up!"}',
+        },
+        { tool: 'get_inbox', status: 'approved', at: new Date().toISOString() },
+      ],
+    });
+    const joined = lines.join('\n');
+    expect(joined).toContain('• send_response (executed)');
+    expect(joined).toContain('    {"channel":"telegram","content":"heads-up!"}');
+    expect(joined).toContain('• get_inbox (approved)');
+  });
+
   it('evicted section shows attribution and out-of-window note', () => {
     const lines = formatContextLines({
       ...baseSections,

--- a/packages/cli/src/repl/ink/context-viewer.tsx
+++ b/packages/cli/src/repl/ink/context-viewer.tsx
@@ -191,6 +191,15 @@ export function ContextViewer({
         scrollDown(Math.floor(viewportHeight / 2));
         return;
       }
+      // Ctrl+T re-jumps to Tool Calls — the viewer owns stdin while open,
+      // so the prompt's Ctrl+T binding can't fire; mirror it here.
+      if (key.ctrl && input === 't') {
+        const target = sectionJumps.get('t');
+        if (target !== undefined) {
+          setScrollOffset(Math.min(maxScroll, target));
+        }
+        return;
+      }
       // Section jumps (e: evicted, t: tools, m: memories, b: bootstrap)
       if (!key.ctrl && !key.meta) {
         const target = sectionJumps.get(input.toLowerCase());

--- a/packages/cli/src/repl/ink/context-viewer.tsx
+++ b/packages/cli/src/repl/ink/context-viewer.tsx
@@ -14,8 +14,8 @@ export interface ContextSections {
     tokenEstimate: number;
     bootstrapTokens: number;
   };
-  /** Tool calls executed this session (most recent last) */
-  toolCalls?: Array<{ tool: string; status: string; at: string }>;
+  /** Tool calls executed this session or replayed from the transcript (most recent last) */
+  toolCalls?: Array<{ tool: string; status: string; at: string; args?: string }>;
   /** Entries evicted from the context window — out of the prompt, not erased */
   evicted?: Array<{
     role: string;
@@ -53,6 +53,9 @@ export function formatContextLines(sections: ContextSections): string[] {
     for (const call of recent) {
       const time = call.at ? new Date(call.at).toLocaleTimeString() : '';
       lines.push(`• ${call.tool} (${call.status})${time ? ` · ${time}` : ''}`);
+      if (call.args) {
+        lines.push(`    ${call.args}`);
+      }
     }
     lines.push('');
   }
@@ -120,18 +123,24 @@ interface ContextViewerProps {
   lines: string[];
   isActive: boolean;
   onDismiss: () => void;
+  /** Open scrolled to a section (a SECTION_JUMP_KEYS key, e.g. 't' for tools) */
+  initialSection?: string;
 }
 
 export function ContextViewer({
   lines,
   isActive,
   onDismiss,
+  initialSection,
 }: ContextViewerProps): React.ReactElement {
   const { stdout } = useStdout();
   const viewportHeight = Math.max(5, (stdout?.rows || 24) - 4);
-  const [scrollOffset, setScrollOffset] = useState(0);
-  const maxScroll = Math.max(0, lines.length - viewportHeight);
   const sectionJumps = useMemo(() => computeSectionJumps(lines), [lines]);
+  const maxScroll = Math.max(0, lines.length - viewportHeight);
+  const [scrollOffset, setScrollOffset] = useState(() => {
+    const target = initialSection ? sectionJumps.get(initialSection) : undefined;
+    return target !== undefined ? Math.min(maxScroll, target) : 0;
+  });
 
   const scrollUp = useCallback(
     (amount = 1) => setScrollOffset((prev) => Math.max(0, prev - amount)),

--- a/packages/cli/src/repl/ink/renderApp.tsx
+++ b/packages/cli/src/repl/ink/renderApp.tsx
@@ -66,8 +66,8 @@ export interface InkRepl {
   setCommandOutput: (lines: string[] | null) => void;
   /** Store surfaced memory details for Ctrl+O expansion. */
   setSurfacedMemories: (lines: string[]) => void;
-  /** Open the context viewer with formatted lines. */
-  showContextView: (lines: string[]) => void;
+  /** Open the context viewer with formatted lines (optionally at a section). */
+  showContextView: (lines: string[], opts?: { initialSection?: string }) => void;
   /** Signal exit from the orchestrator side (makes waitForInput reject). */
   requestExit: () => void;
   /** Unmount the Ink app and restore terminal. */
@@ -208,8 +208,8 @@ export function renderInkChat(options: {
       getHandle().setSurfacedMemories(lines);
     },
 
-    showContextView: (lines) => {
-      getHandle().showContextView(lines);
+    showContextView: (lines, opts) => {
+      getHandle().showContextView(lines, opts);
     },
 
     requestExit: () => {


### PR DESCRIPTION
## What

Conor's polish pass on #410's replayed tool calls — alignment was off, long args clipped mid-word, and there was no way to expand them.

### Alignment

Event rows now sit **flush with message content** (column 3). Two compounding indents were the bug: `MessageLine`'s event role pads to column 3, and every call site (replay + live `printEvent` sites) embedded its own `"  "` prefix on top, landing at column 5. The event role now `trimStart`s content — one normalization point instead of fixing N call sites.

### One line, explicit ellipsis

- Event rows render `wrap="truncate-end"` — single line with a terminal-width ellipsis instead of wrapping or clipping
- The hydration args preview caps at 100 chars with a visible `…` (previously a hard slice mid-word: *"only trade confirmations an"*)

### Expansion: Ctrl+T

**Ctrl+T opens the context inspector pre-jumped to the Tool Calls section**, which now shows fuller args (capped 400) beneath each call. Crucially, the section is now populated from **both** live execution *and* transcript replay — replayed calls previously never reached the inspector at all.

> **Why not Ctrl+M:** in a terminal, Ctrl+M emits the same byte as Enter (0x0D) — it cannot be a distinct binding. Ctrl+T was free and reads as "tools." Ctrl+O is unchanged (full inspector, with `t` as an in-viewer jump).

`ContextViewer` accepts `initialSection` (keyed remount per open, so Ctrl+T while the viewer is already open re-jumps correctly). `/help` documents both keybindings.

## Tests

Hydration regressions extended (explicit ellipsis, toolCalls collection with caps), context-viewer args rendering, 65/65 across touched suites. NUL scan clean.

## Known-unrelated CI

DB integration drift (task `03fcdb56`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)