### PR TITLE
fix: dedupe inbound message logging + tiered live activity rendering (by Wren)

### DIFF
--- a/packages/api/src/channels/gateway.test.ts
+++ b/packages/api/src/channels/gateway.test.ts
@@ -616,7 +616,10 @@ describe('Activity Stream Integration', () => {
   });
 
   describe('Incoming Messages', () => {
-    it('should log incoming message to activity stream when userId is provided', async () => {
+    it('does not log inbound messages itself — SessionService is the canonical logger', async () => {
+      // Regression: the gateway used to log message_in with a hardcoded
+      // agentId of 'myra' AND SessionService logged the same message again,
+      // producing duplicate rows that double-rendered in attached CLI views.
       const handler = vi.fn().mockResolvedValue(undefined);
       gateway.setMessageHandler(handler);
 
@@ -630,38 +633,8 @@ describe('Activity Stream Integration', () => {
         { userId: 'user-uuid-123', chatType: 'direct' }
       );
 
-      expect(mockLogMessage).toHaveBeenCalledTimes(1);
-      expect(mockLogMessage).toHaveBeenCalledWith({
-        userId: 'user-uuid-123',
-        agentId: 'myra',
-        direction: 'in',
-        content: 'Hello from user',
-        platform: 'telegram',
-        platformChatId: 'chat123',
-        isDm: true,
-        payload: {
-          senderName: 'Test User',
-          senderId: 'sender456',
-        },
-      });
-    });
-
-    it('should set isDm to false for group chats', async () => {
-      const handler = vi.fn().mockResolvedValue(undefined);
-      gateway.setMessageHandler(handler);
-
-      const forwardToHandler = (gateway as any).forwardToHandler.bind(gateway);
-
-      await forwardToHandler('telegram', 'group123', { id: 'sender456' }, 'Hello group', {
-        userId: 'user-uuid-123',
-        chatType: 'group',
-      });
-
-      expect(mockLogMessage).toHaveBeenCalledWith(
-        expect.objectContaining({
-          isDm: false,
-        })
-      );
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(mockLogMessage).not.toHaveBeenCalled();
     });
 
     it('should resolve userId from platform + sender ID when not in metadata (Telegram flow)', async () => {
@@ -685,17 +658,9 @@ describe('Activity Stream Integration', () => {
       // Should have resolved user from platform ID
       expect(mockFindByPlatformId).toHaveBeenCalledWith('telegram', 'telegram-sender-789');
 
-      // Should log to activity stream with resolved userId
-      expect(mockLogMessage).toHaveBeenCalledTimes(1);
-      expect(mockLogMessage).toHaveBeenCalledWith(
-        expect.objectContaining({
-          userId: 'resolved-user-uuid',
-          direction: 'in',
-          content: 'Hello from Telegram',
-          platform: 'telegram',
-          platformChatId: 'chat123',
-        })
-      );
+      // Gateway does not log inbound itself (SessionService does) — the
+      // resolution's job is enriching metadata for the handler below.
+      expect(mockLogMessage).not.toHaveBeenCalled();
 
       // Should pass resolved userId to handler in enriched metadata
       expect(handler).toHaveBeenCalledWith(
@@ -764,8 +729,9 @@ describe('Activity Stream Integration', () => {
 
       await sendTelegramMessage('chat123', 'Reply message');
 
-      // Should have logged outbound message using stored userId
-      expect(mockLogMessage).toHaveBeenCalledTimes(2);
+      // Only the outbound message logs from the gateway (inbound is
+      // SessionService's job now)
+      expect(mockLogMessage).toHaveBeenCalledTimes(1);
       expect(mockLogMessage).toHaveBeenLastCalledWith({
         userId: 'user-uuid-123',
         agentId: 'myra',
@@ -821,7 +787,7 @@ describe('Activity Stream Integration', () => {
       const sendTelegramMessage = (gateway as any).sendTelegramMessage.bind(gateway);
       await sendTelegramMessage('chat123', 'Outgoing reply');
 
-      expect(mockLogMessage).toHaveBeenCalledTimes(2);
+      expect(mockLogMessage).toHaveBeenCalledTimes(1);
       expect(mockLogMessage).toHaveBeenLastCalledWith(
         expect.objectContaining({
           userId: 'resolved-user-uuid',

--- a/packages/api/src/channels/gateway.ts
+++ b/packages/api/src/channels/gateway.ts
@@ -591,27 +591,11 @@ export class ChannelGateway extends EventEmitter {
       this.pendingVoiceReplyConversations.add(this.getBufferKey(channel, conversationId));
     }
 
-    // Log incoming message to activity stream
-    if (this.dataComposer && userId) {
-      try {
-        const isGroupChat = metadata?.chatType === 'group' || metadata?.chatType === 'channel';
-        await this.dataComposer.repositories.activityStream.logMessage({
-          userId,
-          agentId: 'myra',
-          direction: 'in',
-          content,
-          platform: channel,
-          platformChatId: conversationId,
-          isDm: !isGroupChat,
-          payload: {
-            senderName: sender.name,
-            senderId: sender.id,
-          },
-        });
-      } catch (activityError) {
-        logger.warn('Failed to log incoming message to activity stream:', activityError);
-      }
-    }
+    // NOTE: inbound messages are NOT logged to the activity stream here.
+    // SessionService.handleMessage logs them first thing with the RESOLVED
+    // agentId and full payload (media, threadKey, sender) — this site used
+    // to log a second copy with a hardcoded agentId of 'myra', producing
+    // duplicate message_in rows (double-rendered in attached CLI views).
 
     // Pass resolved userId to message handler so SessionService can persist messages
     const enrichedMetadata = userId && !metadata?.userId ? { ...metadata, userId } : metadata;

--- a/packages/api/src/services/sessions/session-service.ts
+++ b/packages/api/src/services/sessions/session-service.ts
@@ -206,7 +206,9 @@ export class SessionService implements ISessionService {
         content,
         platform: request.channel,
         platformChatId: request.conversationId,
-        isDm: metadata?.chatType === 'direct',
+        // Telegram reports private chats as 'private' (not 'direct') — treat
+        // anything that isn't group-shaped as a DM
+        isDm: !['group', 'supergroup', 'channel'].includes(metadata?.chatType ?? ''),
         payload: JSON.parse(
           JSON.stringify({
             sender: request.sender,

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -44,6 +44,7 @@ import {
   buildAttachmentBlock,
   collectAttachmentDirs,
 } from '../repl/attachments.js';
+import { classifyActivity } from '../repl/activity-render.js';
 import { ToolMode, ToolPolicyScopeKind, ToolPolicyState } from '../repl/tool-policy.js';
 import { formatBackendTokenUsage, type BackendTokenUsage } from '../repl/token-usage.js';
 import { discoverSkills, loadSkillInstruction, type SkillInstruction } from '../repl/skills.js';
@@ -206,6 +207,8 @@ interface ActivitySummary {
   agentId?: string;
   sessionId?: string;
   createdAt?: string;
+  /** Originating platform for message activities (telegram, discord, …) */
+  platform?: string;
 }
 
 function isBackendAuthBackend(value: string): value is BackendAuthBackend {
@@ -1354,6 +1357,7 @@ function extractActivitySummaries(
             : typeof row.created_at === 'string'
               ? row.created_at
               : undefined,
+        platform: typeof row.platform === 'string' ? row.platform : undefined,
       };
     })
     .filter((activity): activity is ActivitySummary => Boolean(activity));
@@ -3559,24 +3563,36 @@ export async function runChat(options: ChatOptions): Promise<void> {
         createdAt: activity.createdAt || null,
         content: activity.content || null,
       });
-      // This agent's own bookkeeping (session state updates, tool call
-      // echoes) is progress, not conversation — render as a dim event line
-      // instead of a full activity block.
-      const isOwnBookkeeping =
-        activity.agentId === agentId &&
-        (rawType.startsWith('state_change') ||
-          rawType.startsWith('tool_call') ||
-          rawType.startsWith('tool_result'));
-      if (isOwnBookkeeping) {
-        printEvent(
-          chalk.dim(
-            `  ⚡ ${type}${preview ? ` — ${preview}` : ''} · ${formatHumanTime(activity.createdAt, runtime.userTimezone)}`
-          )
-        );
+      // Tiered rendering: platform messages are real conversation and get
+      // proper message blocks; the agent's own mechanics (tools, state,
+      // backend turn lifecycle) are dim event lines; everything else stays
+      // a ⚡ activity block.
+      const plan = classifyActivity(activity, agentId);
+      const activityTime = formatHumanTime(activity.createdAt, runtime.userTimezone);
+      if (plan.mode === 'message-in' || plan.mode === 'message-out') {
+        // Full content, not the 200-char preview — these ARE the conversation
+        const messageContent = (activity.content || '').trim() || '(empty message)';
+        if (inkRepl) {
+          inkRepl.addMessage(plan.role!, messageContent, {
+            label: plan.label,
+            time: activityTime,
+          });
+        } else {
+          printLine('');
+          printLine(
+            renderMessageLine(plan.role!, messageContent, {
+              label: plan.label,
+              timezone: runtime.userTimezone,
+              ts: activity.createdAt,
+            })
+          );
+        }
+      } else if (plan.mode === 'bookkeeping') {
+        printEvent(chalk.dim(`  ⚡ ${type}${preview ? ` — ${preview}` : ''} · ${activityTime}`));
       } else if (inkRepl) {
         inkRepl.addMessage('activity', `${actor} ${type}${preview ? ` — ${preview}` : ''}`, {
           label: '⚡',
-          time: formatHumanTime(activity.createdAt, runtime.userTimezone),
+          time: activityTime,
         });
       } else {
         printLine('');

--- a/packages/cli/src/repl/activity-render.test.ts
+++ b/packages/cli/src/repl/activity-render.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { classifyActivity } from './activity-render.js';
+
+describe('classifyActivity', () => {
+  it('renders inbound platform messages as user-style message blocks', () => {
+    const plan = classifyActivity(
+      { type: 'message_in', agentId: 'myra', platform: 'telegram' },
+      'myra'
+    );
+    expect(plan.mode).toBe('message-in');
+    expect(plan.role).toBe('user');
+    expect(plan.label).toBe('📨 telegram → myra');
+  });
+
+  it('renders outbound platform messages as the agent speaking', () => {
+    const plan = classifyActivity(
+      { type: 'message_out', agentId: 'myra', platform: 'telegram' },
+      'myra'
+    );
+    expect(plan.mode).toBe('message-out');
+    expect(plan.role).toBe('assistant');
+    expect(plan.label).toBe('📤 myra → telegram');
+  });
+
+  it('falls back to a generic channel label when platform is missing', () => {
+    const plan = classifyActivity({ type: 'message_in', agentId: 'myra' }, 'myra');
+    expect(plan.label).toBe('📨 channel → myra');
+  });
+
+  it('classifies own backend turn lifecycle as bookkeeping (regression: rendered as ⚡ blocks)', () => {
+    expect(
+      classifyActivity(
+        { type: 'agent_spawn', subtype: 'backend_cli:claude-code', agentId: 'myra' },
+        'myra'
+      ).mode
+    ).toBe('bookkeeping');
+    expect(
+      classifyActivity(
+        { type: 'agent_complete', subtype: 'backend_cli:claude-code', agentId: 'myra' },
+        'myra'
+      ).mode
+    ).toBe('bookkeeping');
+  });
+
+  it('classifies own tool/state activity as bookkeeping', () => {
+    expect(classifyActivity({ type: 'tool_call', agentId: 'myra' }, 'myra').mode).toBe(
+      'bookkeeping'
+    );
+    expect(classifyActivity({ type: 'state_change', agentId: 'myra' }, 'myra').mode).toBe(
+      'bookkeeping'
+    );
+  });
+
+  it('keeps other agents lifecycle as full blocks (not silently dimmed)', () => {
+    expect(classifyActivity({ type: 'agent_spawn', agentId: 'wren' }, 'myra').mode).toBe('block');
+  });
+
+  it('keeps errors and unknown types as blocks', () => {
+    expect(classifyActivity({ type: 'error', agentId: 'myra' }, 'myra').mode).toBe('block');
+    expect(classifyActivity({}, 'myra').mode).toBe('block');
+  });
+});

--- a/packages/cli/src/repl/activity-render.ts
+++ b/packages/cli/src/repl/activity-render.ts
@@ -1,0 +1,61 @@
+/**
+ * Live activity stream rendering tiers
+ *
+ * When attached to an agent's session, the activity poll surfaces
+ * everything the agent does. Not all of it deserves the same visual
+ * weight:
+ *
+ *   message-in/out — real conversation crossing a 3rd-party platform
+ *                    (Telegram, Discord…). Rendered as proper message
+ *                    blocks with directional labels, not ⚡ blocks.
+ *   bookkeeping    — the agent's own mechanics (tool calls, state
+ *                    changes, backend turn lifecycle). Dim event lines.
+ *   block          — everything else (other agents' activity, errors).
+ *                    The classic ⚡ activity block.
+ */
+
+export interface ActivityLike {
+  type?: string;
+  subtype?: string;
+  agentId?: string;
+  platform?: string;
+}
+
+export type ActivityRenderMode = 'message-in' | 'message-out' | 'bookkeeping' | 'block';
+
+export interface ActivityRenderPlan {
+  mode: ActivityRenderMode;
+  /** Message-line role for message modes */
+  role?: 'user' | 'assistant';
+  /** Display label for message modes (directional) */
+  label?: string;
+}
+
+const BOOKKEEPING_PREFIXES = [
+  'state_change',
+  'tool_call',
+  'tool_result',
+  'agent_spawn',
+  'agent_complete',
+];
+
+export function classifyActivity(activity: ActivityLike, selfAgentId: string): ActivityRenderPlan {
+  const rawType = activity.subtype
+    ? `${activity.type}:${activity.subtype}`
+    : activity.type || 'activity';
+  const actor = activity.agentId || 'system';
+  const platform = activity.platform || 'channel';
+
+  if (rawType.startsWith('message_in')) {
+    // The human's words arriving via a platform — render as a user message
+    return { mode: 'message-in', role: 'user', label: `📨 ${platform} → ${actor}` };
+  }
+  if (rawType.startsWith('message_out')) {
+    // The agent's words leaving via a platform — render as the agent speaking
+    return { mode: 'message-out', role: 'assistant', label: `📤 ${actor} → ${platform}` };
+  }
+  if (activity.agentId === selfAgentId && BOOKKEEPING_PREFIXES.some((p) => rawType.startsWith(p))) {
+    return { mode: 'bookkeeping' };
+  }
+  return { mode: 'block' };
+}


### PR DESCRIPTION
## What

Two catches from Conor watching Myra live in an attached `ink chat` — during the session that also proved the media chain works (Myra described an actual conference photo).

### Double post — duplicate inbound logging at the data source

Every inbound channel message was logged to the activity stream **twice**: once by the gateway (`forwardToHandler`, with a **hardcoded `agentId: 'myra'`**) and again by `SessionService.handleMessage` (resolved agentId, full payload with media/threadKey/sender). Two rows → two ids → double-rendered in every attached view, and polluted `get_activity` for all consumers (dashboard included).

Fix: the gateway log is removed; SessionService is the canonical inbound logger. Verified nothing drops between the two sites — the handler-missing check returns *before* the gateway log, and the approval interceptor runs upstream in the listener.

Bonus: SessionService's `isDm` checked `chatType === 'direct'`, but Telegram reports private chats as `'private'` — DMs were logged `isDm: false`. Now group-shaped types (`group`/`supergroup`/`channel`) are the negative case.

### Everything-is-⚡ — rendering tiers for the live stream

Per Conor: messages crossing a 3rd-party platform are important enough to deserve their own design, and backend lifecycle noise shouldn't shout. New pure classifier (`repl/activity-render.ts`):

| Activity | Before | After |
|---|---|---|
| `message_in` | `⚡ myra received — …` (200-char preview) | **`📨 telegram → myra`** message block, full content, user-colored |
| `message_out` | `⚡ myra sent — …` | **`📤 myra → telegram`** message block, agent-colored |
| own `agent_spawn`/`agent_complete` | loud ⚡ block | dim one-line event |
| other agents' activity, errors | ⚡ block | ⚡ block (unchanged) |

`get_activity` already returned `platform` per row — the CLI extraction now keeps it.

## Tests

Classifier suite (7 cases incl. the lifecycle regression and other-agent non-dimming), gateway no-inbound-log regression, updated outbound count assertions, telegram-flow userId resolution intact. 135/135 across touched suites. Control-byte scan clean.

## Notes

- Server-side changes (gateway + session-service) join the dev-server restart payload
- Known-unrelated CI: DB integration drift (task `03fcdb56`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)