### PR TITLE
feat: on-device Qwen3-TTS voice replies via mlx-audio (by Wren)

### DIFF
--- a/packages/api/src/channels/audio/index.ts
+++ b/packages/api/src/channels/audio/index.ts
@@ -13,6 +13,13 @@ export type {
 export { OpenAITextToSpeechProvider } from './openai-tts';
 export { ElevenLabsTextToSpeechProvider } from './elevenlabs-tts';
 export { CliTextToSpeechProvider } from './cli-tts';
+export {
+  MlxAudioTextToSpeechProvider,
+  mlxPythonCandidates,
+  ffmpegCandidates,
+  DEFAULT_MLX_TTS_MODEL,
+  DEFAULT_MLX_TTS_VOICE,
+} from './mlx-tts';
 export { OpenAITranscriptionProvider } from './openai-stt';
 export { CliTranscriptionProvider } from './cli-stt';
 export {

--- a/packages/api/src/channels/audio/mlx-tts.live.test.ts
+++ b/packages/api/src/channels/audio/mlx-tts.live.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Live e2e for the MLX TTS provider — spawns the REAL mlx-audio CLI with
+ * the real Qwen3-TTS model and re-encodes with the real ffmpeg. Proves
+ * the chain the server uses for Telegram voice replies:
+ *
+ *   text → mlx_audio.tts.generate (Qwen3-TTS) → wav → ffmpeg → ogg/opus
+ *
+ * Requirements: Apple Silicon, `pip install mlx-audio`, ffmpeg, and the
+ * model weights (downloaded automatically on first run, ~700MB).
+ *
+ * Gated behind INK_LIVE_TESTS=1 — run via `yarn test:live`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFile, stat } from 'fs/promises';
+
+import { MlxAudioTextToSpeechProvider } from './mlx-tts.js';
+
+const LIVE = process.env.INK_LIVE_TESTS === '1';
+
+describe.skipIf(!LIVE)('MlxAudioTextToSpeechProvider (live)', () => {
+  it(
+    'synthesizes real speech and encodes a Telegram-ready ogg/opus voice note',
+    { timeout: 600_000 },
+    async () => {
+      const provider = new MlxAudioTextToSpeechProvider({ format: 'opus' });
+
+      const python = await provider.resolvePython();
+      if (!python) {
+        // Machine without mlx-audio — live env requirement not met.
+        expect.fail('mlx-audio is not installed (pip install mlx-audio)');
+      }
+
+      const result = await provider.synthesize({
+        text: 'This is a live test of on-device speech synthesis for Inkwell voice replies.',
+      });
+
+      expect(result).toBeDefined();
+      expect(result!.contentType).toBe('audio/ogg');
+      expect(result!.filename).toBe('reply.ogg');
+
+      const details = await stat(result!.filePath);
+      // A real ~5s opus voice note lands well above this floor; an empty
+      // or header-only file would not.
+      expect(details.size).toBeGreaterThan(5_000);
+
+      // OGG container magic — proves ffmpeg actually re-encoded.
+      const header = await readFile(result!.filePath);
+      expect(header.subarray(0, 4).toString('ascii')).toBe('OggS');
+
+      await result!.cleanup();
+    }
+  );
+
+  it('synthesizes German through the same default model', { timeout: 600_000 }, async () => {
+    const provider = new MlxAudioTextToSpeechProvider({ format: 'wav' });
+    const result = await provider.synthesize({
+      text: 'Hallo! Dies ist ein Live-Test der deutschen Sprachausgabe.',
+    });
+    expect(result).toBeDefined();
+    const details = await stat(result!.filePath);
+    expect(details.size).toBeGreaterThan(50_000);
+    await result!.cleanup();
+  });
+});

--- a/packages/api/src/channels/audio/mlx-tts.test.ts
+++ b/packages/api/src/channels/audio/mlx-tts.test.ts
@@ -143,6 +143,59 @@ describe('MlxAudioTextToSpeechProvider', () => {
     expect(await provider.synthesize({ text: '   ' })).toBeUndefined();
   });
 
+  it('falls back to wav when ffmpeg resolves but fails during encode', async () => {
+    // ffmpeg that passes the -version probe but exits nonzero on the
+    // actual encode — the synthesized WAV must survive, not be discarded.
+    const brokenFfmpeg = join(dir, 'broken-ffmpeg');
+    await writeFile(
+      brokenFfmpeg,
+      '#!/bin/sh\nif [ "$1" = "-version" ]; then echo ffmpeg; exit 0; fi\nexit 2\n'
+    );
+    await chmod(brokenFfmpeg, 0o755);
+    const provider = new MlxAudioTextToSpeechProvider({
+      format: 'opus',
+      pythonCandidates: [fakePython],
+      ffmpegBinCandidates: [brokenFfmpeg],
+    });
+    const result = await provider.synthesize({ text: 'encode failure' });
+    expect(result).toBeDefined();
+    expect(result!.contentType).toBe('audio/wav');
+    expect(result!.filename).toBe('reply.wav');
+    const content = await readFile(result!.filePath, 'utf-8');
+    expect(content).toBe('RIFF:encode failure');
+    await result!.cleanup();
+  });
+
+  it('kills a TERM-ignoring child on timeout — nothing outlives synthesize()', async () => {
+    // A "python" that ignores SIGTERM and loops forever: only the SIGKILL
+    // escalation can stop it. synthesize() must not return while it lives.
+    const pidFile = join(dir, 'hang.pid');
+    const hangPython = join(dir, 'hang-python');
+    await writeFile(
+      hangPython,
+      '#!/bin/sh\n' +
+        'if [ "$1" = "-c" ]; then exit 0; fi\n' +
+        `echo $$ > "${pidFile}"\n` +
+        "trap '' TERM\n" +
+        'while true; do sleep 0.2; done\n'
+    );
+    await chmod(hangPython, 0o755);
+
+    const provider = new MlxAudioTextToSpeechProvider({
+      format: 'wav',
+      timeoutMs: 300,
+      killGraceMs: 300,
+      pythonCandidates: [hangPython],
+    });
+    const result = await provider.synthesize({ text: 'hang forever' });
+    expect(result).toBeUndefined();
+
+    const pid = parseInt((await readFile(pidFile, 'utf-8')).trim(), 10);
+    expect(pid).toBeGreaterThan(0);
+    // Signal 0 probes liveness — ESRCH means the process group is gone.
+    expect(() => process.kill(pid, 0)).toThrow();
+  });
+
   it('returns undefined (not a throw) when generation fails', async () => {
     const brokenPython = join(dir, 'broken-python');
     await writeFile(

--- a/packages/api/src/channels/audio/mlx-tts.test.ts
+++ b/packages/api/src/channels/audio/mlx-tts.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { mkdtemp, writeFile, chmod, rm, readFile, stat } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join, dirname } from 'path';
+
+vi.mock('../../utils/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import { MlxAudioTextToSpeechProvider, mlxPythonCandidates } from './mlx-tts.js';
+
+describe('mlxPythonCandidates', () => {
+  it('puts the env override first when set', () => {
+    process.env.AUDIO_TTS_MLX_PYTHON = '/custom/python3';
+    try {
+      const candidates = mlxPythonCandidates();
+      expect(candidates[0]).toBe('/custom/python3');
+      expect(candidates).toContain('python3');
+    } finally {
+      delete process.env.AUDIO_TTS_MLX_PYTHON;
+    }
+  });
+
+  it('omits the override slot when unset', () => {
+    delete process.env.AUDIO_TTS_MLX_PYTHON;
+    expect(mlxPythonCandidates()[0]).toBe('python3');
+  });
+});
+
+describe('MlxAudioTextToSpeechProvider', () => {
+  let dir: string;
+  let fakePython: string;
+  let fakeFfmpeg: string;
+
+  beforeAll(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'mlx-tts-test-'));
+
+    // A fake python: answers the `-c "import mlx_audio"` probe, and on
+    // generate writes <file_prefix>.wav (containing the --text value)
+    // into --output_path like the real CLI does with --join_audio.
+    fakePython = join(dir, 'fake-python');
+    await writeFile(
+      fakePython,
+      '#!/bin/sh\n' +
+        'if [ "$1" = "-c" ]; then exit 0; fi\n' +
+        'outdir=""; prefix=""; text=""\n' +
+        'prev=""\n' +
+        'for arg in "$@"; do\n' +
+        '  if [ "$prev" = "--output_path" ]; then outdir="$arg"; fi\n' +
+        '  if [ "$prev" = "--file_prefix" ]; then prefix="$arg"; fi\n' +
+        '  if [ "$prev" = "--text" ]; then text="$arg"; fi\n' +
+        '  prev="$arg"\n' +
+        'done\n' +
+        'printf "RIFF:%s" "$text" > "$outdir/$prefix.wav"\n'
+    );
+    await chmod(fakePython, 0o755);
+
+    // A fake ffmpeg: answers -version, writes fake bytes to the last arg.
+    fakeFfmpeg = join(dir, 'fake-ffmpeg');
+    await writeFile(
+      fakeFfmpeg,
+      '#!/bin/sh\n' +
+        'if [ "$1" = "-version" ]; then echo ffmpeg; exit 0; fi\n' +
+        'for last in "$@"; do :; done\n' +
+        'printf "OggS:fake-opus" > "$last"\n'
+    );
+    await chmod(fakeFfmpeg, 0o755);
+  });
+
+  afterAll(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('synthesizes wav and cleans up its temp dir', async () => {
+    const provider = new MlxAudioTextToSpeechProvider({
+      format: 'wav',
+      pythonCandidates: [fakePython],
+    });
+    const result = await provider.synthesize({ text: 'hello world' });
+    expect(result).toBeDefined();
+    expect(result!.contentType).toBe('audio/wav');
+    expect(result!.filename).toBe('reply.wav');
+    const content = await readFile(result!.filePath, 'utf-8');
+    expect(content).toBe('RIFF:hello world');
+
+    await result!.cleanup();
+    await expect(stat(dirname(result!.filePath))).rejects.toThrow();
+  });
+
+  it('re-encodes to ogg/opus when format is opus and ffmpeg is available', async () => {
+    const provider = new MlxAudioTextToSpeechProvider({
+      format: 'opus',
+      pythonCandidates: [fakePython],
+      ffmpegBinCandidates: [fakeFfmpeg],
+    });
+    const result = await provider.synthesize({ text: 'voice bubble' });
+    expect(result).toBeDefined();
+    expect(result!.contentType).toBe('audio/ogg');
+    expect(result!.filename).toBe('reply.ogg');
+    const content = await readFile(result!.filePath, 'utf-8');
+    expect(content).toBe('OggS:fake-opus');
+    await result!.cleanup();
+  });
+
+  it('falls back to wav when opus is requested but ffmpeg is unavailable', async () => {
+    const provider = new MlxAudioTextToSpeechProvider({
+      format: 'opus',
+      pythonCandidates: [fakePython],
+      ffmpegBinCandidates: ['/nonexistent/ffmpeg'],
+    });
+    const result = await provider.synthesize({ text: 'no ffmpeg here' });
+    expect(result).toBeDefined();
+    expect(result!.contentType).toBe('audio/wav');
+    expect(result!.filename).toBe('reply.wav');
+    await result!.cleanup();
+  });
+
+  it('truncates text to maxChars before synthesis', async () => {
+    const provider = new MlxAudioTextToSpeechProvider({
+      format: 'wav',
+      maxChars: 5,
+      pythonCandidates: [fakePython],
+    });
+    const result = await provider.synthesize({ text: 'truncate me please' });
+    expect(result).toBeDefined();
+    const content = await readFile(result!.filePath, 'utf-8');
+    expect(content).toBe('RIFF:trunc');
+    await result!.cleanup();
+  });
+
+  it('self-disables (returns undefined) when no python has mlx_audio', async () => {
+    const provider = new MlxAudioTextToSpeechProvider({
+      pythonCandidates: ['/nonexistent/python3'],
+    });
+    const result = await provider.synthesize({ text: 'hello' });
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined for empty text', async () => {
+    const provider = new MlxAudioTextToSpeechProvider({
+      pythonCandidates: [fakePython],
+    });
+    expect(await provider.synthesize({ text: '   ' })).toBeUndefined();
+  });
+
+  it('returns undefined (not a throw) when generation fails', async () => {
+    const brokenPython = join(dir, 'broken-python');
+    await writeFile(
+      brokenPython,
+      '#!/bin/sh\nif [ "$1" = "-c" ]; then exit 0; fi\necho "boom" >&2\nexit 2\n'
+    );
+    await chmod(brokenPython, 0o755);
+    const provider = new MlxAudioTextToSpeechProvider({
+      format: 'wav',
+      pythonCandidates: [brokenPython],
+    });
+    const result = await provider.synthesize({ text: 'hello' });
+    expect(result).toBeUndefined();
+  });
+
+  it('caches python resolution within the TTL', async () => {
+    const provider = new MlxAudioTextToSpeechProvider({ pythonCandidates: [fakePython] });
+    expect(await provider.resolvePython()).toBe(fakePython);
+    expect(await provider.resolvePython()).toBe(fakePython);
+  });
+});

--- a/packages/api/src/channels/audio/mlx-tts.ts
+++ b/packages/api/src/channels/audio/mlx-tts.ts
@@ -58,6 +58,8 @@ export interface MlxTtsProviderConfig {
   format?: string;
   timeoutMs?: number;
   maxChars?: number;
+  /** Grace period between SIGTERM and SIGKILL on timeout (default 5s) */
+  killGraceMs?: number;
   /** Override python candidate list (tests) */
   pythonCandidates?: string[];
   /** Override ffmpeg candidate list (tests) */
@@ -72,6 +74,7 @@ export class MlxAudioTextToSpeechProvider implements TextToSpeechProvider {
   private readonly format: string;
   private readonly timeoutMs: number;
   private readonly maxChars: number;
+  private readonly killGraceMs: number;
   /** Resolved python path, or null when unavailable. Re-checked after TTL. */
   private resolvedPython: string | null | undefined;
   private resolvedAt = 0;
@@ -87,6 +90,7 @@ export class MlxAudioTextToSpeechProvider implements TextToSpeechProvider {
     // First synthesis downloads model weights — keep generous headroom.
     this.timeoutMs = config?.timeoutMs ?? 300_000;
     this.maxChars = config?.maxChars ?? 4_000;
+    this.killGraceMs = config?.killGraceMs ?? 5_000;
     this.pythonCandidates = config?.pythonCandidates;
     this.ffmpegBinCandidates = config?.ffmpegBinCandidates;
   }
@@ -170,20 +174,31 @@ export class MlxAudioTextToSpeechProvider implements TextToSpeechProvider {
       if (!wavPath) throw new Error('mlx-audio produced no wav output');
 
       // Telegram voice bubbles want OGG/Opus — re-encode when possible.
+      // Any encode problem (no ffmpeg, or ffmpeg fails mid-encode) falls
+      // through to returning the WAV we already have — synthesized speech
+      // must never be discarded over a re-encode failure.
       if (this.format === 'opus' || this.format === 'mp3') {
         const ffmpeg = await this.resolveFfmpeg();
         if (ffmpeg) {
-          const encoded = await this.encode(ffmpeg, wavPath, outputDir, this.format);
-          return {
-            filePath: encoded.path,
-            contentType: contentTypeForFormat(this.format),
-            filename: encoded.filename,
-            cleanup,
-          };
+          try {
+            const encoded = await this.encode(ffmpeg, wavPath, outputDir, this.format);
+            return {
+              filePath: encoded.path,
+              contentType: contentTypeForFormat(this.format),
+              filename: encoded.filename,
+              cleanup,
+            };
+          } catch (error) {
+            logger.warn('MLX TTS: ffmpeg encode failed, returning wav instead', {
+              requestedFormat: this.format,
+              error: error instanceof Error ? error.message : String(error),
+            });
+          }
+        } else {
+          logger.warn('MLX TTS: ffmpeg unavailable, returning wav instead of requested format', {
+            requestedFormat: this.format,
+          });
         }
-        logger.warn('MLX TTS: ffmpeg unavailable, returning wav instead of requested format', {
-          requestedFormat: this.format,
-        });
       }
 
       return {
@@ -205,22 +220,42 @@ export class MlxAudioTextToSpeechProvider implements TextToSpeechProvider {
 
   private runProcess(bin: string, args: string[], timeoutMs: number): Promise<void> {
     return new Promise<void>((resolve, reject) => {
-      const child = spawn(bin, args, { stdio: ['ignore', 'ignore', 'pipe'] });
+      // detached → own process group, so a timeout kill reaches any
+      // descendants the python process spawned, not just the shell/python
+      // itself.
+      const child = spawn(bin, args, { stdio: ['ignore', 'ignore', 'pipe'], detached: true });
       let stderr = '';
+      let timedOut = false;
+      let killTimer: NodeJS.Timeout | undefined;
       child.stderr?.on('data', (chunk: Buffer) => {
         stderr += chunk.toString();
       });
+      const signalGroup = (signal: NodeJS.Signals) => {
+        if (!child.pid) return;
+        try {
+          process.kill(-child.pid, signal); // whole process group
+        } catch {
+          child.kill(signal); // group already gone — best effort
+        }
+      };
       const timeout = setTimeout(() => {
-        child.kill('SIGTERM');
-        reject(new Error(`${bin} timed out after ${timeoutMs}ms`));
+        timedOut = true;
+        signalGroup('SIGTERM');
+        // Escalate: a TERM-ignoring child must not outlive synthesize().
+        killTimer = setTimeout(() => signalGroup('SIGKILL'), this.killGraceMs);
       }, timeoutMs);
+      // Settle ONLY on close — guarantees the process is actually dead
+      // (not merely signalled) by the time the promise resolves/rejects.
       child.on('close', (code) => {
         clearTimeout(timeout);
-        if (code === 0) resolve();
+        if (killTimer) clearTimeout(killTimer);
+        if (timedOut) reject(new Error(`${bin} timed out after ${timeoutMs}ms`));
+        else if (code === 0) resolve();
         else reject(new Error(`${bin} exited ${code}: ${stderr.slice(0, 300)}`));
       });
       child.on('error', (err) => {
         clearTimeout(timeout);
+        if (killTimer) clearTimeout(killTimer);
         reject(err);
       });
     });

--- a/packages/api/src/channels/audio/mlx-tts.ts
+++ b/packages/api/src/channels/audio/mlx-tts.ts
@@ -1,0 +1,266 @@
+/**
+ * MLX TTS provider — on-device speech synthesis via mlx-audio.
+ *
+ * Default model: Qwen3-TTS 0.6B CustomVoice (Apache 2.0) through the MLX
+ * community port — multilingual (incl. German), preset voices, roughly
+ * real-time on Apple Silicon. Model weights download from Hugging Face
+ * automatically on first synthesis.
+ *
+ * Availability is checked lazily PER CALL (cached with a short TTL): a
+ * `pip install mlx-audio` enables this provider on the next voice reply.
+ * No server restart, no env edit — same pattern as the Parakeet STT
+ * provider.
+ *
+ * Output: mlx-audio writes WAV; when the configured format is opus/mp3
+ * (Telegram voice notes want OGG/Opus), ffmpeg re-encodes. Without
+ * ffmpeg the provider falls back to returning the WAV — Telegram then
+ * renders an audio file instead of a voice bubble, which still works.
+ */
+
+import { execFile, spawn } from 'child_process';
+import { promisify } from 'util';
+import { mkdtemp, readdir, rm, stat } from 'fs/promises';
+import { tmpdir, homedir } from 'os';
+import { join } from 'path';
+import { logger } from '../../utils/logger';
+import { contentTypeForFormat } from './audio-utils';
+import type { TextToSpeechProvider, TextToSpeechInput, SynthesizedAudio } from './tts-provider';
+
+const execFileAsync = promisify(execFile);
+
+export const DEFAULT_MLX_TTS_MODEL = 'mlx-community/Qwen3-TTS-12Hz-0.6B-CustomVoice-8bit';
+export const DEFAULT_MLX_TTS_VOICE = 'serena';
+
+/** Python interpreters checked for an importable mlx_audio, in order. */
+export function mlxPythonCandidates(): string[] {
+  return [
+    process.env.AUDIO_TTS_MLX_PYTHON?.trim() || '',
+    'python3', // PATH
+    join(homedir(), '.pyenv', 'shims', 'python3'),
+    '/opt/homebrew/bin/python3',
+    '/usr/local/bin/python3',
+  ].filter(Boolean);
+}
+
+/** ffmpeg locations checked for opus/mp3 re-encoding, in order. */
+export function ffmpegCandidates(): string[] {
+  return [
+    process.env.FFMPEG_BIN?.trim() || '',
+    'ffmpeg', // PATH
+    '/opt/homebrew/bin/ffmpeg',
+    '/usr/local/bin/ffmpeg',
+  ].filter(Boolean);
+}
+
+export interface MlxTtsProviderConfig {
+  model?: string;
+  voice?: string;
+  format?: string;
+  timeoutMs?: number;
+  maxChars?: number;
+  /** Override python candidate list (tests) */
+  pythonCandidates?: string[];
+  /** Override ffmpeg candidate list (tests) */
+  ffmpegBinCandidates?: string[];
+}
+
+export class MlxAudioTextToSpeechProvider implements TextToSpeechProvider {
+  readonly name = 'mlx';
+
+  private readonly model: string;
+  private readonly voice: string;
+  private readonly format: string;
+  private readonly timeoutMs: number;
+  private readonly maxChars: number;
+  /** Resolved python path, or null when unavailable. Re-checked after TTL. */
+  private resolvedPython: string | null | undefined;
+  private resolvedAt = 0;
+  private static readonly AVAILABILITY_TTL_MS = 60_000;
+
+  private readonly pythonCandidates?: string[];
+  private readonly ffmpegBinCandidates?: string[];
+
+  constructor(config?: MlxTtsProviderConfig) {
+    this.model = config?.model || process.env.AUDIO_TTS_MLX_MODEL?.trim() || DEFAULT_MLX_TTS_MODEL;
+    this.voice = config?.voice || process.env.AUDIO_TTS_MLX_VOICE?.trim() || DEFAULT_MLX_TTS_VOICE;
+    this.format = config?.format || 'opus';
+    // First synthesis downloads model weights — keep generous headroom.
+    this.timeoutMs = config?.timeoutMs ?? 300_000;
+    this.maxChars = config?.maxChars ?? 4_000;
+    this.pythonCandidates = config?.pythonCandidates;
+    this.ffmpegBinCandidates = config?.ffmpegBinCandidates;
+  }
+
+  /**
+   * Find a python with mlx_audio importable. Cached with a short TTL so
+   * an install mid-session is picked up without restart, while
+   * steady-state replies don't re-probe every time.
+   */
+  async resolvePython(): Promise<string | null> {
+    const now = Date.now();
+    if (
+      this.resolvedPython !== undefined &&
+      now - this.resolvedAt < MlxAudioTextToSpeechProvider.AVAILABILITY_TTL_MS
+    ) {
+      return this.resolvedPython;
+    }
+    for (const candidate of this.pythonCandidates ?? mlxPythonCandidates()) {
+      try {
+        await execFileAsync(candidate, ['-c', 'import mlx_audio'], { timeout: 20_000 });
+        this.resolvedPython = candidate;
+        this.resolvedAt = now;
+        return candidate;
+      } catch {
+        // try next candidate
+      }
+    }
+    this.resolvedPython = null;
+    this.resolvedAt = now;
+    return null;
+  }
+
+  private async resolveFfmpeg(): Promise<string | null> {
+    for (const candidate of this.ffmpegBinCandidates ?? ffmpegCandidates()) {
+      try {
+        await execFileAsync(candidate, ['-version'], { timeout: 15_000 });
+        return candidate;
+      } catch {
+        // try next candidate
+      }
+    }
+    return null;
+  }
+
+  async synthesize(input: TextToSpeechInput): Promise<SynthesizedAudio | undefined> {
+    const text = input.text.trim().slice(0, this.maxChars);
+    if (!text) return undefined;
+
+    const python = await this.resolvePython();
+    if (!python) return undefined;
+
+    const outputDir = await mkdtemp(join(tmpdir(), 'ink-mlx-tts-'));
+    const cleanup = async () => {
+      await rm(outputDir, { recursive: true, force: true }).catch(() => undefined);
+    };
+
+    try {
+      await this.runProcess(
+        python,
+        [
+          '-m',
+          'mlx_audio.tts.generate',
+          '--model',
+          this.model,
+          '--text',
+          text,
+          '--voice',
+          this.voice,
+          '--output_path',
+          outputDir,
+          '--file_prefix',
+          'reply',
+          '--audio_format',
+          'wav',
+          '--join_audio',
+        ],
+        this.timeoutMs
+      );
+
+      const wavPath = await this.findOutputFile(outputDir, '.wav');
+      if (!wavPath) throw new Error('mlx-audio produced no wav output');
+
+      // Telegram voice bubbles want OGG/Opus — re-encode when possible.
+      if (this.format === 'opus' || this.format === 'mp3') {
+        const ffmpeg = await this.resolveFfmpeg();
+        if (ffmpeg) {
+          const encoded = await this.encode(ffmpeg, wavPath, outputDir, this.format);
+          return {
+            filePath: encoded.path,
+            contentType: contentTypeForFormat(this.format),
+            filename: encoded.filename,
+            cleanup,
+          };
+        }
+        logger.warn('MLX TTS: ffmpeg unavailable, returning wav instead of requested format', {
+          requestedFormat: this.format,
+        });
+      }
+
+      return {
+        filePath: wavPath,
+        contentType: contentTypeForFormat('wav'),
+        filename: 'reply.wav',
+        cleanup,
+      };
+    } catch (error) {
+      await cleanup();
+      logger.warn('MLX TTS synthesis failed', {
+        model: this.model,
+        voice: this.voice,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return undefined;
+    }
+  }
+
+  private runProcess(bin: string, args: string[], timeoutMs: number): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      const child = spawn(bin, args, { stdio: ['ignore', 'ignore', 'pipe'] });
+      let stderr = '';
+      child.stderr?.on('data', (chunk: Buffer) => {
+        stderr += chunk.toString();
+      });
+      const timeout = setTimeout(() => {
+        child.kill('SIGTERM');
+        reject(new Error(`${bin} timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+      child.on('close', (code) => {
+        clearTimeout(timeout);
+        if (code === 0) resolve();
+        else reject(new Error(`${bin} exited ${code}: ${stderr.slice(0, 300)}`));
+      });
+      child.on('error', (err) => {
+        clearTimeout(timeout);
+        reject(err);
+      });
+    });
+  }
+
+  /** Find the largest generated file with the given extension (mlx-audio
+   *  may name segments reply.wav / reply_000.wav depending on model). */
+  private async findOutputFile(dir: string, extension: string): Promise<string | undefined> {
+    const entries = await readdir(dir);
+    const matches = entries.filter((name) => name.startsWith('reply') && name.endsWith(extension));
+    if (matches.length === 0) return undefined;
+    let best: { path: string; size: number } | undefined;
+    for (const name of matches) {
+      const filePath = join(dir, name);
+      const details = await stat(filePath).catch(() => undefined);
+      if (!details?.isFile()) continue;
+      if (!best || details.size > best.size) {
+        best = { path: filePath, size: details.size };
+      }
+    }
+    return best && best.size > 0 ? best.path : undefined;
+  }
+
+  private async encode(
+    ffmpeg: string,
+    wavPath: string,
+    outputDir: string,
+    format: string
+  ): Promise<{ path: string; filename: string }> {
+    const isOpus = format === 'opus';
+    const filename = isOpus ? 'reply.ogg' : 'reply.mp3';
+    const outPath = join(outputDir, filename);
+    const args = isOpus
+      ? ['-y', '-i', wavPath, '-c:a', 'libopus', '-b:a', '32k', '-ar', '48000', outPath]
+      : ['-y', '-i', wavPath, '-c:a', 'libmp3lame', '-b:a', '64k', outPath];
+    await this.runProcess(ffmpeg, args, 60_000);
+    const details = await stat(outPath).catch(() => undefined);
+    if (!details || details.size <= 0) {
+      throw new Error(`ffmpeg produced no ${format} output`);
+    }
+    return { path: outPath, filename };
+  }
+}

--- a/packages/api/src/channels/text-to-speech.test.ts
+++ b/packages/api/src/channels/text-to-speech.test.ts
@@ -31,6 +31,35 @@ describe('TextToSpeechService', () => {
     expect(result).toBeUndefined();
   });
 
+  it('builds the mlx provider with no API key or cliCommand required', () => {
+    // Unlike 'cli' (needs cliCommand to be constructed), 'mlx' is always
+    // constructible — it self-disables at call time when mlx-audio isn't
+    // installed. This is what makes on-device TTS zero-config.
+    const cliOnly = new TextToSpeechService({
+      enabled: true,
+      baseUrl: 'https://api.openai.com/v1',
+      model: 'gpt-4o-mini-tts',
+      voice: 'alloy',
+      format: 'opus',
+      timeoutMs: 5000,
+      maxChars: 1000,
+      providers: ['cli'], // no cliCommand → no providers → disabled
+    });
+    expect(cliOnly.isEnabled()).toBe(false);
+
+    const mlxOnly = new TextToSpeechService({
+      enabled: true,
+      baseUrl: 'https://api.openai.com/v1',
+      model: 'gpt-4o-mini-tts',
+      voice: 'alloy',
+      format: 'opus',
+      timeoutMs: 5000,
+      maxChars: 1000,
+      providers: ['mlx'],
+    });
+    expect(mlxOnly.isEnabled()).toBe(true);
+  });
+
   it('builds elevenlabs provider from config', () => {
     const service = new TextToSpeechService({
       enabled: true,

--- a/packages/api/src/channels/text-to-speech.ts
+++ b/packages/api/src/channels/text-to-speech.ts
@@ -4,12 +4,18 @@ import {
   OpenAITextToSpeechProvider,
   ElevenLabsTextToSpeechProvider,
   CliTextToSpeechProvider,
+  MlxAudioTextToSpeechProvider,
 } from './audio';
 import type { TextToSpeechProvider, TextToSpeechInput, SynthesizedAudio } from './audio';
 
 export type { TextToSpeechInput, SynthesizedAudio };
 
-const DEFAULT_PROVIDER_ORDER = ['openai', 'cli'];
+// mlx sits between openai and cli: it self-disables when no python has
+// mlx_audio importable (lazy per-call availability check), so including
+// it by default costs nothing for users who haven't installed it — and
+// `pip install mlx-audio` enables on-device synthesis with zero config.
+// Same pattern as the Parakeet STT provider.
+const DEFAULT_PROVIDER_ORDER = ['openai', 'mlx', 'cli'];
 
 function normalizeFormat(value: string | undefined): string {
   const format = value?.trim().toLowerCase();
@@ -103,6 +109,17 @@ export class TextToSpeechService {
               voice: this.config.elevenlabsVoice,
               model: this.config.elevenlabsModel,
               timeoutMs: this.config.timeoutMs,
+            })
+          );
+          break;
+        case 'mlx':
+          providers.push(
+            new MlxAudioTextToSpeechProvider({
+              format: this.config.format,
+              // First synthesis downloads model weights (~700MB) — give
+              // it headroom beyond the steady-state timeout
+              timeoutMs: Math.max(this.config.timeoutMs, 300_000),
+              maxChars: this.config.maxChars,
             })
           );
           break;


### PR DESCRIPTION
## What

Myra can speak. New `mlx` TextToSpeechProvider — **Qwen3-TTS 0.6B CustomVoice** (Apache 2.0, open weights released Jan 2026) running on-device through [mlx-audio](https://github.com/Blaizzy/mlx-audio) on Apple Silicon. Multilingual including German, 9 preset voices (default `serena`), roughly real-time generation (~7s for an ~8.5s clip including model load).

Model choice context: Fish/OpenAudio S1 (4B) was never open-released and S1-mini is CC-BY-NC with no MLX port; Kokoro-82M has no German; F5-TTS weights are CC-BY-NC. Qwen3-TTS is the only shortlist option that's Apache 2.0 + mlx-audio-supported + German-capable.

## How

Mirrors the Parakeet STT pattern exactly (#413):

- **Lazy per-call availability** (60s TTL): `pip install mlx-audio` enables the provider on the next voice reply — no restart, no env edit
- **Self-disabling**: returns `undefined` when no python can `import mlx_audio`
- **Default chain**: `openai → mlx → cli` — zero cost to users without it installed
- **Output**: mlx-audio writes WAV → ffmpeg re-encodes to OGG/Opus (32k/48kHz) for Telegram voice bubbles. No ffmpeg → falls back to WAV (Telegram renders an audio file instead of a bubble; still delivered)

Env knobs: `AUDIO_TTS_MLX_MODEL`, `AUDIO_TTS_MLX_VOICE`, `AUDIO_TTS_MLX_PYTHON`, `FFMPEG_BIN`. The `AUDIO_TTS_ENABLED=true` opt-in gate is unchanged — voice replies stay deliberate.

The outbound trigger path already existed (`gateway.ts` `shouldUseVoiceReply` → `sendVoice`): explicit `voiceReply` metadata, or `TELEGRAM_AUTO_VOICE_REPLY=true` for voice-in→voice-out.

## Tests

| Tier | Coverage |
|---|---|
| Unit (8) | fake python/ffmpeg binaries: wav synthesis + cleanup, opus re-encode, ffmpeg-missing wav fallback, maxChars truncation, self-disable, empty text, generation failure → undefined, TTL caching |
| Unit (2) | service wiring: `mlx` constructible with no key/command (vs `cli` disabled without command) |
| Live e2e (2) | real model + real ffmpeg via `INK_LIVE_TESTS=1`: OggS container magic verified on the opus output; German synthesis through the same default model. **Ran green in 12s** (cached weights) |

211/211 across all channel suites. Control-byte scan clean. No new type errors (known pre-existing `gateway.ts`/`mcp/server.ts` ones remain).

## Notes

- Branch cut from post-#413 main — no stacking this time.
- Known-unrelated CI: DB integration drift (task `03fcdb56`).
- Follow-up candidates (not this PR): consent-driven `setup` action for TTS mirroring `setup_audio_transcription`; voice cloning via the Base variant so Myra gets a unique voice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)